### PR TITLE
Tie First and Last VEs

### DIFF
--- a/records/track_1_short/2026-01-28_TieFirstLastVEs/README.md
+++ b/records/track_1_short/2026-01-28_TieFirstLastVEs/README.md
@@ -1,0 +1,81 @@
+# Tie First and Last VEs
+
+Swapping the first two VEs reduces validation loss.
+
+Our long-standing pattern of value embeddings has been:
+
+`12------012`
+
+Switching this to:
+
+`21------012`
+
+reduced loss by -0.0012
+
+Consistent with the previous PR, I found that untying VE1 reduces it further as well.
+
+If we rename VE2 to VE0, it becomes:
+
+`01------230`
+
+```
+                             Runs  Time μ  Time σ  Time +/-  Time p  Loss μ  Loss σ  Loss +/-      p
+baseline                        6 98.3442  0.0686    0.0000     NaN  3.2785  0.0013    0.0000 0.0184
+
+ve_21------012 w/o PolarT       4 98.3590  0.0868    0.0148  0.6077  3.2774  0.0010   -0.0011 0.0077
+ve_21------012                  4 98.3490  0.0336    0.0048  0.5569  3.2772  0.0011   -0.0012 0.0079
+ve_21------012 -5stps           6 98.1192  0.0400   -0.2250  0.0001  3.2786  0.0004    0.0001 0.0002 - Remove more steps?
+
+ve_01------230 -15stps          4 98.0825  0.0896   -0.2617  0.0018  3.2769  0.0010   -0.0016 0.0040 - Best so far
+
+ve_210-----012                  4 98.5325  0.0455    0.1883  0.9996  3.2764  0.0010   -0.0021 0.0024
+ve_210-----012 -10stps          6 97.8797  0.0898   -0.4645  0.0000  3.2791  0.0014    0.0006 0.0899 (Fail)
+ve_210-----012 untie, -5stps    4 98.4843  0.1030    0.1401  0.9677  3.2792  0.0016    0.0007 0.1820 (Fail)
+```
+
+**Rationale**
+
+Trying to make sense of why this unique VE pattern works well lead me to speculate that VE2 (which we've had on our second and last layer, tied) might be more semantic, and therefore relate well to both the first and last layers.
+
+This also might offer some explanation for why shifting VE2 deeper into the model (e.g., via `012-----012`) hasn't worked.
+
+## Polar Express Transpose
+
+I've also included an improvement to the Polar Express kernel. It was written to work on "wide" matrices, but we've had our MLP weights stored vertically. The current Polar Express code handles this by transposing the matrix, resulting in a slow element-wise kernel for the Nesterov momentum step. 
+
+The algebra can be re-ordered instead to allow for working directly on "tall" matrices:
+
+```
+# Polar express
+X = g.bfloat16()
+
+X = X / (X.norm(dim=(-2, -1), keepdim=True) * 1.02 + 1e-6)
+
+if g.size(-2) > g.size(-1): # Tall matrix
+    for a, b, c in polar_express_coeffs[:ns_steps]:
+        A = X.mT @ X
+        B = b * A + c * (A @ A)
+        X = a * X + X @ B
+
+else: # Wide matrix (original math)
+    for a, b, c in polar_express_coeffs[:ns_steps]:
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+
+return X
+```
+
+I had Claude write an XTX variant and verified that it was numerically equivalent.
+
+The speed improvement is likely too small to be measurable, but it's clear in the trace files.
+
+I came across it while exploring nanochat--here's the impact this fix has on a much larger (25-layer) model:
+
+## A100 Support
+
+I added a few things to make our code easier for anyone on a < H100 GPU.
+
+It checks the compute capability to automate the decision on FP8, and also falls back to an FA2 implementation using the same interface we have for FA3 (there's a repo similar to Varun's for retrieving pre-built FA2).
+
+I also added a fallback for the fused ReLU kernel, but need to review that change further.

--- a/records/track_1_short/2026-01-28_TieFirstLastVEs/baseline/1539b2ec-6ee8-4e0a-98a3-57f04baee657.txt
+++ b/records/track_1_short/2026-01-28_TieFirstLastVEs/baseline/1539b2ec-6ee8-4e0a-98a3-57f04baee657.txt
@@ -1,0 +1,4120 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.12.12 | packaged by conda-forge | (main, Jan 26 2026, 23:51:32) [GCC 14.3.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Thu Jan 29 02:24:02 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                  Off |
+| N/A   45C    P0            135W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:06:00.0 Off |                  Off |
+| N/A   38C    P0            130W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:07:00.0 Off |                  Off |
+| N/A   45C    P0            125W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:08:00.0 Off |                  Off |
+| N/A   38C    P0            128W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:09:00.0 Off |                  Off |
+| N/A   44C    P0            129W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                  Off |
+| N/A   38C    P0            128W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                  Off |
+| N/A   44C    P0            132W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:0C:00.0 Off |                  Off |
+| N/A   38C    P0            126W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A           52558      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    1   N/A  N/A           52559      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    2   N/A  N/A           52560      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    3   N/A  N/A           52561      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    4   N/A  N/A           52562      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    5   N/A  N/A           52563      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    6   N/A  N/A           52564      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    7   N/A  N/A           52565      C   .../envs/speedrun/bin/python3.12       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8309 train_time:0ms step_avg:0.04ms
+step:1/1600 train_time:65ms step_avg:64.96ms
+step:2/1600 train_time:86ms step_avg:43.00ms
+step:3/1600 train_time:104ms step_avg:34.56ms
+step:4/1600 train_time:136ms step_avg:33.97ms
+step:5/1600 train_time:166ms step_avg:33.15ms
+step:6/1600 train_time:251ms step_avg:41.78ms
+step:7/1600 train_time:267ms step_avg:38.18ms
+step:8/1600 train_time:302ms step_avg:37.72ms
+step:9/1600 train_time:332ms step_avg:36.87ms
+step:10/1600 train_time:369ms step_avg:36.89ms
+step:11/1600 train_time:399ms step_avg:36.30ms
+step:12/1600 train_time:438ms step_avg:36.47ms
+step:13/1600 train_time:468ms step_avg:36.00ms
+step:14/1600 train_time:505ms step_avg:36.09ms
+step:15/1600 train_time:535ms step_avg:35.69ms
+step:16/1600 train_time:573ms step_avg:35.81ms
+step:17/1600 train_time:603ms step_avg:35.48ms
+step:18/1600 train_time:641ms step_avg:35.61ms
+step:19/1600 train_time:672ms step_avg:35.35ms
+step:20/1600 train_time:709ms step_avg:35.45ms
+step:21/1600 train_time:739ms step_avg:35.21ms
+step:22/1600 train_time:778ms step_avg:35.35ms
+step:23/1600 train_time:808ms step_avg:35.14ms
+step:24/1600 train_time:845ms step_avg:35.22ms
+step:25/1600 train_time:876ms step_avg:35.03ms
+step:26/1600 train_time:913ms step_avg:35.12ms
+step:27/1600 train_time:943ms step_avg:34.94ms
+step:28/1600 train_time:981ms step_avg:35.03ms
+step:29/1600 train_time:1012ms step_avg:34.89ms
+step:30/1600 train_time:1049ms step_avg:34.96ms
+step:31/1600 train_time:1079ms step_avg:34.81ms
+step:32/1600 train_time:1117ms step_avg:34.91ms
+step:33/1600 train_time:1147ms step_avg:34.76ms
+step:34/1600 train_time:1185ms step_avg:34.86ms
+step:35/1600 train_time:1216ms step_avg:34.75ms
+step:36/1600 train_time:1255ms step_avg:34.85ms
+step:37/1600 train_time:1285ms step_avg:34.74ms
+step:38/1600 train_time:1323ms step_avg:34.82ms
+step:39/1600 train_time:1354ms step_avg:34.72ms
+step:40/1600 train_time:1392ms step_avg:34.80ms
+step:41/1600 train_time:1422ms step_avg:34.69ms
+step:42/1600 train_time:1460ms step_avg:34.77ms
+step:43/1600 train_time:1491ms step_avg:34.68ms
+step:44/1600 train_time:1528ms step_avg:34.73ms
+step:45/1600 train_time:1559ms step_avg:34.64ms
+step:46/1600 train_time:1597ms step_avg:34.71ms
+step:47/1600 train_time:1627ms step_avg:34.61ms
+step:48/1600 train_time:1664ms step_avg:34.68ms
+step:49/1600 train_time:1695ms step_avg:34.59ms
+step:50/1600 train_time:1732ms step_avg:34.64ms
+step:51/1600 train_time:1762ms step_avg:34.56ms
+step:52/1600 train_time:1800ms step_avg:34.62ms
+step:53/1600 train_time:1830ms step_avg:34.53ms
+step:54/1600 train_time:1868ms step_avg:34.59ms
+step:55/1600 train_time:1898ms step_avg:34.51ms
+step:56/1600 train_time:1936ms step_avg:34.58ms
+step:57/1600 train_time:1967ms step_avg:34.50ms
+step:58/1600 train_time:2004ms step_avg:34.55ms
+step:59/1600 train_time:2035ms step_avg:34.49ms
+step:60/1600 train_time:2072ms step_avg:34.54ms
+step:61/1600 train_time:2103ms step_avg:34.47ms
+step:62/1600 train_time:2141ms step_avg:34.53ms
+step:63/1600 train_time:2171ms step_avg:34.47ms
+step:64/1600 train_time:2209ms step_avg:34.51ms
+step:65/1600 train_time:2240ms step_avg:34.46ms
+step:66/1600 train_time:2278ms step_avg:34.51ms
+step:67/1600 train_time:2308ms step_avg:34.45ms
+step:68/1600 train_time:2346ms step_avg:34.50ms
+step:69/1600 train_time:2376ms step_avg:34.44ms
+step:70/1600 train_time:2414ms step_avg:34.49ms
+step:71/1600 train_time:2445ms step_avg:34.43ms
+step:72/1600 train_time:2483ms step_avg:34.48ms
+step:73/1600 train_time:2513ms step_avg:34.43ms
+step:74/1600 train_time:2551ms step_avg:34.47ms
+step:75/1600 train_time:2581ms step_avg:34.42ms
+step:76/1600 train_time:2619ms step_avg:34.46ms
+step:77/1600 train_time:2649ms step_avg:34.41ms
+step:78/1600 train_time:2687ms step_avg:34.45ms
+step:79/1600 train_time:2717ms step_avg:34.39ms
+step:80/1600 train_time:2754ms step_avg:34.43ms
+step:81/1600 train_time:2785ms step_avg:34.38ms
+step:82/1600 train_time:2823ms step_avg:34.42ms
+step:83/1600 train_time:2853ms step_avg:34.38ms
+step:84/1600 train_time:2891ms step_avg:34.41ms
+step:85/1600 train_time:2921ms step_avg:34.36ms
+step:86/1600 train_time:2958ms step_avg:34.40ms
+step:87/1600 train_time:2989ms step_avg:34.35ms
+step:88/1600 train_time:3026ms step_avg:34.39ms
+step:89/1600 train_time:3056ms step_avg:34.34ms
+step:90/1600 train_time:3094ms step_avg:34.38ms
+step:91/1600 train_time:3124ms step_avg:34.33ms
+step:92/1600 train_time:3162ms step_avg:34.37ms
+step:93/1600 train_time:3192ms step_avg:34.33ms
+step:94/1600 train_time:3230ms step_avg:34.36ms
+step:95/1600 train_time:3260ms step_avg:34.32ms
+step:96/1600 train_time:3298ms step_avg:34.36ms
+step:97/1600 train_time:3328ms step_avg:34.31ms
+step:98/1600 train_time:3366ms step_avg:34.35ms
+step:99/1600 train_time:3397ms step_avg:34.31ms
+step:100/1600 train_time:3434ms step_avg:34.34ms
+step:101/1600 train_time:3464ms step_avg:34.30ms
+step:102/1600 train_time:3502ms step_avg:34.33ms
+step:103/1600 train_time:3533ms step_avg:34.30ms
+step:104/1600 train_time:3570ms step_avg:34.33ms
+step:105/1600 train_time:3601ms step_avg:34.29ms
+step:106/1600 train_time:3639ms step_avg:34.33ms
+step:107/1600 train_time:3669ms step_avg:34.29ms
+step:108/1600 train_time:3706ms step_avg:34.32ms
+step:109/1600 train_time:3737ms step_avg:34.28ms
+step:110/1600 train_time:3775ms step_avg:34.31ms
+step:111/1600 train_time:3805ms step_avg:34.28ms
+step:112/1600 train_time:3842ms step_avg:34.31ms
+step:113/1600 train_time:3873ms step_avg:34.27ms
+step:114/1600 train_time:3911ms step_avg:34.31ms
+step:115/1600 train_time:3941ms step_avg:34.27ms
+step:116/1600 train_time:3979ms step_avg:34.30ms
+step:117/1600 train_time:4010ms step_avg:34.27ms
+step:118/1600 train_time:4047ms step_avg:34.30ms
+step:119/1600 train_time:4077ms step_avg:34.26ms
+step:120/1600 train_time:4115ms step_avg:34.29ms
+step:121/1600 train_time:4145ms step_avg:34.26ms
+step:122/1600 train_time:4183ms step_avg:34.28ms
+step:123/1600 train_time:4214ms step_avg:34.26ms
+step:124/1600 train_time:4251ms step_avg:34.28ms
+step:125/1600 train_time:4282ms step_avg:34.25ms
+step:126/1600 train_time:4319ms step_avg:34.28ms
+step:127/1600 train_time:4350ms step_avg:34.25ms
+step:128/1600 train_time:4387ms step_avg:34.28ms
+step:129/1600 train_time:4418ms step_avg:34.25ms
+step:130/1600 train_time:4456ms step_avg:34.28ms
+step:131/1600 train_time:4486ms step_avg:34.25ms
+step:132/1600 train_time:4524ms step_avg:34.27ms
+step:133/1600 train_time:4554ms step_avg:34.24ms
+step:134/1600 train_time:4592ms step_avg:34.27ms
+step:135/1600 train_time:4622ms step_avg:34.24ms
+step:136/1600 train_time:4659ms step_avg:34.26ms
+step:137/1600 train_time:4690ms step_avg:34.23ms
+step:138/1600 train_time:4727ms step_avg:34.25ms
+step:139/1600 train_time:4757ms step_avg:34.23ms
+step:140/1600 train_time:4795ms step_avg:34.25ms
+step:141/1600 train_time:4826ms step_avg:34.22ms
+step:142/1600 train_time:4863ms step_avg:34.25ms
+step:143/1600 train_time:4893ms step_avg:34.22ms
+step:144/1600 train_time:4931ms step_avg:34.24ms
+step:145/1600 train_time:4962ms step_avg:34.22ms
+step:146/1600 train_time:4999ms step_avg:34.24ms
+step:147/1600 train_time:5030ms step_avg:34.22ms
+step:148/1600 train_time:5067ms step_avg:34.24ms
+step:149/1600 train_time:5098ms step_avg:34.21ms
+step:150/1600 train_time:5136ms step_avg:34.24ms
+step:151/1600 train_time:5166ms step_avg:34.21ms
+step:152/1600 train_time:5204ms step_avg:34.24ms
+step:153/1600 train_time:5235ms step_avg:34.21ms
+step:154/1600 train_time:5272ms step_avg:34.24ms
+step:155/1600 train_time:5302ms step_avg:34.21ms
+step:156/1600 train_time:5340ms step_avg:34.23ms
+step:157/1600 train_time:5372ms step_avg:34.22ms
+step:158/1600 train_time:5408ms step_avg:34.23ms
+step:159/1600 train_time:5439ms step_avg:34.21ms
+step:160/1600 train_time:5477ms step_avg:34.23ms
+step:161/1600 train_time:5507ms step_avg:34.20ms
+step:162/1600 train_time:5545ms step_avg:34.23ms
+step:163/1600 train_time:5575ms step_avg:34.20ms
+step:164/1600 train_time:5612ms step_avg:34.22ms
+step:165/1600 train_time:5642ms step_avg:34.19ms
+step:166/1600 train_time:5680ms step_avg:34.22ms
+step:167/1600 train_time:5710ms step_avg:34.19ms
+step:168/1600 train_time:5747ms step_avg:34.21ms
+step:169/1600 train_time:5778ms step_avg:34.19ms
+step:170/1600 train_time:5816ms step_avg:34.21ms
+step:171/1600 train_time:5846ms step_avg:34.19ms
+step:172/1600 train_time:5884ms step_avg:34.21ms
+step:173/1600 train_time:5914ms step_avg:34.18ms
+step:174/1600 train_time:5951ms step_avg:34.20ms
+step:175/1600 train_time:5982ms step_avg:34.18ms
+step:176/1600 train_time:6019ms step_avg:34.20ms
+step:177/1600 train_time:6049ms step_avg:34.18ms
+step:178/1600 train_time:6087ms step_avg:34.19ms
+step:179/1600 train_time:6117ms step_avg:34.17ms
+step:180/1600 train_time:6154ms step_avg:34.19ms
+step:181/1600 train_time:6185ms step_avg:34.17ms
+step:182/1600 train_time:6223ms step_avg:34.19ms
+step:183/1600 train_time:6253ms step_avg:34.17ms
+step:184/1600 train_time:6290ms step_avg:34.19ms
+step:185/1600 train_time:6321ms step_avg:34.17ms
+step:186/1600 train_time:6359ms step_avg:34.19ms
+step:187/1600 train_time:6389ms step_avg:34.17ms
+step:188/1600 train_time:6427ms step_avg:34.19ms
+step:189/1600 train_time:6457ms step_avg:34.17ms
+step:190/1600 train_time:6495ms step_avg:34.18ms
+step:191/1600 train_time:6525ms step_avg:34.16ms
+step:192/1600 train_time:6563ms step_avg:34.18ms
+step:193/1600 train_time:6594ms step_avg:34.16ms
+step:194/1600 train_time:6631ms step_avg:34.18ms
+step:195/1600 train_time:6661ms step_avg:34.16ms
+step:196/1600 train_time:6699ms step_avg:34.18ms
+step:197/1600 train_time:6729ms step_avg:34.16ms
+step:198/1600 train_time:6766ms step_avg:34.17ms
+step:199/1600 train_time:6797ms step_avg:34.15ms
+step:200/1600 train_time:6834ms step_avg:34.17ms
+step:201/1600 train_time:6864ms step_avg:34.15ms
+step:202/1600 train_time:6902ms step_avg:34.17ms
+step:203/1600 train_time:6932ms step_avg:34.15ms
+step:204/1600 train_time:6969ms step_avg:34.16ms
+step:205/1600 train_time:7000ms step_avg:34.15ms
+step:206/1600 train_time:7038ms step_avg:34.16ms
+step:207/1600 train_time:7068ms step_avg:34.14ms
+step:208/1600 train_time:7105ms step_avg:34.16ms
+step:209/1600 train_time:7135ms step_avg:34.14ms
+step:210/1600 train_time:7173ms step_avg:34.16ms
+step:211/1600 train_time:7203ms step_avg:34.14ms
+step:212/1600 train_time:7241ms step_avg:34.15ms
+step:213/1600 train_time:7271ms step_avg:34.14ms
+step:214/1600 train_time:7308ms step_avg:34.15ms
+step:215/1600 train_time:7339ms step_avg:34.13ms
+step:216/1600 train_time:7377ms step_avg:34.15ms
+step:217/1600 train_time:7407ms step_avg:34.13ms
+step:218/1600 train_time:7444ms step_avg:34.15ms
+step:219/1600 train_time:7475ms step_avg:34.13ms
+step:220/1600 train_time:7512ms step_avg:34.15ms
+step:221/1600 train_time:7542ms step_avg:34.13ms
+step:222/1600 train_time:7580ms step_avg:34.14ms
+step:223/1600 train_time:7610ms step_avg:34.13ms
+step:224/1600 train_time:7647ms step_avg:34.14ms
+step:225/1600 train_time:7678ms step_avg:34.12ms
+step:226/1600 train_time:7716ms step_avg:34.14ms
+step:227/1600 train_time:7746ms step_avg:34.13ms
+step:228/1600 train_time:7784ms step_avg:34.14ms
+step:229/1600 train_time:7815ms step_avg:34.13ms
+step:230/1600 train_time:7853ms step_avg:34.14ms
+step:231/1600 train_time:7883ms step_avg:34.13ms
+step:232/1600 train_time:7921ms step_avg:34.14ms
+step:233/1600 train_time:7951ms step_avg:34.12ms
+step:234/1600 train_time:7988ms step_avg:34.14ms
+step:235/1600 train_time:8019ms step_avg:34.12ms
+step:236/1600 train_time:8057ms step_avg:34.14ms
+step:237/1600 train_time:8087ms step_avg:34.12ms
+step:238/1600 train_time:8124ms step_avg:34.14ms
+step:239/1600 train_time:8154ms step_avg:34.12ms
+step:240/1600 train_time:8191ms step_avg:34.13ms
+step:241/1600 train_time:8221ms step_avg:34.11ms
+step:242/1600 train_time:8259ms step_avg:34.13ms
+step:243/1600 train_time:8289ms step_avg:34.11ms
+step:244/1600 train_time:8327ms step_avg:34.13ms
+step:245/1600 train_time:8357ms step_avg:34.11ms
+step:246/1600 train_time:8394ms step_avg:34.12ms
+step:247/1600 train_time:8425ms step_avg:34.11ms
+step:248/1600 train_time:8462ms step_avg:34.12ms
+step:249/1600 train_time:8493ms step_avg:34.11ms
+step:250/1600 train_time:8530ms step_avg:34.12ms
+step:250/1600 val_loss:4.5913 train_time:8578ms step_avg:34.31ms
+step:251/1600 train_time:8597ms step_avg:34.25ms
+step:252/1600 train_time:8614ms step_avg:34.18ms
+step:253/1600 train_time:8630ms step_avg:34.11ms
+step:254/1600 train_time:8669ms step_avg:34.13ms
+step:255/1600 train_time:8700ms step_avg:34.12ms
+step:256/1600 train_time:8738ms step_avg:34.13ms
+step:257/1600 train_time:8769ms step_avg:34.12ms
+step:258/1600 train_time:8807ms step_avg:34.14ms
+step:259/1600 train_time:8838ms step_avg:34.12ms
+step:260/1600 train_time:8875ms step_avg:34.13ms
+step:261/1600 train_time:8905ms step_avg:34.12ms
+step:262/1600 train_time:8942ms step_avg:34.13ms
+step:263/1600 train_time:8973ms step_avg:34.12ms
+step:264/1600 train_time:9010ms step_avg:34.13ms
+step:265/1600 train_time:9040ms step_avg:34.11ms
+step:266/1600 train_time:9077ms step_avg:34.12ms
+step:267/1600 train_time:9107ms step_avg:34.11ms
+step:268/1600 train_time:9144ms step_avg:34.12ms
+step:269/1600 train_time:9174ms step_avg:34.11ms
+step:270/1600 train_time:9212ms step_avg:34.12ms
+step:271/1600 train_time:9242ms step_avg:34.10ms
+step:272/1600 train_time:9279ms step_avg:34.11ms
+step:273/1600 train_time:9309ms step_avg:34.10ms
+step:274/1600 train_time:9346ms step_avg:34.11ms
+step:275/1600 train_time:9377ms step_avg:34.10ms
+step:276/1600 train_time:9414ms step_avg:34.11ms
+step:277/1600 train_time:9444ms step_avg:34.09ms
+step:278/1600 train_time:9481ms step_avg:34.10ms
+step:279/1600 train_time:9511ms step_avg:34.09ms
+step:280/1600 train_time:9549ms step_avg:34.10ms
+step:281/1600 train_time:9579ms step_avg:34.09ms
+step:282/1600 train_time:9616ms step_avg:34.10ms
+step:283/1600 train_time:9647ms step_avg:34.09ms
+step:284/1600 train_time:9686ms step_avg:34.11ms
+step:285/1600 train_time:9716ms step_avg:34.09ms
+step:286/1600 train_time:9754ms step_avg:34.11ms
+step:287/1600 train_time:9785ms step_avg:34.09ms
+step:288/1600 train_time:9822ms step_avg:34.10ms
+step:289/1600 train_time:9852ms step_avg:34.09ms
+step:290/1600 train_time:9890ms step_avg:34.10ms
+step:291/1600 train_time:9921ms step_avg:34.09ms
+step:292/1600 train_time:9958ms step_avg:34.10ms
+step:293/1600 train_time:9988ms step_avg:34.09ms
+step:294/1600 train_time:10025ms step_avg:34.10ms
+step:295/1600 train_time:10055ms step_avg:34.09ms
+step:296/1600 train_time:10093ms step_avg:34.10ms
+step:297/1600 train_time:10123ms step_avg:34.08ms
+step:298/1600 train_time:10160ms step_avg:34.09ms
+step:299/1600 train_time:10190ms step_avg:34.08ms
+step:300/1600 train_time:10228ms step_avg:34.09ms
+step:301/1600 train_time:10258ms step_avg:34.08ms
+step:302/1600 train_time:10295ms step_avg:34.09ms
+step:303/1600 train_time:10325ms step_avg:34.08ms
+step:304/1600 train_time:10363ms step_avg:34.09ms
+step:305/1600 train_time:10393ms step_avg:34.08ms
+step:306/1600 train_time:10431ms step_avg:34.09ms
+step:307/1600 train_time:10461ms step_avg:34.07ms
+step:308/1600 train_time:10498ms step_avg:34.08ms
+step:309/1600 train_time:10528ms step_avg:34.07ms
+step:310/1600 train_time:10565ms step_avg:34.08ms
+step:311/1600 train_time:10595ms step_avg:34.07ms
+step:312/1600 train_time:10633ms step_avg:34.08ms
+step:313/1600 train_time:10663ms step_avg:34.07ms
+step:314/1600 train_time:10700ms step_avg:34.08ms
+step:315/1600 train_time:10731ms step_avg:34.07ms
+step:316/1600 train_time:10769ms step_avg:34.08ms
+step:317/1600 train_time:10799ms step_avg:34.07ms
+step:318/1600 train_time:10836ms step_avg:34.08ms
+step:319/1600 train_time:10867ms step_avg:34.07ms
+step:320/1600 train_time:10905ms step_avg:34.08ms
+step:321/1600 train_time:10935ms step_avg:34.07ms
+step:322/1600 train_time:10972ms step_avg:34.08ms
+step:323/1600 train_time:11002ms step_avg:34.06ms
+step:324/1600 train_time:11040ms step_avg:34.07ms
+step:325/1600 train_time:11070ms step_avg:34.06ms
+step:326/1600 train_time:11108ms step_avg:34.07ms
+step:327/1600 train_time:11138ms step_avg:34.06ms
+step:328/1600 train_time:11175ms step_avg:34.07ms
+step:329/1600 train_time:11205ms step_avg:34.06ms
+step:330/1600 train_time:11242ms step_avg:34.07ms
+step:331/1600 train_time:11273ms step_avg:34.06ms
+step:332/1600 train_time:11310ms step_avg:34.07ms
+step:333/1600 train_time:11341ms step_avg:34.06ms
+step:334/1600 train_time:11378ms step_avg:34.07ms
+step:335/1600 train_time:11408ms step_avg:34.05ms
+step:336/1600 train_time:11445ms step_avg:34.06ms
+step:337/1600 train_time:11475ms step_avg:34.05ms
+step:338/1600 train_time:11513ms step_avg:34.06ms
+step:339/1600 train_time:11543ms step_avg:34.05ms
+step:340/1600 train_time:11581ms step_avg:34.06ms
+step:341/1600 train_time:11611ms step_avg:34.05ms
+step:342/1600 train_time:11648ms step_avg:34.06ms
+step:343/1600 train_time:11679ms step_avg:34.05ms
+step:344/1600 train_time:11716ms step_avg:34.06ms
+step:345/1600 train_time:11747ms step_avg:34.05ms
+step:346/1600 train_time:11784ms step_avg:34.06ms
+step:347/1600 train_time:11814ms step_avg:34.05ms
+step:348/1600 train_time:11852ms step_avg:34.06ms
+step:349/1600 train_time:11883ms step_avg:34.05ms
+step:350/1600 train_time:11920ms step_avg:34.06ms
+step:351/1600 train_time:11951ms step_avg:34.05ms
+step:352/1600 train_time:11989ms step_avg:34.06ms
+step:353/1600 train_time:12019ms step_avg:34.05ms
+step:354/1600 train_time:12056ms step_avg:34.06ms
+step:355/1600 train_time:12087ms step_avg:34.05ms
+step:356/1600 train_time:12124ms step_avg:34.06ms
+step:357/1600 train_time:12154ms step_avg:34.05ms
+step:358/1600 train_time:12192ms step_avg:34.06ms
+step:359/1600 train_time:12222ms step_avg:34.05ms
+step:360/1600 train_time:12259ms step_avg:34.05ms
+step:361/1600 train_time:12289ms step_avg:34.04ms
+step:362/1600 train_time:12327ms step_avg:34.05ms
+step:363/1600 train_time:12357ms step_avg:34.04ms
+step:364/1600 train_time:12394ms step_avg:34.05ms
+step:365/1600 train_time:12425ms step_avg:34.04ms
+step:366/1600 train_time:12462ms step_avg:34.05ms
+step:367/1600 train_time:12492ms step_avg:34.04ms
+step:368/1600 train_time:12530ms step_avg:34.05ms
+step:369/1600 train_time:12560ms step_avg:34.04ms
+step:370/1600 train_time:12597ms step_avg:34.05ms
+step:371/1600 train_time:12628ms step_avg:34.04ms
+step:372/1600 train_time:12666ms step_avg:34.05ms
+step:373/1600 train_time:12696ms step_avg:34.04ms
+step:374/1600 train_time:12734ms step_avg:34.05ms
+step:375/1600 train_time:12764ms step_avg:34.04ms
+step:376/1600 train_time:12802ms step_avg:34.05ms
+step:377/1600 train_time:12832ms step_avg:34.04ms
+step:378/1600 train_time:12870ms step_avg:34.05ms
+step:379/1600 train_time:12900ms step_avg:34.04ms
+step:380/1600 train_time:12938ms step_avg:34.05ms
+step:381/1600 train_time:12968ms step_avg:34.04ms
+step:382/1600 train_time:13006ms step_avg:34.05ms
+step:383/1600 train_time:13036ms step_avg:34.04ms
+step:384/1600 train_time:13074ms step_avg:34.05ms
+step:385/1600 train_time:13104ms step_avg:34.04ms
+step:386/1600 train_time:13141ms step_avg:34.04ms
+step:387/1600 train_time:13171ms step_avg:34.03ms
+step:388/1600 train_time:13208ms step_avg:34.04ms
+step:389/1600 train_time:13238ms step_avg:34.03ms
+step:390/1600 train_time:13276ms step_avg:34.04ms
+step:391/1600 train_time:13306ms step_avg:34.03ms
+step:392/1600 train_time:13344ms step_avg:34.04ms
+step:393/1600 train_time:13374ms step_avg:34.03ms
+step:394/1600 train_time:13411ms step_avg:34.04ms
+step:395/1600 train_time:13442ms step_avg:34.03ms
+step:396/1600 train_time:13480ms step_avg:34.04ms
+step:397/1600 train_time:13510ms step_avg:34.03ms
+step:398/1600 train_time:13547ms step_avg:34.04ms
+step:399/1600 train_time:13577ms step_avg:34.03ms
+step:400/1600 train_time:13614ms step_avg:34.04ms
+step:401/1600 train_time:13645ms step_avg:34.03ms
+step:402/1600 train_time:13682ms step_avg:34.04ms
+step:403/1600 train_time:13713ms step_avg:34.03ms
+step:404/1600 train_time:13750ms step_avg:34.04ms
+step:405/1600 train_time:13781ms step_avg:34.03ms
+step:406/1600 train_time:13818ms step_avg:34.03ms
+step:407/1600 train_time:13848ms step_avg:34.02ms
+step:408/1600 train_time:13885ms step_avg:34.03ms
+step:409/1600 train_time:13915ms step_avg:34.02ms
+step:410/1600 train_time:13953ms step_avg:34.03ms
+step:411/1600 train_time:13984ms step_avg:34.03ms
+step:412/1600 train_time:14022ms step_avg:34.03ms
+step:413/1600 train_time:14052ms step_avg:34.02ms
+step:414/1600 train_time:14090ms step_avg:34.03ms
+step:415/1600 train_time:14120ms step_avg:34.02ms
+step:416/1600 train_time:14157ms step_avg:34.03ms
+step:417/1600 train_time:14188ms step_avg:34.02ms
+step:418/1600 train_time:14225ms step_avg:34.03ms
+step:419/1600 train_time:14255ms step_avg:34.02ms
+step:420/1600 train_time:14293ms step_avg:34.03ms
+step:421/1600 train_time:14323ms step_avg:34.02ms
+step:422/1600 train_time:14360ms step_avg:34.03ms
+step:423/1600 train_time:14391ms step_avg:34.02ms
+step:424/1600 train_time:14429ms step_avg:34.03ms
+step:425/1600 train_time:14459ms step_avg:34.02ms
+step:426/1600 train_time:14497ms step_avg:34.03ms
+step:427/1600 train_time:14527ms step_avg:34.02ms
+step:428/1600 train_time:14565ms step_avg:34.03ms
+step:429/1600 train_time:14595ms step_avg:34.02ms
+step:430/1600 train_time:14632ms step_avg:34.03ms
+step:431/1600 train_time:14663ms step_avg:34.02ms
+step:432/1600 train_time:14700ms step_avg:34.03ms
+step:433/1600 train_time:14731ms step_avg:34.02ms
+step:434/1600 train_time:14769ms step_avg:34.03ms
+step:435/1600 train_time:14799ms step_avg:34.02ms
+step:436/1600 train_time:14836ms step_avg:34.03ms
+step:437/1600 train_time:14866ms step_avg:34.02ms
+step:438/1600 train_time:14904ms step_avg:34.03ms
+step:439/1600 train_time:14934ms step_avg:34.02ms
+step:440/1600 train_time:14971ms step_avg:34.03ms
+step:441/1600 train_time:15002ms step_avg:34.02ms
+step:442/1600 train_time:15039ms step_avg:34.02ms
+step:443/1600 train_time:15069ms step_avg:34.02ms
+step:444/1600 train_time:15107ms step_avg:34.02ms
+step:445/1600 train_time:15137ms step_avg:34.02ms
+step:446/1600 train_time:15174ms step_avg:34.02ms
+step:447/1600 train_time:15205ms step_avg:34.01ms
+step:448/1600 train_time:15242ms step_avg:34.02ms
+step:449/1600 train_time:15273ms step_avg:34.02ms
+step:450/1600 train_time:15310ms step_avg:34.02ms
+step:451/1600 train_time:15341ms step_avg:34.01ms
+step:452/1600 train_time:15378ms step_avg:34.02ms
+step:453/1600 train_time:15408ms step_avg:34.01ms
+step:454/1600 train_time:15446ms step_avg:34.02ms
+step:455/1600 train_time:15476ms step_avg:34.01ms
+step:456/1600 train_time:15514ms step_avg:34.02ms
+step:457/1600 train_time:15544ms step_avg:34.01ms
+step:458/1600 train_time:15581ms step_avg:34.02ms
+step:459/1600 train_time:15611ms step_avg:34.01ms
+step:460/1600 train_time:15648ms step_avg:34.02ms
+step:461/1600 train_time:15679ms step_avg:34.01ms
+step:462/1600 train_time:15717ms step_avg:34.02ms
+step:463/1600 train_time:15747ms step_avg:34.01ms
+step:464/1600 train_time:15784ms step_avg:34.02ms
+step:465/1600 train_time:15814ms step_avg:34.01ms
+step:466/1600 train_time:15852ms step_avg:34.02ms
+step:467/1600 train_time:15882ms step_avg:34.01ms
+step:468/1600 train_time:15920ms step_avg:34.02ms
+step:469/1600 train_time:15950ms step_avg:34.01ms
+step:470/1600 train_time:15988ms step_avg:34.02ms
+step:471/1600 train_time:16018ms step_avg:34.01ms
+step:472/1600 train_time:16055ms step_avg:34.01ms
+step:473/1600 train_time:16085ms step_avg:34.01ms
+step:474/1600 train_time:16122ms step_avg:34.01ms
+step:475/1600 train_time:16152ms step_avg:34.00ms
+step:476/1600 train_time:16190ms step_avg:34.01ms
+step:477/1600 train_time:16220ms step_avg:34.00ms
+step:478/1600 train_time:16257ms step_avg:34.01ms
+step:479/1600 train_time:16288ms step_avg:34.00ms
+step:480/1600 train_time:16326ms step_avg:34.01ms
+step:481/1600 train_time:16356ms step_avg:34.00ms
+step:482/1600 train_time:16393ms step_avg:34.01ms
+step:483/1600 train_time:16424ms step_avg:34.00ms
+step:484/1600 train_time:16461ms step_avg:34.01ms
+step:485/1600 train_time:16491ms step_avg:34.00ms
+step:486/1600 train_time:16529ms step_avg:34.01ms
+step:487/1600 train_time:16559ms step_avg:34.00ms
+step:488/1600 train_time:16596ms step_avg:34.01ms
+step:489/1600 train_time:16627ms step_avg:34.00ms
+step:490/1600 train_time:16665ms step_avg:34.01ms
+step:491/1600 train_time:16695ms step_avg:34.00ms
+step:492/1600 train_time:16732ms step_avg:34.01ms
+step:493/1600 train_time:16763ms step_avg:34.00ms
+step:494/1600 train_time:16800ms step_avg:34.01ms
+step:495/1600 train_time:16830ms step_avg:34.00ms
+step:496/1600 train_time:16868ms step_avg:34.01ms
+step:497/1600 train_time:16898ms step_avg:34.00ms
+step:498/1600 train_time:16935ms step_avg:34.01ms
+step:499/1600 train_time:16965ms step_avg:34.00ms
+step:500/1600 train_time:17003ms step_avg:34.01ms
+step:500/1600 val_loss:4.2419 train_time:17051ms step_avg:34.10ms
+step:501/1600 train_time:17070ms step_avg:34.07ms
+step:502/1600 train_time:17087ms step_avg:34.04ms
+step:503/1600 train_time:17104ms step_avg:34.00ms
+step:504/1600 train_time:17141ms step_avg:34.01ms
+step:505/1600 train_time:17173ms step_avg:34.01ms
+step:506/1600 train_time:17212ms step_avg:34.01ms
+step:507/1600 train_time:17242ms step_avg:34.01ms
+step:508/1600 train_time:17279ms step_avg:34.01ms
+step:509/1600 train_time:17310ms step_avg:34.01ms
+step:510/1600 train_time:17347ms step_avg:34.01ms
+step:511/1600 train_time:17378ms step_avg:34.01ms
+step:512/1600 train_time:17415ms step_avg:34.01ms
+step:513/1600 train_time:17445ms step_avg:34.01ms
+step:514/1600 train_time:17483ms step_avg:34.01ms
+step:515/1600 train_time:17513ms step_avg:34.01ms
+step:516/1600 train_time:17550ms step_avg:34.01ms
+step:517/1600 train_time:17580ms step_avg:34.00ms
+step:518/1600 train_time:17617ms step_avg:34.01ms
+step:519/1600 train_time:17647ms step_avg:34.00ms
+step:520/1600 train_time:17684ms step_avg:34.01ms
+step:521/1600 train_time:17755ms step_avg:34.08ms
+step:522/1600 train_time:17811ms step_avg:34.12ms
+step:523/1600 train_time:17874ms step_avg:34.18ms
+step:524/1600 train_time:17932ms step_avg:34.22ms
+step:525/1600 train_time:17996ms step_avg:34.28ms
+step:526/1600 train_time:18056ms step_avg:34.33ms
+step:527/1600 train_time:18119ms step_avg:34.38ms
+step:528/1600 train_time:18178ms step_avg:34.43ms
+step:529/1600 train_time:18242ms step_avg:34.48ms
+step:530/1600 train_time:18301ms step_avg:34.53ms
+step:531/1600 train_time:18365ms step_avg:34.58ms
+step:532/1600 train_time:18424ms step_avg:34.63ms
+step:533/1600 train_time:18486ms step_avg:34.68ms
+step:534/1600 train_time:18545ms step_avg:34.73ms
+step:535/1600 train_time:18608ms step_avg:34.78ms
+step:536/1600 train_time:18667ms step_avg:34.83ms
+step:537/1600 train_time:18729ms step_avg:34.88ms
+step:538/1600 train_time:18789ms step_avg:34.92ms
+step:539/1600 train_time:18851ms step_avg:34.97ms
+step:540/1600 train_time:18910ms step_avg:35.02ms
+step:541/1600 train_time:18973ms step_avg:35.07ms
+step:542/1600 train_time:19034ms step_avg:35.12ms
+step:543/1600 train_time:19097ms step_avg:35.17ms
+step:544/1600 train_time:19158ms step_avg:35.22ms
+step:545/1600 train_time:19221ms step_avg:35.27ms
+step:546/1600 train_time:19280ms step_avg:35.31ms
+step:547/1600 train_time:19343ms step_avg:35.36ms
+step:548/1600 train_time:19402ms step_avg:35.41ms
+step:549/1600 train_time:19464ms step_avg:35.45ms
+step:550/1600 train_time:19524ms step_avg:35.50ms
+step:551/1600 train_time:19586ms step_avg:35.55ms
+step:552/1600 train_time:19644ms step_avg:35.59ms
+step:553/1600 train_time:19706ms step_avg:35.64ms
+step:554/1600 train_time:19765ms step_avg:35.68ms
+step:555/1600 train_time:19828ms step_avg:35.73ms
+step:556/1600 train_time:19887ms step_avg:35.77ms
+step:557/1600 train_time:19950ms step_avg:35.82ms
+step:558/1600 train_time:20010ms step_avg:35.86ms
+step:559/1600 train_time:20073ms step_avg:35.91ms
+step:560/1600 train_time:20133ms step_avg:35.95ms
+step:561/1600 train_time:20196ms step_avg:36.00ms
+step:562/1600 train_time:20256ms step_avg:36.04ms
+step:563/1600 train_time:20319ms step_avg:36.09ms
+step:564/1600 train_time:20379ms step_avg:36.13ms
+step:565/1600 train_time:20442ms step_avg:36.18ms
+step:566/1600 train_time:20501ms step_avg:36.22ms
+step:567/1600 train_time:20564ms step_avg:36.27ms
+step:568/1600 train_time:20623ms step_avg:36.31ms
+step:569/1600 train_time:20685ms step_avg:36.35ms
+step:570/1600 train_time:20744ms step_avg:36.39ms
+step:571/1600 train_time:20806ms step_avg:36.44ms
+step:572/1600 train_time:20865ms step_avg:36.48ms
+step:573/1600 train_time:20930ms step_avg:36.53ms
+step:574/1600 train_time:20991ms step_avg:36.57ms
+step:575/1600 train_time:21054ms step_avg:36.62ms
+step:576/1600 train_time:21113ms step_avg:36.65ms
+step:577/1600 train_time:21175ms step_avg:36.70ms
+step:578/1600 train_time:21234ms step_avg:36.74ms
+step:579/1600 train_time:21297ms step_avg:36.78ms
+step:580/1600 train_time:21358ms step_avg:36.82ms
+step:581/1600 train_time:21421ms step_avg:36.87ms
+step:582/1600 train_time:21480ms step_avg:36.91ms
+step:583/1600 train_time:21542ms step_avg:36.95ms
+step:584/1600 train_time:21601ms step_avg:36.99ms
+step:585/1600 train_time:21664ms step_avg:37.03ms
+step:586/1600 train_time:21724ms step_avg:37.07ms
+step:587/1600 train_time:21786ms step_avg:37.11ms
+step:588/1600 train_time:21845ms step_avg:37.15ms
+step:589/1600 train_time:21907ms step_avg:37.19ms
+step:590/1600 train_time:21967ms step_avg:37.23ms
+step:591/1600 train_time:22030ms step_avg:37.28ms
+step:592/1600 train_time:22089ms step_avg:37.31ms
+step:593/1600 train_time:22153ms step_avg:37.36ms
+step:594/1600 train_time:22212ms step_avg:37.39ms
+step:595/1600 train_time:22275ms step_avg:37.44ms
+step:596/1600 train_time:22335ms step_avg:37.48ms
+step:597/1600 train_time:22399ms step_avg:37.52ms
+step:598/1600 train_time:22458ms step_avg:37.56ms
+step:599/1600 train_time:22520ms step_avg:37.60ms
+step:600/1600 train_time:22580ms step_avg:37.63ms
+step:601/1600 train_time:22642ms step_avg:37.67ms
+step:602/1600 train_time:22702ms step_avg:37.71ms
+step:603/1600 train_time:22763ms step_avg:37.75ms
+step:604/1600 train_time:22823ms step_avg:37.79ms
+step:605/1600 train_time:22886ms step_avg:37.83ms
+step:606/1600 train_time:22946ms step_avg:37.86ms
+step:607/1600 train_time:23009ms step_avg:37.91ms
+step:608/1600 train_time:23068ms step_avg:37.94ms
+step:609/1600 train_time:23131ms step_avg:37.98ms
+step:610/1600 train_time:23190ms step_avg:38.02ms
+step:611/1600 train_time:23253ms step_avg:38.06ms
+step:612/1600 train_time:23314ms step_avg:38.09ms
+step:613/1600 train_time:23377ms step_avg:38.14ms
+step:614/1600 train_time:23437ms step_avg:38.17ms
+step:615/1600 train_time:23500ms step_avg:38.21ms
+step:616/1600 train_time:23559ms step_avg:38.25ms
+step:617/1600 train_time:23621ms step_avg:38.28ms
+step:618/1600 train_time:23681ms step_avg:38.32ms
+step:619/1600 train_time:23743ms step_avg:38.36ms
+step:620/1600 train_time:23802ms step_avg:38.39ms
+step:621/1600 train_time:23865ms step_avg:38.43ms
+step:622/1600 train_time:23924ms step_avg:38.46ms
+step:623/1600 train_time:23986ms step_avg:38.50ms
+step:624/1600 train_time:24045ms step_avg:38.53ms
+step:625/1600 train_time:24108ms step_avg:38.57ms
+step:626/1600 train_time:24168ms step_avg:38.61ms
+step:627/1600 train_time:24232ms step_avg:38.65ms
+step:628/1600 train_time:24291ms step_avg:38.68ms
+step:629/1600 train_time:24353ms step_avg:38.72ms
+step:630/1600 train_time:24414ms step_avg:38.75ms
+step:631/1600 train_time:24477ms step_avg:38.79ms
+step:632/1600 train_time:24536ms step_avg:38.82ms
+step:633/1600 train_time:24599ms step_avg:38.86ms
+step:634/1600 train_time:24659ms step_avg:38.89ms
+step:635/1600 train_time:24721ms step_avg:38.93ms
+step:636/1600 train_time:24780ms step_avg:38.96ms
+step:637/1600 train_time:24843ms step_avg:39.00ms
+step:638/1600 train_time:24902ms step_avg:39.03ms
+step:639/1600 train_time:24965ms step_avg:39.07ms
+step:640/1600 train_time:25026ms step_avg:39.10ms
+step:641/1600 train_time:25088ms step_avg:39.14ms
+step:642/1600 train_time:25147ms step_avg:39.17ms
+step:643/1600 train_time:25209ms step_avg:39.21ms
+step:644/1600 train_time:25269ms step_avg:39.24ms
+step:645/1600 train_time:25332ms step_avg:39.27ms
+step:646/1600 train_time:25391ms step_avg:39.30ms
+step:647/1600 train_time:25454ms step_avg:39.34ms
+step:648/1600 train_time:25514ms step_avg:39.37ms
+step:649/1600 train_time:25577ms step_avg:39.41ms
+step:650/1600 train_time:25637ms step_avg:39.44ms
+step:651/1600 train_time:25700ms step_avg:39.48ms
+step:652/1600 train_time:25760ms step_avg:39.51ms
+step:653/1600 train_time:25822ms step_avg:39.54ms
+step:654/1600 train_time:25881ms step_avg:39.57ms
+step:655/1600 train_time:25943ms step_avg:39.61ms
+step:656/1600 train_time:26002ms step_avg:39.64ms
+step:657/1600 train_time:26066ms step_avg:39.67ms
+step:658/1600 train_time:26125ms step_avg:39.70ms
+step:659/1600 train_time:26188ms step_avg:39.74ms
+step:660/1600 train_time:26247ms step_avg:39.77ms
+step:661/1600 train_time:26310ms step_avg:39.80ms
+step:662/1600 train_time:26369ms step_avg:39.83ms
+step:663/1600 train_time:26431ms step_avg:39.87ms
+step:664/1600 train_time:26491ms step_avg:39.90ms
+step:665/1600 train_time:26554ms step_avg:39.93ms
+step:666/1600 train_time:26614ms step_avg:39.96ms
+step:667/1600 train_time:26678ms step_avg:40.00ms
+step:668/1600 train_time:26737ms step_avg:40.03ms
+step:669/1600 train_time:26800ms step_avg:40.06ms
+step:670/1600 train_time:26860ms step_avg:40.09ms
+step:671/1600 train_time:26922ms step_avg:40.12ms
+step:672/1600 train_time:26981ms step_avg:40.15ms
+step:673/1600 train_time:27043ms step_avg:40.18ms
+step:674/1600 train_time:27103ms step_avg:40.21ms
+step:675/1600 train_time:27165ms step_avg:40.24ms
+step:676/1600 train_time:27225ms step_avg:40.27ms
+step:677/1600 train_time:27288ms step_avg:40.31ms
+step:678/1600 train_time:27347ms step_avg:40.33ms
+step:679/1600 train_time:27410ms step_avg:40.37ms
+step:680/1600 train_time:27469ms step_avg:40.40ms
+step:681/1600 train_time:27531ms step_avg:40.43ms
+step:682/1600 train_time:27591ms step_avg:40.46ms
+step:683/1600 train_time:27655ms step_avg:40.49ms
+step:684/1600 train_time:27715ms step_avg:40.52ms
+step:685/1600 train_time:27779ms step_avg:40.55ms
+step:686/1600 train_time:27839ms step_avg:40.58ms
+step:687/1600 train_time:27902ms step_avg:40.61ms
+step:688/1600 train_time:27961ms step_avg:40.64ms
+step:689/1600 train_time:28023ms step_avg:40.67ms
+step:690/1600 train_time:28082ms step_avg:40.70ms
+step:691/1600 train_time:28145ms step_avg:40.73ms
+step:692/1600 train_time:28204ms step_avg:40.76ms
+step:693/1600 train_time:28267ms step_avg:40.79ms
+step:694/1600 train_time:28326ms step_avg:40.82ms
+step:695/1600 train_time:28389ms step_avg:40.85ms
+step:696/1600 train_time:28447ms step_avg:40.87ms
+step:697/1600 train_time:28511ms step_avg:40.91ms
+step:698/1600 train_time:28570ms step_avg:40.93ms
+step:699/1600 train_time:28633ms step_avg:40.96ms
+step:700/1600 train_time:28693ms step_avg:40.99ms
+step:701/1600 train_time:28757ms step_avg:41.02ms
+step:702/1600 train_time:28816ms step_avg:41.05ms
+step:703/1600 train_time:28880ms step_avg:41.08ms
+step:704/1600 train_time:28940ms step_avg:41.11ms
+step:705/1600 train_time:29002ms step_avg:41.14ms
+step:706/1600 train_time:29062ms step_avg:41.16ms
+step:707/1600 train_time:29123ms step_avg:41.19ms
+step:708/1600 train_time:29183ms step_avg:41.22ms
+step:709/1600 train_time:29246ms step_avg:41.25ms
+step:710/1600 train_time:29305ms step_avg:41.27ms
+step:711/1600 train_time:29367ms step_avg:41.30ms
+step:712/1600 train_time:29428ms step_avg:41.33ms
+step:713/1600 train_time:29490ms step_avg:41.36ms
+step:714/1600 train_time:29549ms step_avg:41.38ms
+step:715/1600 train_time:29612ms step_avg:41.42ms
+step:716/1600 train_time:29672ms step_avg:41.44ms
+step:717/1600 train_time:29735ms step_avg:41.47ms
+step:718/1600 train_time:29795ms step_avg:41.50ms
+step:719/1600 train_time:29859ms step_avg:41.53ms
+step:720/1600 train_time:29918ms step_avg:41.55ms
+step:721/1600 train_time:29981ms step_avg:41.58ms
+step:722/1600 train_time:30040ms step_avg:41.61ms
+step:723/1600 train_time:30103ms step_avg:41.64ms
+step:724/1600 train_time:30162ms step_avg:41.66ms
+step:725/1600 train_time:30224ms step_avg:41.69ms
+step:726/1600 train_time:30284ms step_avg:41.71ms
+step:727/1600 train_time:30346ms step_avg:41.74ms
+step:728/1600 train_time:30406ms step_avg:41.77ms
+step:729/1600 train_time:30468ms step_avg:41.79ms
+step:730/1600 train_time:30527ms step_avg:41.82ms
+step:731/1600 train_time:30591ms step_avg:41.85ms
+step:732/1600 train_time:30650ms step_avg:41.87ms
+step:733/1600 train_time:30714ms step_avg:41.90ms
+step:734/1600 train_time:30774ms step_avg:41.93ms
+step:735/1600 train_time:30837ms step_avg:41.95ms
+step:736/1600 train_time:30896ms step_avg:41.98ms
+step:737/1600 train_time:30959ms step_avg:42.01ms
+step:738/1600 train_time:31018ms step_avg:42.03ms
+step:739/1600 train_time:31081ms step_avg:42.06ms
+step:740/1600 train_time:31140ms step_avg:42.08ms
+step:741/1600 train_time:31202ms step_avg:42.11ms
+step:742/1600 train_time:31261ms step_avg:42.13ms
+step:743/1600 train_time:31324ms step_avg:42.16ms
+step:744/1600 train_time:31384ms step_avg:42.18ms
+step:745/1600 train_time:31446ms step_avg:42.21ms
+step:746/1600 train_time:31506ms step_avg:42.23ms
+step:747/1600 train_time:31568ms step_avg:42.26ms
+step:748/1600 train_time:31628ms step_avg:42.28ms
+step:749/1600 train_time:31691ms step_avg:42.31ms
+step:750/1600 train_time:31751ms step_avg:42.33ms
+step:750/1600 val_loss:3.8895 train_time:31797ms step_avg:42.40ms
+step:751/1600 train_time:31817ms step_avg:42.37ms
+step:752/1600 train_time:31874ms step_avg:42.39ms
+step:753/1600 train_time:31939ms step_avg:42.42ms
+step:754/1600 train_time:31998ms step_avg:42.44ms
+step:755/1600 train_time:32060ms step_avg:42.46ms
+step:756/1600 train_time:32119ms step_avg:42.49ms
+step:757/1600 train_time:32181ms step_avg:42.51ms
+step:758/1600 train_time:32240ms step_avg:42.53ms
+step:759/1600 train_time:32303ms step_avg:42.56ms
+step:760/1600 train_time:32362ms step_avg:42.58ms
+step:761/1600 train_time:32426ms step_avg:42.61ms
+step:762/1600 train_time:32486ms step_avg:42.63ms
+step:763/1600 train_time:32548ms step_avg:42.66ms
+step:764/1600 train_time:32607ms step_avg:42.68ms
+step:765/1600 train_time:32668ms step_avg:42.70ms
+step:766/1600 train_time:32727ms step_avg:42.72ms
+step:767/1600 train_time:32791ms step_avg:42.75ms
+step:768/1600 train_time:32851ms step_avg:42.77ms
+step:769/1600 train_time:32914ms step_avg:42.80ms
+step:770/1600 train_time:32974ms step_avg:42.82ms
+step:771/1600 train_time:33037ms step_avg:42.85ms
+step:772/1600 train_time:33096ms step_avg:42.87ms
+step:773/1600 train_time:33159ms step_avg:42.90ms
+step:774/1600 train_time:33218ms step_avg:42.92ms
+step:775/1600 train_time:33280ms step_avg:42.94ms
+step:776/1600 train_time:33339ms step_avg:42.96ms
+step:777/1600 train_time:33402ms step_avg:42.99ms
+step:778/1600 train_time:33461ms step_avg:43.01ms
+step:779/1600 train_time:33525ms step_avg:43.04ms
+step:780/1600 train_time:33585ms step_avg:43.06ms
+step:781/1600 train_time:33648ms step_avg:43.08ms
+step:782/1600 train_time:33706ms step_avg:43.10ms
+step:783/1600 train_time:33769ms step_avg:43.13ms
+step:784/1600 train_time:33829ms step_avg:43.15ms
+step:785/1600 train_time:33892ms step_avg:43.18ms
+step:786/1600 train_time:33951ms step_avg:43.19ms
+step:787/1600 train_time:34013ms step_avg:43.22ms
+step:788/1600 train_time:34072ms step_avg:43.24ms
+step:789/1600 train_time:34135ms step_avg:43.26ms
+step:790/1600 train_time:34194ms step_avg:43.28ms
+step:791/1600 train_time:34256ms step_avg:43.31ms
+step:792/1600 train_time:34316ms step_avg:43.33ms
+step:793/1600 train_time:34378ms step_avg:43.35ms
+step:794/1600 train_time:34437ms step_avg:43.37ms
+step:795/1600 train_time:34501ms step_avg:43.40ms
+step:796/1600 train_time:34560ms step_avg:43.42ms
+step:797/1600 train_time:34623ms step_avg:43.44ms
+step:798/1600 train_time:34683ms step_avg:43.46ms
+step:799/1600 train_time:34747ms step_avg:43.49ms
+step:800/1600 train_time:34807ms step_avg:43.51ms
+step:801/1600 train_time:34871ms step_avg:43.53ms
+step:802/1600 train_time:34929ms step_avg:43.55ms
+step:803/1600 train_time:34991ms step_avg:43.58ms
+step:804/1600 train_time:35050ms step_avg:43.59ms
+step:805/1600 train_time:35112ms step_avg:43.62ms
+step:806/1600 train_time:35171ms step_avg:43.64ms
+step:807/1600 train_time:35234ms step_avg:43.66ms
+step:808/1600 train_time:35293ms step_avg:43.68ms
+step:809/1600 train_time:35356ms step_avg:43.70ms
+step:810/1600 train_time:35416ms step_avg:43.72ms
+step:811/1600 train_time:35480ms step_avg:43.75ms
+step:812/1600 train_time:35539ms step_avg:43.77ms
+step:813/1600 train_time:35601ms step_avg:43.79ms
+step:814/1600 train_time:35660ms step_avg:43.81ms
+step:815/1600 train_time:35725ms step_avg:43.83ms
+step:816/1600 train_time:35784ms step_avg:43.85ms
+step:817/1600 train_time:35847ms step_avg:43.88ms
+step:818/1600 train_time:35907ms step_avg:43.90ms
+step:819/1600 train_time:35970ms step_avg:43.92ms
+step:820/1600 train_time:36029ms step_avg:43.94ms
+step:821/1600 train_time:36091ms step_avg:43.96ms
+step:822/1600 train_time:36150ms step_avg:43.98ms
+step:823/1600 train_time:36213ms step_avg:44.00ms
+step:824/1600 train_time:36271ms step_avg:44.02ms
+step:825/1600 train_time:36334ms step_avg:44.04ms
+step:826/1600 train_time:36394ms step_avg:44.06ms
+step:827/1600 train_time:36457ms step_avg:44.08ms
+step:828/1600 train_time:36517ms step_avg:44.10ms
+step:829/1600 train_time:36580ms step_avg:44.13ms
+step:830/1600 train_time:36639ms step_avg:44.14ms
+step:831/1600 train_time:36702ms step_avg:44.17ms
+step:832/1600 train_time:36762ms step_avg:44.18ms
+step:833/1600 train_time:36824ms step_avg:44.21ms
+step:834/1600 train_time:36885ms step_avg:44.23ms
+step:835/1600 train_time:36949ms step_avg:44.25ms
+step:836/1600 train_time:37007ms step_avg:44.27ms
+step:837/1600 train_time:37071ms step_avg:44.29ms
+step:838/1600 train_time:37130ms step_avg:44.31ms
+step:839/1600 train_time:37191ms step_avg:44.33ms
+step:840/1600 train_time:37250ms step_avg:44.35ms
+step:841/1600 train_time:37313ms step_avg:44.37ms
+step:842/1600 train_time:37372ms step_avg:44.38ms
+step:843/1600 train_time:37435ms step_avg:44.41ms
+step:844/1600 train_time:37495ms step_avg:44.43ms
+step:845/1600 train_time:37558ms step_avg:44.45ms
+step:846/1600 train_time:37618ms step_avg:44.47ms
+step:847/1600 train_time:37681ms step_avg:44.49ms
+step:848/1600 train_time:37741ms step_avg:44.51ms
+step:849/1600 train_time:37803ms step_avg:44.53ms
+step:850/1600 train_time:37862ms step_avg:44.54ms
+step:851/1600 train_time:37924ms step_avg:44.56ms
+step:852/1600 train_time:37984ms step_avg:44.58ms
+step:853/1600 train_time:38047ms step_avg:44.60ms
+step:854/1600 train_time:38107ms step_avg:44.62ms
+step:855/1600 train_time:38169ms step_avg:44.64ms
+step:856/1600 train_time:38228ms step_avg:44.66ms
+step:857/1600 train_time:38291ms step_avg:44.68ms
+step:858/1600 train_time:38350ms step_avg:44.70ms
+step:859/1600 train_time:38412ms step_avg:44.72ms
+step:860/1600 train_time:38473ms step_avg:44.74ms
+step:861/1600 train_time:38536ms step_avg:44.76ms
+step:862/1600 train_time:38595ms step_avg:44.77ms
+step:863/1600 train_time:38658ms step_avg:44.80ms
+step:864/1600 train_time:38717ms step_avg:44.81ms
+step:865/1600 train_time:38780ms step_avg:44.83ms
+step:866/1600 train_time:38842ms step_avg:44.85ms
+step:867/1600 train_time:38903ms step_avg:44.87ms
+step:868/1600 train_time:38962ms step_avg:44.89ms
+step:869/1600 train_time:39025ms step_avg:44.91ms
+step:870/1600 train_time:39085ms step_avg:44.92ms
+step:871/1600 train_time:39147ms step_avg:44.95ms
+step:872/1600 train_time:39206ms step_avg:44.96ms
+step:873/1600 train_time:39269ms step_avg:44.98ms
+step:874/1600 train_time:39328ms step_avg:45.00ms
+step:875/1600 train_time:39391ms step_avg:45.02ms
+step:876/1600 train_time:39450ms step_avg:45.03ms
+step:877/1600 train_time:39513ms step_avg:45.05ms
+step:878/1600 train_time:39572ms step_avg:45.07ms
+step:879/1600 train_time:39635ms step_avg:45.09ms
+step:880/1600 train_time:39695ms step_avg:45.11ms
+step:881/1600 train_time:39758ms step_avg:45.13ms
+step:882/1600 train_time:39817ms step_avg:45.14ms
+step:883/1600 train_time:39880ms step_avg:45.16ms
+step:884/1600 train_time:39940ms step_avg:45.18ms
+step:885/1600 train_time:40003ms step_avg:45.20ms
+step:886/1600 train_time:40061ms step_avg:45.22ms
+step:887/1600 train_time:40124ms step_avg:45.24ms
+step:888/1600 train_time:40184ms step_avg:45.25ms
+step:889/1600 train_time:40247ms step_avg:45.27ms
+step:890/1600 train_time:40308ms step_avg:45.29ms
+step:891/1600 train_time:40371ms step_avg:45.31ms
+step:892/1600 train_time:40432ms step_avg:45.33ms
+step:893/1600 train_time:40493ms step_avg:45.34ms
+step:894/1600 train_time:40551ms step_avg:45.36ms
+step:895/1600 train_time:40614ms step_avg:45.38ms
+step:896/1600 train_time:40672ms step_avg:45.39ms
+step:897/1600 train_time:40736ms step_avg:45.41ms
+step:898/1600 train_time:40796ms step_avg:45.43ms
+step:899/1600 train_time:40858ms step_avg:45.45ms
+step:900/1600 train_time:40917ms step_avg:45.46ms
+step:901/1600 train_time:40980ms step_avg:45.48ms
+step:902/1600 train_time:41040ms step_avg:45.50ms
+step:903/1600 train_time:41103ms step_avg:45.52ms
+step:904/1600 train_time:41161ms step_avg:45.53ms
+step:905/1600 train_time:41224ms step_avg:45.55ms
+step:906/1600 train_time:41285ms step_avg:45.57ms
+step:907/1600 train_time:41348ms step_avg:45.59ms
+step:908/1600 train_time:41408ms step_avg:45.60ms
+step:909/1600 train_time:41471ms step_avg:45.62ms
+step:910/1600 train_time:41530ms step_avg:45.64ms
+step:911/1600 train_time:41593ms step_avg:45.66ms
+step:912/1600 train_time:41652ms step_avg:45.67ms
+step:913/1600 train_time:41715ms step_avg:45.69ms
+step:914/1600 train_time:41773ms step_avg:45.70ms
+step:915/1600 train_time:41835ms step_avg:45.72ms
+step:916/1600 train_time:41895ms step_avg:45.74ms
+step:917/1600 train_time:41958ms step_avg:45.76ms
+step:918/1600 train_time:42017ms step_avg:45.77ms
+step:919/1600 train_time:42080ms step_avg:45.79ms
+step:920/1600 train_time:42140ms step_avg:45.80ms
+step:921/1600 train_time:42202ms step_avg:45.82ms
+step:922/1600 train_time:42262ms step_avg:45.84ms
+step:923/1600 train_time:42325ms step_avg:45.86ms
+step:924/1600 train_time:42386ms step_avg:45.87ms
+step:925/1600 train_time:42449ms step_avg:45.89ms
+step:926/1600 train_time:42509ms step_avg:45.91ms
+step:927/1600 train_time:42572ms step_avg:45.92ms
+step:928/1600 train_time:42631ms step_avg:45.94ms
+step:929/1600 train_time:42695ms step_avg:45.96ms
+step:930/1600 train_time:42753ms step_avg:45.97ms
+step:931/1600 train_time:42815ms step_avg:45.99ms
+step:932/1600 train_time:42875ms step_avg:46.00ms
+step:933/1600 train_time:42937ms step_avg:46.02ms
+step:934/1600 train_time:42996ms step_avg:46.03ms
+step:935/1600 train_time:43060ms step_avg:46.05ms
+step:936/1600 train_time:43119ms step_avg:46.07ms
+step:937/1600 train_time:43182ms step_avg:46.09ms
+step:938/1600 train_time:43242ms step_avg:46.10ms
+step:939/1600 train_time:43304ms step_avg:46.12ms
+step:940/1600 train_time:43364ms step_avg:46.13ms
+step:941/1600 train_time:43428ms step_avg:46.15ms
+step:942/1600 train_time:43488ms step_avg:46.17ms
+step:943/1600 train_time:43550ms step_avg:46.18ms
+step:944/1600 train_time:43609ms step_avg:46.20ms
+step:945/1600 train_time:43672ms step_avg:46.21ms
+step:946/1600 train_time:43731ms step_avg:46.23ms
+step:947/1600 train_time:43793ms step_avg:46.24ms
+step:948/1600 train_time:43852ms step_avg:46.26ms
+step:949/1600 train_time:43915ms step_avg:46.28ms
+step:950/1600 train_time:43974ms step_avg:46.29ms
+step:951/1600 train_time:44037ms step_avg:46.31ms
+step:952/1600 train_time:44097ms step_avg:46.32ms
+step:953/1600 train_time:44161ms step_avg:46.34ms
+step:954/1600 train_time:44220ms step_avg:46.35ms
+step:955/1600 train_time:44283ms step_avg:46.37ms
+step:956/1600 train_time:44342ms step_avg:46.38ms
+step:957/1600 train_time:44405ms step_avg:46.40ms
+step:958/1600 train_time:44465ms step_avg:46.41ms
+step:959/1600 train_time:44528ms step_avg:46.43ms
+step:960/1600 train_time:44588ms step_avg:46.45ms
+step:961/1600 train_time:44652ms step_avg:46.46ms
+step:962/1600 train_time:44710ms step_avg:46.48ms
+step:963/1600 train_time:44773ms step_avg:46.49ms
+step:964/1600 train_time:44832ms step_avg:46.51ms
+step:965/1600 train_time:44894ms step_avg:46.52ms
+step:966/1600 train_time:44953ms step_avg:46.54ms
+step:967/1600 train_time:45016ms step_avg:46.55ms
+step:968/1600 train_time:45075ms step_avg:46.57ms
+step:969/1600 train_time:45139ms step_avg:46.58ms
+step:970/1600 train_time:45198ms step_avg:46.60ms
+step:971/1600 train_time:45262ms step_avg:46.61ms
+step:972/1600 train_time:45321ms step_avg:46.63ms
+step:973/1600 train_time:45384ms step_avg:46.64ms
+step:974/1600 train_time:45444ms step_avg:46.66ms
+step:975/1600 train_time:45507ms step_avg:46.67ms
+step:976/1600 train_time:45565ms step_avg:46.69ms
+step:977/1600 train_time:45628ms step_avg:46.70ms
+step:978/1600 train_time:45689ms step_avg:46.72ms
+step:979/1600 train_time:45752ms step_avg:46.73ms
+step:980/1600 train_time:45811ms step_avg:46.75ms
+step:981/1600 train_time:45873ms step_avg:46.76ms
+step:982/1600 train_time:45932ms step_avg:46.77ms
+step:983/1600 train_time:45995ms step_avg:46.79ms
+step:984/1600 train_time:46053ms step_avg:46.80ms
+step:985/1600 train_time:46116ms step_avg:46.82ms
+step:986/1600 train_time:46177ms step_avg:46.83ms
+step:987/1600 train_time:46241ms step_avg:46.85ms
+step:988/1600 train_time:46301ms step_avg:46.86ms
+step:989/1600 train_time:46363ms step_avg:46.88ms
+step:990/1600 train_time:46423ms step_avg:46.89ms
+step:991/1600 train_time:46485ms step_avg:46.91ms
+step:992/1600 train_time:46544ms step_avg:46.92ms
+step:993/1600 train_time:46607ms step_avg:46.94ms
+step:994/1600 train_time:46666ms step_avg:46.95ms
+step:995/1600 train_time:46729ms step_avg:46.96ms
+step:996/1600 train_time:46790ms step_avg:46.98ms
+step:997/1600 train_time:46852ms step_avg:46.99ms
+step:998/1600 train_time:46911ms step_avg:47.01ms
+step:999/1600 train_time:46975ms step_avg:47.02ms
+step:1000/1600 train_time:47034ms step_avg:47.03ms
+step:1000/1600 val_loss:3.5982 train_time:47079ms step_avg:47.08ms
+step:1001/1600 train_time:47098ms step_avg:47.05ms
+step:1002/1600 train_time:47157ms step_avg:47.06ms
+step:1003/1600 train_time:47221ms step_avg:47.08ms
+step:1004/1600 train_time:47280ms step_avg:47.09ms
+step:1005/1600 train_time:47343ms step_avg:47.11ms
+step:1006/1600 train_time:47403ms step_avg:47.12ms
+step:1007/1600 train_time:47465ms step_avg:47.14ms
+step:1008/1600 train_time:47525ms step_avg:47.15ms
+step:1009/1600 train_time:47587ms step_avg:47.16ms
+step:1010/1600 train_time:47645ms step_avg:47.17ms
+step:1011/1600 train_time:47708ms step_avg:47.19ms
+step:1012/1600 train_time:47766ms step_avg:47.20ms
+step:1013/1600 train_time:47828ms step_avg:47.21ms
+step:1014/1600 train_time:47888ms step_avg:47.23ms
+step:1015/1600 train_time:47950ms step_avg:47.24ms
+step:1016/1600 train_time:48010ms step_avg:47.25ms
+step:1017/1600 train_time:48074ms step_avg:47.27ms
+step:1018/1600 train_time:48135ms step_avg:47.28ms
+step:1019/1600 train_time:48200ms step_avg:47.30ms
+step:1020/1600 train_time:48259ms step_avg:47.31ms
+step:1021/1600 train_time:48322ms step_avg:47.33ms
+step:1022/1600 train_time:48380ms step_avg:47.34ms
+step:1023/1600 train_time:48443ms step_avg:47.35ms
+step:1024/1600 train_time:48502ms step_avg:47.36ms
+step:1025/1600 train_time:48564ms step_avg:47.38ms
+step:1026/1600 train_time:48623ms step_avg:47.39ms
+step:1027/1600 train_time:48685ms step_avg:47.41ms
+step:1028/1600 train_time:48744ms step_avg:47.42ms
+step:1029/1600 train_time:48807ms step_avg:47.43ms
+step:1030/1600 train_time:48867ms step_avg:47.44ms
+step:1031/1600 train_time:48929ms step_avg:47.46ms
+step:1032/1600 train_time:48989ms step_avg:47.47ms
+step:1033/1600 train_time:49054ms step_avg:47.49ms
+step:1034/1600 train_time:49113ms step_avg:47.50ms
+step:1035/1600 train_time:49177ms step_avg:47.51ms
+step:1036/1600 train_time:49237ms step_avg:47.53ms
+step:1037/1600 train_time:49300ms step_avg:47.54ms
+step:1038/1600 train_time:49359ms step_avg:47.55ms
+step:1039/1600 train_time:49422ms step_avg:47.57ms
+step:1040/1600 train_time:49481ms step_avg:47.58ms
+step:1041/1600 train_time:49550ms step_avg:47.60ms
+step:1042/1600 train_time:49635ms step_avg:47.63ms
+step:1043/1600 train_time:49725ms step_avg:47.67ms
+step:1044/1600 train_time:49811ms step_avg:47.71ms
+step:1045/1600 train_time:49900ms step_avg:47.75ms
+step:1046/1600 train_time:49986ms step_avg:47.79ms
+step:1047/1600 train_time:50074ms step_avg:47.83ms
+step:1048/1600 train_time:50162ms step_avg:47.86ms
+step:1049/1600 train_time:50252ms step_avg:47.90ms
+step:1050/1600 train_time:50340ms step_avg:47.94ms
+step:1051/1600 train_time:50430ms step_avg:47.98ms
+step:1052/1600 train_time:50515ms step_avg:48.02ms
+step:1053/1600 train_time:50603ms step_avg:48.06ms
+step:1054/1600 train_time:50689ms step_avg:48.09ms
+step:1055/1600 train_time:50778ms step_avg:48.13ms
+step:1056/1600 train_time:50864ms step_avg:48.17ms
+step:1057/1600 train_time:50953ms step_avg:48.20ms
+step:1058/1600 train_time:51039ms step_avg:48.24ms
+step:1059/1600 train_time:51127ms step_avg:48.28ms
+step:1060/1600 train_time:51213ms step_avg:48.31ms
+step:1061/1600 train_time:51302ms step_avg:48.35ms
+step:1062/1600 train_time:51389ms step_avg:48.39ms
+step:1063/1600 train_time:51477ms step_avg:48.43ms
+step:1064/1600 train_time:51563ms step_avg:48.46ms
+step:1065/1600 train_time:51651ms step_avg:48.50ms
+step:1066/1600 train_time:51737ms step_avg:48.53ms
+step:1067/1600 train_time:51824ms step_avg:48.57ms
+step:1068/1600 train_time:51911ms step_avg:48.61ms
+step:1069/1600 train_time:52000ms step_avg:48.64ms
+step:1070/1600 train_time:52086ms step_avg:48.68ms
+step:1071/1600 train_time:52175ms step_avg:48.72ms
+step:1072/1600 train_time:52261ms step_avg:48.75ms
+step:1073/1600 train_time:52351ms step_avg:48.79ms
+step:1074/1600 train_time:52437ms step_avg:48.82ms
+step:1075/1600 train_time:52526ms step_avg:48.86ms
+step:1076/1600 train_time:52611ms step_avg:48.90ms
+step:1077/1600 train_time:52700ms step_avg:48.93ms
+step:1078/1600 train_time:52797ms step_avg:48.98ms
+step:1079/1600 train_time:52874ms step_avg:49.00ms
+step:1080/1600 train_time:52960ms step_avg:49.04ms
+step:1081/1600 train_time:53048ms step_avg:49.07ms
+step:1082/1600 train_time:53134ms step_avg:49.11ms
+step:1083/1600 train_time:53223ms step_avg:49.14ms
+step:1084/1600 train_time:53309ms step_avg:49.18ms
+step:1085/1600 train_time:53398ms step_avg:49.21ms
+step:1086/1600 train_time:53484ms step_avg:49.25ms
+step:1087/1600 train_time:53573ms step_avg:49.28ms
+step:1088/1600 train_time:53658ms step_avg:49.32ms
+step:1089/1600 train_time:53747ms step_avg:49.35ms
+step:1090/1600 train_time:53832ms step_avg:49.39ms
+step:1091/1600 train_time:53921ms step_avg:49.42ms
+step:1092/1600 train_time:54007ms step_avg:49.46ms
+step:1093/1600 train_time:54095ms step_avg:49.49ms
+step:1094/1600 train_time:54181ms step_avg:49.53ms
+step:1095/1600 train_time:54271ms step_avg:49.56ms
+step:1096/1600 train_time:54357ms step_avg:49.60ms
+step:1097/1600 train_time:54446ms step_avg:49.63ms
+step:1098/1600 train_time:54531ms step_avg:49.66ms
+step:1099/1600 train_time:54620ms step_avg:49.70ms
+step:1100/1600 train_time:54705ms step_avg:49.73ms
+step:1101/1600 train_time:54794ms step_avg:49.77ms
+step:1102/1600 train_time:54880ms step_avg:49.80ms
+step:1103/1600 train_time:54968ms step_avg:49.83ms
+step:1104/1600 train_time:55053ms step_avg:49.87ms
+step:1105/1600 train_time:55142ms step_avg:49.90ms
+step:1106/1600 train_time:55228ms step_avg:49.93ms
+step:1107/1600 train_time:55316ms step_avg:49.97ms
+step:1108/1600 train_time:55402ms step_avg:50.00ms
+step:1109/1600 train_time:55491ms step_avg:50.04ms
+step:1110/1600 train_time:55577ms step_avg:50.07ms
+step:1111/1600 train_time:55665ms step_avg:50.10ms
+step:1112/1600 train_time:55751ms step_avg:50.14ms
+step:1113/1600 train_time:55839ms step_avg:50.17ms
+step:1114/1600 train_time:55925ms step_avg:50.20ms
+step:1115/1600 train_time:56014ms step_avg:50.24ms
+step:1116/1600 train_time:56100ms step_avg:50.27ms
+step:1117/1600 train_time:56191ms step_avg:50.31ms
+step:1118/1600 train_time:56277ms step_avg:50.34ms
+step:1119/1600 train_time:56365ms step_avg:50.37ms
+step:1120/1600 train_time:56451ms step_avg:50.40ms
+step:1121/1600 train_time:56539ms step_avg:50.44ms
+step:1122/1600 train_time:56626ms step_avg:50.47ms
+step:1123/1600 train_time:56713ms step_avg:50.50ms
+step:1124/1600 train_time:56799ms step_avg:50.53ms
+step:1125/1600 train_time:56888ms step_avg:50.57ms
+step:1126/1600 train_time:56974ms step_avg:50.60ms
+step:1127/1600 train_time:57062ms step_avg:50.63ms
+step:1128/1600 train_time:57148ms step_avg:50.66ms
+step:1129/1600 train_time:57237ms step_avg:50.70ms
+step:1130/1600 train_time:57323ms step_avg:50.73ms
+step:1131/1600 train_time:57411ms step_avg:50.76ms
+step:1132/1600 train_time:57497ms step_avg:50.79ms
+step:1133/1600 train_time:57586ms step_avg:50.83ms
+step:1134/1600 train_time:57671ms step_avg:50.86ms
+step:1135/1600 train_time:57760ms step_avg:50.89ms
+step:1136/1600 train_time:57846ms step_avg:50.92ms
+step:1137/1600 train_time:57935ms step_avg:50.95ms
+step:1138/1600 train_time:58021ms step_avg:50.99ms
+step:1139/1600 train_time:58110ms step_avg:51.02ms
+step:1140/1600 train_time:58196ms step_avg:51.05ms
+step:1141/1600 train_time:58285ms step_avg:51.08ms
+step:1142/1600 train_time:58370ms step_avg:51.11ms
+step:1143/1600 train_time:58458ms step_avg:51.14ms
+step:1144/1600 train_time:58544ms step_avg:51.17ms
+step:1145/1600 train_time:58633ms step_avg:51.21ms
+step:1146/1600 train_time:58718ms step_avg:51.24ms
+step:1147/1600 train_time:58807ms step_avg:51.27ms
+step:1148/1600 train_time:58893ms step_avg:51.30ms
+step:1149/1600 train_time:58982ms step_avg:51.33ms
+step:1150/1600 train_time:59067ms step_avg:51.36ms
+step:1151/1600 train_time:59156ms step_avg:51.40ms
+step:1152/1600 train_time:59242ms step_avg:51.43ms
+step:1153/1600 train_time:59331ms step_avg:51.46ms
+step:1154/1600 train_time:59420ms step_avg:51.49ms
+step:1155/1600 train_time:59508ms step_avg:51.52ms
+step:1156/1600 train_time:59592ms step_avg:51.55ms
+step:1157/1600 train_time:59681ms step_avg:51.58ms
+step:1158/1600 train_time:59766ms step_avg:51.61ms
+step:1159/1600 train_time:59855ms step_avg:51.64ms
+step:1160/1600 train_time:59941ms step_avg:51.67ms
+step:1161/1600 train_time:60029ms step_avg:51.70ms
+step:1162/1600 train_time:60115ms step_avg:51.73ms
+step:1163/1600 train_time:60203ms step_avg:51.77ms
+step:1164/1600 train_time:60289ms step_avg:51.79ms
+step:1165/1600 train_time:60378ms step_avg:51.83ms
+step:1166/1600 train_time:60464ms step_avg:51.86ms
+step:1167/1600 train_time:60552ms step_avg:51.89ms
+step:1168/1600 train_time:60638ms step_avg:51.92ms
+step:1169/1600 train_time:60726ms step_avg:51.95ms
+step:1170/1600 train_time:60812ms step_avg:51.98ms
+step:1171/1600 train_time:60900ms step_avg:52.01ms
+step:1172/1600 train_time:60986ms step_avg:52.04ms
+step:1173/1600 train_time:61074ms step_avg:52.07ms
+step:1174/1600 train_time:61161ms step_avg:52.10ms
+step:1175/1600 train_time:61251ms step_avg:52.13ms
+step:1176/1600 train_time:61336ms step_avg:52.16ms
+step:1177/1600 train_time:61425ms step_avg:52.19ms
+step:1178/1600 train_time:61511ms step_avg:52.22ms
+step:1179/1600 train_time:61600ms step_avg:52.25ms
+step:1180/1600 train_time:61685ms step_avg:52.28ms
+step:1181/1600 train_time:61773ms step_avg:52.31ms
+step:1182/1600 train_time:61860ms step_avg:52.33ms
+step:1183/1600 train_time:61949ms step_avg:52.37ms
+step:1184/1600 train_time:62035ms step_avg:52.39ms
+step:1185/1600 train_time:62123ms step_avg:52.42ms
+step:1186/1600 train_time:62209ms step_avg:52.45ms
+step:1187/1600 train_time:62298ms step_avg:52.48ms
+step:1188/1600 train_time:62384ms step_avg:52.51ms
+step:1189/1600 train_time:62472ms step_avg:52.54ms
+step:1190/1600 train_time:62558ms step_avg:52.57ms
+step:1191/1600 train_time:62647ms step_avg:52.60ms
+step:1192/1600 train_time:62733ms step_avg:52.63ms
+step:1193/1600 train_time:62822ms step_avg:52.66ms
+step:1194/1600 train_time:62908ms step_avg:52.69ms
+step:1195/1600 train_time:62995ms step_avg:52.72ms
+step:1196/1600 train_time:63082ms step_avg:52.74ms
+step:1197/1600 train_time:63170ms step_avg:52.77ms
+step:1198/1600 train_time:63256ms step_avg:52.80ms
+step:1199/1600 train_time:63345ms step_avg:52.83ms
+step:1200/1600 train_time:63431ms step_avg:52.86ms
+step:1201/1600 train_time:63519ms step_avg:52.89ms
+step:1202/1600 train_time:63605ms step_avg:52.92ms
+step:1203/1600 train_time:63693ms step_avg:52.94ms
+step:1204/1600 train_time:63779ms step_avg:52.97ms
+step:1205/1600 train_time:63867ms step_avg:53.00ms
+step:1206/1600 train_time:63954ms step_avg:53.03ms
+step:1207/1600 train_time:64041ms step_avg:53.06ms
+step:1208/1600 train_time:64126ms step_avg:53.08ms
+step:1209/1600 train_time:64215ms step_avg:53.11ms
+step:1210/1600 train_time:64300ms step_avg:53.14ms
+step:1211/1600 train_time:64390ms step_avg:53.17ms
+step:1212/1600 train_time:64475ms step_avg:53.20ms
+step:1213/1600 train_time:64564ms step_avg:53.23ms
+step:1214/1600 train_time:64649ms step_avg:53.25ms
+step:1215/1600 train_time:64738ms step_avg:53.28ms
+step:1216/1600 train_time:64823ms step_avg:53.31ms
+step:1217/1600 train_time:64912ms step_avg:53.34ms
+step:1218/1600 train_time:64999ms step_avg:53.37ms
+step:1219/1600 train_time:65088ms step_avg:53.39ms
+step:1220/1600 train_time:65173ms step_avg:53.42ms
+step:1221/1600 train_time:65262ms step_avg:53.45ms
+step:1222/1600 train_time:65348ms step_avg:53.48ms
+step:1223/1600 train_time:65436ms step_avg:53.50ms
+step:1224/1600 train_time:65522ms step_avg:53.53ms
+step:1225/1600 train_time:65611ms step_avg:53.56ms
+step:1226/1600 train_time:65697ms step_avg:53.59ms
+step:1227/1600 train_time:65785ms step_avg:53.61ms
+step:1228/1600 train_time:65872ms step_avg:53.64ms
+step:1229/1600 train_time:65960ms step_avg:53.67ms
+step:1230/1600 train_time:66046ms step_avg:53.70ms
+step:1231/1600 train_time:66135ms step_avg:53.72ms
+step:1232/1600 train_time:66221ms step_avg:53.75ms
+step:1233/1600 train_time:66309ms step_avg:53.78ms
+step:1234/1600 train_time:66395ms step_avg:53.80ms
+step:1235/1600 train_time:66484ms step_avg:53.83ms
+step:1236/1600 train_time:66569ms step_avg:53.86ms
+step:1237/1600 train_time:66658ms step_avg:53.89ms
+step:1238/1600 train_time:66744ms step_avg:53.91ms
+step:1239/1600 train_time:66833ms step_avg:53.94ms
+step:1240/1600 train_time:66919ms step_avg:53.97ms
+step:1241/1600 train_time:67007ms step_avg:53.99ms
+step:1242/1600 train_time:67094ms step_avg:54.02ms
+step:1243/1600 train_time:67183ms step_avg:54.05ms
+step:1244/1600 train_time:67268ms step_avg:54.07ms
+step:1245/1600 train_time:67357ms step_avg:54.10ms
+step:1246/1600 train_time:67443ms step_avg:54.13ms
+step:1247/1600 train_time:67532ms step_avg:54.16ms
+step:1248/1600 train_time:67618ms step_avg:54.18ms
+step:1249/1600 train_time:67706ms step_avg:54.21ms
+step:1250/1600 train_time:67791ms step_avg:54.23ms
+step:1250/1600 val_loss:3.4188 train_time:67862ms step_avg:54.29ms
+step:1251/1600 train_time:67882ms step_avg:54.26ms
+step:1252/1600 train_time:67971ms step_avg:54.29ms
+step:1253/1600 train_time:68061ms step_avg:54.32ms
+step:1254/1600 train_time:68147ms step_avg:54.34ms
+step:1255/1600 train_time:68235ms step_avg:54.37ms
+step:1256/1600 train_time:68320ms step_avg:54.39ms
+step:1257/1600 train_time:68407ms step_avg:54.42ms
+step:1258/1600 train_time:68493ms step_avg:54.45ms
+step:1259/1600 train_time:68580ms step_avg:54.47ms
+step:1260/1600 train_time:68667ms step_avg:54.50ms
+step:1261/1600 train_time:68755ms step_avg:54.52ms
+step:1262/1600 train_time:68844ms step_avg:54.55ms
+step:1263/1600 train_time:68934ms step_avg:54.58ms
+step:1264/1600 train_time:69022ms step_avg:54.61ms
+step:1265/1600 train_time:69111ms step_avg:54.63ms
+step:1266/1600 train_time:69198ms step_avg:54.66ms
+step:1267/1600 train_time:69286ms step_avg:54.69ms
+step:1268/1600 train_time:69371ms step_avg:54.71ms
+step:1269/1600 train_time:69459ms step_avg:54.74ms
+step:1270/1600 train_time:69543ms step_avg:54.76ms
+step:1271/1600 train_time:69631ms step_avg:54.78ms
+step:1272/1600 train_time:69717ms step_avg:54.81ms
+step:1273/1600 train_time:69807ms step_avg:54.84ms
+step:1274/1600 train_time:69894ms step_avg:54.86ms
+step:1275/1600 train_time:69984ms step_avg:54.89ms
+step:1276/1600 train_time:70070ms step_avg:54.91ms
+step:1277/1600 train_time:70159ms step_avg:54.94ms
+step:1278/1600 train_time:70244ms step_avg:54.96ms
+step:1279/1600 train_time:70332ms step_avg:54.99ms
+step:1280/1600 train_time:70417ms step_avg:55.01ms
+step:1281/1600 train_time:70506ms step_avg:55.04ms
+step:1282/1600 train_time:70591ms step_avg:55.06ms
+step:1283/1600 train_time:70679ms step_avg:55.09ms
+step:1284/1600 train_time:70766ms step_avg:55.11ms
+step:1285/1600 train_time:70855ms step_avg:55.14ms
+step:1286/1600 train_time:70942ms step_avg:55.17ms
+step:1287/1600 train_time:71032ms step_avg:55.19ms
+step:1288/1600 train_time:71118ms step_avg:55.22ms
+step:1289/1600 train_time:71208ms step_avg:55.24ms
+step:1290/1600 train_time:71293ms step_avg:55.27ms
+step:1291/1600 train_time:71382ms step_avg:55.29ms
+step:1292/1600 train_time:71468ms step_avg:55.32ms
+step:1293/1600 train_time:71556ms step_avg:55.34ms
+step:1294/1600 train_time:71642ms step_avg:55.36ms
+step:1295/1600 train_time:71731ms step_avg:55.39ms
+step:1296/1600 train_time:71816ms step_avg:55.41ms
+step:1297/1600 train_time:71905ms step_avg:55.44ms
+step:1298/1600 train_time:71992ms step_avg:55.46ms
+step:1299/1600 train_time:72081ms step_avg:55.49ms
+step:1300/1600 train_time:72167ms step_avg:55.51ms
+step:1301/1600 train_time:72255ms step_avg:55.54ms
+step:1302/1600 train_time:72341ms step_avg:55.56ms
+step:1303/1600 train_time:72430ms step_avg:55.59ms
+step:1304/1600 train_time:72515ms step_avg:55.61ms
+step:1305/1600 train_time:72603ms step_avg:55.63ms
+step:1306/1600 train_time:72689ms step_avg:55.66ms
+step:1307/1600 train_time:72778ms step_avg:55.68ms
+step:1308/1600 train_time:72865ms step_avg:55.71ms
+step:1309/1600 train_time:72953ms step_avg:55.73ms
+step:1310/1600 train_time:73039ms step_avg:55.76ms
+step:1311/1600 train_time:73129ms step_avg:55.78ms
+step:1312/1600 train_time:73215ms step_avg:55.80ms
+step:1313/1600 train_time:73304ms step_avg:55.83ms
+step:1314/1600 train_time:73389ms step_avg:55.85ms
+step:1315/1600 train_time:73477ms step_avg:55.88ms
+step:1316/1600 train_time:73562ms step_avg:55.90ms
+step:1317/1600 train_time:73650ms step_avg:55.92ms
+step:1318/1600 train_time:73736ms step_avg:55.95ms
+step:1319/1600 train_time:73824ms step_avg:55.97ms
+step:1320/1600 train_time:73910ms step_avg:55.99ms
+step:1321/1600 train_time:73999ms step_avg:56.02ms
+step:1322/1600 train_time:74086ms step_avg:56.04ms
+step:1323/1600 train_time:74175ms step_avg:56.07ms
+step:1324/1600 train_time:74261ms step_avg:56.09ms
+step:1325/1600 train_time:74350ms step_avg:56.11ms
+step:1326/1600 train_time:74435ms step_avg:56.14ms
+step:1327/1600 train_time:74524ms step_avg:56.16ms
+step:1328/1600 train_time:74609ms step_avg:56.18ms
+step:1329/1600 train_time:74697ms step_avg:56.21ms
+step:1330/1600 train_time:74783ms step_avg:56.23ms
+step:1331/1600 train_time:74871ms step_avg:56.25ms
+step:1332/1600 train_time:74958ms step_avg:56.27ms
+step:1333/1600 train_time:75046ms step_avg:56.30ms
+step:1334/1600 train_time:75132ms step_avg:56.32ms
+step:1335/1600 train_time:75221ms step_avg:56.35ms
+step:1336/1600 train_time:75306ms step_avg:56.37ms
+step:1337/1600 train_time:75395ms step_avg:56.39ms
+step:1338/1600 train_time:75481ms step_avg:56.41ms
+step:1339/1600 train_time:75570ms step_avg:56.44ms
+step:1340/1600 train_time:75655ms step_avg:56.46ms
+step:1341/1600 train_time:75744ms step_avg:56.48ms
+step:1342/1600 train_time:75829ms step_avg:56.50ms
+step:1343/1600 train_time:75918ms step_avg:56.53ms
+step:1344/1600 train_time:76004ms step_avg:56.55ms
+step:1345/1600 train_time:76092ms step_avg:56.57ms
+step:1346/1600 train_time:76179ms step_avg:56.60ms
+step:1347/1600 train_time:76269ms step_avg:56.62ms
+step:1348/1600 train_time:76355ms step_avg:56.64ms
+step:1349/1600 train_time:76443ms step_avg:56.67ms
+step:1350/1600 train_time:76529ms step_avg:56.69ms
+step:1351/1600 train_time:76617ms step_avg:56.71ms
+step:1352/1600 train_time:76704ms step_avg:56.73ms
+step:1353/1600 train_time:76793ms step_avg:56.76ms
+step:1354/1600 train_time:76878ms step_avg:56.78ms
+step:1355/1600 train_time:76966ms step_avg:56.80ms
+step:1356/1600 train_time:77051ms step_avg:56.82ms
+step:1357/1600 train_time:77140ms step_avg:56.85ms
+step:1358/1600 train_time:77226ms step_avg:56.87ms
+step:1359/1600 train_time:77315ms step_avg:56.89ms
+step:1360/1600 train_time:77400ms step_avg:56.91ms
+step:1361/1600 train_time:77490ms step_avg:56.94ms
+step:1362/1600 train_time:77576ms step_avg:56.96ms
+step:1363/1600 train_time:77664ms step_avg:56.98ms
+step:1364/1600 train_time:77750ms step_avg:57.00ms
+step:1365/1600 train_time:77838ms step_avg:57.02ms
+step:1366/1600 train_time:77927ms step_avg:57.05ms
+step:1367/1600 train_time:78015ms step_avg:57.07ms
+step:1368/1600 train_time:78099ms step_avg:57.09ms
+step:1369/1600 train_time:78187ms step_avg:57.11ms
+step:1370/1600 train_time:78273ms step_avg:57.13ms
+step:1371/1600 train_time:78361ms step_avg:57.16ms
+step:1372/1600 train_time:78447ms step_avg:57.18ms
+step:1373/1600 train_time:78537ms step_avg:57.20ms
+step:1374/1600 train_time:78623ms step_avg:57.22ms
+step:1375/1600 train_time:78711ms step_avg:57.24ms
+step:1376/1600 train_time:78797ms step_avg:57.27ms
+step:1377/1600 train_time:78886ms step_avg:57.29ms
+step:1378/1600 train_time:78972ms step_avg:57.31ms
+step:1379/1600 train_time:79060ms step_avg:57.33ms
+step:1380/1600 train_time:79146ms step_avg:57.35ms
+step:1381/1600 train_time:79234ms step_avg:57.37ms
+step:1382/1600 train_time:79320ms step_avg:57.40ms
+step:1383/1600 train_time:79409ms step_avg:57.42ms
+step:1384/1600 train_time:79495ms step_avg:57.44ms
+step:1385/1600 train_time:79584ms step_avg:57.46ms
+step:1386/1600 train_time:79669ms step_avg:57.48ms
+step:1387/1600 train_time:79758ms step_avg:57.50ms
+step:1388/1600 train_time:79845ms step_avg:57.53ms
+step:1389/1600 train_time:79934ms step_avg:57.55ms
+step:1390/1600 train_time:80019ms step_avg:57.57ms
+step:1391/1600 train_time:80108ms step_avg:57.59ms
+step:1392/1600 train_time:80194ms step_avg:57.61ms
+step:1393/1600 train_time:80283ms step_avg:57.63ms
+step:1394/1600 train_time:80369ms step_avg:57.65ms
+step:1395/1600 train_time:80457ms step_avg:57.68ms
+step:1396/1600 train_time:80543ms step_avg:57.70ms
+step:1397/1600 train_time:80631ms step_avg:57.72ms
+step:1398/1600 train_time:80717ms step_avg:57.74ms
+step:1399/1600 train_time:80805ms step_avg:57.76ms
+step:1400/1600 train_time:80892ms step_avg:57.78ms
+step:1401/1600 train_time:80981ms step_avg:57.80ms
+step:1402/1600 train_time:81067ms step_avg:57.82ms
+step:1403/1600 train_time:81155ms step_avg:57.84ms
+step:1404/1600 train_time:81240ms step_avg:57.86ms
+step:1405/1600 train_time:81330ms step_avg:57.89ms
+step:1406/1600 train_time:81415ms step_avg:57.91ms
+step:1407/1600 train_time:81504ms step_avg:57.93ms
+step:1408/1600 train_time:81589ms step_avg:57.95ms
+step:1409/1600 train_time:81678ms step_avg:57.97ms
+step:1410/1600 train_time:81764ms step_avg:57.99ms
+step:1411/1600 train_time:81853ms step_avg:58.01ms
+step:1412/1600 train_time:81940ms step_avg:58.03ms
+step:1413/1600 train_time:82050ms step_avg:58.07ms
+step:1414/1600 train_time:82119ms step_avg:58.08ms
+step:1415/1600 train_time:82202ms step_avg:58.09ms
+step:1416/1600 train_time:82288ms step_avg:58.11ms
+step:1417/1600 train_time:82377ms step_avg:58.13ms
+step:1418/1600 train_time:82464ms step_avg:58.15ms
+step:1419/1600 train_time:82551ms step_avg:58.18ms
+step:1420/1600 train_time:82638ms step_avg:58.20ms
+step:1421/1600 train_time:82726ms step_avg:58.22ms
+step:1422/1600 train_time:82812ms step_avg:58.24ms
+step:1423/1600 train_time:82901ms step_avg:58.26ms
+step:1424/1600 train_time:82987ms step_avg:58.28ms
+step:1425/1600 train_time:83075ms step_avg:58.30ms
+step:1426/1600 train_time:83160ms step_avg:58.32ms
+step:1427/1600 train_time:83249ms step_avg:58.34ms
+step:1428/1600 train_time:83335ms step_avg:58.36ms
+step:1429/1600 train_time:83424ms step_avg:58.38ms
+step:1430/1600 train_time:83510ms step_avg:58.40ms
+step:1431/1600 train_time:83598ms step_avg:58.42ms
+step:1432/1600 train_time:83684ms step_avg:58.44ms
+step:1433/1600 train_time:83773ms step_avg:58.46ms
+step:1434/1600 train_time:83858ms step_avg:58.48ms
+step:1435/1600 train_time:83947ms step_avg:58.50ms
+step:1436/1600 train_time:84033ms step_avg:58.52ms
+step:1437/1600 train_time:84121ms step_avg:58.54ms
+step:1438/1600 train_time:84207ms step_avg:58.56ms
+step:1439/1600 train_time:84295ms step_avg:58.58ms
+step:1440/1600 train_time:84381ms step_avg:58.60ms
+step:1441/1600 train_time:84470ms step_avg:58.62ms
+step:1442/1600 train_time:84557ms step_avg:58.64ms
+step:1443/1600 train_time:84645ms step_avg:58.66ms
+step:1444/1600 train_time:84731ms step_avg:58.68ms
+step:1445/1600 train_time:84820ms step_avg:58.70ms
+step:1446/1600 train_time:84906ms step_avg:58.72ms
+step:1447/1600 train_time:84994ms step_avg:58.74ms
+step:1448/1600 train_time:85081ms step_avg:58.76ms
+step:1449/1600 train_time:85170ms step_avg:58.78ms
+step:1450/1600 train_time:85255ms step_avg:58.80ms
+step:1451/1600 train_time:85344ms step_avg:58.82ms
+step:1452/1600 train_time:85429ms step_avg:58.84ms
+step:1453/1600 train_time:85518ms step_avg:58.86ms
+step:1454/1600 train_time:85604ms step_avg:58.87ms
+step:1455/1600 train_time:85693ms step_avg:58.90ms
+step:1456/1600 train_time:85778ms step_avg:58.91ms
+step:1457/1600 train_time:85868ms step_avg:58.93ms
+step:1458/1600 train_time:85954ms step_avg:58.95ms
+step:1459/1600 train_time:86042ms step_avg:58.97ms
+step:1460/1600 train_time:86128ms step_avg:58.99ms
+step:1461/1600 train_time:86216ms step_avg:59.01ms
+step:1462/1600 train_time:86303ms step_avg:59.03ms
+step:1463/1600 train_time:86391ms step_avg:59.05ms
+step:1464/1600 train_time:86477ms step_avg:59.07ms
+step:1465/1600 train_time:86565ms step_avg:59.09ms
+step:1466/1600 train_time:86651ms step_avg:59.11ms
+step:1467/1600 train_time:86739ms step_avg:59.13ms
+step:1468/1600 train_time:86825ms step_avg:59.15ms
+step:1469/1600 train_time:86914ms step_avg:59.17ms
+step:1470/1600 train_time:87000ms step_avg:59.18ms
+step:1471/1600 train_time:87089ms step_avg:59.20ms
+step:1472/1600 train_time:87174ms step_avg:59.22ms
+step:1473/1600 train_time:87262ms step_avg:59.24ms
+step:1474/1600 train_time:87348ms step_avg:59.26ms
+step:1475/1600 train_time:87437ms step_avg:59.28ms
+step:1476/1600 train_time:87522ms step_avg:59.30ms
+step:1477/1600 train_time:87611ms step_avg:59.32ms
+step:1478/1600 train_time:87696ms step_avg:59.33ms
+step:1479/1600 train_time:87785ms step_avg:59.35ms
+step:1480/1600 train_time:87870ms step_avg:59.37ms
+step:1481/1600 train_time:87959ms step_avg:59.39ms
+step:1482/1600 train_time:88045ms step_avg:59.41ms
+step:1483/1600 train_time:88133ms step_avg:59.43ms
+step:1484/1600 train_time:88219ms step_avg:59.45ms
+step:1485/1600 train_time:88307ms step_avg:59.47ms
+step:1486/1600 train_time:88393ms step_avg:59.48ms
+step:1487/1600 train_time:88481ms step_avg:59.50ms
+step:1488/1600 train_time:88566ms step_avg:59.52ms
+step:1489/1600 train_time:88654ms step_avg:59.54ms
+step:1490/1600 train_time:88740ms step_avg:59.56ms
+step:1491/1600 train_time:88829ms step_avg:59.58ms
+step:1492/1600 train_time:88915ms step_avg:59.59ms
+step:1493/1600 train_time:89003ms step_avg:59.61ms
+step:1494/1600 train_time:89090ms step_avg:59.63ms
+step:1495/1600 train_time:89178ms step_avg:59.65ms
+step:1496/1600 train_time:89265ms step_avg:59.67ms
+step:1497/1600 train_time:89353ms step_avg:59.69ms
+step:1498/1600 train_time:89439ms step_avg:59.71ms
+step:1499/1600 train_time:89528ms step_avg:59.72ms
+step:1500/1600 train_time:89613ms step_avg:59.74ms
+step:1500/1600 val_loss:3.3089 train_time:89683ms step_avg:59.79ms
+step:1501/1600 train_time:89703ms step_avg:59.76ms
+step:1502/1600 train_time:89790ms step_avg:59.78ms
+step:1503/1600 train_time:89879ms step_avg:59.80ms
+step:1504/1600 train_time:89965ms step_avg:59.82ms
+step:1505/1600 train_time:90053ms step_avg:59.84ms
+step:1506/1600 train_time:90137ms step_avg:59.85ms
+step:1507/1600 train_time:90225ms step_avg:59.87ms
+step:1508/1600 train_time:90310ms step_avg:59.89ms
+step:1509/1600 train_time:90398ms step_avg:59.91ms
+step:1510/1600 train_time:90485ms step_avg:59.92ms
+step:1511/1600 train_time:90572ms step_avg:59.94ms
+step:1512/1600 train_time:90661ms step_avg:59.96ms
+step:1513/1600 train_time:90751ms step_avg:59.98ms
+step:1514/1600 train_time:90838ms step_avg:60.00ms
+step:1515/1600 train_time:90927ms step_avg:60.02ms
+step:1516/1600 train_time:91013ms step_avg:60.03ms
+step:1517/1600 train_time:91101ms step_avg:60.05ms
+step:1518/1600 train_time:91186ms step_avg:60.07ms
+step:1519/1600 train_time:91274ms step_avg:60.09ms
+step:1520/1600 train_time:91359ms step_avg:60.10ms
+step:1521/1600 train_time:91448ms step_avg:60.12ms
+step:1522/1600 train_time:91534ms step_avg:60.14ms
+step:1523/1600 train_time:91623ms step_avg:60.16ms
+step:1524/1600 train_time:91710ms step_avg:60.18ms
+step:1525/1600 train_time:91800ms step_avg:60.20ms
+step:1526/1600 train_time:91886ms step_avg:60.21ms
+step:1527/1600 train_time:91974ms step_avg:60.23ms
+step:1528/1600 train_time:92061ms step_avg:60.25ms
+step:1529/1600 train_time:92150ms step_avg:60.27ms
+step:1530/1600 train_time:92236ms step_avg:60.28ms
+step:1531/1600 train_time:92324ms step_avg:60.30ms
+step:1532/1600 train_time:92410ms step_avg:60.32ms
+step:1533/1600 train_time:92498ms step_avg:60.34ms
+step:1534/1600 train_time:92585ms step_avg:60.36ms
+step:1535/1600 train_time:92674ms step_avg:60.37ms
+step:1536/1600 train_time:92760ms step_avg:60.39ms
+step:1537/1600 train_time:92851ms step_avg:60.41ms
+step:1538/1600 train_time:92936ms step_avg:60.43ms
+step:1539/1600 train_time:93025ms step_avg:60.44ms
+step:1540/1600 train_time:93111ms step_avg:60.46ms
+step:1541/1600 train_time:93199ms step_avg:60.48ms
+step:1542/1600 train_time:93285ms step_avg:60.50ms
+step:1543/1600 train_time:93373ms step_avg:60.51ms
+step:1544/1600 train_time:93458ms step_avg:60.53ms
+step:1545/1600 train_time:93547ms step_avg:60.55ms
+step:1546/1600 train_time:93633ms step_avg:60.56ms
+step:1547/1600 train_time:93722ms step_avg:60.58ms
+step:1548/1600 train_time:93808ms step_avg:60.60ms
+step:1549/1600 train_time:93897ms step_avg:60.62ms
+step:1550/1600 train_time:93984ms step_avg:60.63ms
+step:1551/1600 train_time:94072ms step_avg:60.65ms
+step:1552/1600 train_time:94158ms step_avg:60.67ms
+step:1553/1600 train_time:94246ms step_avg:60.69ms
+step:1554/1600 train_time:94332ms step_avg:60.70ms
+step:1555/1600 train_time:94421ms step_avg:60.72ms
+step:1556/1600 train_time:94507ms step_avg:60.74ms
+step:1557/1600 train_time:94596ms step_avg:60.76ms
+step:1558/1600 train_time:94683ms step_avg:60.77ms
+step:1559/1600 train_time:94771ms step_avg:60.79ms
+step:1560/1600 train_time:94857ms step_avg:60.81ms
+step:1561/1600 train_time:94952ms step_avg:60.83ms
+step:1562/1600 train_time:95037ms step_avg:60.84ms
+step:1563/1600 train_time:95125ms step_avg:60.86ms
+step:1564/1600 train_time:95212ms step_avg:60.88ms
+step:1565/1600 train_time:95300ms step_avg:60.89ms
+step:1566/1600 train_time:95386ms step_avg:60.91ms
+step:1567/1600 train_time:95475ms step_avg:60.93ms
+step:1568/1600 train_time:95561ms step_avg:60.94ms
+step:1569/1600 train_time:95649ms step_avg:60.96ms
+step:1570/1600 train_time:95737ms step_avg:60.98ms
+step:1571/1600 train_time:95825ms step_avg:61.00ms
+step:1572/1600 train_time:95912ms step_avg:61.01ms
+step:1573/1600 train_time:96001ms step_avg:61.03ms
+step:1574/1600 train_time:96087ms step_avg:61.05ms
+step:1575/1600 train_time:96176ms step_avg:61.06ms
+step:1576/1600 train_time:96261ms step_avg:61.08ms
+step:1577/1600 train_time:96352ms step_avg:61.10ms
+step:1578/1600 train_time:96438ms step_avg:61.11ms
+step:1579/1600 train_time:96525ms step_avg:61.13ms
+step:1580/1600 train_time:96611ms step_avg:61.15ms
+step:1581/1600 train_time:96701ms step_avg:61.16ms
+step:1582/1600 train_time:96787ms step_avg:61.18ms
+step:1583/1600 train_time:96876ms step_avg:61.20ms
+step:1584/1600 train_time:96963ms step_avg:61.21ms
+step:1585/1600 train_time:97052ms step_avg:61.23ms
+step:1586/1600 train_time:97138ms step_avg:61.25ms
+step:1587/1600 train_time:97226ms step_avg:61.26ms
+step:1588/1600 train_time:97313ms step_avg:61.28ms
+step:1589/1600 train_time:97401ms step_avg:61.30ms
+step:1590/1600 train_time:97487ms step_avg:61.31ms
+step:1591/1600 train_time:97576ms step_avg:61.33ms
+step:1592/1600 train_time:97662ms step_avg:61.35ms
+step:1593/1600 train_time:97751ms step_avg:61.36ms
+step:1594/1600 train_time:97837ms step_avg:61.38ms
+step:1595/1600 train_time:97927ms step_avg:61.40ms
+step:1596/1600 train_time:98013ms step_avg:61.41ms
+step:1597/1600 train_time:98102ms step_avg:61.43ms
+step:1598/1600 train_time:98188ms step_avg:61.44ms
+step:1599/1600 train_time:98276ms step_avg:61.46ms
+step:1600/1600 train_time:98362ms step_avg:61.48ms
+step:1600/1600 val_loss:3.2792 train_time:98433ms step_avg:61.52ms
+peak memory allocated: 30264 MiB reserved: 46338 MiB

--- a/records/track_1_short/2026-01-28_TieFirstLastVEs/baseline/154d4c6c-546f-4ebe-8fbf-29475ac1ccb0.txt
+++ b/records/track_1_short/2026-01-28_TieFirstLastVEs/baseline/154d4c6c-546f-4ebe-8fbf-29475ac1ccb0.txt
@@ -1,0 +1,4120 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.12.12 | packaged by conda-forge | (main, Jan 26 2026, 23:51:32) [GCC 14.3.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Thu Jan 29 02:20:38 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                  Off |
+| N/A   41C    P0            129W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:06:00.0 Off |                  Off |
+| N/A   36C    P0            128W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:07:00.0 Off |                  Off |
+| N/A   41C    P0            124W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:08:00.0 Off |                  Off |
+| N/A   36C    P0            127W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:09:00.0 Off |                  Off |
+| N/A   40C    P0            126W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                  Off |
+| N/A   36C    P0            124W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                  Off |
+| N/A   41C    P0            129W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:0C:00.0 Off |                  Off |
+| N/A   36C    P0            127W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A           36638      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    1   N/A  N/A           36639      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    2   N/A  N/A           36640      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    3   N/A  N/A           36641      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    4   N/A  N/A           36642      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    5   N/A  N/A           36643      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    6   N/A  N/A           36644      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    7   N/A  N/A           36645      C   .../envs/speedrun/bin/python3.12       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8273 train_time:0ms step_avg:0.03ms
+step:1/1600 train_time:51ms step_avg:50.57ms
+step:2/1600 train_time:67ms step_avg:33.60ms
+step:3/1600 train_time:96ms step_avg:31.92ms
+step:4/1600 train_time:132ms step_avg:33.09ms
+step:5/1600 train_time:163ms step_avg:32.53ms
+step:6/1600 train_time:234ms step_avg:39.01ms
+step:7/1600 train_time:249ms step_avg:35.55ms
+step:8/1600 train_time:283ms step_avg:35.35ms
+step:9/1600 train_time:314ms step_avg:34.85ms
+step:10/1600 train_time:350ms step_avg:35.04ms
+step:11/1600 train_time:381ms step_avg:34.66ms
+step:12/1600 train_time:418ms step_avg:34.86ms
+step:13/1600 train_time:449ms step_avg:34.56ms
+step:14/1600 train_time:486ms step_avg:34.70ms
+step:15/1600 train_time:517ms step_avg:34.46ms
+step:16/1600 train_time:554ms step_avg:34.62ms
+step:17/1600 train_time:585ms step_avg:34.40ms
+step:18/1600 train_time:622ms step_avg:34.54ms
+step:19/1600 train_time:653ms step_avg:34.36ms
+step:20/1600 train_time:689ms step_avg:34.47ms
+step:21/1600 train_time:721ms step_avg:34.31ms
+step:22/1600 train_time:758ms step_avg:34.46ms
+step:23/1600 train_time:789ms step_avg:34.31ms
+step:24/1600 train_time:826ms step_avg:34.41ms
+step:25/1600 train_time:856ms step_avg:34.25ms
+step:26/1600 train_time:894ms step_avg:34.37ms
+step:27/1600 train_time:924ms step_avg:34.23ms
+step:28/1600 train_time:961ms step_avg:34.33ms
+step:29/1600 train_time:993ms step_avg:34.23ms
+step:30/1600 train_time:1030ms step_avg:34.32ms
+step:31/1600 train_time:1060ms step_avg:34.21ms
+step:32/1600 train_time:1097ms step_avg:34.29ms
+step:33/1600 train_time:1129ms step_avg:34.20ms
+step:34/1600 train_time:1165ms step_avg:34.28ms
+step:35/1600 train_time:1198ms step_avg:34.23ms
+step:36/1600 train_time:1236ms step_avg:34.34ms
+step:37/1600 train_time:1267ms step_avg:34.25ms
+step:38/1600 train_time:1304ms step_avg:34.33ms
+step:39/1600 train_time:1336ms step_avg:34.25ms
+step:40/1600 train_time:1373ms step_avg:34.33ms
+step:41/1600 train_time:1404ms step_avg:34.25ms
+step:42/1600 train_time:1441ms step_avg:34.31ms
+step:43/1600 train_time:1472ms step_avg:34.23ms
+step:44/1600 train_time:1509ms step_avg:34.29ms
+step:45/1600 train_time:1540ms step_avg:34.22ms
+step:46/1600 train_time:1577ms step_avg:34.29ms
+step:47/1600 train_time:1608ms step_avg:34.21ms
+step:48/1600 train_time:1645ms step_avg:34.27ms
+step:49/1600 train_time:1676ms step_avg:34.20ms
+step:50/1600 train_time:1713ms step_avg:34.27ms
+step:51/1600 train_time:1744ms step_avg:34.20ms
+step:52/1600 train_time:1781ms step_avg:34.25ms
+step:53/1600 train_time:1812ms step_avg:34.19ms
+step:54/1600 train_time:1849ms step_avg:34.24ms
+step:55/1600 train_time:1880ms step_avg:34.18ms
+step:56/1600 train_time:1917ms step_avg:34.23ms
+step:57/1600 train_time:1948ms step_avg:34.17ms
+step:58/1600 train_time:1985ms step_avg:34.22ms
+step:59/1600 train_time:2016ms step_avg:34.16ms
+step:60/1600 train_time:2053ms step_avg:34.21ms
+step:61/1600 train_time:2083ms step_avg:34.16ms
+step:62/1600 train_time:2121ms step_avg:34.21ms
+step:63/1600 train_time:2152ms step_avg:34.15ms
+step:64/1600 train_time:2189ms step_avg:34.21ms
+step:65/1600 train_time:2221ms step_avg:34.16ms
+step:66/1600 train_time:2258ms step_avg:34.21ms
+step:67/1600 train_time:2290ms step_avg:34.17ms
+step:68/1600 train_time:2326ms step_avg:34.21ms
+step:69/1600 train_time:2357ms step_avg:34.16ms
+step:70/1600 train_time:2395ms step_avg:34.21ms
+step:71/1600 train_time:2426ms step_avg:34.17ms
+step:72/1600 train_time:2463ms step_avg:34.21ms
+step:73/1600 train_time:2494ms step_avg:34.17ms
+step:74/1600 train_time:2531ms step_avg:34.21ms
+step:75/1600 train_time:2562ms step_avg:34.16ms
+step:76/1600 train_time:2600ms step_avg:34.21ms
+step:77/1600 train_time:2631ms step_avg:34.16ms
+step:78/1600 train_time:2668ms step_avg:34.20ms
+step:79/1600 train_time:2700ms step_avg:34.17ms
+step:80/1600 train_time:2737ms step_avg:34.22ms
+step:81/1600 train_time:2768ms step_avg:34.18ms
+step:82/1600 train_time:2805ms step_avg:34.21ms
+step:83/1600 train_time:2837ms step_avg:34.18ms
+step:84/1600 train_time:2875ms step_avg:34.22ms
+step:85/1600 train_time:2906ms step_avg:34.19ms
+step:86/1600 train_time:2943ms step_avg:34.22ms
+step:87/1600 train_time:2974ms step_avg:34.18ms
+step:88/1600 train_time:3011ms step_avg:34.22ms
+step:89/1600 train_time:3042ms step_avg:34.18ms
+step:90/1600 train_time:3079ms step_avg:34.21ms
+step:91/1600 train_time:3110ms step_avg:34.17ms
+step:92/1600 train_time:3147ms step_avg:34.20ms
+step:93/1600 train_time:3178ms step_avg:34.17ms
+step:94/1600 train_time:3215ms step_avg:34.20ms
+step:95/1600 train_time:3245ms step_avg:34.16ms
+step:96/1600 train_time:3283ms step_avg:34.19ms
+step:97/1600 train_time:3313ms step_avg:34.16ms
+step:98/1600 train_time:3350ms step_avg:34.18ms
+step:99/1600 train_time:3381ms step_avg:34.15ms
+step:100/1600 train_time:3419ms step_avg:34.19ms
+step:101/1600 train_time:3450ms step_avg:34.16ms
+step:102/1600 train_time:3487ms step_avg:34.18ms
+step:103/1600 train_time:3518ms step_avg:34.16ms
+step:104/1600 train_time:3556ms step_avg:34.19ms
+step:105/1600 train_time:3587ms step_avg:34.16ms
+step:106/1600 train_time:3624ms step_avg:34.19ms
+step:107/1600 train_time:3655ms step_avg:34.16ms
+step:108/1600 train_time:3692ms step_avg:34.18ms
+step:109/1600 train_time:3723ms step_avg:34.16ms
+step:110/1600 train_time:3760ms step_avg:34.18ms
+step:111/1600 train_time:3791ms step_avg:34.16ms
+step:112/1600 train_time:3829ms step_avg:34.18ms
+step:113/1600 train_time:3859ms step_avg:34.15ms
+step:114/1600 train_time:3897ms step_avg:34.18ms
+step:115/1600 train_time:3927ms step_avg:34.15ms
+step:116/1600 train_time:3964ms step_avg:34.18ms
+step:117/1600 train_time:3996ms step_avg:34.15ms
+step:118/1600 train_time:4033ms step_avg:34.18ms
+step:119/1600 train_time:4064ms step_avg:34.15ms
+step:120/1600 train_time:4101ms step_avg:34.18ms
+step:121/1600 train_time:4132ms step_avg:34.15ms
+step:122/1600 train_time:4169ms step_avg:34.17ms
+step:123/1600 train_time:4200ms step_avg:34.14ms
+step:124/1600 train_time:4237ms step_avg:34.17ms
+step:125/1600 train_time:4268ms step_avg:34.14ms
+step:126/1600 train_time:4305ms step_avg:34.16ms
+step:127/1600 train_time:4335ms step_avg:34.14ms
+step:128/1600 train_time:4373ms step_avg:34.16ms
+step:129/1600 train_time:4404ms step_avg:34.14ms
+step:130/1600 train_time:4441ms step_avg:34.16ms
+step:131/1600 train_time:4472ms step_avg:34.14ms
+step:132/1600 train_time:4509ms step_avg:34.16ms
+step:133/1600 train_time:4540ms step_avg:34.14ms
+step:134/1600 train_time:4577ms step_avg:34.16ms
+step:135/1600 train_time:4608ms step_avg:34.13ms
+step:136/1600 train_time:4645ms step_avg:34.16ms
+step:137/1600 train_time:4676ms step_avg:34.13ms
+step:138/1600 train_time:4713ms step_avg:34.15ms
+step:139/1600 train_time:4744ms step_avg:34.13ms
+step:140/1600 train_time:4781ms step_avg:34.15ms
+step:141/1600 train_time:4812ms step_avg:34.13ms
+step:142/1600 train_time:4849ms step_avg:34.15ms
+step:143/1600 train_time:4880ms step_avg:34.12ms
+step:144/1600 train_time:4917ms step_avg:34.15ms
+step:145/1600 train_time:4949ms step_avg:34.13ms
+step:146/1600 train_time:4985ms step_avg:34.15ms
+step:147/1600 train_time:5016ms step_avg:34.13ms
+step:148/1600 train_time:5054ms step_avg:34.15ms
+step:149/1600 train_time:5085ms step_avg:34.13ms
+step:150/1600 train_time:5122ms step_avg:34.14ms
+step:151/1600 train_time:5152ms step_avg:34.12ms
+step:152/1600 train_time:5189ms step_avg:34.14ms
+step:153/1600 train_time:5221ms step_avg:34.12ms
+step:154/1600 train_time:5258ms step_avg:34.14ms
+step:155/1600 train_time:5289ms step_avg:34.12ms
+step:156/1600 train_time:5325ms step_avg:34.14ms
+step:157/1600 train_time:5356ms step_avg:34.12ms
+step:158/1600 train_time:5394ms step_avg:34.14ms
+step:159/1600 train_time:5425ms step_avg:34.12ms
+step:160/1600 train_time:5461ms step_avg:34.13ms
+step:161/1600 train_time:5492ms step_avg:34.11ms
+step:162/1600 train_time:5529ms step_avg:34.13ms
+step:163/1600 train_time:5560ms step_avg:34.11ms
+step:164/1600 train_time:5597ms step_avg:34.13ms
+step:165/1600 train_time:5628ms step_avg:34.11ms
+step:166/1600 train_time:5665ms step_avg:34.13ms
+step:167/1600 train_time:5696ms step_avg:34.11ms
+step:168/1600 train_time:5733ms step_avg:34.13ms
+step:169/1600 train_time:5764ms step_avg:34.10ms
+step:170/1600 train_time:5800ms step_avg:34.12ms
+step:171/1600 train_time:5831ms step_avg:34.10ms
+step:172/1600 train_time:5868ms step_avg:34.11ms
+step:173/1600 train_time:5899ms step_avg:34.10ms
+step:174/1600 train_time:5936ms step_avg:34.12ms
+step:175/1600 train_time:5967ms step_avg:34.10ms
+step:176/1600 train_time:6004ms step_avg:34.11ms
+step:177/1600 train_time:6035ms step_avg:34.10ms
+step:178/1600 train_time:6072ms step_avg:34.11ms
+step:179/1600 train_time:6104ms step_avg:34.10ms
+step:180/1600 train_time:6141ms step_avg:34.12ms
+step:181/1600 train_time:6171ms step_avg:34.10ms
+step:182/1600 train_time:6208ms step_avg:34.11ms
+step:183/1600 train_time:6239ms step_avg:34.09ms
+step:184/1600 train_time:6276ms step_avg:34.11ms
+step:185/1600 train_time:6307ms step_avg:34.09ms
+step:186/1600 train_time:6344ms step_avg:34.11ms
+step:187/1600 train_time:6375ms step_avg:34.09ms
+step:188/1600 train_time:6412ms step_avg:34.10ms
+step:189/1600 train_time:6442ms step_avg:34.09ms
+step:190/1600 train_time:6479ms step_avg:34.10ms
+step:191/1600 train_time:6510ms step_avg:34.08ms
+step:192/1600 train_time:6547ms step_avg:34.10ms
+step:193/1600 train_time:6578ms step_avg:34.08ms
+step:194/1600 train_time:6616ms step_avg:34.10ms
+step:195/1600 train_time:6646ms step_avg:34.08ms
+step:196/1600 train_time:6683ms step_avg:34.10ms
+step:197/1600 train_time:6714ms step_avg:34.08ms
+step:198/1600 train_time:6751ms step_avg:34.09ms
+step:199/1600 train_time:6782ms step_avg:34.08ms
+step:200/1600 train_time:6819ms step_avg:34.09ms
+step:201/1600 train_time:6850ms step_avg:34.08ms
+step:202/1600 train_time:6887ms step_avg:34.09ms
+step:203/1600 train_time:6918ms step_avg:34.08ms
+step:204/1600 train_time:6955ms step_avg:34.09ms
+step:205/1600 train_time:6986ms step_avg:34.08ms
+step:206/1600 train_time:7023ms step_avg:34.09ms
+step:207/1600 train_time:7054ms step_avg:34.08ms
+step:208/1600 train_time:7091ms step_avg:34.09ms
+step:209/1600 train_time:7122ms step_avg:34.07ms
+step:210/1600 train_time:7159ms step_avg:34.09ms
+step:211/1600 train_time:7190ms step_avg:34.07ms
+step:212/1600 train_time:7226ms step_avg:34.09ms
+step:213/1600 train_time:7258ms step_avg:34.08ms
+step:214/1600 train_time:7296ms step_avg:34.09ms
+step:215/1600 train_time:7327ms step_avg:34.08ms
+step:216/1600 train_time:7364ms step_avg:34.09ms
+step:217/1600 train_time:7395ms step_avg:34.08ms
+step:218/1600 train_time:7431ms step_avg:34.09ms
+step:219/1600 train_time:7462ms step_avg:34.07ms
+step:220/1600 train_time:7499ms step_avg:34.09ms
+step:221/1600 train_time:7530ms step_avg:34.07ms
+step:222/1600 train_time:7567ms step_avg:34.08ms
+step:223/1600 train_time:7597ms step_avg:34.07ms
+step:224/1600 train_time:7634ms step_avg:34.08ms
+step:225/1600 train_time:7665ms step_avg:34.07ms
+step:226/1600 train_time:7702ms step_avg:34.08ms
+step:227/1600 train_time:7733ms step_avg:34.06ms
+step:228/1600 train_time:7770ms step_avg:34.08ms
+step:229/1600 train_time:7801ms step_avg:34.06ms
+step:230/1600 train_time:7838ms step_avg:34.08ms
+step:231/1600 train_time:7869ms step_avg:34.07ms
+step:232/1600 train_time:7906ms step_avg:34.08ms
+step:233/1600 train_time:7937ms step_avg:34.06ms
+step:234/1600 train_time:7974ms step_avg:34.08ms
+step:235/1600 train_time:8005ms step_avg:34.06ms
+step:236/1600 train_time:8042ms step_avg:34.08ms
+step:237/1600 train_time:8073ms step_avg:34.06ms
+step:238/1600 train_time:8110ms step_avg:34.07ms
+step:239/1600 train_time:8141ms step_avg:34.06ms
+step:240/1600 train_time:8178ms step_avg:34.07ms
+step:241/1600 train_time:8209ms step_avg:34.06ms
+step:242/1600 train_time:8246ms step_avg:34.07ms
+step:243/1600 train_time:8277ms step_avg:34.06ms
+step:244/1600 train_time:8314ms step_avg:34.07ms
+step:245/1600 train_time:8345ms step_avg:34.06ms
+step:246/1600 train_time:8382ms step_avg:34.07ms
+step:247/1600 train_time:8413ms step_avg:34.06ms
+step:248/1600 train_time:8449ms step_avg:34.07ms
+step:249/1600 train_time:8480ms step_avg:34.06ms
+step:250/1600 train_time:8517ms step_avg:34.07ms
+step:250/1600 val_loss:4.5843 train_time:8565ms step_avg:34.26ms
+step:251/1600 train_time:8581ms step_avg:34.19ms
+step:252/1600 train_time:8597ms step_avg:34.12ms
+step:253/1600 train_time:8623ms step_avg:34.08ms
+step:254/1600 train_time:8660ms step_avg:34.09ms
+step:255/1600 train_time:8691ms step_avg:34.08ms
+step:256/1600 train_time:8728ms step_avg:34.09ms
+step:257/1600 train_time:8759ms step_avg:34.08ms
+step:258/1600 train_time:8796ms step_avg:34.09ms
+step:259/1600 train_time:8827ms step_avg:34.08ms
+step:260/1600 train_time:8864ms step_avg:34.09ms
+step:261/1600 train_time:8895ms step_avg:34.08ms
+step:262/1600 train_time:8931ms step_avg:34.09ms
+step:263/1600 train_time:8962ms step_avg:34.08ms
+step:264/1600 train_time:8998ms step_avg:34.08ms
+step:265/1600 train_time:9029ms step_avg:34.07ms
+step:266/1600 train_time:9066ms step_avg:34.08ms
+step:267/1600 train_time:9096ms step_avg:34.07ms
+step:268/1600 train_time:9133ms step_avg:34.08ms
+step:269/1600 train_time:9164ms step_avg:34.07ms
+step:270/1600 train_time:9201ms step_avg:34.08ms
+step:271/1600 train_time:9231ms step_avg:34.06ms
+step:272/1600 train_time:9268ms step_avg:34.07ms
+step:273/1600 train_time:9299ms step_avg:34.06ms
+step:274/1600 train_time:9335ms step_avg:34.07ms
+step:275/1600 train_time:9366ms step_avg:34.06ms
+step:276/1600 train_time:9402ms step_avg:34.07ms
+step:277/1600 train_time:9433ms step_avg:34.05ms
+step:278/1600 train_time:9470ms step_avg:34.06ms
+step:279/1600 train_time:9501ms step_avg:34.06ms
+step:280/1600 train_time:9538ms step_avg:34.07ms
+step:281/1600 train_time:9570ms step_avg:34.06ms
+step:282/1600 train_time:9608ms step_avg:34.07ms
+step:283/1600 train_time:9639ms step_avg:34.06ms
+step:284/1600 train_time:9676ms step_avg:34.07ms
+step:285/1600 train_time:9707ms step_avg:34.06ms
+step:286/1600 train_time:9745ms step_avg:34.07ms
+step:287/1600 train_time:9775ms step_avg:34.06ms
+step:288/1600 train_time:9812ms step_avg:34.07ms
+step:289/1600 train_time:9843ms step_avg:34.06ms
+step:290/1600 train_time:9881ms step_avg:34.07ms
+step:291/1600 train_time:9911ms step_avg:34.06ms
+step:292/1600 train_time:9948ms step_avg:34.07ms
+step:293/1600 train_time:9979ms step_avg:34.06ms
+step:294/1600 train_time:10016ms step_avg:34.07ms
+step:295/1600 train_time:10046ms step_avg:34.06ms
+step:296/1600 train_time:10084ms step_avg:34.07ms
+step:297/1600 train_time:10115ms step_avg:34.06ms
+step:298/1600 train_time:10151ms step_avg:34.07ms
+step:299/1600 train_time:10183ms step_avg:34.06ms
+step:300/1600 train_time:10219ms step_avg:34.06ms
+step:301/1600 train_time:10250ms step_avg:34.05ms
+step:302/1600 train_time:10287ms step_avg:34.06ms
+step:303/1600 train_time:10317ms step_avg:34.05ms
+step:304/1600 train_time:10354ms step_avg:34.06ms
+step:305/1600 train_time:10385ms step_avg:34.05ms
+step:306/1600 train_time:10422ms step_avg:34.06ms
+step:307/1600 train_time:10452ms step_avg:34.05ms
+step:308/1600 train_time:10489ms step_avg:34.06ms
+step:309/1600 train_time:10520ms step_avg:34.05ms
+step:310/1600 train_time:10557ms step_avg:34.05ms
+step:311/1600 train_time:10588ms step_avg:34.04ms
+step:312/1600 train_time:10625ms step_avg:34.06ms
+step:313/1600 train_time:10656ms step_avg:34.04ms
+step:314/1600 train_time:10693ms step_avg:34.05ms
+step:315/1600 train_time:10724ms step_avg:34.04ms
+step:316/1600 train_time:10761ms step_avg:34.05ms
+step:317/1600 train_time:10792ms step_avg:34.04ms
+step:318/1600 train_time:10829ms step_avg:34.05ms
+step:319/1600 train_time:10860ms step_avg:34.04ms
+step:320/1600 train_time:10897ms step_avg:34.05ms
+step:321/1600 train_time:10927ms step_avg:34.04ms
+step:322/1600 train_time:10964ms step_avg:34.05ms
+step:323/1600 train_time:10995ms step_avg:34.04ms
+step:324/1600 train_time:11032ms step_avg:34.05ms
+step:325/1600 train_time:11062ms step_avg:34.04ms
+step:326/1600 train_time:11099ms step_avg:34.05ms
+step:327/1600 train_time:11130ms step_avg:34.04ms
+step:328/1600 train_time:11167ms step_avg:34.05ms
+step:329/1600 train_time:11198ms step_avg:34.04ms
+step:330/1600 train_time:11235ms step_avg:34.04ms
+step:331/1600 train_time:11265ms step_avg:34.03ms
+step:332/1600 train_time:11303ms step_avg:34.05ms
+step:333/1600 train_time:11334ms step_avg:34.04ms
+step:334/1600 train_time:11371ms step_avg:34.05ms
+step:335/1600 train_time:11403ms step_avg:34.04ms
+step:336/1600 train_time:11440ms step_avg:34.05ms
+step:337/1600 train_time:11471ms step_avg:34.04ms
+step:338/1600 train_time:11508ms step_avg:34.05ms
+step:339/1600 train_time:11538ms step_avg:34.04ms
+step:340/1600 train_time:11575ms step_avg:34.04ms
+step:341/1600 train_time:11606ms step_avg:34.04ms
+step:342/1600 train_time:11643ms step_avg:34.04ms
+step:343/1600 train_time:11674ms step_avg:34.03ms
+step:344/1600 train_time:11711ms step_avg:34.04ms
+step:345/1600 train_time:11742ms step_avg:34.04ms
+step:346/1600 train_time:11780ms step_avg:34.05ms
+step:347/1600 train_time:11810ms step_avg:34.04ms
+step:348/1600 train_time:11847ms step_avg:34.04ms
+step:349/1600 train_time:11879ms step_avg:34.04ms
+step:350/1600 train_time:11916ms step_avg:34.04ms
+step:351/1600 train_time:11947ms step_avg:34.04ms
+step:352/1600 train_time:11984ms step_avg:34.05ms
+step:353/1600 train_time:12015ms step_avg:34.04ms
+step:354/1600 train_time:12052ms step_avg:34.05ms
+step:355/1600 train_time:12084ms step_avg:34.04ms
+step:356/1600 train_time:12121ms step_avg:34.05ms
+step:357/1600 train_time:12152ms step_avg:34.04ms
+step:358/1600 train_time:12189ms step_avg:34.05ms
+step:359/1600 train_time:12220ms step_avg:34.04ms
+step:360/1600 train_time:12256ms step_avg:34.05ms
+step:361/1600 train_time:12288ms step_avg:34.04ms
+step:362/1600 train_time:12325ms step_avg:34.05ms
+step:363/1600 train_time:12356ms step_avg:34.04ms
+step:364/1600 train_time:12392ms step_avg:34.05ms
+step:365/1600 train_time:12424ms step_avg:34.04ms
+step:366/1600 train_time:12461ms step_avg:34.05ms
+step:367/1600 train_time:12492ms step_avg:34.04ms
+step:368/1600 train_time:12528ms step_avg:34.04ms
+step:369/1600 train_time:12559ms step_avg:34.04ms
+step:370/1600 train_time:12596ms step_avg:34.04ms
+step:371/1600 train_time:12627ms step_avg:34.03ms
+step:372/1600 train_time:12664ms step_avg:34.04ms
+step:373/1600 train_time:12695ms step_avg:34.03ms
+step:374/1600 train_time:12732ms step_avg:34.04ms
+step:375/1600 train_time:12763ms step_avg:34.03ms
+step:376/1600 train_time:12800ms step_avg:34.04ms
+step:377/1600 train_time:12831ms step_avg:34.03ms
+step:378/1600 train_time:12867ms step_avg:34.04ms
+step:379/1600 train_time:12898ms step_avg:34.03ms
+step:380/1600 train_time:12935ms step_avg:34.04ms
+step:381/1600 train_time:12966ms step_avg:34.03ms
+step:382/1600 train_time:13003ms step_avg:34.04ms
+step:383/1600 train_time:13034ms step_avg:34.03ms
+step:384/1600 train_time:13071ms step_avg:34.04ms
+step:385/1600 train_time:13102ms step_avg:34.03ms
+step:386/1600 train_time:13139ms step_avg:34.04ms
+step:387/1600 train_time:13170ms step_avg:34.03ms
+step:388/1600 train_time:13207ms step_avg:34.04ms
+step:389/1600 train_time:13238ms step_avg:34.03ms
+step:390/1600 train_time:13274ms step_avg:34.04ms
+step:391/1600 train_time:13305ms step_avg:34.03ms
+step:392/1600 train_time:13342ms step_avg:34.04ms
+step:393/1600 train_time:13373ms step_avg:34.03ms
+step:394/1600 train_time:13410ms step_avg:34.04ms
+step:395/1600 train_time:13442ms step_avg:34.03ms
+step:396/1600 train_time:13479ms step_avg:34.04ms
+step:397/1600 train_time:13510ms step_avg:34.03ms
+step:398/1600 train_time:13547ms step_avg:34.04ms
+step:399/1600 train_time:13578ms step_avg:34.03ms
+step:400/1600 train_time:13614ms step_avg:34.04ms
+step:401/1600 train_time:13645ms step_avg:34.03ms
+step:402/1600 train_time:13682ms step_avg:34.03ms
+step:403/1600 train_time:13713ms step_avg:34.03ms
+step:404/1600 train_time:13749ms step_avg:34.03ms
+step:405/1600 train_time:13781ms step_avg:34.03ms
+step:406/1600 train_time:13818ms step_avg:34.03ms
+step:407/1600 train_time:13848ms step_avg:34.03ms
+step:408/1600 train_time:13885ms step_avg:34.03ms
+step:409/1600 train_time:13916ms step_avg:34.02ms
+step:410/1600 train_time:13953ms step_avg:34.03ms
+step:411/1600 train_time:13984ms step_avg:34.02ms
+step:412/1600 train_time:14021ms step_avg:34.03ms
+step:413/1600 train_time:14051ms step_avg:34.02ms
+step:414/1600 train_time:14088ms step_avg:34.03ms
+step:415/1600 train_time:14119ms step_avg:34.02ms
+step:416/1600 train_time:14156ms step_avg:34.03ms
+step:417/1600 train_time:14187ms step_avg:34.02ms
+step:418/1600 train_time:14224ms step_avg:34.03ms
+step:419/1600 train_time:14255ms step_avg:34.02ms
+step:420/1600 train_time:14292ms step_avg:34.03ms
+step:421/1600 train_time:14323ms step_avg:34.02ms
+step:422/1600 train_time:14360ms step_avg:34.03ms
+step:423/1600 train_time:14390ms step_avg:34.02ms
+step:424/1600 train_time:14428ms step_avg:34.03ms
+step:425/1600 train_time:14459ms step_avg:34.02ms
+step:426/1600 train_time:14495ms step_avg:34.03ms
+step:427/1600 train_time:14526ms step_avg:34.02ms
+step:428/1600 train_time:14563ms step_avg:34.03ms
+step:429/1600 train_time:14594ms step_avg:34.02ms
+step:430/1600 train_time:14632ms step_avg:34.03ms
+step:431/1600 train_time:14662ms step_avg:34.02ms
+step:432/1600 train_time:14699ms step_avg:34.03ms
+step:433/1600 train_time:14730ms step_avg:34.02ms
+step:434/1600 train_time:14767ms step_avg:34.03ms
+step:435/1600 train_time:14798ms step_avg:34.02ms
+step:436/1600 train_time:14834ms step_avg:34.02ms
+step:437/1600 train_time:14865ms step_avg:34.02ms
+step:438/1600 train_time:14902ms step_avg:34.02ms
+step:439/1600 train_time:14933ms step_avg:34.02ms
+step:440/1600 train_time:14970ms step_avg:34.02ms
+step:441/1600 train_time:15001ms step_avg:34.02ms
+step:442/1600 train_time:15038ms step_avg:34.02ms
+step:443/1600 train_time:15069ms step_avg:34.02ms
+step:444/1600 train_time:15106ms step_avg:34.02ms
+step:445/1600 train_time:15138ms step_avg:34.02ms
+step:446/1600 train_time:15174ms step_avg:34.02ms
+step:447/1600 train_time:15205ms step_avg:34.02ms
+step:448/1600 train_time:15242ms step_avg:34.02ms
+step:449/1600 train_time:15273ms step_avg:34.02ms
+step:450/1600 train_time:15310ms step_avg:34.02ms
+step:451/1600 train_time:15341ms step_avg:34.01ms
+step:452/1600 train_time:15377ms step_avg:34.02ms
+step:453/1600 train_time:15408ms step_avg:34.01ms
+step:454/1600 train_time:15446ms step_avg:34.02ms
+step:455/1600 train_time:15476ms step_avg:34.01ms
+step:456/1600 train_time:15513ms step_avg:34.02ms
+step:457/1600 train_time:15544ms step_avg:34.01ms
+step:458/1600 train_time:15581ms step_avg:34.02ms
+step:459/1600 train_time:15611ms step_avg:34.01ms
+step:460/1600 train_time:15648ms step_avg:34.02ms
+step:461/1600 train_time:15679ms step_avg:34.01ms
+step:462/1600 train_time:15716ms step_avg:34.02ms
+step:463/1600 train_time:15747ms step_avg:34.01ms
+step:464/1600 train_time:15784ms step_avg:34.02ms
+step:465/1600 train_time:15816ms step_avg:34.01ms
+step:466/1600 train_time:15852ms step_avg:34.02ms
+step:467/1600 train_time:15883ms step_avg:34.01ms
+step:468/1600 train_time:15920ms step_avg:34.02ms
+step:469/1600 train_time:15951ms step_avg:34.01ms
+step:470/1600 train_time:15988ms step_avg:34.02ms
+step:471/1600 train_time:16019ms step_avg:34.01ms
+step:472/1600 train_time:16055ms step_avg:34.02ms
+step:473/1600 train_time:16087ms step_avg:34.01ms
+step:474/1600 train_time:16124ms step_avg:34.02ms
+step:475/1600 train_time:16155ms step_avg:34.01ms
+step:476/1600 train_time:16192ms step_avg:34.02ms
+step:477/1600 train_time:16223ms step_avg:34.01ms
+step:478/1600 train_time:16260ms step_avg:34.02ms
+step:479/1600 train_time:16291ms step_avg:34.01ms
+step:480/1600 train_time:16328ms step_avg:34.02ms
+step:481/1600 train_time:16359ms step_avg:34.01ms
+step:482/1600 train_time:16395ms step_avg:34.02ms
+step:483/1600 train_time:16426ms step_avg:34.01ms
+step:484/1600 train_time:16463ms step_avg:34.01ms
+step:485/1600 train_time:16494ms step_avg:34.01ms
+step:486/1600 train_time:16531ms step_avg:34.01ms
+step:487/1600 train_time:16561ms step_avg:34.01ms
+step:488/1600 train_time:16598ms step_avg:34.01ms
+step:489/1600 train_time:16629ms step_avg:34.01ms
+step:490/1600 train_time:16666ms step_avg:34.01ms
+step:491/1600 train_time:16697ms step_avg:34.01ms
+step:492/1600 train_time:16734ms step_avg:34.01ms
+step:493/1600 train_time:16764ms step_avg:34.00ms
+step:494/1600 train_time:16802ms step_avg:34.01ms
+step:495/1600 train_time:16833ms step_avg:34.01ms
+step:496/1600 train_time:16870ms step_avg:34.01ms
+step:497/1600 train_time:16902ms step_avg:34.01ms
+step:498/1600 train_time:16938ms step_avg:34.01ms
+step:499/1600 train_time:16969ms step_avg:34.01ms
+step:500/1600 train_time:17006ms step_avg:34.01ms
+step:500/1600 val_loss:4.2323 train_time:17054ms step_avg:34.11ms
+step:501/1600 train_time:17070ms step_avg:34.07ms
+step:502/1600 train_time:17085ms step_avg:34.03ms
+step:503/1600 train_time:17107ms step_avg:34.01ms
+step:504/1600 train_time:17145ms step_avg:34.02ms
+step:505/1600 train_time:17176ms step_avg:34.01ms
+step:506/1600 train_time:17214ms step_avg:34.02ms
+step:507/1600 train_time:17245ms step_avg:34.01ms
+step:508/1600 train_time:17282ms step_avg:34.02ms
+step:509/1600 train_time:17312ms step_avg:34.01ms
+step:510/1600 train_time:17349ms step_avg:34.02ms
+step:511/1600 train_time:17379ms step_avg:34.01ms
+step:512/1600 train_time:17416ms step_avg:34.02ms
+step:513/1600 train_time:17447ms step_avg:34.01ms
+step:514/1600 train_time:17483ms step_avg:34.01ms
+step:515/1600 train_time:17514ms step_avg:34.01ms
+step:516/1600 train_time:17551ms step_avg:34.01ms
+step:517/1600 train_time:17581ms step_avg:34.01ms
+step:518/1600 train_time:17618ms step_avg:34.01ms
+step:519/1600 train_time:17649ms step_avg:34.01ms
+step:520/1600 train_time:17685ms step_avg:34.01ms
+step:521/1600 train_time:17755ms step_avg:34.08ms
+step:522/1600 train_time:17812ms step_avg:34.12ms
+step:523/1600 train_time:17875ms step_avg:34.18ms
+step:524/1600 train_time:17933ms step_avg:34.22ms
+step:525/1600 train_time:17996ms step_avg:34.28ms
+step:526/1600 train_time:18057ms step_avg:34.33ms
+step:527/1600 train_time:18121ms step_avg:34.38ms
+step:528/1600 train_time:18181ms step_avg:34.43ms
+step:529/1600 train_time:18245ms step_avg:34.49ms
+step:530/1600 train_time:18304ms step_avg:34.54ms
+step:531/1600 train_time:18367ms step_avg:34.59ms
+step:532/1600 train_time:18426ms step_avg:34.63ms
+step:533/1600 train_time:18488ms step_avg:34.69ms
+step:534/1600 train_time:18546ms step_avg:34.73ms
+step:535/1600 train_time:18609ms step_avg:34.78ms
+step:536/1600 train_time:18668ms step_avg:34.83ms
+step:537/1600 train_time:18730ms step_avg:34.88ms
+step:538/1600 train_time:18790ms step_avg:34.93ms
+step:539/1600 train_time:18852ms step_avg:34.98ms
+step:540/1600 train_time:18910ms step_avg:35.02ms
+step:541/1600 train_time:18974ms step_avg:35.07ms
+step:542/1600 train_time:19034ms step_avg:35.12ms
+step:543/1600 train_time:19097ms step_avg:35.17ms
+step:544/1600 train_time:19157ms step_avg:35.21ms
+step:545/1600 train_time:19220ms step_avg:35.27ms
+step:546/1600 train_time:19280ms step_avg:35.31ms
+step:547/1600 train_time:19343ms step_avg:35.36ms
+step:548/1600 train_time:19402ms step_avg:35.41ms
+step:549/1600 train_time:19465ms step_avg:35.46ms
+step:550/1600 train_time:19524ms step_avg:35.50ms
+step:551/1600 train_time:19587ms step_avg:35.55ms
+step:552/1600 train_time:19646ms step_avg:35.59ms
+step:553/1600 train_time:19708ms step_avg:35.64ms
+step:554/1600 train_time:19768ms step_avg:35.68ms
+step:555/1600 train_time:19830ms step_avg:35.73ms
+step:556/1600 train_time:19890ms step_avg:35.77ms
+step:557/1600 train_time:19953ms step_avg:35.82ms
+step:558/1600 train_time:20012ms step_avg:35.86ms
+step:559/1600 train_time:20076ms step_avg:35.91ms
+step:560/1600 train_time:20136ms step_avg:35.96ms
+step:561/1600 train_time:20199ms step_avg:36.01ms
+step:562/1600 train_time:20258ms step_avg:36.05ms
+step:563/1600 train_time:20322ms step_avg:36.10ms
+step:564/1600 train_time:20381ms step_avg:36.14ms
+step:565/1600 train_time:20444ms step_avg:36.18ms
+step:566/1600 train_time:20503ms step_avg:36.22ms
+step:567/1600 train_time:20566ms step_avg:36.27ms
+step:568/1600 train_time:20625ms step_avg:36.31ms
+step:569/1600 train_time:20687ms step_avg:36.36ms
+step:570/1600 train_time:20746ms step_avg:36.40ms
+step:571/1600 train_time:20809ms step_avg:36.44ms
+step:572/1600 train_time:20868ms step_avg:36.48ms
+step:573/1600 train_time:20933ms step_avg:36.53ms
+step:574/1600 train_time:20992ms step_avg:36.57ms
+step:575/1600 train_time:21055ms step_avg:36.62ms
+step:576/1600 train_time:21113ms step_avg:36.65ms
+step:577/1600 train_time:21175ms step_avg:36.70ms
+step:578/1600 train_time:21234ms step_avg:36.74ms
+step:579/1600 train_time:21297ms step_avg:36.78ms
+step:580/1600 train_time:21357ms step_avg:36.82ms
+step:581/1600 train_time:21420ms step_avg:36.87ms
+step:582/1600 train_time:21480ms step_avg:36.91ms
+step:583/1600 train_time:21544ms step_avg:36.95ms
+step:584/1600 train_time:21602ms step_avg:36.99ms
+step:585/1600 train_time:21665ms step_avg:37.03ms
+step:586/1600 train_time:21725ms step_avg:37.07ms
+step:587/1600 train_time:21787ms step_avg:37.12ms
+step:588/1600 train_time:21846ms step_avg:37.15ms
+step:589/1600 train_time:21909ms step_avg:37.20ms
+step:590/1600 train_time:21968ms step_avg:37.23ms
+step:591/1600 train_time:22031ms step_avg:37.28ms
+step:592/1600 train_time:22090ms step_avg:37.31ms
+step:593/1600 train_time:22153ms step_avg:37.36ms
+step:594/1600 train_time:22212ms step_avg:37.39ms
+step:595/1600 train_time:22275ms step_avg:37.44ms
+step:596/1600 train_time:22334ms step_avg:37.47ms
+step:597/1600 train_time:22398ms step_avg:37.52ms
+step:598/1600 train_time:22457ms step_avg:37.55ms
+step:599/1600 train_time:22521ms step_avg:37.60ms
+step:600/1600 train_time:22580ms step_avg:37.63ms
+step:601/1600 train_time:22643ms step_avg:37.68ms
+step:602/1600 train_time:22703ms step_avg:37.71ms
+step:603/1600 train_time:22766ms step_avg:37.75ms
+step:604/1600 train_time:22825ms step_avg:37.79ms
+step:605/1600 train_time:22888ms step_avg:37.83ms
+step:606/1600 train_time:22947ms step_avg:37.87ms
+step:607/1600 train_time:23009ms step_avg:37.91ms
+step:608/1600 train_time:23069ms step_avg:37.94ms
+step:609/1600 train_time:23132ms step_avg:37.98ms
+step:610/1600 train_time:23191ms step_avg:38.02ms
+step:611/1600 train_time:23254ms step_avg:38.06ms
+step:612/1600 train_time:23313ms step_avg:38.09ms
+step:613/1600 train_time:23377ms step_avg:38.13ms
+step:614/1600 train_time:23435ms step_avg:38.17ms
+step:615/1600 train_time:23498ms step_avg:38.21ms
+step:616/1600 train_time:23558ms step_avg:38.24ms
+step:617/1600 train_time:23622ms step_avg:38.28ms
+step:618/1600 train_time:23681ms step_avg:38.32ms
+step:619/1600 train_time:23744ms step_avg:38.36ms
+step:620/1600 train_time:23803ms step_avg:38.39ms
+step:621/1600 train_time:23866ms step_avg:38.43ms
+step:622/1600 train_time:23926ms step_avg:38.47ms
+step:623/1600 train_time:23989ms step_avg:38.51ms
+step:624/1600 train_time:24048ms step_avg:38.54ms
+step:625/1600 train_time:24112ms step_avg:38.58ms
+step:626/1600 train_time:24170ms step_avg:38.61ms
+step:627/1600 train_time:24232ms step_avg:38.65ms
+step:628/1600 train_time:24291ms step_avg:38.68ms
+step:629/1600 train_time:24355ms step_avg:38.72ms
+step:630/1600 train_time:24413ms step_avg:38.75ms
+step:631/1600 train_time:24476ms step_avg:38.79ms
+step:632/1600 train_time:24535ms step_avg:38.82ms
+step:633/1600 train_time:24599ms step_avg:38.86ms
+step:634/1600 train_time:24659ms step_avg:38.89ms
+step:635/1600 train_time:24722ms step_avg:38.93ms
+step:636/1600 train_time:24781ms step_avg:38.96ms
+step:637/1600 train_time:24845ms step_avg:39.00ms
+step:638/1600 train_time:24904ms step_avg:39.03ms
+step:639/1600 train_time:24967ms step_avg:39.07ms
+step:640/1600 train_time:25027ms step_avg:39.10ms
+step:641/1600 train_time:25089ms step_avg:39.14ms
+step:642/1600 train_time:25148ms step_avg:39.17ms
+step:643/1600 train_time:25211ms step_avg:39.21ms
+step:644/1600 train_time:25271ms step_avg:39.24ms
+step:645/1600 train_time:25333ms step_avg:39.28ms
+step:646/1600 train_time:25392ms step_avg:39.31ms
+step:647/1600 train_time:25455ms step_avg:39.34ms
+step:648/1600 train_time:25514ms step_avg:39.37ms
+step:649/1600 train_time:25578ms step_avg:39.41ms
+step:650/1600 train_time:25638ms step_avg:39.44ms
+step:651/1600 train_time:25701ms step_avg:39.48ms
+step:652/1600 train_time:25760ms step_avg:39.51ms
+step:653/1600 train_time:25823ms step_avg:39.55ms
+step:654/1600 train_time:25882ms step_avg:39.57ms
+step:655/1600 train_time:25946ms step_avg:39.61ms
+step:656/1600 train_time:26004ms step_avg:39.64ms
+step:657/1600 train_time:26067ms step_avg:39.68ms
+step:658/1600 train_time:26127ms step_avg:39.71ms
+step:659/1600 train_time:26189ms step_avg:39.74ms
+step:660/1600 train_time:26248ms step_avg:39.77ms
+step:661/1600 train_time:26311ms step_avg:39.80ms
+step:662/1600 train_time:26371ms step_avg:39.83ms
+step:663/1600 train_time:26433ms step_avg:39.87ms
+step:664/1600 train_time:26492ms step_avg:39.90ms
+step:665/1600 train_time:26560ms step_avg:39.94ms
+step:666/1600 train_time:26619ms step_avg:39.97ms
+step:667/1600 train_time:26682ms step_avg:40.00ms
+step:668/1600 train_time:26741ms step_avg:40.03ms
+step:669/1600 train_time:26804ms step_avg:40.07ms
+step:670/1600 train_time:26863ms step_avg:40.09ms
+step:671/1600 train_time:26927ms step_avg:40.13ms
+step:672/1600 train_time:26985ms step_avg:40.16ms
+step:673/1600 train_time:27049ms step_avg:40.19ms
+step:674/1600 train_time:27108ms step_avg:40.22ms
+step:675/1600 train_time:27170ms step_avg:40.25ms
+step:676/1600 train_time:27229ms step_avg:40.28ms
+step:677/1600 train_time:27293ms step_avg:40.31ms
+step:678/1600 train_time:27351ms step_avg:40.34ms
+step:679/1600 train_time:27415ms step_avg:40.38ms
+step:680/1600 train_time:27475ms step_avg:40.40ms
+step:681/1600 train_time:27537ms step_avg:40.44ms
+step:682/1600 train_time:27597ms step_avg:40.47ms
+step:683/1600 train_time:27660ms step_avg:40.50ms
+step:684/1600 train_time:27719ms step_avg:40.52ms
+step:685/1600 train_time:27781ms step_avg:40.56ms
+step:686/1600 train_time:27841ms step_avg:40.58ms
+step:687/1600 train_time:27904ms step_avg:40.62ms
+step:688/1600 train_time:27964ms step_avg:40.65ms
+step:689/1600 train_time:28028ms step_avg:40.68ms
+step:690/1600 train_time:28086ms step_avg:40.70ms
+step:691/1600 train_time:28150ms step_avg:40.74ms
+step:692/1600 train_time:28208ms step_avg:40.76ms
+step:693/1600 train_time:28271ms step_avg:40.79ms
+step:694/1600 train_time:28330ms step_avg:40.82ms
+step:695/1600 train_time:28392ms step_avg:40.85ms
+step:696/1600 train_time:28452ms step_avg:40.88ms
+step:697/1600 train_time:28515ms step_avg:40.91ms
+step:698/1600 train_time:28575ms step_avg:40.94ms
+step:699/1600 train_time:28637ms step_avg:40.97ms
+step:700/1600 train_time:28696ms step_avg:40.99ms
+step:701/1600 train_time:28759ms step_avg:41.03ms
+step:702/1600 train_time:28819ms step_avg:41.05ms
+step:703/1600 train_time:28882ms step_avg:41.08ms
+step:704/1600 train_time:28941ms step_avg:41.11ms
+step:705/1600 train_time:29004ms step_avg:41.14ms
+step:706/1600 train_time:29063ms step_avg:41.17ms
+step:707/1600 train_time:29126ms step_avg:41.20ms
+step:708/1600 train_time:29186ms step_avg:41.22ms
+step:709/1600 train_time:29249ms step_avg:41.25ms
+step:710/1600 train_time:29308ms step_avg:41.28ms
+step:711/1600 train_time:29371ms step_avg:41.31ms
+step:712/1600 train_time:29430ms step_avg:41.33ms
+step:713/1600 train_time:29493ms step_avg:41.36ms
+step:714/1600 train_time:29552ms step_avg:41.39ms
+step:715/1600 train_time:29615ms step_avg:41.42ms
+step:716/1600 train_time:29675ms step_avg:41.45ms
+step:717/1600 train_time:29738ms step_avg:41.48ms
+step:718/1600 train_time:29798ms step_avg:41.50ms
+step:719/1600 train_time:29860ms step_avg:41.53ms
+step:720/1600 train_time:29919ms step_avg:41.55ms
+step:721/1600 train_time:29983ms step_avg:41.58ms
+step:722/1600 train_time:30042ms step_avg:41.61ms
+step:723/1600 train_time:30105ms step_avg:41.64ms
+step:724/1600 train_time:30165ms step_avg:41.66ms
+step:725/1600 train_time:30228ms step_avg:41.69ms
+step:726/1600 train_time:30287ms step_avg:41.72ms
+step:727/1600 train_time:30350ms step_avg:41.75ms
+step:728/1600 train_time:30410ms step_avg:41.77ms
+step:729/1600 train_time:30472ms step_avg:41.80ms
+step:730/1600 train_time:30531ms step_avg:41.82ms
+step:731/1600 train_time:30594ms step_avg:41.85ms
+step:732/1600 train_time:30653ms step_avg:41.88ms
+step:733/1600 train_time:30716ms step_avg:41.90ms
+step:734/1600 train_time:30775ms step_avg:41.93ms
+step:735/1600 train_time:30837ms step_avg:41.96ms
+step:736/1600 train_time:30896ms step_avg:41.98ms
+step:737/1600 train_time:30960ms step_avg:42.01ms
+step:738/1600 train_time:31019ms step_avg:42.03ms
+step:739/1600 train_time:31083ms step_avg:42.06ms
+step:740/1600 train_time:31142ms step_avg:42.08ms
+step:741/1600 train_time:31205ms step_avg:42.11ms
+step:742/1600 train_time:31264ms step_avg:42.13ms
+step:743/1600 train_time:31328ms step_avg:42.16ms
+step:744/1600 train_time:31387ms step_avg:42.19ms
+step:745/1600 train_time:31450ms step_avg:42.21ms
+step:746/1600 train_time:31509ms step_avg:42.24ms
+step:747/1600 train_time:31572ms step_avg:42.26ms
+step:748/1600 train_time:31631ms step_avg:42.29ms
+step:749/1600 train_time:31694ms step_avg:42.31ms
+step:750/1600 train_time:31753ms step_avg:42.34ms
+step:750/1600 val_loss:3.8836 train_time:31797ms step_avg:42.40ms
+step:751/1600 train_time:31817ms step_avg:42.37ms
+step:752/1600 train_time:31876ms step_avg:42.39ms
+step:753/1600 train_time:31941ms step_avg:42.42ms
+step:754/1600 train_time:32000ms step_avg:42.44ms
+step:755/1600 train_time:32063ms step_avg:42.47ms
+step:756/1600 train_time:32122ms step_avg:42.49ms
+step:757/1600 train_time:32184ms step_avg:42.51ms
+step:758/1600 train_time:32243ms step_avg:42.54ms
+step:759/1600 train_time:32306ms step_avg:42.56ms
+step:760/1600 train_time:32364ms step_avg:42.58ms
+step:761/1600 train_time:32426ms step_avg:42.61ms
+step:762/1600 train_time:32484ms step_avg:42.63ms
+step:763/1600 train_time:32546ms step_avg:42.66ms
+step:764/1600 train_time:32604ms step_avg:42.68ms
+step:765/1600 train_time:32667ms step_avg:42.70ms
+step:766/1600 train_time:32726ms step_avg:42.72ms
+step:767/1600 train_time:32790ms step_avg:42.75ms
+step:768/1600 train_time:32851ms step_avg:42.77ms
+step:769/1600 train_time:32914ms step_avg:42.80ms
+step:770/1600 train_time:32973ms step_avg:42.82ms
+step:771/1600 train_time:33036ms step_avg:42.85ms
+step:772/1600 train_time:33096ms step_avg:42.87ms
+step:773/1600 train_time:33158ms step_avg:42.90ms
+step:774/1600 train_time:33218ms step_avg:42.92ms
+step:775/1600 train_time:33281ms step_avg:42.94ms
+step:776/1600 train_time:33340ms step_avg:42.96ms
+step:777/1600 train_time:33403ms step_avg:42.99ms
+step:778/1600 train_time:33462ms step_avg:43.01ms
+step:779/1600 train_time:33524ms step_avg:43.04ms
+step:780/1600 train_time:33583ms step_avg:43.06ms
+step:781/1600 train_time:33646ms step_avg:43.08ms
+step:782/1600 train_time:33705ms step_avg:43.10ms
+step:783/1600 train_time:33769ms step_avg:43.13ms
+step:784/1600 train_time:33829ms step_avg:43.15ms
+step:785/1600 train_time:33891ms step_avg:43.17ms
+step:786/1600 train_time:33951ms step_avg:43.19ms
+step:787/1600 train_time:34013ms step_avg:43.22ms
+step:788/1600 train_time:34073ms step_avg:43.24ms
+step:789/1600 train_time:34136ms step_avg:43.26ms
+step:790/1600 train_time:34195ms step_avg:43.28ms
+step:791/1600 train_time:34258ms step_avg:43.31ms
+step:792/1600 train_time:34316ms step_avg:43.33ms
+step:793/1600 train_time:34379ms step_avg:43.35ms
+step:794/1600 train_time:34439ms step_avg:43.37ms
+step:795/1600 train_time:34502ms step_avg:43.40ms
+step:796/1600 train_time:34561ms step_avg:43.42ms
+step:797/1600 train_time:34624ms step_avg:43.44ms
+step:798/1600 train_time:34683ms step_avg:43.46ms
+step:799/1600 train_time:34745ms step_avg:43.49ms
+step:800/1600 train_time:34805ms step_avg:43.51ms
+step:801/1600 train_time:34868ms step_avg:43.53ms
+step:802/1600 train_time:34928ms step_avg:43.55ms
+step:803/1600 train_time:34990ms step_avg:43.57ms
+step:804/1600 train_time:35049ms step_avg:43.59ms
+step:805/1600 train_time:35112ms step_avg:43.62ms
+step:806/1600 train_time:35171ms step_avg:43.64ms
+step:807/1600 train_time:35233ms step_avg:43.66ms
+step:808/1600 train_time:35293ms step_avg:43.68ms
+step:809/1600 train_time:35356ms step_avg:43.70ms
+step:810/1600 train_time:35415ms step_avg:43.72ms
+step:811/1600 train_time:35478ms step_avg:43.75ms
+step:812/1600 train_time:35537ms step_avg:43.76ms
+step:813/1600 train_time:35601ms step_avg:43.79ms
+step:814/1600 train_time:35660ms step_avg:43.81ms
+step:815/1600 train_time:35723ms step_avg:43.83ms
+step:816/1600 train_time:35783ms step_avg:43.85ms
+step:817/1600 train_time:35846ms step_avg:43.88ms
+step:818/1600 train_time:35905ms step_avg:43.89ms
+step:819/1600 train_time:35968ms step_avg:43.92ms
+step:820/1600 train_time:36026ms step_avg:43.93ms
+step:821/1600 train_time:36089ms step_avg:43.96ms
+step:822/1600 train_time:36149ms step_avg:43.98ms
+step:823/1600 train_time:36211ms step_avg:44.00ms
+step:824/1600 train_time:36271ms step_avg:44.02ms
+step:825/1600 train_time:36333ms step_avg:44.04ms
+step:826/1600 train_time:36393ms step_avg:44.06ms
+step:827/1600 train_time:36456ms step_avg:44.08ms
+step:828/1600 train_time:36515ms step_avg:44.10ms
+step:829/1600 train_time:36578ms step_avg:44.12ms
+step:830/1600 train_time:36637ms step_avg:44.14ms
+step:831/1600 train_time:36701ms step_avg:44.16ms
+step:832/1600 train_time:36760ms step_avg:44.18ms
+step:833/1600 train_time:36823ms step_avg:44.21ms
+step:834/1600 train_time:36883ms step_avg:44.22ms
+step:835/1600 train_time:36946ms step_avg:44.25ms
+step:836/1600 train_time:37005ms step_avg:44.26ms
+step:837/1600 train_time:37067ms step_avg:44.29ms
+step:838/1600 train_time:37126ms step_avg:44.30ms
+step:839/1600 train_time:37188ms step_avg:44.32ms
+step:840/1600 train_time:37247ms step_avg:44.34ms
+step:841/1600 train_time:37309ms step_avg:44.36ms
+step:842/1600 train_time:37370ms step_avg:44.38ms
+step:843/1600 train_time:37432ms step_avg:44.40ms
+step:844/1600 train_time:37491ms step_avg:44.42ms
+step:845/1600 train_time:37555ms step_avg:44.44ms
+step:846/1600 train_time:37615ms step_avg:44.46ms
+step:847/1600 train_time:37678ms step_avg:44.48ms
+step:848/1600 train_time:37737ms step_avg:44.50ms
+step:849/1600 train_time:37803ms step_avg:44.53ms
+step:850/1600 train_time:37861ms step_avg:44.54ms
+step:851/1600 train_time:37923ms step_avg:44.56ms
+step:852/1600 train_time:37982ms step_avg:44.58ms
+step:853/1600 train_time:38045ms step_avg:44.60ms
+step:854/1600 train_time:38104ms step_avg:44.62ms
+step:855/1600 train_time:38167ms step_avg:44.64ms
+step:856/1600 train_time:38225ms step_avg:44.66ms
+step:857/1600 train_time:38288ms step_avg:44.68ms
+step:858/1600 train_time:38348ms step_avg:44.69ms
+step:859/1600 train_time:38410ms step_avg:44.71ms
+step:860/1600 train_time:38470ms step_avg:44.73ms
+step:861/1600 train_time:38532ms step_avg:44.75ms
+step:862/1600 train_time:38592ms step_avg:44.77ms
+step:863/1600 train_time:38655ms step_avg:44.79ms
+step:864/1600 train_time:38715ms step_avg:44.81ms
+step:865/1600 train_time:38779ms step_avg:44.83ms
+step:866/1600 train_time:38838ms step_avg:44.85ms
+step:867/1600 train_time:38901ms step_avg:44.87ms
+step:868/1600 train_time:38960ms step_avg:44.88ms
+step:869/1600 train_time:39023ms step_avg:44.91ms
+step:870/1600 train_time:39081ms step_avg:44.92ms
+step:871/1600 train_time:39144ms step_avg:44.94ms
+step:872/1600 train_time:39202ms step_avg:44.96ms
+step:873/1600 train_time:39266ms step_avg:44.98ms
+step:874/1600 train_time:39325ms step_avg:44.99ms
+step:875/1600 train_time:39388ms step_avg:45.01ms
+step:876/1600 train_time:39448ms step_avg:45.03ms
+step:877/1600 train_time:39511ms step_avg:45.05ms
+step:878/1600 train_time:39570ms step_avg:45.07ms
+step:879/1600 train_time:39632ms step_avg:45.09ms
+step:880/1600 train_time:39693ms step_avg:45.11ms
+step:881/1600 train_time:39756ms step_avg:45.13ms
+step:882/1600 train_time:39815ms step_avg:45.14ms
+step:883/1600 train_time:39878ms step_avg:45.16ms
+step:884/1600 train_time:39936ms step_avg:45.18ms
+step:885/1600 train_time:39999ms step_avg:45.20ms
+step:886/1600 train_time:40059ms step_avg:45.21ms
+step:887/1600 train_time:40122ms step_avg:45.23ms
+step:888/1600 train_time:40181ms step_avg:45.25ms
+step:889/1600 train_time:40243ms step_avg:45.27ms
+step:890/1600 train_time:40304ms step_avg:45.29ms
+step:891/1600 train_time:40368ms step_avg:45.31ms
+step:892/1600 train_time:40426ms step_avg:45.32ms
+step:893/1600 train_time:40489ms step_avg:45.34ms
+step:894/1600 train_time:40548ms step_avg:45.36ms
+step:895/1600 train_time:40610ms step_avg:45.37ms
+step:896/1600 train_time:40669ms step_avg:45.39ms
+step:897/1600 train_time:40732ms step_avg:45.41ms
+step:898/1600 train_time:40791ms step_avg:45.42ms
+step:899/1600 train_time:40855ms step_avg:45.44ms
+step:900/1600 train_time:40914ms step_avg:45.46ms
+step:901/1600 train_time:40977ms step_avg:45.48ms
+step:902/1600 train_time:41036ms step_avg:45.49ms
+step:903/1600 train_time:41099ms step_avg:45.51ms
+step:904/1600 train_time:41157ms step_avg:45.53ms
+step:905/1600 train_time:41221ms step_avg:45.55ms
+step:906/1600 train_time:41280ms step_avg:45.56ms
+step:907/1600 train_time:41343ms step_avg:45.58ms
+step:908/1600 train_time:41403ms step_avg:45.60ms
+step:909/1600 train_time:41466ms step_avg:45.62ms
+step:910/1600 train_time:41525ms step_avg:45.63ms
+step:911/1600 train_time:41588ms step_avg:45.65ms
+step:912/1600 train_time:41647ms step_avg:45.67ms
+step:913/1600 train_time:41710ms step_avg:45.69ms
+step:914/1600 train_time:41770ms step_avg:45.70ms
+step:915/1600 train_time:41832ms step_avg:45.72ms
+step:916/1600 train_time:41891ms step_avg:45.73ms
+step:917/1600 train_time:41954ms step_avg:45.75ms
+step:918/1600 train_time:42014ms step_avg:45.77ms
+step:919/1600 train_time:42076ms step_avg:45.78ms
+step:920/1600 train_time:42135ms step_avg:45.80ms
+step:921/1600 train_time:42198ms step_avg:45.82ms
+step:922/1600 train_time:42257ms step_avg:45.83ms
+step:923/1600 train_time:42321ms step_avg:45.85ms
+step:924/1600 train_time:42381ms step_avg:45.87ms
+step:925/1600 train_time:42443ms step_avg:45.88ms
+step:926/1600 train_time:42502ms step_avg:45.90ms
+step:927/1600 train_time:42565ms step_avg:45.92ms
+step:928/1600 train_time:42624ms step_avg:45.93ms
+step:929/1600 train_time:42688ms step_avg:45.95ms
+step:930/1600 train_time:42746ms step_avg:45.96ms
+step:931/1600 train_time:42809ms step_avg:45.98ms
+step:932/1600 train_time:42868ms step_avg:46.00ms
+step:933/1600 train_time:42930ms step_avg:46.01ms
+step:934/1600 train_time:42989ms step_avg:46.03ms
+step:935/1600 train_time:43053ms step_avg:46.05ms
+step:936/1600 train_time:43112ms step_avg:46.06ms
+step:937/1600 train_time:43176ms step_avg:46.08ms
+step:938/1600 train_time:43235ms step_avg:46.09ms
+step:939/1600 train_time:43297ms step_avg:46.11ms
+step:940/1600 train_time:43356ms step_avg:46.12ms
+step:941/1600 train_time:43420ms step_avg:46.14ms
+step:942/1600 train_time:43480ms step_avg:46.16ms
+step:943/1600 train_time:43542ms step_avg:46.17ms
+step:944/1600 train_time:43603ms step_avg:46.19ms
+step:945/1600 train_time:43665ms step_avg:46.21ms
+step:946/1600 train_time:43724ms step_avg:46.22ms
+step:947/1600 train_time:43787ms step_avg:46.24ms
+step:948/1600 train_time:43846ms step_avg:46.25ms
+step:949/1600 train_time:43910ms step_avg:46.27ms
+step:950/1600 train_time:43968ms step_avg:46.28ms
+step:951/1600 train_time:44031ms step_avg:46.30ms
+step:952/1600 train_time:44089ms step_avg:46.31ms
+step:953/1600 train_time:44152ms step_avg:46.33ms
+step:954/1600 train_time:44212ms step_avg:46.34ms
+step:955/1600 train_time:44275ms step_avg:46.36ms
+step:956/1600 train_time:44334ms step_avg:46.37ms
+step:957/1600 train_time:44397ms step_avg:46.39ms
+step:958/1600 train_time:44456ms step_avg:46.40ms
+step:959/1600 train_time:44518ms step_avg:46.42ms
+step:960/1600 train_time:44577ms step_avg:46.43ms
+step:961/1600 train_time:44641ms step_avg:46.45ms
+step:962/1600 train_time:44700ms step_avg:46.47ms
+step:963/1600 train_time:44763ms step_avg:46.48ms
+step:964/1600 train_time:44823ms step_avg:46.50ms
+step:965/1600 train_time:44886ms step_avg:46.51ms
+step:966/1600 train_time:44945ms step_avg:46.53ms
+step:967/1600 train_time:45008ms step_avg:46.54ms
+step:968/1600 train_time:45068ms step_avg:46.56ms
+step:969/1600 train_time:45130ms step_avg:46.57ms
+step:970/1600 train_time:45189ms step_avg:46.59ms
+step:971/1600 train_time:45252ms step_avg:46.60ms
+step:972/1600 train_time:45312ms step_avg:46.62ms
+step:973/1600 train_time:45375ms step_avg:46.63ms
+step:974/1600 train_time:45433ms step_avg:46.65ms
+step:975/1600 train_time:45496ms step_avg:46.66ms
+step:976/1600 train_time:45556ms step_avg:46.68ms
+step:977/1600 train_time:45619ms step_avg:46.69ms
+step:978/1600 train_time:45678ms step_avg:46.71ms
+step:979/1600 train_time:45741ms step_avg:46.72ms
+step:980/1600 train_time:45800ms step_avg:46.73ms
+step:981/1600 train_time:45863ms step_avg:46.75ms
+step:982/1600 train_time:45922ms step_avg:46.76ms
+step:983/1600 train_time:45985ms step_avg:46.78ms
+step:984/1600 train_time:46044ms step_avg:46.79ms
+step:985/1600 train_time:46106ms step_avg:46.81ms
+step:986/1600 train_time:46166ms step_avg:46.82ms
+step:987/1600 train_time:46229ms step_avg:46.84ms
+step:988/1600 train_time:46288ms step_avg:46.85ms
+step:989/1600 train_time:46350ms step_avg:46.87ms
+step:990/1600 train_time:46410ms step_avg:46.88ms
+step:991/1600 train_time:46473ms step_avg:46.90ms
+step:992/1600 train_time:46532ms step_avg:46.91ms
+step:993/1600 train_time:46596ms step_avg:46.92ms
+step:994/1600 train_time:46655ms step_avg:46.94ms
+step:995/1600 train_time:46717ms step_avg:46.95ms
+step:996/1600 train_time:46776ms step_avg:46.96ms
+step:997/1600 train_time:46839ms step_avg:46.98ms
+step:998/1600 train_time:46898ms step_avg:46.99ms
+step:999/1600 train_time:46961ms step_avg:47.01ms
+step:1000/1600 train_time:47021ms step_avg:47.02ms
+step:1000/1600 val_loss:3.5936 train_time:47066ms step_avg:47.07ms
+step:1001/1600 train_time:47086ms step_avg:47.04ms
+step:1002/1600 train_time:47145ms step_avg:47.05ms
+step:1003/1600 train_time:47209ms step_avg:47.07ms
+step:1004/1600 train_time:47269ms step_avg:47.08ms
+step:1005/1600 train_time:47331ms step_avg:47.10ms
+step:1006/1600 train_time:47390ms step_avg:47.11ms
+step:1007/1600 train_time:47451ms step_avg:47.12ms
+step:1008/1600 train_time:47510ms step_avg:47.13ms
+step:1009/1600 train_time:47572ms step_avg:47.15ms
+step:1010/1600 train_time:47631ms step_avg:47.16ms
+step:1011/1600 train_time:47693ms step_avg:47.17ms
+step:1012/1600 train_time:47752ms step_avg:47.19ms
+step:1013/1600 train_time:47813ms step_avg:47.20ms
+step:1014/1600 train_time:47873ms step_avg:47.21ms
+step:1015/1600 train_time:47935ms step_avg:47.23ms
+step:1016/1600 train_time:47994ms step_avg:47.24ms
+step:1017/1600 train_time:48059ms step_avg:47.26ms
+step:1018/1600 train_time:48121ms step_avg:47.27ms
+step:1019/1600 train_time:48184ms step_avg:47.29ms
+step:1020/1600 train_time:48243ms step_avg:47.30ms
+step:1021/1600 train_time:48305ms step_avg:47.31ms
+step:1022/1600 train_time:48365ms step_avg:47.32ms
+step:1023/1600 train_time:48426ms step_avg:47.34ms
+step:1024/1600 train_time:48485ms step_avg:47.35ms
+step:1025/1600 train_time:48547ms step_avg:47.36ms
+step:1026/1600 train_time:48606ms step_avg:47.37ms
+step:1027/1600 train_time:48669ms step_avg:47.39ms
+step:1028/1600 train_time:48728ms step_avg:47.40ms
+step:1029/1600 train_time:48790ms step_avg:47.41ms
+step:1030/1600 train_time:48850ms step_avg:47.43ms
+step:1031/1600 train_time:48912ms step_avg:47.44ms
+step:1032/1600 train_time:48973ms step_avg:47.45ms
+step:1033/1600 train_time:49036ms step_avg:47.47ms
+step:1034/1600 train_time:49096ms step_avg:47.48ms
+step:1035/1600 train_time:49160ms step_avg:47.50ms
+step:1036/1600 train_time:49219ms step_avg:47.51ms
+step:1037/1600 train_time:49282ms step_avg:47.52ms
+step:1038/1600 train_time:49341ms step_avg:47.53ms
+step:1039/1600 train_time:49403ms step_avg:47.55ms
+step:1040/1600 train_time:49462ms step_avg:47.56ms
+step:1041/1600 train_time:49531ms step_avg:47.58ms
+step:1042/1600 train_time:49616ms step_avg:47.62ms
+step:1043/1600 train_time:49706ms step_avg:47.66ms
+step:1044/1600 train_time:49791ms step_avg:47.69ms
+step:1045/1600 train_time:49882ms step_avg:47.73ms
+step:1046/1600 train_time:49967ms step_avg:47.77ms
+step:1047/1600 train_time:50057ms step_avg:47.81ms
+step:1048/1600 train_time:50144ms step_avg:47.85ms
+step:1049/1600 train_time:50233ms step_avg:47.89ms
+step:1050/1600 train_time:50318ms step_avg:47.92ms
+step:1051/1600 train_time:50407ms step_avg:47.96ms
+step:1052/1600 train_time:50492ms step_avg:48.00ms
+step:1053/1600 train_time:50581ms step_avg:48.04ms
+step:1054/1600 train_time:50666ms step_avg:48.07ms
+step:1055/1600 train_time:50755ms step_avg:48.11ms
+step:1056/1600 train_time:50841ms step_avg:48.14ms
+step:1057/1600 train_time:50929ms step_avg:48.18ms
+step:1058/1600 train_time:51015ms step_avg:48.22ms
+step:1059/1600 train_time:51104ms step_avg:48.26ms
+step:1060/1600 train_time:51190ms step_avg:48.29ms
+step:1061/1600 train_time:51278ms step_avg:48.33ms
+step:1062/1600 train_time:51364ms step_avg:48.37ms
+step:1063/1600 train_time:51452ms step_avg:48.40ms
+step:1064/1600 train_time:51537ms step_avg:48.44ms
+step:1065/1600 train_time:51625ms step_avg:48.47ms
+step:1066/1600 train_time:51711ms step_avg:48.51ms
+step:1067/1600 train_time:51801ms step_avg:48.55ms
+step:1068/1600 train_time:51886ms step_avg:48.58ms
+step:1069/1600 train_time:51975ms step_avg:48.62ms
+step:1070/1600 train_time:52061ms step_avg:48.66ms
+step:1071/1600 train_time:52150ms step_avg:48.69ms
+step:1072/1600 train_time:52235ms step_avg:48.73ms
+step:1073/1600 train_time:52322ms step_avg:48.76ms
+step:1074/1600 train_time:52409ms step_avg:48.80ms
+step:1075/1600 train_time:52498ms step_avg:48.84ms
+step:1076/1600 train_time:52583ms step_avg:48.87ms
+step:1077/1600 train_time:52671ms step_avg:48.91ms
+step:1078/1600 train_time:52757ms step_avg:48.94ms
+step:1079/1600 train_time:52845ms step_avg:48.98ms
+step:1080/1600 train_time:52931ms step_avg:49.01ms
+step:1081/1600 train_time:53020ms step_avg:49.05ms
+step:1082/1600 train_time:53106ms step_avg:49.08ms
+step:1083/1600 train_time:53194ms step_avg:49.12ms
+step:1084/1600 train_time:53280ms step_avg:49.15ms
+step:1085/1600 train_time:53368ms step_avg:49.19ms
+step:1086/1600 train_time:53453ms step_avg:49.22ms
+step:1087/1600 train_time:53541ms step_avg:49.26ms
+step:1088/1600 train_time:53627ms step_avg:49.29ms
+step:1089/1600 train_time:53716ms step_avg:49.33ms
+step:1090/1600 train_time:53801ms step_avg:49.36ms
+step:1091/1600 train_time:53891ms step_avg:49.40ms
+step:1092/1600 train_time:53976ms step_avg:49.43ms
+step:1093/1600 train_time:54065ms step_avg:49.46ms
+step:1094/1600 train_time:54150ms step_avg:49.50ms
+step:1095/1600 train_time:54238ms step_avg:49.53ms
+step:1096/1600 train_time:54323ms step_avg:49.57ms
+step:1097/1600 train_time:54411ms step_avg:49.60ms
+step:1098/1600 train_time:54496ms step_avg:49.63ms
+step:1099/1600 train_time:54585ms step_avg:49.67ms
+step:1100/1600 train_time:54671ms step_avg:49.70ms
+step:1101/1600 train_time:54760ms step_avg:49.74ms
+step:1102/1600 train_time:54845ms step_avg:49.77ms
+step:1103/1600 train_time:54934ms step_avg:49.80ms
+step:1104/1600 train_time:55020ms step_avg:49.84ms
+step:1105/1600 train_time:55108ms step_avg:49.87ms
+step:1106/1600 train_time:55193ms step_avg:49.90ms
+step:1107/1600 train_time:55282ms step_avg:49.94ms
+step:1108/1600 train_time:55367ms step_avg:49.97ms
+step:1109/1600 train_time:55456ms step_avg:50.00ms
+step:1110/1600 train_time:55541ms step_avg:50.04ms
+step:1111/1600 train_time:55629ms step_avg:50.07ms
+step:1112/1600 train_time:55714ms step_avg:50.10ms
+step:1113/1600 train_time:55803ms step_avg:50.14ms
+step:1114/1600 train_time:55888ms step_avg:50.17ms
+step:1115/1600 train_time:55978ms step_avg:50.20ms
+step:1116/1600 train_time:56064ms step_avg:50.24ms
+step:1117/1600 train_time:56153ms step_avg:50.27ms
+step:1118/1600 train_time:56238ms step_avg:50.30ms
+step:1119/1600 train_time:56326ms step_avg:50.34ms
+step:1120/1600 train_time:56412ms step_avg:50.37ms
+step:1121/1600 train_time:56500ms step_avg:50.40ms
+step:1122/1600 train_time:56585ms step_avg:50.43ms
+step:1123/1600 train_time:56674ms step_avg:50.47ms
+step:1124/1600 train_time:56760ms step_avg:50.50ms
+step:1125/1600 train_time:56848ms step_avg:50.53ms
+step:1126/1600 train_time:56933ms step_avg:50.56ms
+step:1127/1600 train_time:57023ms step_avg:50.60ms
+step:1128/1600 train_time:57108ms step_avg:50.63ms
+step:1129/1600 train_time:57196ms step_avg:50.66ms
+step:1130/1600 train_time:57282ms step_avg:50.69ms
+step:1131/1600 train_time:57371ms step_avg:50.73ms
+step:1132/1600 train_time:57456ms step_avg:50.76ms
+step:1133/1600 train_time:57544ms step_avg:50.79ms
+step:1134/1600 train_time:57630ms step_avg:50.82ms
+step:1135/1600 train_time:57719ms step_avg:50.85ms
+step:1136/1600 train_time:57804ms step_avg:50.88ms
+step:1137/1600 train_time:57892ms step_avg:50.92ms
+step:1138/1600 train_time:57979ms step_avg:50.95ms
+step:1139/1600 train_time:58066ms step_avg:50.98ms
+step:1140/1600 train_time:58152ms step_avg:51.01ms
+step:1141/1600 train_time:58241ms step_avg:51.04ms
+step:1142/1600 train_time:58326ms step_avg:51.07ms
+step:1143/1600 train_time:58415ms step_avg:51.11ms
+step:1144/1600 train_time:58500ms step_avg:51.14ms
+step:1145/1600 train_time:58588ms step_avg:51.17ms
+step:1146/1600 train_time:58674ms step_avg:51.20ms
+step:1147/1600 train_time:58762ms step_avg:51.23ms
+step:1148/1600 train_time:58848ms step_avg:51.26ms
+step:1149/1600 train_time:58937ms step_avg:51.29ms
+step:1150/1600 train_time:59022ms step_avg:51.32ms
+step:1151/1600 train_time:59110ms step_avg:51.36ms
+step:1152/1600 train_time:59196ms step_avg:51.39ms
+step:1153/1600 train_time:59285ms step_avg:51.42ms
+step:1154/1600 train_time:59372ms step_avg:51.45ms
+step:1155/1600 train_time:59459ms step_avg:51.48ms
+step:1156/1600 train_time:59544ms step_avg:51.51ms
+step:1157/1600 train_time:59633ms step_avg:51.54ms
+step:1158/1600 train_time:59719ms step_avg:51.57ms
+step:1159/1600 train_time:59807ms step_avg:51.60ms
+step:1160/1600 train_time:59892ms step_avg:51.63ms
+step:1161/1600 train_time:59981ms step_avg:51.66ms
+step:1162/1600 train_time:60066ms step_avg:51.69ms
+step:1163/1600 train_time:60155ms step_avg:51.72ms
+step:1164/1600 train_time:60240ms step_avg:51.75ms
+step:1165/1600 train_time:60328ms step_avg:51.78ms
+step:1166/1600 train_time:60415ms step_avg:51.81ms
+step:1167/1600 train_time:60502ms step_avg:51.84ms
+step:1168/1600 train_time:60588ms step_avg:51.87ms
+step:1169/1600 train_time:60677ms step_avg:51.90ms
+step:1170/1600 train_time:60762ms step_avg:51.93ms
+step:1171/1600 train_time:60850ms step_avg:51.96ms
+step:1172/1600 train_time:60935ms step_avg:51.99ms
+step:1173/1600 train_time:61024ms step_avg:52.02ms
+step:1174/1600 train_time:61109ms step_avg:52.05ms
+step:1175/1600 train_time:61198ms step_avg:52.08ms
+step:1176/1600 train_time:61283ms step_avg:52.11ms
+step:1177/1600 train_time:61371ms step_avg:52.14ms
+step:1178/1600 train_time:61457ms step_avg:52.17ms
+step:1179/1600 train_time:61545ms step_avg:52.20ms
+step:1180/1600 train_time:61631ms step_avg:52.23ms
+step:1181/1600 train_time:61719ms step_avg:52.26ms
+step:1182/1600 train_time:61805ms step_avg:52.29ms
+step:1183/1600 train_time:61894ms step_avg:52.32ms
+step:1184/1600 train_time:61980ms step_avg:52.35ms
+step:1185/1600 train_time:62068ms step_avg:52.38ms
+step:1186/1600 train_time:62154ms step_avg:52.41ms
+step:1187/1600 train_time:62242ms step_avg:52.44ms
+step:1188/1600 train_time:62329ms step_avg:52.47ms
+step:1189/1600 train_time:62416ms step_avg:52.49ms
+step:1190/1600 train_time:62502ms step_avg:52.52ms
+step:1191/1600 train_time:62591ms step_avg:52.55ms
+step:1192/1600 train_time:62676ms step_avg:52.58ms
+step:1193/1600 train_time:62764ms step_avg:52.61ms
+step:1194/1600 train_time:62849ms step_avg:52.64ms
+step:1195/1600 train_time:62937ms step_avg:52.67ms
+step:1196/1600 train_time:63023ms step_avg:52.69ms
+step:1197/1600 train_time:63111ms step_avg:52.72ms
+step:1198/1600 train_time:63197ms step_avg:52.75ms
+step:1199/1600 train_time:63285ms step_avg:52.78ms
+step:1200/1600 train_time:63369ms step_avg:52.81ms
+step:1201/1600 train_time:63458ms step_avg:52.84ms
+step:1202/1600 train_time:63544ms step_avg:52.86ms
+step:1203/1600 train_time:63632ms step_avg:52.89ms
+step:1204/1600 train_time:63717ms step_avg:52.92ms
+step:1205/1600 train_time:63806ms step_avg:52.95ms
+step:1206/1600 train_time:63891ms step_avg:52.98ms
+step:1207/1600 train_time:63980ms step_avg:53.01ms
+step:1208/1600 train_time:64066ms step_avg:53.03ms
+step:1209/1600 train_time:64156ms step_avg:53.07ms
+step:1210/1600 train_time:64241ms step_avg:53.09ms
+step:1211/1600 train_time:64329ms step_avg:53.12ms
+step:1212/1600 train_time:64414ms step_avg:53.15ms
+step:1213/1600 train_time:64503ms step_avg:53.18ms
+step:1214/1600 train_time:64589ms step_avg:53.20ms
+step:1215/1600 train_time:64678ms step_avg:53.23ms
+step:1216/1600 train_time:64764ms step_avg:53.26ms
+step:1217/1600 train_time:64852ms step_avg:53.29ms
+step:1218/1600 train_time:64938ms step_avg:53.31ms
+step:1219/1600 train_time:65026ms step_avg:53.34ms
+step:1220/1600 train_time:65111ms step_avg:53.37ms
+step:1221/1600 train_time:65200ms step_avg:53.40ms
+step:1222/1600 train_time:65286ms step_avg:53.43ms
+step:1223/1600 train_time:65375ms step_avg:53.45ms
+step:1224/1600 train_time:65461ms step_avg:53.48ms
+step:1225/1600 train_time:65550ms step_avg:53.51ms
+step:1226/1600 train_time:65635ms step_avg:53.54ms
+step:1227/1600 train_time:65723ms step_avg:53.56ms
+step:1228/1600 train_time:65808ms step_avg:53.59ms
+step:1229/1600 train_time:65898ms step_avg:53.62ms
+step:1230/1600 train_time:65983ms step_avg:53.64ms
+step:1231/1600 train_time:66070ms step_avg:53.67ms
+step:1232/1600 train_time:66155ms step_avg:53.70ms
+step:1233/1600 train_time:66244ms step_avg:53.73ms
+step:1234/1600 train_time:66330ms step_avg:53.75ms
+step:1235/1600 train_time:66417ms step_avg:53.78ms
+step:1236/1600 train_time:66503ms step_avg:53.80ms
+step:1237/1600 train_time:66592ms step_avg:53.83ms
+step:1238/1600 train_time:66677ms step_avg:53.86ms
+step:1239/1600 train_time:66766ms step_avg:53.89ms
+step:1240/1600 train_time:66852ms step_avg:53.91ms
+step:1241/1600 train_time:66940ms step_avg:53.94ms
+step:1242/1600 train_time:67026ms step_avg:53.97ms
+step:1243/1600 train_time:67115ms step_avg:53.99ms
+step:1244/1600 train_time:67201ms step_avg:54.02ms
+step:1245/1600 train_time:67290ms step_avg:54.05ms
+step:1246/1600 train_time:67376ms step_avg:54.07ms
+step:1247/1600 train_time:67464ms step_avg:54.10ms
+step:1248/1600 train_time:67549ms step_avg:54.13ms
+step:1249/1600 train_time:67638ms step_avg:54.15ms
+step:1250/1600 train_time:67724ms step_avg:54.18ms
+step:1250/1600 val_loss:3.4141 train_time:67793ms step_avg:54.23ms
+step:1251/1600 train_time:67814ms step_avg:54.21ms
+step:1252/1600 train_time:67901ms step_avg:54.23ms
+step:1253/1600 train_time:67991ms step_avg:54.26ms
+step:1254/1600 train_time:68076ms step_avg:54.29ms
+step:1255/1600 train_time:68165ms step_avg:54.31ms
+step:1256/1600 train_time:68250ms step_avg:54.34ms
+step:1257/1600 train_time:68337ms step_avg:54.37ms
+step:1258/1600 train_time:68422ms step_avg:54.39ms
+step:1259/1600 train_time:68510ms step_avg:54.42ms
+step:1260/1600 train_time:68596ms step_avg:54.44ms
+step:1261/1600 train_time:68683ms step_avg:54.47ms
+step:1262/1600 train_time:68770ms step_avg:54.49ms
+step:1263/1600 train_time:68861ms step_avg:54.52ms
+step:1264/1600 train_time:68948ms step_avg:54.55ms
+step:1265/1600 train_time:69037ms step_avg:54.57ms
+step:1266/1600 train_time:69123ms step_avg:54.60ms
+step:1267/1600 train_time:69212ms step_avg:54.63ms
+step:1268/1600 train_time:69296ms step_avg:54.65ms
+step:1269/1600 train_time:69385ms step_avg:54.68ms
+step:1270/1600 train_time:69470ms step_avg:54.70ms
+step:1271/1600 train_time:69558ms step_avg:54.73ms
+step:1272/1600 train_time:69644ms step_avg:54.75ms
+step:1273/1600 train_time:69732ms step_avg:54.78ms
+step:1274/1600 train_time:69819ms step_avg:54.80ms
+step:1275/1600 train_time:69908ms step_avg:54.83ms
+step:1276/1600 train_time:69994ms step_avg:54.85ms
+step:1277/1600 train_time:70082ms step_avg:54.88ms
+step:1278/1600 train_time:70168ms step_avg:54.90ms
+step:1279/1600 train_time:70256ms step_avg:54.93ms
+step:1280/1600 train_time:70341ms step_avg:54.95ms
+step:1281/1600 train_time:70429ms step_avg:54.98ms
+step:1282/1600 train_time:70513ms step_avg:55.00ms
+step:1283/1600 train_time:70601ms step_avg:55.03ms
+step:1284/1600 train_time:70687ms step_avg:55.05ms
+step:1285/1600 train_time:70776ms step_avg:55.08ms
+step:1286/1600 train_time:70864ms step_avg:55.10ms
+step:1287/1600 train_time:70954ms step_avg:55.13ms
+step:1288/1600 train_time:71040ms step_avg:55.16ms
+step:1289/1600 train_time:71130ms step_avg:55.18ms
+step:1290/1600 train_time:71214ms step_avg:55.21ms
+step:1291/1600 train_time:71303ms step_avg:55.23ms
+step:1292/1600 train_time:71388ms step_avg:55.25ms
+step:1293/1600 train_time:71476ms step_avg:55.28ms
+step:1294/1600 train_time:71562ms step_avg:55.30ms
+step:1295/1600 train_time:71650ms step_avg:55.33ms
+step:1296/1600 train_time:71735ms step_avg:55.35ms
+step:1297/1600 train_time:71824ms step_avg:55.38ms
+step:1298/1600 train_time:71910ms step_avg:55.40ms
+step:1299/1600 train_time:71999ms step_avg:55.43ms
+step:1300/1600 train_time:72085ms step_avg:55.45ms
+step:1301/1600 train_time:72173ms step_avg:55.48ms
+step:1302/1600 train_time:72259ms step_avg:55.50ms
+step:1303/1600 train_time:72347ms step_avg:55.52ms
+step:1304/1600 train_time:72432ms step_avg:55.55ms
+step:1305/1600 train_time:72519ms step_avg:55.57ms
+step:1306/1600 train_time:72605ms step_avg:55.59ms
+step:1307/1600 train_time:72693ms step_avg:55.62ms
+step:1308/1600 train_time:72779ms step_avg:55.64ms
+step:1309/1600 train_time:72868ms step_avg:55.67ms
+step:1310/1600 train_time:72953ms step_avg:55.69ms
+step:1311/1600 train_time:73042ms step_avg:55.71ms
+step:1312/1600 train_time:73128ms step_avg:55.74ms
+step:1313/1600 train_time:73216ms step_avg:55.76ms
+step:1314/1600 train_time:73302ms step_avg:55.79ms
+step:1315/1600 train_time:73390ms step_avg:55.81ms
+step:1316/1600 train_time:73476ms step_avg:55.83ms
+step:1317/1600 train_time:73564ms step_avg:55.86ms
+step:1318/1600 train_time:73650ms step_avg:55.88ms
+step:1319/1600 train_time:73738ms step_avg:55.90ms
+step:1320/1600 train_time:73824ms step_avg:55.93ms
+step:1321/1600 train_time:73912ms step_avg:55.95ms
+step:1322/1600 train_time:73999ms step_avg:55.97ms
+step:1323/1600 train_time:74087ms step_avg:56.00ms
+step:1324/1600 train_time:74172ms step_avg:56.02ms
+step:1325/1600 train_time:74260ms step_avg:56.05ms
+step:1326/1600 train_time:74345ms step_avg:56.07ms
+step:1327/1600 train_time:74434ms step_avg:56.09ms
+step:1328/1600 train_time:74520ms step_avg:56.11ms
+step:1329/1600 train_time:74608ms step_avg:56.14ms
+step:1330/1600 train_time:74694ms step_avg:56.16ms
+step:1331/1600 train_time:74782ms step_avg:56.18ms
+step:1332/1600 train_time:74868ms step_avg:56.21ms
+step:1333/1600 train_time:74956ms step_avg:56.23ms
+step:1334/1600 train_time:75042ms step_avg:56.25ms
+step:1335/1600 train_time:75130ms step_avg:56.28ms
+step:1336/1600 train_time:75215ms step_avg:56.30ms
+step:1337/1600 train_time:75304ms step_avg:56.32ms
+step:1338/1600 train_time:75390ms step_avg:56.35ms
+step:1339/1600 train_time:75478ms step_avg:56.37ms
+step:1340/1600 train_time:75565ms step_avg:56.39ms
+step:1341/1600 train_time:75654ms step_avg:56.42ms
+step:1342/1600 train_time:75738ms step_avg:56.44ms
+step:1343/1600 train_time:75827ms step_avg:56.46ms
+step:1344/1600 train_time:75913ms step_avg:56.48ms
+step:1345/1600 train_time:76002ms step_avg:56.51ms
+step:1346/1600 train_time:76088ms step_avg:56.53ms
+step:1347/1600 train_time:76176ms step_avg:56.55ms
+step:1348/1600 train_time:76262ms step_avg:56.57ms
+step:1349/1600 train_time:76351ms step_avg:56.60ms
+step:1350/1600 train_time:76436ms step_avg:56.62ms
+step:1351/1600 train_time:76525ms step_avg:56.64ms
+step:1352/1600 train_time:76611ms step_avg:56.66ms
+step:1353/1600 train_time:76699ms step_avg:56.69ms
+step:1354/1600 train_time:76785ms step_avg:56.71ms
+step:1355/1600 train_time:76873ms step_avg:56.73ms
+step:1356/1600 train_time:76958ms step_avg:56.75ms
+step:1357/1600 train_time:77046ms step_avg:56.78ms
+step:1358/1600 train_time:77132ms step_avg:56.80ms
+step:1359/1600 train_time:77220ms step_avg:56.82ms
+step:1360/1600 train_time:77306ms step_avg:56.84ms
+step:1361/1600 train_time:77394ms step_avg:56.87ms
+step:1362/1600 train_time:77480ms step_avg:56.89ms
+step:1363/1600 train_time:77569ms step_avg:56.91ms
+step:1364/1600 train_time:77654ms step_avg:56.93ms
+step:1365/1600 train_time:77743ms step_avg:56.95ms
+step:1366/1600 train_time:77830ms step_avg:56.98ms
+step:1367/1600 train_time:77918ms step_avg:57.00ms
+step:1368/1600 train_time:78003ms step_avg:57.02ms
+step:1369/1600 train_time:78092ms step_avg:57.04ms
+step:1370/1600 train_time:78177ms step_avg:57.06ms
+step:1371/1600 train_time:78266ms step_avg:57.09ms
+step:1372/1600 train_time:78352ms step_avg:57.11ms
+step:1373/1600 train_time:78441ms step_avg:57.13ms
+step:1374/1600 train_time:78526ms step_avg:57.15ms
+step:1375/1600 train_time:78615ms step_avg:57.17ms
+step:1376/1600 train_time:78701ms step_avg:57.20ms
+step:1377/1600 train_time:78790ms step_avg:57.22ms
+step:1378/1600 train_time:78874ms step_avg:57.24ms
+step:1379/1600 train_time:78964ms step_avg:57.26ms
+step:1380/1600 train_time:79050ms step_avg:57.28ms
+step:1381/1600 train_time:79138ms step_avg:57.30ms
+step:1382/1600 train_time:79223ms step_avg:57.32ms
+step:1383/1600 train_time:79311ms step_avg:57.35ms
+step:1384/1600 train_time:79396ms step_avg:57.37ms
+step:1385/1600 train_time:79485ms step_avg:57.39ms
+step:1386/1600 train_time:79570ms step_avg:57.41ms
+step:1387/1600 train_time:79659ms step_avg:57.43ms
+step:1388/1600 train_time:79744ms step_avg:57.45ms
+step:1389/1600 train_time:79834ms step_avg:57.48ms
+step:1390/1600 train_time:79919ms step_avg:57.50ms
+step:1391/1600 train_time:80009ms step_avg:57.52ms
+step:1392/1600 train_time:80094ms step_avg:57.54ms
+step:1393/1600 train_time:80182ms step_avg:57.56ms
+step:1394/1600 train_time:80267ms step_avg:57.58ms
+step:1395/1600 train_time:80356ms step_avg:57.60ms
+step:1396/1600 train_time:80441ms step_avg:57.62ms
+step:1397/1600 train_time:80529ms step_avg:57.64ms
+step:1398/1600 train_time:80615ms step_avg:57.66ms
+step:1399/1600 train_time:80703ms step_avg:57.69ms
+step:1400/1600 train_time:80789ms step_avg:57.71ms
+step:1401/1600 train_time:80877ms step_avg:57.73ms
+step:1402/1600 train_time:80964ms step_avg:57.75ms
+step:1403/1600 train_time:81052ms step_avg:57.77ms
+step:1404/1600 train_time:81137ms step_avg:57.79ms
+step:1405/1600 train_time:81226ms step_avg:57.81ms
+step:1406/1600 train_time:81312ms step_avg:57.83ms
+step:1407/1600 train_time:81400ms step_avg:57.85ms
+step:1408/1600 train_time:81485ms step_avg:57.87ms
+step:1409/1600 train_time:81574ms step_avg:57.90ms
+step:1410/1600 train_time:81660ms step_avg:57.91ms
+step:1411/1600 train_time:81748ms step_avg:57.94ms
+step:1412/1600 train_time:81835ms step_avg:57.96ms
+step:1413/1600 train_time:81924ms step_avg:57.98ms
+step:1414/1600 train_time:82009ms step_avg:58.00ms
+step:1415/1600 train_time:82098ms step_avg:58.02ms
+step:1416/1600 train_time:82183ms step_avg:58.04ms
+step:1417/1600 train_time:82272ms step_avg:58.06ms
+step:1418/1600 train_time:82357ms step_avg:58.08ms
+step:1419/1600 train_time:82446ms step_avg:58.10ms
+step:1420/1600 train_time:82532ms step_avg:58.12ms
+step:1421/1600 train_time:82620ms step_avg:58.14ms
+step:1422/1600 train_time:82706ms step_avg:58.16ms
+step:1423/1600 train_time:82794ms step_avg:58.18ms
+step:1424/1600 train_time:82880ms step_avg:58.20ms
+step:1425/1600 train_time:82969ms step_avg:58.22ms
+step:1426/1600 train_time:83055ms step_avg:58.24ms
+step:1427/1600 train_time:83143ms step_avg:58.26ms
+step:1428/1600 train_time:83229ms step_avg:58.28ms
+step:1429/1600 train_time:83318ms step_avg:58.30ms
+step:1430/1600 train_time:83403ms step_avg:58.32ms
+step:1431/1600 train_time:83491ms step_avg:58.34ms
+step:1432/1600 train_time:83576ms step_avg:58.36ms
+step:1433/1600 train_time:83665ms step_avg:58.38ms
+step:1434/1600 train_time:83751ms step_avg:58.40ms
+step:1435/1600 train_time:83839ms step_avg:58.42ms
+step:1436/1600 train_time:83924ms step_avg:58.44ms
+step:1437/1600 train_time:84014ms step_avg:58.47ms
+step:1438/1600 train_time:84100ms step_avg:58.48ms
+step:1439/1600 train_time:84188ms step_avg:58.50ms
+step:1440/1600 train_time:84275ms step_avg:58.52ms
+step:1441/1600 train_time:84364ms step_avg:58.55ms
+step:1442/1600 train_time:84449ms step_avg:58.56ms
+step:1443/1600 train_time:84538ms step_avg:58.58ms
+step:1444/1600 train_time:84623ms step_avg:58.60ms
+step:1445/1600 train_time:84712ms step_avg:58.62ms
+step:1446/1600 train_time:84797ms step_avg:58.64ms
+step:1447/1600 train_time:84887ms step_avg:58.66ms
+step:1448/1600 train_time:84972ms step_avg:58.68ms
+step:1449/1600 train_time:85060ms step_avg:58.70ms
+step:1450/1600 train_time:85145ms step_avg:58.72ms
+step:1451/1600 train_time:85234ms step_avg:58.74ms
+step:1452/1600 train_time:85319ms step_avg:58.76ms
+step:1453/1600 train_time:85408ms step_avg:58.78ms
+step:1454/1600 train_time:85494ms step_avg:58.80ms
+step:1455/1600 train_time:85583ms step_avg:58.82ms
+step:1456/1600 train_time:85668ms step_avg:58.84ms
+step:1457/1600 train_time:85757ms step_avg:58.86ms
+step:1458/1600 train_time:85842ms step_avg:58.88ms
+step:1459/1600 train_time:85931ms step_avg:58.90ms
+step:1460/1600 train_time:86016ms step_avg:58.91ms
+step:1461/1600 train_time:86105ms step_avg:58.94ms
+step:1462/1600 train_time:86191ms step_avg:58.95ms
+step:1463/1600 train_time:86280ms step_avg:58.97ms
+step:1464/1600 train_time:86365ms step_avg:58.99ms
+step:1465/1600 train_time:86453ms step_avg:59.01ms
+step:1466/1600 train_time:86539ms step_avg:59.03ms
+step:1467/1600 train_time:86628ms step_avg:59.05ms
+step:1468/1600 train_time:86712ms step_avg:59.07ms
+step:1469/1600 train_time:86801ms step_avg:59.09ms
+step:1470/1600 train_time:86888ms step_avg:59.11ms
+step:1471/1600 train_time:86976ms step_avg:59.13ms
+step:1472/1600 train_time:87061ms step_avg:59.14ms
+step:1473/1600 train_time:87150ms step_avg:59.16ms
+step:1474/1600 train_time:87236ms step_avg:59.18ms
+step:1475/1600 train_time:87325ms step_avg:59.20ms
+step:1476/1600 train_time:87410ms step_avg:59.22ms
+step:1477/1600 train_time:87498ms step_avg:59.24ms
+step:1478/1600 train_time:87584ms step_avg:59.26ms
+step:1479/1600 train_time:87672ms step_avg:59.28ms
+step:1480/1600 train_time:87758ms step_avg:59.30ms
+step:1481/1600 train_time:87847ms step_avg:59.32ms
+step:1482/1600 train_time:87932ms step_avg:59.33ms
+step:1483/1600 train_time:88021ms step_avg:59.35ms
+step:1484/1600 train_time:88107ms step_avg:59.37ms
+step:1485/1600 train_time:88196ms step_avg:59.39ms
+step:1486/1600 train_time:88282ms step_avg:59.41ms
+step:1487/1600 train_time:88370ms step_avg:59.43ms
+step:1488/1600 train_time:88456ms step_avg:59.45ms
+step:1489/1600 train_time:88544ms step_avg:59.47ms
+step:1490/1600 train_time:88629ms step_avg:59.48ms
+step:1491/1600 train_time:88717ms step_avg:59.50ms
+step:1492/1600 train_time:88803ms step_avg:59.52ms
+step:1493/1600 train_time:88891ms step_avg:59.54ms
+step:1494/1600 train_time:88976ms step_avg:59.56ms
+step:1495/1600 train_time:89065ms step_avg:59.58ms
+step:1496/1600 train_time:89151ms step_avg:59.59ms
+step:1497/1600 train_time:89240ms step_avg:59.61ms
+step:1498/1600 train_time:89326ms step_avg:59.63ms
+step:1499/1600 train_time:89414ms step_avg:59.65ms
+step:1500/1600 train_time:89500ms step_avg:59.67ms
+step:1500/1600 val_loss:3.3058 train_time:89569ms step_avg:59.71ms
+step:1501/1600 train_time:89589ms step_avg:59.69ms
+step:1502/1600 train_time:89676ms step_avg:59.70ms
+step:1503/1600 train_time:89766ms step_avg:59.72ms
+step:1504/1600 train_time:89851ms step_avg:59.74ms
+step:1505/1600 train_time:89938ms step_avg:59.76ms
+step:1506/1600 train_time:90023ms step_avg:59.78ms
+step:1507/1600 train_time:90112ms step_avg:59.80ms
+step:1508/1600 train_time:90196ms step_avg:59.81ms
+step:1509/1600 train_time:90283ms step_avg:59.83ms
+step:1510/1600 train_time:90369ms step_avg:59.85ms
+step:1511/1600 train_time:90457ms step_avg:59.87ms
+step:1512/1600 train_time:90545ms step_avg:59.88ms
+step:1513/1600 train_time:90636ms step_avg:59.90ms
+step:1514/1600 train_time:90723ms step_avg:59.92ms
+step:1515/1600 train_time:90812ms step_avg:59.94ms
+step:1516/1600 train_time:90896ms step_avg:59.96ms
+step:1517/1600 train_time:90984ms step_avg:59.98ms
+step:1518/1600 train_time:91069ms step_avg:59.99ms
+step:1519/1600 train_time:91157ms step_avg:60.01ms
+step:1520/1600 train_time:91242ms step_avg:60.03ms
+step:1521/1600 train_time:91330ms step_avg:60.05ms
+step:1522/1600 train_time:91416ms step_avg:60.06ms
+step:1523/1600 train_time:91505ms step_avg:60.08ms
+step:1524/1600 train_time:91593ms step_avg:60.10ms
+step:1525/1600 train_time:91682ms step_avg:60.12ms
+step:1526/1600 train_time:91768ms step_avg:60.14ms
+step:1527/1600 train_time:91857ms step_avg:60.16ms
+step:1528/1600 train_time:91942ms step_avg:60.17ms
+step:1529/1600 train_time:92030ms step_avg:60.19ms
+step:1530/1600 train_time:92115ms step_avg:60.21ms
+step:1531/1600 train_time:92203ms step_avg:60.22ms
+step:1532/1600 train_time:92288ms step_avg:60.24ms
+step:1533/1600 train_time:92377ms step_avg:60.26ms
+step:1534/1600 train_time:92462ms step_avg:60.28ms
+step:1535/1600 train_time:92552ms step_avg:60.29ms
+step:1536/1600 train_time:92638ms step_avg:60.31ms
+step:1537/1600 train_time:92727ms step_avg:60.33ms
+step:1538/1600 train_time:92814ms step_avg:60.35ms
+step:1539/1600 train_time:92902ms step_avg:60.37ms
+step:1540/1600 train_time:92987ms step_avg:60.38ms
+step:1541/1600 train_time:93075ms step_avg:60.40ms
+step:1542/1600 train_time:93159ms step_avg:60.41ms
+step:1543/1600 train_time:93248ms step_avg:60.43ms
+step:1544/1600 train_time:93333ms step_avg:60.45ms
+step:1545/1600 train_time:93422ms step_avg:60.47ms
+step:1546/1600 train_time:93509ms step_avg:60.48ms
+step:1547/1600 train_time:93598ms step_avg:60.50ms
+step:1548/1600 train_time:93684ms step_avg:60.52ms
+step:1549/1600 train_time:93773ms step_avg:60.54ms
+step:1550/1600 train_time:93859ms step_avg:60.55ms
+step:1551/1600 train_time:93948ms step_avg:60.57ms
+step:1552/1600 train_time:94034ms step_avg:60.59ms
+step:1553/1600 train_time:94122ms step_avg:60.61ms
+step:1554/1600 train_time:94207ms step_avg:60.62ms
+step:1555/1600 train_time:94295ms step_avg:60.64ms
+step:1556/1600 train_time:94381ms step_avg:60.66ms
+step:1557/1600 train_time:94470ms step_avg:60.67ms
+step:1558/1600 train_time:94556ms step_avg:60.69ms
+step:1559/1600 train_time:94645ms step_avg:60.71ms
+step:1560/1600 train_time:94731ms step_avg:60.72ms
+step:1561/1600 train_time:94825ms step_avg:60.75ms
+step:1562/1600 train_time:94910ms step_avg:60.76ms
+step:1563/1600 train_time:94999ms step_avg:60.78ms
+step:1564/1600 train_time:95084ms step_avg:60.80ms
+step:1565/1600 train_time:95172ms step_avg:60.81ms
+step:1566/1600 train_time:95259ms step_avg:60.83ms
+step:1567/1600 train_time:95347ms step_avg:60.85ms
+step:1568/1600 train_time:95434ms step_avg:60.86ms
+step:1569/1600 train_time:95524ms step_avg:60.88ms
+step:1570/1600 train_time:95611ms step_avg:60.90ms
+step:1571/1600 train_time:95700ms step_avg:60.92ms
+step:1572/1600 train_time:95786ms step_avg:60.93ms
+step:1573/1600 train_time:95875ms step_avg:60.95ms
+step:1574/1600 train_time:95960ms step_avg:60.97ms
+step:1575/1600 train_time:96049ms step_avg:60.98ms
+step:1576/1600 train_time:96135ms step_avg:61.00ms
+step:1577/1600 train_time:96225ms step_avg:61.02ms
+step:1578/1600 train_time:96310ms step_avg:61.03ms
+step:1579/1600 train_time:96399ms step_avg:61.05ms
+step:1580/1600 train_time:96486ms step_avg:61.07ms
+step:1581/1600 train_time:96575ms step_avg:61.08ms
+step:1582/1600 train_time:96661ms step_avg:61.10ms
+step:1583/1600 train_time:96751ms step_avg:61.12ms
+step:1584/1600 train_time:96838ms step_avg:61.13ms
+step:1585/1600 train_time:96926ms step_avg:61.15ms
+step:1586/1600 train_time:97012ms step_avg:61.17ms
+step:1587/1600 train_time:97101ms step_avg:61.19ms
+step:1588/1600 train_time:97187ms step_avg:61.20ms
+step:1589/1600 train_time:97275ms step_avg:61.22ms
+step:1590/1600 train_time:97361ms step_avg:61.23ms
+step:1591/1600 train_time:97450ms step_avg:61.25ms
+step:1592/1600 train_time:97536ms step_avg:61.27ms
+step:1593/1600 train_time:97625ms step_avg:61.28ms
+step:1594/1600 train_time:97711ms step_avg:61.30ms
+step:1595/1600 train_time:97801ms step_avg:61.32ms
+step:1596/1600 train_time:97888ms step_avg:61.33ms
+step:1597/1600 train_time:97976ms step_avg:61.35ms
+step:1598/1600 train_time:98061ms step_avg:61.37ms
+step:1599/1600 train_time:98149ms step_avg:61.38ms
+step:1600/1600 train_time:98235ms step_avg:61.40ms
+step:1600/1600 val_loss:3.2762 train_time:98304ms step_avg:61.44ms
+peak memory allocated: 30789 MiB reserved: 46238 MiB

--- a/records/track_1_short/2026-01-28_TieFirstLastVEs/baseline/52a4fe9b-5667-406c-834a-cc8f78e1b683.txt
+++ b/records/track_1_short/2026-01-28_TieFirstLastVEs/baseline/52a4fe9b-5667-406c-834a-cc8f78e1b683.txt
@@ -1,0 +1,4120 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.12.12 | packaged by conda-forge | (main, Jan 26 2026, 23:51:32) [GCC 14.3.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Thu Jan 29 02:27:27 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                  Off |
+| N/A   45C    P0            135W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:06:00.0 Off |                  Off |
+| N/A   38C    P0            129W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:07:00.0 Off |                  Off |
+| N/A   45C    P0            126W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:08:00.0 Off |                  Off |
+| N/A   38C    P0            127W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:09:00.0 Off |                  Off |
+| N/A   45C    P0            130W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                  Off |
+| N/A   39C    P0            127W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                  Off |
+| N/A   45C    P0            131W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:0C:00.0 Off |                  Off |
+| N/A   38C    P0            127W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A           69868      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    1   N/A  N/A           69869      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    2   N/A  N/A           69870      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    3   N/A  N/A           69871      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    4   N/A  N/A           69872      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    5   N/A  N/A           69873      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    6   N/A  N/A           69874      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    7   N/A  N/A           69875      C   .../envs/speedrun/bin/python3.12       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8272 train_time:0ms step_avg:0.03ms
+step:1/1600 train_time:49ms step_avg:49.05ms
+step:2/1600 train_time:67ms step_avg:33.51ms
+step:3/1600 train_time:89ms step_avg:29.68ms
+step:4/1600 train_time:127ms step_avg:31.66ms
+step:5/1600 train_time:156ms step_avg:31.27ms
+step:6/1600 train_time:230ms step_avg:38.38ms
+step:7/1600 train_time:246ms step_avg:35.10ms
+step:8/1600 train_time:284ms step_avg:35.51ms
+step:9/1600 train_time:315ms step_avg:34.95ms
+step:10/1600 train_time:352ms step_avg:35.18ms
+step:11/1600 train_time:382ms step_avg:34.72ms
+step:12/1600 train_time:419ms step_avg:34.90ms
+step:13/1600 train_time:449ms step_avg:34.57ms
+step:14/1600 train_time:487ms step_avg:34.76ms
+step:15/1600 train_time:517ms step_avg:34.50ms
+step:16/1600 train_time:555ms step_avg:34.67ms
+step:17/1600 train_time:585ms step_avg:34.44ms
+step:18/1600 train_time:622ms step_avg:34.58ms
+step:19/1600 train_time:653ms step_avg:34.37ms
+step:20/1600 train_time:690ms step_avg:34.51ms
+step:21/1600 train_time:721ms step_avg:34.34ms
+step:22/1600 train_time:759ms step_avg:34.48ms
+step:23/1600 train_time:789ms step_avg:34.30ms
+step:24/1600 train_time:826ms step_avg:34.43ms
+step:25/1600 train_time:857ms step_avg:34.27ms
+step:26/1600 train_time:894ms step_avg:34.40ms
+step:27/1600 train_time:925ms step_avg:34.25ms
+step:28/1600 train_time:962ms step_avg:34.35ms
+step:29/1600 train_time:992ms step_avg:34.22ms
+step:30/1600 train_time:1030ms step_avg:34.32ms
+step:31/1600 train_time:1060ms step_avg:34.20ms
+step:32/1600 train_time:1098ms step_avg:34.30ms
+step:33/1600 train_time:1129ms step_avg:34.21ms
+step:34/1600 train_time:1167ms step_avg:34.31ms
+step:35/1600 train_time:1198ms step_avg:34.23ms
+step:36/1600 train_time:1236ms step_avg:34.34ms
+step:37/1600 train_time:1267ms step_avg:34.23ms
+step:38/1600 train_time:1304ms step_avg:34.31ms
+step:39/1600 train_time:1334ms step_avg:34.22ms
+step:40/1600 train_time:1372ms step_avg:34.31ms
+step:41/1600 train_time:1403ms step_avg:34.23ms
+step:42/1600 train_time:1441ms step_avg:34.31ms
+step:43/1600 train_time:1472ms step_avg:34.23ms
+step:44/1600 train_time:1509ms step_avg:34.30ms
+step:45/1600 train_time:1540ms step_avg:34.23ms
+step:46/1600 train_time:1577ms step_avg:34.29ms
+step:47/1600 train_time:1608ms step_avg:34.22ms
+step:48/1600 train_time:1646ms step_avg:34.29ms
+step:49/1600 train_time:1676ms step_avg:34.21ms
+step:50/1600 train_time:1713ms step_avg:34.27ms
+step:51/1600 train_time:1744ms step_avg:34.20ms
+step:52/1600 train_time:1781ms step_avg:34.26ms
+step:53/1600 train_time:1812ms step_avg:34.19ms
+step:54/1600 train_time:1849ms step_avg:34.25ms
+step:55/1600 train_time:1880ms step_avg:34.18ms
+step:56/1600 train_time:1917ms step_avg:34.23ms
+step:57/1600 train_time:1948ms step_avg:34.17ms
+step:58/1600 train_time:1985ms step_avg:34.22ms
+step:59/1600 train_time:2016ms step_avg:34.16ms
+step:60/1600 train_time:2053ms step_avg:34.22ms
+step:61/1600 train_time:2084ms step_avg:34.16ms
+step:62/1600 train_time:2121ms step_avg:34.20ms
+step:63/1600 train_time:2151ms step_avg:34.15ms
+step:64/1600 train_time:2190ms step_avg:34.22ms
+step:65/1600 train_time:2220ms step_avg:34.16ms
+step:66/1600 train_time:2258ms step_avg:34.21ms
+step:67/1600 train_time:2288ms step_avg:34.16ms
+step:68/1600 train_time:2326ms step_avg:34.20ms
+step:69/1600 train_time:2356ms step_avg:34.15ms
+step:70/1600 train_time:2394ms step_avg:34.20ms
+step:71/1600 train_time:2425ms step_avg:34.16ms
+step:72/1600 train_time:2463ms step_avg:34.21ms
+step:73/1600 train_time:2494ms step_avg:34.16ms
+step:74/1600 train_time:2531ms step_avg:34.20ms
+step:75/1600 train_time:2562ms step_avg:34.16ms
+step:76/1600 train_time:2599ms step_avg:34.20ms
+step:77/1600 train_time:2630ms step_avg:34.16ms
+step:78/1600 train_time:2668ms step_avg:34.20ms
+step:79/1600 train_time:2698ms step_avg:34.15ms
+step:80/1600 train_time:2736ms step_avg:34.20ms
+step:81/1600 train_time:2766ms step_avg:34.15ms
+step:82/1600 train_time:2804ms step_avg:34.19ms
+step:83/1600 train_time:2834ms step_avg:34.15ms
+step:84/1600 train_time:2872ms step_avg:34.19ms
+step:85/1600 train_time:2902ms step_avg:34.14ms
+step:86/1600 train_time:2939ms step_avg:34.18ms
+step:87/1600 train_time:2970ms step_avg:34.14ms
+step:88/1600 train_time:3007ms step_avg:34.17ms
+step:89/1600 train_time:3038ms step_avg:34.14ms
+step:90/1600 train_time:3076ms step_avg:34.18ms
+step:91/1600 train_time:3107ms step_avg:34.14ms
+step:92/1600 train_time:3143ms step_avg:34.17ms
+step:93/1600 train_time:3174ms step_avg:34.13ms
+step:94/1600 train_time:3212ms step_avg:34.17ms
+step:95/1600 train_time:3243ms step_avg:34.13ms
+step:96/1600 train_time:3280ms step_avg:34.17ms
+step:97/1600 train_time:3311ms step_avg:34.13ms
+step:98/1600 train_time:3349ms step_avg:34.17ms
+step:99/1600 train_time:3379ms step_avg:34.13ms
+step:100/1600 train_time:3416ms step_avg:34.16ms
+step:101/1600 train_time:3447ms step_avg:34.13ms
+step:102/1600 train_time:3485ms step_avg:34.16ms
+step:103/1600 train_time:3515ms step_avg:34.13ms
+step:104/1600 train_time:3553ms step_avg:34.16ms
+step:105/1600 train_time:3584ms step_avg:34.13ms
+step:106/1600 train_time:3621ms step_avg:34.16ms
+step:107/1600 train_time:3652ms step_avg:34.13ms
+step:108/1600 train_time:3690ms step_avg:34.17ms
+step:109/1600 train_time:3721ms step_avg:34.14ms
+step:110/1600 train_time:3758ms step_avg:34.16ms
+step:111/1600 train_time:3790ms step_avg:34.14ms
+step:112/1600 train_time:3827ms step_avg:34.17ms
+step:113/1600 train_time:3858ms step_avg:34.14ms
+step:114/1600 train_time:3895ms step_avg:34.17ms
+step:115/1600 train_time:3926ms step_avg:34.14ms
+step:116/1600 train_time:3963ms step_avg:34.16ms
+step:117/1600 train_time:3994ms step_avg:34.13ms
+step:118/1600 train_time:4031ms step_avg:34.16ms
+step:119/1600 train_time:4062ms step_avg:34.13ms
+step:120/1600 train_time:4099ms step_avg:34.16ms
+step:121/1600 train_time:4129ms step_avg:34.13ms
+step:122/1600 train_time:4167ms step_avg:34.15ms
+step:123/1600 train_time:4197ms step_avg:34.13ms
+step:124/1600 train_time:4235ms step_avg:34.16ms
+step:125/1600 train_time:4266ms step_avg:34.13ms
+step:126/1600 train_time:4303ms step_avg:34.15ms
+step:127/1600 train_time:4334ms step_avg:34.12ms
+step:128/1600 train_time:4371ms step_avg:34.15ms
+step:129/1600 train_time:4402ms step_avg:34.13ms
+step:130/1600 train_time:4439ms step_avg:34.15ms
+step:131/1600 train_time:4470ms step_avg:34.12ms
+step:132/1600 train_time:4507ms step_avg:34.14ms
+step:133/1600 train_time:4537ms step_avg:34.11ms
+step:134/1600 train_time:4575ms step_avg:34.14ms
+step:135/1600 train_time:4606ms step_avg:34.12ms
+step:136/1600 train_time:4643ms step_avg:34.14ms
+step:137/1600 train_time:4674ms step_avg:34.12ms
+step:138/1600 train_time:4711ms step_avg:34.14ms
+step:139/1600 train_time:4742ms step_avg:34.12ms
+step:140/1600 train_time:4780ms step_avg:34.14ms
+step:141/1600 train_time:4810ms step_avg:34.11ms
+step:142/1600 train_time:4847ms step_avg:34.14ms
+step:143/1600 train_time:4878ms step_avg:34.11ms
+step:144/1600 train_time:4915ms step_avg:34.13ms
+step:145/1600 train_time:4946ms step_avg:34.11ms
+step:146/1600 train_time:4983ms step_avg:34.13ms
+step:147/1600 train_time:5014ms step_avg:34.11ms
+step:148/1600 train_time:5051ms step_avg:34.13ms
+step:149/1600 train_time:5082ms step_avg:34.11ms
+step:150/1600 train_time:5119ms step_avg:34.13ms
+step:151/1600 train_time:5149ms step_avg:34.10ms
+step:152/1600 train_time:5186ms step_avg:34.12ms
+step:153/1600 train_time:5217ms step_avg:34.10ms
+step:154/1600 train_time:5255ms step_avg:34.12ms
+step:155/1600 train_time:5285ms step_avg:34.10ms
+step:156/1600 train_time:5323ms step_avg:34.12ms
+step:157/1600 train_time:5354ms step_avg:34.10ms
+step:158/1600 train_time:5391ms step_avg:34.12ms
+step:159/1600 train_time:5422ms step_avg:34.10ms
+step:160/1600 train_time:5459ms step_avg:34.12ms
+step:161/1600 train_time:5490ms step_avg:34.10ms
+step:162/1600 train_time:5527ms step_avg:34.12ms
+step:163/1600 train_time:5558ms step_avg:34.10ms
+step:164/1600 train_time:5595ms step_avg:34.12ms
+step:165/1600 train_time:5626ms step_avg:34.10ms
+step:166/1600 train_time:5663ms step_avg:34.12ms
+step:167/1600 train_time:5694ms step_avg:34.10ms
+step:168/1600 train_time:5732ms step_avg:34.12ms
+step:169/1600 train_time:5763ms step_avg:34.10ms
+step:170/1600 train_time:5800ms step_avg:34.12ms
+step:171/1600 train_time:5831ms step_avg:34.10ms
+step:172/1600 train_time:5868ms step_avg:34.12ms
+step:173/1600 train_time:5898ms step_avg:34.09ms
+step:174/1600 train_time:5936ms step_avg:34.11ms
+step:175/1600 train_time:5967ms step_avg:34.09ms
+step:176/1600 train_time:6003ms step_avg:34.11ms
+step:177/1600 train_time:6034ms step_avg:34.09ms
+step:178/1600 train_time:6072ms step_avg:34.11ms
+step:179/1600 train_time:6102ms step_avg:34.09ms
+step:180/1600 train_time:6139ms step_avg:34.11ms
+step:181/1600 train_time:6170ms step_avg:34.09ms
+step:182/1600 train_time:6207ms step_avg:34.11ms
+step:183/1600 train_time:6238ms step_avg:34.09ms
+step:184/1600 train_time:6276ms step_avg:34.11ms
+step:185/1600 train_time:6306ms step_avg:34.09ms
+step:186/1600 train_time:6343ms step_avg:34.10ms
+step:187/1600 train_time:6374ms step_avg:34.08ms
+step:188/1600 train_time:6412ms step_avg:34.10ms
+step:189/1600 train_time:6443ms step_avg:34.09ms
+step:190/1600 train_time:6480ms step_avg:34.10ms
+step:191/1600 train_time:6510ms step_avg:34.09ms
+step:192/1600 train_time:6548ms step_avg:34.10ms
+step:193/1600 train_time:6579ms step_avg:34.09ms
+step:194/1600 train_time:6616ms step_avg:34.10ms
+step:195/1600 train_time:6646ms step_avg:34.08ms
+step:196/1600 train_time:6684ms step_avg:34.10ms
+step:197/1600 train_time:6714ms step_avg:34.08ms
+step:198/1600 train_time:6752ms step_avg:34.10ms
+step:199/1600 train_time:6783ms step_avg:34.09ms
+step:200/1600 train_time:6820ms step_avg:34.10ms
+step:201/1600 train_time:6851ms step_avg:34.08ms
+step:202/1600 train_time:6888ms step_avg:34.10ms
+step:203/1600 train_time:6918ms step_avg:34.08ms
+step:204/1600 train_time:6955ms step_avg:34.09ms
+step:205/1600 train_time:6986ms step_avg:34.08ms
+step:206/1600 train_time:7023ms step_avg:34.09ms
+step:207/1600 train_time:7054ms step_avg:34.07ms
+step:208/1600 train_time:7091ms step_avg:34.09ms
+step:209/1600 train_time:7121ms step_avg:34.07ms
+step:210/1600 train_time:7159ms step_avg:34.09ms
+step:211/1600 train_time:7190ms step_avg:34.07ms
+step:212/1600 train_time:7228ms step_avg:34.09ms
+step:213/1600 train_time:7258ms step_avg:34.08ms
+step:214/1600 train_time:7295ms step_avg:34.09ms
+step:215/1600 train_time:7326ms step_avg:34.07ms
+step:216/1600 train_time:7363ms step_avg:34.09ms
+step:217/1600 train_time:7393ms step_avg:34.07ms
+step:218/1600 train_time:7430ms step_avg:34.08ms
+step:219/1600 train_time:7461ms step_avg:34.07ms
+step:220/1600 train_time:7499ms step_avg:34.08ms
+step:221/1600 train_time:7529ms step_avg:34.07ms
+step:222/1600 train_time:7567ms step_avg:34.09ms
+step:223/1600 train_time:7598ms step_avg:34.07ms
+step:224/1600 train_time:7635ms step_avg:34.09ms
+step:225/1600 train_time:7666ms step_avg:34.07ms
+step:226/1600 train_time:7703ms step_avg:34.09ms
+step:227/1600 train_time:7734ms step_avg:34.07ms
+step:228/1600 train_time:7772ms step_avg:34.09ms
+step:229/1600 train_time:7802ms step_avg:34.07ms
+step:230/1600 train_time:7839ms step_avg:34.08ms
+step:231/1600 train_time:7869ms step_avg:34.07ms
+step:232/1600 train_time:7906ms step_avg:34.08ms
+step:233/1600 train_time:7937ms step_avg:34.06ms
+step:234/1600 train_time:7974ms step_avg:34.08ms
+step:235/1600 train_time:8004ms step_avg:34.06ms
+step:236/1600 train_time:8041ms step_avg:34.07ms
+step:237/1600 train_time:8072ms step_avg:34.06ms
+step:238/1600 train_time:8109ms step_avg:34.07ms
+step:239/1600 train_time:8139ms step_avg:34.06ms
+step:240/1600 train_time:8177ms step_avg:34.07ms
+step:241/1600 train_time:8208ms step_avg:34.06ms
+step:242/1600 train_time:8245ms step_avg:34.07ms
+step:243/1600 train_time:8275ms step_avg:34.05ms
+step:244/1600 train_time:8312ms step_avg:34.07ms
+step:245/1600 train_time:8343ms step_avg:34.05ms
+step:246/1600 train_time:8381ms step_avg:34.07ms
+step:247/1600 train_time:8411ms step_avg:34.05ms
+step:248/1600 train_time:8449ms step_avg:34.07ms
+step:249/1600 train_time:8479ms step_avg:34.05ms
+step:250/1600 train_time:8517ms step_avg:34.07ms
+step:250/1600 val_loss:4.5714 train_time:8565ms step_avg:34.26ms
+step:251/1600 train_time:8582ms step_avg:34.19ms
+step:252/1600 train_time:8598ms step_avg:34.12ms
+step:253/1600 train_time:8619ms step_avg:34.07ms
+step:254/1600 train_time:8656ms step_avg:34.08ms
+step:255/1600 train_time:8687ms step_avg:34.07ms
+step:256/1600 train_time:8725ms step_avg:34.08ms
+step:257/1600 train_time:8756ms step_avg:34.07ms
+step:258/1600 train_time:8793ms step_avg:34.08ms
+step:259/1600 train_time:8823ms step_avg:34.06ms
+step:260/1600 train_time:8860ms step_avg:34.08ms
+step:261/1600 train_time:8890ms step_avg:34.06ms
+step:262/1600 train_time:8927ms step_avg:34.07ms
+step:263/1600 train_time:8957ms step_avg:34.06ms
+step:264/1600 train_time:8994ms step_avg:34.07ms
+step:265/1600 train_time:9025ms step_avg:34.06ms
+step:266/1600 train_time:9063ms step_avg:34.07ms
+step:267/1600 train_time:9093ms step_avg:34.06ms
+step:268/1600 train_time:9131ms step_avg:34.07ms
+step:269/1600 train_time:9161ms step_avg:34.05ms
+step:270/1600 train_time:9198ms step_avg:34.07ms
+step:271/1600 train_time:9228ms step_avg:34.05ms
+step:272/1600 train_time:9265ms step_avg:34.06ms
+step:273/1600 train_time:9296ms step_avg:34.05ms
+step:274/1600 train_time:9333ms step_avg:34.06ms
+step:275/1600 train_time:9364ms step_avg:34.05ms
+step:276/1600 train_time:9401ms step_avg:34.06ms
+step:277/1600 train_time:9431ms step_avg:34.05ms
+step:278/1600 train_time:9468ms step_avg:34.06ms
+step:279/1600 train_time:9498ms step_avg:34.04ms
+step:280/1600 train_time:9535ms step_avg:34.06ms
+step:281/1600 train_time:9566ms step_avg:34.04ms
+step:282/1600 train_time:9603ms step_avg:34.05ms
+step:283/1600 train_time:9634ms step_avg:34.04ms
+step:284/1600 train_time:9671ms step_avg:34.05ms
+step:285/1600 train_time:9703ms step_avg:34.04ms
+step:286/1600 train_time:9741ms step_avg:34.06ms
+step:287/1600 train_time:9771ms step_avg:34.05ms
+step:288/1600 train_time:9808ms step_avg:34.06ms
+step:289/1600 train_time:9839ms step_avg:34.04ms
+step:290/1600 train_time:9876ms step_avg:34.05ms
+step:291/1600 train_time:9907ms step_avg:34.04ms
+step:292/1600 train_time:9944ms step_avg:34.05ms
+step:293/1600 train_time:9974ms step_avg:34.04ms
+step:294/1600 train_time:10011ms step_avg:34.05ms
+step:295/1600 train_time:10042ms step_avg:34.04ms
+step:296/1600 train_time:10079ms step_avg:34.05ms
+step:297/1600 train_time:10110ms step_avg:34.04ms
+step:298/1600 train_time:10147ms step_avg:34.05ms
+step:299/1600 train_time:10178ms step_avg:34.04ms
+step:300/1600 train_time:10215ms step_avg:34.05ms
+step:301/1600 train_time:10245ms step_avg:34.04ms
+step:302/1600 train_time:10282ms step_avg:34.05ms
+step:303/1600 train_time:10312ms step_avg:34.03ms
+step:304/1600 train_time:10349ms step_avg:34.04ms
+step:305/1600 train_time:10380ms step_avg:34.03ms
+step:306/1600 train_time:10417ms step_avg:34.04ms
+step:307/1600 train_time:10447ms step_avg:34.03ms
+step:308/1600 train_time:10484ms step_avg:34.04ms
+step:309/1600 train_time:10514ms step_avg:34.03ms
+step:310/1600 train_time:10552ms step_avg:34.04ms
+step:311/1600 train_time:10582ms step_avg:34.03ms
+step:312/1600 train_time:10619ms step_avg:34.04ms
+step:313/1600 train_time:10650ms step_avg:34.03ms
+step:314/1600 train_time:10687ms step_avg:34.04ms
+step:315/1600 train_time:10718ms step_avg:34.03ms
+step:316/1600 train_time:10756ms step_avg:34.04ms
+step:317/1600 train_time:10786ms step_avg:34.03ms
+step:318/1600 train_time:10823ms step_avg:34.04ms
+step:319/1600 train_time:10854ms step_avg:34.02ms
+step:320/1600 train_time:10891ms step_avg:34.03ms
+step:321/1600 train_time:10922ms step_avg:34.02ms
+step:322/1600 train_time:10959ms step_avg:34.03ms
+step:323/1600 train_time:10990ms step_avg:34.02ms
+step:324/1600 train_time:11027ms step_avg:34.04ms
+step:325/1600 train_time:11057ms step_avg:34.02ms
+step:326/1600 train_time:11094ms step_avg:34.03ms
+step:327/1600 train_time:11125ms step_avg:34.02ms
+step:328/1600 train_time:11162ms step_avg:34.03ms
+step:329/1600 train_time:11192ms step_avg:34.02ms
+step:330/1600 train_time:11230ms step_avg:34.03ms
+step:331/1600 train_time:11260ms step_avg:34.02ms
+step:332/1600 train_time:11297ms step_avg:34.03ms
+step:333/1600 train_time:11327ms step_avg:34.01ms
+step:334/1600 train_time:11364ms step_avg:34.03ms
+step:335/1600 train_time:11395ms step_avg:34.01ms
+step:336/1600 train_time:11432ms step_avg:34.02ms
+step:337/1600 train_time:11462ms step_avg:34.01ms
+step:338/1600 train_time:11499ms step_avg:34.02ms
+step:339/1600 train_time:11530ms step_avg:34.01ms
+step:340/1600 train_time:11567ms step_avg:34.02ms
+step:341/1600 train_time:11598ms step_avg:34.01ms
+step:342/1600 train_time:11635ms step_avg:34.02ms
+step:343/1600 train_time:11665ms step_avg:34.01ms
+step:344/1600 train_time:11702ms step_avg:34.02ms
+step:345/1600 train_time:11733ms step_avg:34.01ms
+step:346/1600 train_time:11770ms step_avg:34.02ms
+step:347/1600 train_time:11801ms step_avg:34.01ms
+step:348/1600 train_time:11839ms step_avg:34.02ms
+step:349/1600 train_time:11869ms step_avg:34.01ms
+step:350/1600 train_time:11907ms step_avg:34.02ms
+step:351/1600 train_time:11937ms step_avg:34.01ms
+step:352/1600 train_time:11974ms step_avg:34.02ms
+step:353/1600 train_time:12005ms step_avg:34.01ms
+step:354/1600 train_time:12042ms step_avg:34.02ms
+step:355/1600 train_time:12072ms step_avg:34.01ms
+step:356/1600 train_time:12110ms step_avg:34.02ms
+step:357/1600 train_time:12141ms step_avg:34.01ms
+step:358/1600 train_time:12177ms step_avg:34.02ms
+step:359/1600 train_time:12208ms step_avg:34.01ms
+step:360/1600 train_time:12245ms step_avg:34.01ms
+step:361/1600 train_time:12275ms step_avg:34.00ms
+step:362/1600 train_time:12312ms step_avg:34.01ms
+step:363/1600 train_time:12343ms step_avg:34.00ms
+step:364/1600 train_time:12379ms step_avg:34.01ms
+step:365/1600 train_time:12410ms step_avg:34.00ms
+step:366/1600 train_time:12447ms step_avg:34.01ms
+step:367/1600 train_time:12477ms step_avg:34.00ms
+step:368/1600 train_time:12514ms step_avg:34.01ms
+step:369/1600 train_time:12545ms step_avg:34.00ms
+step:370/1600 train_time:12582ms step_avg:34.01ms
+step:371/1600 train_time:12612ms step_avg:34.00ms
+step:372/1600 train_time:12650ms step_avg:34.01ms
+step:373/1600 train_time:12681ms step_avg:34.00ms
+step:374/1600 train_time:12718ms step_avg:34.00ms
+step:375/1600 train_time:12749ms step_avg:34.00ms
+step:376/1600 train_time:12786ms step_avg:34.01ms
+step:377/1600 train_time:12816ms step_avg:34.00ms
+step:378/1600 train_time:12853ms step_avg:34.00ms
+step:379/1600 train_time:12884ms step_avg:33.99ms
+step:380/1600 train_time:12921ms step_avg:34.00ms
+step:381/1600 train_time:12952ms step_avg:33.99ms
+step:382/1600 train_time:12989ms step_avg:34.00ms
+step:383/1600 train_time:13019ms step_avg:33.99ms
+step:384/1600 train_time:13056ms step_avg:34.00ms
+step:385/1600 train_time:13087ms step_avg:33.99ms
+step:386/1600 train_time:13124ms step_avg:34.00ms
+step:387/1600 train_time:13155ms step_avg:33.99ms
+step:388/1600 train_time:13192ms step_avg:34.00ms
+step:389/1600 train_time:13223ms step_avg:33.99ms
+step:390/1600 train_time:13260ms step_avg:34.00ms
+step:391/1600 train_time:13291ms step_avg:33.99ms
+step:392/1600 train_time:13328ms step_avg:34.00ms
+step:393/1600 train_time:13359ms step_avg:33.99ms
+step:394/1600 train_time:13396ms step_avg:34.00ms
+step:395/1600 train_time:13426ms step_avg:33.99ms
+step:396/1600 train_time:13463ms step_avg:34.00ms
+step:397/1600 train_time:13494ms step_avg:33.99ms
+step:398/1600 train_time:13531ms step_avg:34.00ms
+step:399/1600 train_time:13561ms step_avg:33.99ms
+step:400/1600 train_time:13598ms step_avg:34.00ms
+step:401/1600 train_time:13629ms step_avg:33.99ms
+step:402/1600 train_time:13666ms step_avg:34.00ms
+step:403/1600 train_time:13697ms step_avg:33.99ms
+step:404/1600 train_time:13734ms step_avg:34.00ms
+step:405/1600 train_time:13764ms step_avg:33.99ms
+step:406/1600 train_time:13802ms step_avg:33.99ms
+step:407/1600 train_time:13832ms step_avg:33.99ms
+step:408/1600 train_time:13870ms step_avg:33.99ms
+step:409/1600 train_time:13900ms step_avg:33.99ms
+step:410/1600 train_time:13938ms step_avg:33.99ms
+step:411/1600 train_time:13968ms step_avg:33.98ms
+step:412/1600 train_time:14006ms step_avg:33.99ms
+step:413/1600 train_time:14036ms step_avg:33.99ms
+step:414/1600 train_time:14073ms step_avg:33.99ms
+step:415/1600 train_time:14103ms step_avg:33.98ms
+step:416/1600 train_time:14140ms step_avg:33.99ms
+step:417/1600 train_time:14171ms step_avg:33.98ms
+step:418/1600 train_time:14208ms step_avg:33.99ms
+step:419/1600 train_time:14238ms step_avg:33.98ms
+step:420/1600 train_time:14275ms step_avg:33.99ms
+step:421/1600 train_time:14306ms step_avg:33.98ms
+step:422/1600 train_time:14343ms step_avg:33.99ms
+step:423/1600 train_time:14373ms step_avg:33.98ms
+step:424/1600 train_time:14410ms step_avg:33.99ms
+step:425/1600 train_time:14441ms step_avg:33.98ms
+step:426/1600 train_time:14478ms step_avg:33.99ms
+step:427/1600 train_time:14509ms step_avg:33.98ms
+step:428/1600 train_time:14547ms step_avg:33.99ms
+step:429/1600 train_time:14577ms step_avg:33.98ms
+step:430/1600 train_time:14614ms step_avg:33.99ms
+step:431/1600 train_time:14645ms step_avg:33.98ms
+step:432/1600 train_time:14681ms step_avg:33.98ms
+step:433/1600 train_time:14712ms step_avg:33.98ms
+step:434/1600 train_time:14749ms step_avg:33.98ms
+step:435/1600 train_time:14780ms step_avg:33.98ms
+step:436/1600 train_time:14818ms step_avg:33.99ms
+step:437/1600 train_time:14848ms step_avg:33.98ms
+step:438/1600 train_time:14886ms step_avg:33.99ms
+step:439/1600 train_time:14916ms step_avg:33.98ms
+step:440/1600 train_time:14953ms step_avg:33.98ms
+step:441/1600 train_time:14984ms step_avg:33.98ms
+step:442/1600 train_time:15021ms step_avg:33.98ms
+step:443/1600 train_time:15052ms step_avg:33.98ms
+step:444/1600 train_time:15089ms step_avg:33.98ms
+step:445/1600 train_time:15120ms step_avg:33.98ms
+step:446/1600 train_time:15157ms step_avg:33.98ms
+step:447/1600 train_time:15187ms step_avg:33.98ms
+step:448/1600 train_time:15224ms step_avg:33.98ms
+step:449/1600 train_time:15255ms step_avg:33.97ms
+step:450/1600 train_time:15292ms step_avg:33.98ms
+step:451/1600 train_time:15323ms step_avg:33.98ms
+step:452/1600 train_time:15360ms step_avg:33.98ms
+step:453/1600 train_time:15391ms step_avg:33.97ms
+step:454/1600 train_time:15428ms step_avg:33.98ms
+step:455/1600 train_time:15458ms step_avg:33.97ms
+step:456/1600 train_time:15495ms step_avg:33.98ms
+step:457/1600 train_time:15526ms step_avg:33.97ms
+step:458/1600 train_time:15563ms step_avg:33.98ms
+step:459/1600 train_time:15593ms step_avg:33.97ms
+step:460/1600 train_time:15631ms step_avg:33.98ms
+step:461/1600 train_time:15662ms step_avg:33.97ms
+step:462/1600 train_time:15699ms step_avg:33.98ms
+step:463/1600 train_time:15729ms step_avg:33.97ms
+step:464/1600 train_time:15766ms step_avg:33.98ms
+step:465/1600 train_time:15797ms step_avg:33.97ms
+step:466/1600 train_time:15834ms step_avg:33.98ms
+step:467/1600 train_time:15865ms step_avg:33.97ms
+step:468/1600 train_time:15902ms step_avg:33.98ms
+step:469/1600 train_time:15932ms step_avg:33.97ms
+step:470/1600 train_time:15970ms step_avg:33.98ms
+step:471/1600 train_time:16001ms step_avg:33.97ms
+step:472/1600 train_time:16038ms step_avg:33.98ms
+step:473/1600 train_time:16068ms step_avg:33.97ms
+step:474/1600 train_time:16105ms step_avg:33.98ms
+step:475/1600 train_time:16136ms step_avg:33.97ms
+step:476/1600 train_time:16173ms step_avg:33.98ms
+step:477/1600 train_time:16204ms step_avg:33.97ms
+step:478/1600 train_time:16240ms step_avg:33.98ms
+step:479/1600 train_time:16271ms step_avg:33.97ms
+step:480/1600 train_time:16308ms step_avg:33.98ms
+step:481/1600 train_time:16339ms step_avg:33.97ms
+step:482/1600 train_time:16377ms step_avg:33.98ms
+step:483/1600 train_time:16407ms step_avg:33.97ms
+step:484/1600 train_time:16444ms step_avg:33.98ms
+step:485/1600 train_time:16474ms step_avg:33.97ms
+step:486/1600 train_time:16512ms step_avg:33.97ms
+step:487/1600 train_time:16542ms step_avg:33.97ms
+step:488/1600 train_time:16579ms step_avg:33.97ms
+step:489/1600 train_time:16609ms step_avg:33.97ms
+step:490/1600 train_time:16647ms step_avg:33.97ms
+step:491/1600 train_time:16677ms step_avg:33.97ms
+step:492/1600 train_time:16714ms step_avg:33.97ms
+step:493/1600 train_time:16745ms step_avg:33.96ms
+step:494/1600 train_time:16782ms step_avg:33.97ms
+step:495/1600 train_time:16812ms step_avg:33.96ms
+step:496/1600 train_time:16850ms step_avg:33.97ms
+step:497/1600 train_time:16880ms step_avg:33.96ms
+step:498/1600 train_time:16917ms step_avg:33.97ms
+step:499/1600 train_time:16948ms step_avg:33.96ms
+step:500/1600 train_time:16985ms step_avg:33.97ms
+step:500/1600 val_loss:4.2401 train_time:17033ms step_avg:34.07ms
+step:501/1600 train_time:17050ms step_avg:34.03ms
+step:502/1600 train_time:17067ms step_avg:34.00ms
+step:503/1600 train_time:17088ms step_avg:33.97ms
+step:504/1600 train_time:17125ms step_avg:33.98ms
+step:505/1600 train_time:17156ms step_avg:33.97ms
+step:506/1600 train_time:17194ms step_avg:33.98ms
+step:507/1600 train_time:17225ms step_avg:33.97ms
+step:508/1600 train_time:17262ms step_avg:33.98ms
+step:509/1600 train_time:17293ms step_avg:33.97ms
+step:510/1600 train_time:17330ms step_avg:33.98ms
+step:511/1600 train_time:17361ms step_avg:33.97ms
+step:512/1600 train_time:17398ms step_avg:33.98ms
+step:513/1600 train_time:17428ms step_avg:33.97ms
+step:514/1600 train_time:17465ms step_avg:33.98ms
+step:515/1600 train_time:17496ms step_avg:33.97ms
+step:516/1600 train_time:17533ms step_avg:33.98ms
+step:517/1600 train_time:17564ms step_avg:33.97ms
+step:518/1600 train_time:17601ms step_avg:33.98ms
+step:519/1600 train_time:17631ms step_avg:33.97ms
+step:520/1600 train_time:17668ms step_avg:33.98ms
+step:521/1600 train_time:17738ms step_avg:34.05ms
+step:522/1600 train_time:17795ms step_avg:34.09ms
+step:523/1600 train_time:17857ms step_avg:34.14ms
+step:524/1600 train_time:17915ms step_avg:34.19ms
+step:525/1600 train_time:17978ms step_avg:34.24ms
+step:526/1600 train_time:18038ms step_avg:34.29ms
+step:527/1600 train_time:18102ms step_avg:34.35ms
+step:528/1600 train_time:18162ms step_avg:34.40ms
+step:529/1600 train_time:18226ms step_avg:34.45ms
+step:530/1600 train_time:18285ms step_avg:34.50ms
+step:531/1600 train_time:18347ms step_avg:34.55ms
+step:532/1600 train_time:18407ms step_avg:34.60ms
+step:533/1600 train_time:18469ms step_avg:34.65ms
+step:534/1600 train_time:18528ms step_avg:34.70ms
+step:535/1600 train_time:18591ms step_avg:34.75ms
+step:536/1600 train_time:18650ms step_avg:34.79ms
+step:537/1600 train_time:18712ms step_avg:34.85ms
+step:538/1600 train_time:18771ms step_avg:34.89ms
+step:539/1600 train_time:18833ms step_avg:34.94ms
+step:540/1600 train_time:18892ms step_avg:34.99ms
+step:541/1600 train_time:18955ms step_avg:35.04ms
+step:542/1600 train_time:19014ms step_avg:35.08ms
+step:543/1600 train_time:19078ms step_avg:35.14ms
+step:544/1600 train_time:19138ms step_avg:35.18ms
+step:545/1600 train_time:19202ms step_avg:35.23ms
+step:546/1600 train_time:19261ms step_avg:35.28ms
+step:547/1600 train_time:19324ms step_avg:35.33ms
+step:548/1600 train_time:19383ms step_avg:35.37ms
+step:549/1600 train_time:19447ms step_avg:35.42ms
+step:550/1600 train_time:19506ms step_avg:35.47ms
+step:551/1600 train_time:19569ms step_avg:35.52ms
+step:552/1600 train_time:19628ms step_avg:35.56ms
+step:553/1600 train_time:19690ms step_avg:35.61ms
+step:554/1600 train_time:19748ms step_avg:35.65ms
+step:555/1600 train_time:19811ms step_avg:35.70ms
+step:556/1600 train_time:19870ms step_avg:35.74ms
+step:557/1600 train_time:19933ms step_avg:35.79ms
+step:558/1600 train_time:19992ms step_avg:35.83ms
+step:559/1600 train_time:20056ms step_avg:35.88ms
+step:560/1600 train_time:20115ms step_avg:35.92ms
+step:561/1600 train_time:20179ms step_avg:35.97ms
+step:562/1600 train_time:20238ms step_avg:36.01ms
+step:563/1600 train_time:20300ms step_avg:36.06ms
+step:564/1600 train_time:20360ms step_avg:36.10ms
+step:565/1600 train_time:20422ms step_avg:36.15ms
+step:566/1600 train_time:20482ms step_avg:36.19ms
+step:567/1600 train_time:20545ms step_avg:36.23ms
+step:568/1600 train_time:20604ms step_avg:36.27ms
+step:569/1600 train_time:20667ms step_avg:36.32ms
+step:570/1600 train_time:20727ms step_avg:36.36ms
+step:571/1600 train_time:20789ms step_avg:36.41ms
+step:572/1600 train_time:20848ms step_avg:36.45ms
+step:573/1600 train_time:20912ms step_avg:36.50ms
+step:574/1600 train_time:20971ms step_avg:36.53ms
+step:575/1600 train_time:21034ms step_avg:36.58ms
+step:576/1600 train_time:21092ms step_avg:36.62ms
+step:577/1600 train_time:21155ms step_avg:36.66ms
+step:578/1600 train_time:21214ms step_avg:36.70ms
+step:579/1600 train_time:21277ms step_avg:36.75ms
+step:580/1600 train_time:21336ms step_avg:36.79ms
+step:581/1600 train_time:21399ms step_avg:36.83ms
+step:582/1600 train_time:21459ms step_avg:36.87ms
+step:583/1600 train_time:21522ms step_avg:36.92ms
+step:584/1600 train_time:21581ms step_avg:36.95ms
+step:585/1600 train_time:21644ms step_avg:37.00ms
+step:586/1600 train_time:21703ms step_avg:37.04ms
+step:587/1600 train_time:21766ms step_avg:37.08ms
+step:588/1600 train_time:21826ms step_avg:37.12ms
+step:589/1600 train_time:21889ms step_avg:37.16ms
+step:590/1600 train_time:21948ms step_avg:37.20ms
+step:591/1600 train_time:22011ms step_avg:37.24ms
+step:592/1600 train_time:22070ms step_avg:37.28ms
+step:593/1600 train_time:22132ms step_avg:37.32ms
+step:594/1600 train_time:22191ms step_avg:37.36ms
+step:595/1600 train_time:22254ms step_avg:37.40ms
+step:596/1600 train_time:22313ms step_avg:37.44ms
+step:597/1600 train_time:22376ms step_avg:37.48ms
+step:598/1600 train_time:22435ms step_avg:37.52ms
+step:599/1600 train_time:22498ms step_avg:37.56ms
+step:600/1600 train_time:22558ms step_avg:37.60ms
+step:601/1600 train_time:22621ms step_avg:37.64ms
+step:602/1600 train_time:22680ms step_avg:37.67ms
+step:603/1600 train_time:22742ms step_avg:37.72ms
+step:604/1600 train_time:22801ms step_avg:37.75ms
+step:605/1600 train_time:22864ms step_avg:37.79ms
+step:606/1600 train_time:22925ms step_avg:37.83ms
+step:607/1600 train_time:22987ms step_avg:37.87ms
+step:608/1600 train_time:23046ms step_avg:37.91ms
+step:609/1600 train_time:23109ms step_avg:37.95ms
+step:610/1600 train_time:23169ms step_avg:37.98ms
+step:611/1600 train_time:23231ms step_avg:38.02ms
+step:612/1600 train_time:23290ms step_avg:38.06ms
+step:613/1600 train_time:23353ms step_avg:38.10ms
+step:614/1600 train_time:23413ms step_avg:38.13ms
+step:615/1600 train_time:23475ms step_avg:38.17ms
+step:616/1600 train_time:23535ms step_avg:38.21ms
+step:617/1600 train_time:23597ms step_avg:38.24ms
+step:618/1600 train_time:23656ms step_avg:38.28ms
+step:619/1600 train_time:23719ms step_avg:38.32ms
+step:620/1600 train_time:23778ms step_avg:38.35ms
+step:621/1600 train_time:23842ms step_avg:38.39ms
+step:622/1600 train_time:23901ms step_avg:38.43ms
+step:623/1600 train_time:23964ms step_avg:38.47ms
+step:624/1600 train_time:24024ms step_avg:38.50ms
+step:625/1600 train_time:24086ms step_avg:38.54ms
+step:626/1600 train_time:24145ms step_avg:38.57ms
+step:627/1600 train_time:24208ms step_avg:38.61ms
+step:628/1600 train_time:24267ms step_avg:38.64ms
+step:629/1600 train_time:24331ms step_avg:38.68ms
+step:630/1600 train_time:24390ms step_avg:38.71ms
+step:631/1600 train_time:24453ms step_avg:38.75ms
+step:632/1600 train_time:24511ms step_avg:38.78ms
+step:633/1600 train_time:24574ms step_avg:38.82ms
+step:634/1600 train_time:24633ms step_avg:38.85ms
+step:635/1600 train_time:24697ms step_avg:38.89ms
+step:636/1600 train_time:24756ms step_avg:38.92ms
+step:637/1600 train_time:24818ms step_avg:38.96ms
+step:638/1600 train_time:24878ms step_avg:38.99ms
+step:639/1600 train_time:24941ms step_avg:39.03ms
+step:640/1600 train_time:25000ms step_avg:39.06ms
+step:641/1600 train_time:25064ms step_avg:39.10ms
+step:642/1600 train_time:25122ms step_avg:39.13ms
+step:643/1600 train_time:25184ms step_avg:39.17ms
+step:644/1600 train_time:25244ms step_avg:39.20ms
+step:645/1600 train_time:25307ms step_avg:39.24ms
+step:646/1600 train_time:25366ms step_avg:39.27ms
+step:647/1600 train_time:25430ms step_avg:39.30ms
+step:648/1600 train_time:25488ms step_avg:39.33ms
+step:649/1600 train_time:25552ms step_avg:39.37ms
+step:650/1600 train_time:25611ms step_avg:39.40ms
+step:651/1600 train_time:25673ms step_avg:39.44ms
+step:652/1600 train_time:25733ms step_avg:39.47ms
+step:653/1600 train_time:25796ms step_avg:39.50ms
+step:654/1600 train_time:25856ms step_avg:39.53ms
+step:655/1600 train_time:25918ms step_avg:39.57ms
+step:656/1600 train_time:25977ms step_avg:39.60ms
+step:657/1600 train_time:26041ms step_avg:39.64ms
+step:658/1600 train_time:26099ms step_avg:39.66ms
+step:659/1600 train_time:26162ms step_avg:39.70ms
+step:660/1600 train_time:26221ms step_avg:39.73ms
+step:661/1600 train_time:26284ms step_avg:39.76ms
+step:662/1600 train_time:26344ms step_avg:39.80ms
+step:663/1600 train_time:26408ms step_avg:39.83ms
+step:664/1600 train_time:26467ms step_avg:39.86ms
+step:665/1600 train_time:26531ms step_avg:39.90ms
+step:666/1600 train_time:26590ms step_avg:39.92ms
+step:667/1600 train_time:26652ms step_avg:39.96ms
+step:668/1600 train_time:26711ms step_avg:39.99ms
+step:669/1600 train_time:26774ms step_avg:40.02ms
+step:670/1600 train_time:26833ms step_avg:40.05ms
+step:671/1600 train_time:26895ms step_avg:40.08ms
+step:672/1600 train_time:26955ms step_avg:40.11ms
+step:673/1600 train_time:27019ms step_avg:40.15ms
+step:674/1600 train_time:27077ms step_avg:40.17ms
+step:675/1600 train_time:27141ms step_avg:40.21ms
+step:676/1600 train_time:27200ms step_avg:40.24ms
+step:677/1600 train_time:27263ms step_avg:40.27ms
+step:678/1600 train_time:27322ms step_avg:40.30ms
+step:679/1600 train_time:27385ms step_avg:40.33ms
+step:680/1600 train_time:27444ms step_avg:40.36ms
+step:681/1600 train_time:27507ms step_avg:40.39ms
+step:682/1600 train_time:27566ms step_avg:40.42ms
+step:683/1600 train_time:27629ms step_avg:40.45ms
+step:684/1600 train_time:27687ms step_avg:40.48ms
+step:685/1600 train_time:27750ms step_avg:40.51ms
+step:686/1600 train_time:27810ms step_avg:40.54ms
+step:687/1600 train_time:27874ms step_avg:40.57ms
+step:688/1600 train_time:27933ms step_avg:40.60ms
+step:689/1600 train_time:27995ms step_avg:40.63ms
+step:690/1600 train_time:28055ms step_avg:40.66ms
+step:691/1600 train_time:28117ms step_avg:40.69ms
+step:692/1600 train_time:28177ms step_avg:40.72ms
+step:693/1600 train_time:28239ms step_avg:40.75ms
+step:694/1600 train_time:28299ms step_avg:40.78ms
+step:695/1600 train_time:28362ms step_avg:40.81ms
+step:696/1600 train_time:28422ms step_avg:40.84ms
+step:697/1600 train_time:28485ms step_avg:40.87ms
+step:698/1600 train_time:28543ms step_avg:40.89ms
+step:699/1600 train_time:28606ms step_avg:40.92ms
+step:700/1600 train_time:28665ms step_avg:40.95ms
+step:701/1600 train_time:28727ms step_avg:40.98ms
+step:702/1600 train_time:28787ms step_avg:41.01ms
+step:703/1600 train_time:28851ms step_avg:41.04ms
+step:704/1600 train_time:28909ms step_avg:41.06ms
+step:705/1600 train_time:28972ms step_avg:41.09ms
+step:706/1600 train_time:29032ms step_avg:41.12ms
+step:707/1600 train_time:29094ms step_avg:41.15ms
+step:708/1600 train_time:29153ms step_avg:41.18ms
+step:709/1600 train_time:29217ms step_avg:41.21ms
+step:710/1600 train_time:29277ms step_avg:41.23ms
+step:711/1600 train_time:29340ms step_avg:41.27ms
+step:712/1600 train_time:29399ms step_avg:41.29ms
+step:713/1600 train_time:29462ms step_avg:41.32ms
+step:714/1600 train_time:29521ms step_avg:41.35ms
+step:715/1600 train_time:29583ms step_avg:41.38ms
+step:716/1600 train_time:29642ms step_avg:41.40ms
+step:717/1600 train_time:29706ms step_avg:41.43ms
+step:718/1600 train_time:29765ms step_avg:41.46ms
+step:719/1600 train_time:29827ms step_avg:41.48ms
+step:720/1600 train_time:29887ms step_avg:41.51ms
+step:721/1600 train_time:29950ms step_avg:41.54ms
+step:722/1600 train_time:30009ms step_avg:41.56ms
+step:723/1600 train_time:30073ms step_avg:41.59ms
+step:724/1600 train_time:30132ms step_avg:41.62ms
+step:725/1600 train_time:30194ms step_avg:41.65ms
+step:726/1600 train_time:30253ms step_avg:41.67ms
+step:727/1600 train_time:30316ms step_avg:41.70ms
+step:728/1600 train_time:30376ms step_avg:41.73ms
+step:729/1600 train_time:30439ms step_avg:41.75ms
+step:730/1600 train_time:30498ms step_avg:41.78ms
+step:731/1600 train_time:30561ms step_avg:41.81ms
+step:732/1600 train_time:30620ms step_avg:41.83ms
+step:733/1600 train_time:30684ms step_avg:41.86ms
+step:734/1600 train_time:30742ms step_avg:41.88ms
+step:735/1600 train_time:30805ms step_avg:41.91ms
+step:736/1600 train_time:30864ms step_avg:41.93ms
+step:737/1600 train_time:30927ms step_avg:41.96ms
+step:738/1600 train_time:30986ms step_avg:41.99ms
+step:739/1600 train_time:31049ms step_avg:42.02ms
+step:740/1600 train_time:31109ms step_avg:42.04ms
+step:741/1600 train_time:31172ms step_avg:42.07ms
+step:742/1600 train_time:31231ms step_avg:42.09ms
+step:743/1600 train_time:31294ms step_avg:42.12ms
+step:744/1600 train_time:31354ms step_avg:42.14ms
+step:745/1600 train_time:31416ms step_avg:42.17ms
+step:746/1600 train_time:31477ms step_avg:42.19ms
+step:747/1600 train_time:31540ms step_avg:42.22ms
+step:748/1600 train_time:31599ms step_avg:42.24ms
+step:749/1600 train_time:31662ms step_avg:42.27ms
+step:750/1600 train_time:31721ms step_avg:42.29ms
+step:750/1600 val_loss:3.9064 train_time:31767ms step_avg:42.36ms
+step:751/1600 train_time:31785ms step_avg:42.32ms
+step:752/1600 train_time:31844ms step_avg:42.35ms
+step:753/1600 train_time:31909ms step_avg:42.38ms
+step:754/1600 train_time:31969ms step_avg:42.40ms
+step:755/1600 train_time:32032ms step_avg:42.43ms
+step:756/1600 train_time:32090ms step_avg:42.45ms
+step:757/1600 train_time:32151ms step_avg:42.47ms
+step:758/1600 train_time:32210ms step_avg:42.49ms
+step:759/1600 train_time:32272ms step_avg:42.52ms
+step:760/1600 train_time:32331ms step_avg:42.54ms
+step:761/1600 train_time:32393ms step_avg:42.57ms
+step:762/1600 train_time:32452ms step_avg:42.59ms
+step:763/1600 train_time:32514ms step_avg:42.61ms
+step:764/1600 train_time:32573ms step_avg:42.63ms
+step:765/1600 train_time:32636ms step_avg:42.66ms
+step:766/1600 train_time:32697ms step_avg:42.68ms
+step:767/1600 train_time:32762ms step_avg:42.71ms
+step:768/1600 train_time:32821ms step_avg:42.74ms
+step:769/1600 train_time:32884ms step_avg:42.76ms
+step:770/1600 train_time:32943ms step_avg:42.78ms
+step:771/1600 train_time:33006ms step_avg:42.81ms
+step:772/1600 train_time:33065ms step_avg:42.83ms
+step:773/1600 train_time:33128ms step_avg:42.86ms
+step:774/1600 train_time:33186ms step_avg:42.88ms
+step:775/1600 train_time:33248ms step_avg:42.90ms
+step:776/1600 train_time:33308ms step_avg:42.92ms
+step:777/1600 train_time:33370ms step_avg:42.95ms
+step:778/1600 train_time:33429ms step_avg:42.97ms
+step:779/1600 train_time:33491ms step_avg:42.99ms
+step:780/1600 train_time:33550ms step_avg:43.01ms
+step:781/1600 train_time:33612ms step_avg:43.04ms
+step:782/1600 train_time:33672ms step_avg:43.06ms
+step:783/1600 train_time:33736ms step_avg:43.09ms
+step:784/1600 train_time:33796ms step_avg:43.11ms
+step:785/1600 train_time:33859ms step_avg:43.13ms
+step:786/1600 train_time:33919ms step_avg:43.15ms
+step:787/1600 train_time:33981ms step_avg:43.18ms
+step:788/1600 train_time:34040ms step_avg:43.20ms
+step:789/1600 train_time:34104ms step_avg:43.22ms
+step:790/1600 train_time:34163ms step_avg:43.24ms
+step:791/1600 train_time:34226ms step_avg:43.27ms
+step:792/1600 train_time:34284ms step_avg:43.29ms
+step:793/1600 train_time:34347ms step_avg:43.31ms
+step:794/1600 train_time:34407ms step_avg:43.33ms
+step:795/1600 train_time:34469ms step_avg:43.36ms
+step:796/1600 train_time:34528ms step_avg:43.38ms
+step:797/1600 train_time:34591ms step_avg:43.40ms
+step:798/1600 train_time:34649ms step_avg:43.42ms
+step:799/1600 train_time:34713ms step_avg:43.45ms
+step:800/1600 train_time:34772ms step_avg:43.47ms
+step:801/1600 train_time:34836ms step_avg:43.49ms
+step:802/1600 train_time:34896ms step_avg:43.51ms
+step:803/1600 train_time:34959ms step_avg:43.54ms
+step:804/1600 train_time:35018ms step_avg:43.55ms
+step:805/1600 train_time:35081ms step_avg:43.58ms
+step:806/1600 train_time:35140ms step_avg:43.60ms
+step:807/1600 train_time:35203ms step_avg:43.62ms
+step:808/1600 train_time:35261ms step_avg:43.64ms
+step:809/1600 train_time:35324ms step_avg:43.66ms
+step:810/1600 train_time:35384ms step_avg:43.68ms
+step:811/1600 train_time:35446ms step_avg:43.71ms
+step:812/1600 train_time:35506ms step_avg:43.73ms
+step:813/1600 train_time:35569ms step_avg:43.75ms
+step:814/1600 train_time:35627ms step_avg:43.77ms
+step:815/1600 train_time:35690ms step_avg:43.79ms
+step:816/1600 train_time:35749ms step_avg:43.81ms
+step:817/1600 train_time:35812ms step_avg:43.83ms
+step:818/1600 train_time:35872ms step_avg:43.85ms
+step:819/1600 train_time:35935ms step_avg:43.88ms
+step:820/1600 train_time:35994ms step_avg:43.90ms
+step:821/1600 train_time:36058ms step_avg:43.92ms
+step:822/1600 train_time:36117ms step_avg:43.94ms
+step:823/1600 train_time:36180ms step_avg:43.96ms
+step:824/1600 train_time:36239ms step_avg:43.98ms
+step:825/1600 train_time:36302ms step_avg:44.00ms
+step:826/1600 train_time:36360ms step_avg:44.02ms
+step:827/1600 train_time:36423ms step_avg:44.04ms
+step:828/1600 train_time:36482ms step_avg:44.06ms
+step:829/1600 train_time:36545ms step_avg:44.08ms
+step:830/1600 train_time:36605ms step_avg:44.10ms
+step:831/1600 train_time:36669ms step_avg:44.13ms
+step:832/1600 train_time:36728ms step_avg:44.14ms
+step:833/1600 train_time:36791ms step_avg:44.17ms
+step:834/1600 train_time:36850ms step_avg:44.18ms
+step:835/1600 train_time:36913ms step_avg:44.21ms
+step:836/1600 train_time:36972ms step_avg:44.22ms
+step:837/1600 train_time:37035ms step_avg:44.25ms
+step:838/1600 train_time:37094ms step_avg:44.27ms
+step:839/1600 train_time:37158ms step_avg:44.29ms
+step:840/1600 train_time:37217ms step_avg:44.31ms
+step:841/1600 train_time:37280ms step_avg:44.33ms
+step:842/1600 train_time:37339ms step_avg:44.35ms
+step:843/1600 train_time:37402ms step_avg:44.37ms
+step:844/1600 train_time:37461ms step_avg:44.39ms
+step:845/1600 train_time:37524ms step_avg:44.41ms
+step:846/1600 train_time:37583ms step_avg:44.42ms
+step:847/1600 train_time:37646ms step_avg:44.45ms
+step:848/1600 train_time:37705ms step_avg:44.46ms
+step:849/1600 train_time:37769ms step_avg:44.49ms
+step:850/1600 train_time:37828ms step_avg:44.50ms
+step:851/1600 train_time:37891ms step_avg:44.52ms
+step:852/1600 train_time:37949ms step_avg:44.54ms
+step:853/1600 train_time:38013ms step_avg:44.56ms
+step:854/1600 train_time:38072ms step_avg:44.58ms
+step:855/1600 train_time:38134ms step_avg:44.60ms
+step:856/1600 train_time:38194ms step_avg:44.62ms
+step:857/1600 train_time:38257ms step_avg:44.64ms
+step:858/1600 train_time:38317ms step_avg:44.66ms
+step:859/1600 train_time:38379ms step_avg:44.68ms
+step:860/1600 train_time:38439ms step_avg:44.70ms
+step:861/1600 train_time:38502ms step_avg:44.72ms
+step:862/1600 train_time:38561ms step_avg:44.73ms
+step:863/1600 train_time:38624ms step_avg:44.76ms
+step:864/1600 train_time:38684ms step_avg:44.77ms
+step:865/1600 train_time:38746ms step_avg:44.79ms
+step:866/1600 train_time:38806ms step_avg:44.81ms
+step:867/1600 train_time:38869ms step_avg:44.83ms
+step:868/1600 train_time:38928ms step_avg:44.85ms
+step:869/1600 train_time:38990ms step_avg:44.87ms
+step:870/1600 train_time:39050ms step_avg:44.88ms
+step:871/1600 train_time:39113ms step_avg:44.91ms
+step:872/1600 train_time:39172ms step_avg:44.92ms
+step:873/1600 train_time:39235ms step_avg:44.94ms
+step:874/1600 train_time:39294ms step_avg:44.96ms
+step:875/1600 train_time:39357ms step_avg:44.98ms
+step:876/1600 train_time:39418ms step_avg:45.00ms
+step:877/1600 train_time:39481ms step_avg:45.02ms
+step:878/1600 train_time:39540ms step_avg:45.03ms
+step:879/1600 train_time:39603ms step_avg:45.05ms
+step:880/1600 train_time:39662ms step_avg:45.07ms
+step:881/1600 train_time:39725ms step_avg:45.09ms
+step:882/1600 train_time:39784ms step_avg:45.11ms
+step:883/1600 train_time:39847ms step_avg:45.13ms
+step:884/1600 train_time:39906ms step_avg:45.14ms
+step:885/1600 train_time:39969ms step_avg:45.16ms
+step:886/1600 train_time:40028ms step_avg:45.18ms
+step:887/1600 train_time:40090ms step_avg:45.20ms
+step:888/1600 train_time:40149ms step_avg:45.21ms
+step:889/1600 train_time:40212ms step_avg:45.23ms
+step:890/1600 train_time:40272ms step_avg:45.25ms
+step:891/1600 train_time:40336ms step_avg:45.27ms
+step:892/1600 train_time:40396ms step_avg:45.29ms
+step:893/1600 train_time:40458ms step_avg:45.31ms
+step:894/1600 train_time:40517ms step_avg:45.32ms
+step:895/1600 train_time:40580ms step_avg:45.34ms
+step:896/1600 train_time:40639ms step_avg:45.36ms
+step:897/1600 train_time:40701ms step_avg:45.37ms
+step:898/1600 train_time:40760ms step_avg:45.39ms
+step:899/1600 train_time:40824ms step_avg:45.41ms
+step:900/1600 train_time:40883ms step_avg:45.43ms
+step:901/1600 train_time:40946ms step_avg:45.45ms
+step:902/1600 train_time:41005ms step_avg:45.46ms
+step:903/1600 train_time:41068ms step_avg:45.48ms
+step:904/1600 train_time:41127ms step_avg:45.49ms
+step:905/1600 train_time:41190ms step_avg:45.51ms
+step:906/1600 train_time:41250ms step_avg:45.53ms
+step:907/1600 train_time:41312ms step_avg:45.55ms
+step:908/1600 train_time:41371ms step_avg:45.56ms
+step:909/1600 train_time:41434ms step_avg:45.58ms
+step:910/1600 train_time:41494ms step_avg:45.60ms
+step:911/1600 train_time:41557ms step_avg:45.62ms
+step:912/1600 train_time:41617ms step_avg:45.63ms
+step:913/1600 train_time:41679ms step_avg:45.65ms
+step:914/1600 train_time:41738ms step_avg:45.66ms
+step:915/1600 train_time:41800ms step_avg:45.68ms
+step:916/1600 train_time:41859ms step_avg:45.70ms
+step:917/1600 train_time:41923ms step_avg:45.72ms
+step:918/1600 train_time:41982ms step_avg:45.73ms
+step:919/1600 train_time:42045ms step_avg:45.75ms
+step:920/1600 train_time:42104ms step_avg:45.76ms
+step:921/1600 train_time:42167ms step_avg:45.78ms
+step:922/1600 train_time:42226ms step_avg:45.80ms
+step:923/1600 train_time:42289ms step_avg:45.82ms
+step:924/1600 train_time:42348ms step_avg:45.83ms
+step:925/1600 train_time:42411ms step_avg:45.85ms
+step:926/1600 train_time:42471ms step_avg:45.86ms
+step:927/1600 train_time:42534ms step_avg:45.88ms
+step:928/1600 train_time:42594ms step_avg:45.90ms
+step:929/1600 train_time:42657ms step_avg:45.92ms
+step:930/1600 train_time:42716ms step_avg:45.93ms
+step:931/1600 train_time:42778ms step_avg:45.95ms
+step:932/1600 train_time:42837ms step_avg:45.96ms
+step:933/1600 train_time:42900ms step_avg:45.98ms
+step:934/1600 train_time:42959ms step_avg:46.00ms
+step:935/1600 train_time:43023ms step_avg:46.01ms
+step:936/1600 train_time:43081ms step_avg:46.03ms
+step:937/1600 train_time:43144ms step_avg:46.05ms
+step:938/1600 train_time:43204ms step_avg:46.06ms
+step:939/1600 train_time:43267ms step_avg:46.08ms
+step:940/1600 train_time:43326ms step_avg:46.09ms
+step:941/1600 train_time:43389ms step_avg:46.11ms
+step:942/1600 train_time:43448ms step_avg:46.12ms
+step:943/1600 train_time:43511ms step_avg:46.14ms
+step:944/1600 train_time:43571ms step_avg:46.16ms
+step:945/1600 train_time:43633ms step_avg:46.17ms
+step:946/1600 train_time:43692ms step_avg:46.19ms
+step:947/1600 train_time:43755ms step_avg:46.20ms
+step:948/1600 train_time:43815ms step_avg:46.22ms
+step:949/1600 train_time:43877ms step_avg:46.24ms
+step:950/1600 train_time:43936ms step_avg:46.25ms
+step:951/1600 train_time:44000ms step_avg:46.27ms
+step:952/1600 train_time:44059ms step_avg:46.28ms
+step:953/1600 train_time:44123ms step_avg:46.30ms
+step:954/1600 train_time:44181ms step_avg:46.31ms
+step:955/1600 train_time:44244ms step_avg:46.33ms
+step:956/1600 train_time:44302ms step_avg:46.34ms
+step:957/1600 train_time:44366ms step_avg:46.36ms
+step:958/1600 train_time:44425ms step_avg:46.37ms
+step:959/1600 train_time:44488ms step_avg:46.39ms
+step:960/1600 train_time:44548ms step_avg:46.40ms
+step:961/1600 train_time:44610ms step_avg:46.42ms
+step:962/1600 train_time:44670ms step_avg:46.43ms
+step:963/1600 train_time:44732ms step_avg:46.45ms
+step:964/1600 train_time:44792ms step_avg:46.46ms
+step:965/1600 train_time:44855ms step_avg:46.48ms
+step:966/1600 train_time:44915ms step_avg:46.50ms
+step:967/1600 train_time:44978ms step_avg:46.51ms
+step:968/1600 train_time:45038ms step_avg:46.53ms
+step:969/1600 train_time:45101ms step_avg:46.54ms
+step:970/1600 train_time:45159ms step_avg:46.56ms
+step:971/1600 train_time:45223ms step_avg:46.57ms
+step:972/1600 train_time:45281ms step_avg:46.59ms
+step:973/1600 train_time:45343ms step_avg:46.60ms
+step:974/1600 train_time:45403ms step_avg:46.62ms
+step:975/1600 train_time:45467ms step_avg:46.63ms
+step:976/1600 train_time:45526ms step_avg:46.65ms
+step:977/1600 train_time:45589ms step_avg:46.66ms
+step:978/1600 train_time:45648ms step_avg:46.67ms
+step:979/1600 train_time:45710ms step_avg:46.69ms
+step:980/1600 train_time:45770ms step_avg:46.70ms
+step:981/1600 train_time:45833ms step_avg:46.72ms
+step:982/1600 train_time:45892ms step_avg:46.73ms
+step:983/1600 train_time:45956ms step_avg:46.75ms
+step:984/1600 train_time:46016ms step_avg:46.76ms
+step:985/1600 train_time:46078ms step_avg:46.78ms
+step:986/1600 train_time:46137ms step_avg:46.79ms
+step:987/1600 train_time:46199ms step_avg:46.81ms
+step:988/1600 train_time:46259ms step_avg:46.82ms
+step:989/1600 train_time:46322ms step_avg:46.84ms
+step:990/1600 train_time:46381ms step_avg:46.85ms
+step:991/1600 train_time:46443ms step_avg:46.86ms
+step:992/1600 train_time:46503ms step_avg:46.88ms
+step:993/1600 train_time:46565ms step_avg:46.89ms
+step:994/1600 train_time:46624ms step_avg:46.91ms
+step:995/1600 train_time:46688ms step_avg:46.92ms
+step:996/1600 train_time:46747ms step_avg:46.93ms
+step:997/1600 train_time:46810ms step_avg:46.95ms
+step:998/1600 train_time:46869ms step_avg:46.96ms
+step:999/1600 train_time:46931ms step_avg:46.98ms
+step:1000/1600 train_time:46991ms step_avg:46.99ms
+step:1000/1600 val_loss:3.6012 train_time:47038ms step_avg:47.04ms
+step:1001/1600 train_time:47055ms step_avg:47.01ms
+step:1002/1600 train_time:47114ms step_avg:47.02ms
+step:1003/1600 train_time:47178ms step_avg:47.04ms
+step:1004/1600 train_time:47237ms step_avg:47.05ms
+step:1005/1600 train_time:47299ms step_avg:47.06ms
+step:1006/1600 train_time:47358ms step_avg:47.08ms
+step:1007/1600 train_time:47420ms step_avg:47.09ms
+step:1008/1600 train_time:47479ms step_avg:47.10ms
+step:1009/1600 train_time:47542ms step_avg:47.12ms
+step:1010/1600 train_time:47600ms step_avg:47.13ms
+step:1011/1600 train_time:47662ms step_avg:47.14ms
+step:1012/1600 train_time:47720ms step_avg:47.15ms
+step:1013/1600 train_time:47783ms step_avg:47.17ms
+step:1014/1600 train_time:47842ms step_avg:47.18ms
+step:1015/1600 train_time:47905ms step_avg:47.20ms
+step:1016/1600 train_time:47965ms step_avg:47.21ms
+step:1017/1600 train_time:48029ms step_avg:47.23ms
+step:1018/1600 train_time:48088ms step_avg:47.24ms
+step:1019/1600 train_time:48151ms step_avg:47.25ms
+step:1020/1600 train_time:48210ms step_avg:47.26ms
+step:1021/1600 train_time:48273ms step_avg:47.28ms
+step:1022/1600 train_time:48332ms step_avg:47.29ms
+step:1023/1600 train_time:48394ms step_avg:47.31ms
+step:1024/1600 train_time:48453ms step_avg:47.32ms
+step:1025/1600 train_time:48515ms step_avg:47.33ms
+step:1026/1600 train_time:48574ms step_avg:47.34ms
+step:1027/1600 train_time:48636ms step_avg:47.36ms
+step:1028/1600 train_time:48695ms step_avg:47.37ms
+step:1029/1600 train_time:48758ms step_avg:47.38ms
+step:1030/1600 train_time:48818ms step_avg:47.40ms
+step:1031/1600 train_time:48881ms step_avg:47.41ms
+step:1032/1600 train_time:48941ms step_avg:47.42ms
+step:1033/1600 train_time:49004ms step_avg:47.44ms
+step:1034/1600 train_time:49063ms step_avg:47.45ms
+step:1035/1600 train_time:49126ms step_avg:47.46ms
+step:1036/1600 train_time:49185ms step_avg:47.48ms
+step:1037/1600 train_time:49248ms step_avg:47.49ms
+step:1038/1600 train_time:49307ms step_avg:47.50ms
+step:1039/1600 train_time:49369ms step_avg:47.52ms
+step:1040/1600 train_time:49428ms step_avg:47.53ms
+step:1041/1600 train_time:49498ms step_avg:47.55ms
+step:1042/1600 train_time:49586ms step_avg:47.59ms
+step:1043/1600 train_time:49675ms step_avg:47.63ms
+step:1044/1600 train_time:49760ms step_avg:47.66ms
+step:1045/1600 train_time:49848ms step_avg:47.70ms
+step:1046/1600 train_time:49934ms step_avg:47.74ms
+step:1047/1600 train_time:50023ms step_avg:47.78ms
+step:1048/1600 train_time:50109ms step_avg:47.81ms
+step:1049/1600 train_time:50199ms step_avg:47.85ms
+step:1050/1600 train_time:50285ms step_avg:47.89ms
+step:1051/1600 train_time:50374ms step_avg:47.93ms
+step:1052/1600 train_time:50459ms step_avg:47.96ms
+step:1053/1600 train_time:50548ms step_avg:48.00ms
+step:1054/1600 train_time:50633ms step_avg:48.04ms
+step:1055/1600 train_time:50722ms step_avg:48.08ms
+step:1056/1600 train_time:50808ms step_avg:48.11ms
+step:1057/1600 train_time:50896ms step_avg:48.15ms
+step:1058/1600 train_time:50981ms step_avg:48.19ms
+step:1059/1600 train_time:51071ms step_avg:48.23ms
+step:1060/1600 train_time:51156ms step_avg:48.26ms
+step:1061/1600 train_time:51245ms step_avg:48.30ms
+step:1062/1600 train_time:51331ms step_avg:48.33ms
+step:1063/1600 train_time:51419ms step_avg:48.37ms
+step:1064/1600 train_time:51506ms step_avg:48.41ms
+step:1065/1600 train_time:51594ms step_avg:48.44ms
+step:1066/1600 train_time:51680ms step_avg:48.48ms
+step:1067/1600 train_time:51768ms step_avg:48.52ms
+step:1068/1600 train_time:51854ms step_avg:48.55ms
+step:1069/1600 train_time:51941ms step_avg:48.59ms
+step:1070/1600 train_time:52028ms step_avg:48.62ms
+step:1071/1600 train_time:52117ms step_avg:48.66ms
+step:1072/1600 train_time:52202ms step_avg:48.70ms
+step:1073/1600 train_time:52290ms step_avg:48.73ms
+step:1074/1600 train_time:52376ms step_avg:48.77ms
+step:1075/1600 train_time:52464ms step_avg:48.80ms
+step:1076/1600 train_time:52551ms step_avg:48.84ms
+step:1077/1600 train_time:52639ms step_avg:48.88ms
+step:1078/1600 train_time:52724ms step_avg:48.91ms
+step:1079/1600 train_time:52813ms step_avg:48.95ms
+step:1080/1600 train_time:52899ms step_avg:48.98ms
+step:1081/1600 train_time:52987ms step_avg:49.02ms
+step:1082/1600 train_time:53073ms step_avg:49.05ms
+step:1083/1600 train_time:53161ms step_avg:49.09ms
+step:1084/1600 train_time:53248ms step_avg:49.12ms
+step:1085/1600 train_time:53338ms step_avg:49.16ms
+step:1086/1600 train_time:53423ms step_avg:49.19ms
+step:1087/1600 train_time:53512ms step_avg:49.23ms
+step:1088/1600 train_time:53597ms step_avg:49.26ms
+step:1089/1600 train_time:53686ms step_avg:49.30ms
+step:1090/1600 train_time:53771ms step_avg:49.33ms
+step:1091/1600 train_time:53859ms step_avg:49.37ms
+step:1092/1600 train_time:53945ms step_avg:49.40ms
+step:1093/1600 train_time:54033ms step_avg:49.44ms
+step:1094/1600 train_time:54119ms step_avg:49.47ms
+step:1095/1600 train_time:54208ms step_avg:49.50ms
+step:1096/1600 train_time:54296ms step_avg:49.54ms
+step:1097/1600 train_time:54383ms step_avg:49.57ms
+step:1098/1600 train_time:54468ms step_avg:49.61ms
+step:1099/1600 train_time:54557ms step_avg:49.64ms
+step:1100/1600 train_time:54643ms step_avg:49.68ms
+step:1101/1600 train_time:54730ms step_avg:49.71ms
+step:1102/1600 train_time:54816ms step_avg:49.74ms
+step:1103/1600 train_time:54904ms step_avg:49.78ms
+step:1104/1600 train_time:54990ms step_avg:49.81ms
+step:1105/1600 train_time:55078ms step_avg:49.84ms
+step:1106/1600 train_time:55164ms step_avg:49.88ms
+step:1107/1600 train_time:55253ms step_avg:49.91ms
+step:1108/1600 train_time:55339ms step_avg:49.94ms
+step:1109/1600 train_time:55427ms step_avg:49.98ms
+step:1110/1600 train_time:55512ms step_avg:50.01ms
+step:1111/1600 train_time:55600ms step_avg:50.05ms
+step:1112/1600 train_time:55686ms step_avg:50.08ms
+step:1113/1600 train_time:55775ms step_avg:50.11ms
+step:1114/1600 train_time:55860ms step_avg:50.14ms
+step:1115/1600 train_time:55948ms step_avg:50.18ms
+step:1116/1600 train_time:56034ms step_avg:50.21ms
+step:1117/1600 train_time:56122ms step_avg:50.24ms
+step:1118/1600 train_time:56208ms step_avg:50.28ms
+step:1119/1600 train_time:56297ms step_avg:50.31ms
+step:1120/1600 train_time:56383ms step_avg:50.34ms
+step:1121/1600 train_time:56472ms step_avg:50.38ms
+step:1122/1600 train_time:56557ms step_avg:50.41ms
+step:1123/1600 train_time:56646ms step_avg:50.44ms
+step:1124/1600 train_time:56732ms step_avg:50.47ms
+step:1125/1600 train_time:56820ms step_avg:50.51ms
+step:1126/1600 train_time:56906ms step_avg:50.54ms
+step:1127/1600 train_time:56994ms step_avg:50.57ms
+step:1128/1600 train_time:57080ms step_avg:50.60ms
+step:1129/1600 train_time:57168ms step_avg:50.64ms
+step:1130/1600 train_time:57255ms step_avg:50.67ms
+step:1131/1600 train_time:57344ms step_avg:50.70ms
+step:1132/1600 train_time:57430ms step_avg:50.73ms
+step:1133/1600 train_time:57518ms step_avg:50.77ms
+step:1134/1600 train_time:57604ms step_avg:50.80ms
+step:1135/1600 train_time:57692ms step_avg:50.83ms
+step:1136/1600 train_time:57777ms step_avg:50.86ms
+step:1137/1600 train_time:57866ms step_avg:50.89ms
+step:1138/1600 train_time:57952ms step_avg:50.92ms
+step:1139/1600 train_time:58040ms step_avg:50.96ms
+step:1140/1600 train_time:58126ms step_avg:50.99ms
+step:1141/1600 train_time:58215ms step_avg:51.02ms
+step:1142/1600 train_time:58301ms step_avg:51.05ms
+step:1143/1600 train_time:58389ms step_avg:51.08ms
+step:1144/1600 train_time:58476ms step_avg:51.12ms
+step:1145/1600 train_time:58564ms step_avg:51.15ms
+step:1146/1600 train_time:58650ms step_avg:51.18ms
+step:1147/1600 train_time:58738ms step_avg:51.21ms
+step:1148/1600 train_time:58824ms step_avg:51.24ms
+step:1149/1600 train_time:58912ms step_avg:51.27ms
+step:1150/1600 train_time:58997ms step_avg:51.30ms
+step:1151/1600 train_time:59086ms step_avg:51.33ms
+step:1152/1600 train_time:59172ms step_avg:51.36ms
+step:1153/1600 train_time:59261ms step_avg:51.40ms
+step:1154/1600 train_time:59348ms step_avg:51.43ms
+step:1155/1600 train_time:59437ms step_avg:51.46ms
+step:1156/1600 train_time:59523ms step_avg:51.49ms
+step:1157/1600 train_time:59611ms step_avg:51.52ms
+step:1158/1600 train_time:59697ms step_avg:51.55ms
+step:1159/1600 train_time:59786ms step_avg:51.58ms
+step:1160/1600 train_time:59871ms step_avg:51.61ms
+step:1161/1600 train_time:59960ms step_avg:51.64ms
+step:1162/1600 train_time:60044ms step_avg:51.67ms
+step:1163/1600 train_time:60133ms step_avg:51.71ms
+step:1164/1600 train_time:60219ms step_avg:51.73ms
+step:1165/1600 train_time:60309ms step_avg:51.77ms
+step:1166/1600 train_time:60395ms step_avg:51.80ms
+step:1167/1600 train_time:60484ms step_avg:51.83ms
+step:1168/1600 train_time:60569ms step_avg:51.86ms
+step:1169/1600 train_time:60658ms step_avg:51.89ms
+step:1170/1600 train_time:60743ms step_avg:51.92ms
+step:1171/1600 train_time:60832ms step_avg:51.95ms
+step:1172/1600 train_time:60918ms step_avg:51.98ms
+step:1173/1600 train_time:61006ms step_avg:52.01ms
+step:1174/1600 train_time:61091ms step_avg:52.04ms
+step:1175/1600 train_time:61181ms step_avg:52.07ms
+step:1176/1600 train_time:61266ms step_avg:52.10ms
+step:1177/1600 train_time:61355ms step_avg:52.13ms
+step:1178/1600 train_time:61441ms step_avg:52.16ms
+step:1179/1600 train_time:61530ms step_avg:52.19ms
+step:1180/1600 train_time:61615ms step_avg:52.22ms
+step:1181/1600 train_time:61703ms step_avg:52.25ms
+step:1182/1600 train_time:61789ms step_avg:52.27ms
+step:1183/1600 train_time:61877ms step_avg:52.31ms
+step:1184/1600 train_time:61963ms step_avg:52.33ms
+step:1185/1600 train_time:62051ms step_avg:52.36ms
+step:1186/1600 train_time:62137ms step_avg:52.39ms
+step:1187/1600 train_time:62225ms step_avg:52.42ms
+step:1188/1600 train_time:62311ms step_avg:52.45ms
+step:1189/1600 train_time:62400ms step_avg:52.48ms
+step:1190/1600 train_time:62486ms step_avg:52.51ms
+step:1191/1600 train_time:62575ms step_avg:52.54ms
+step:1192/1600 train_time:62661ms step_avg:52.57ms
+step:1193/1600 train_time:62749ms step_avg:52.60ms
+step:1194/1600 train_time:62835ms step_avg:52.63ms
+step:1195/1600 train_time:62923ms step_avg:52.66ms
+step:1196/1600 train_time:63008ms step_avg:52.68ms
+step:1197/1600 train_time:63097ms step_avg:52.71ms
+step:1198/1600 train_time:63183ms step_avg:52.74ms
+step:1199/1600 train_time:63272ms step_avg:52.77ms
+step:1200/1600 train_time:63358ms step_avg:52.80ms
+step:1201/1600 train_time:63446ms step_avg:52.83ms
+step:1202/1600 train_time:63532ms step_avg:52.86ms
+step:1203/1600 train_time:63621ms step_avg:52.88ms
+step:1204/1600 train_time:63707ms step_avg:52.91ms
+step:1205/1600 train_time:63796ms step_avg:52.94ms
+step:1206/1600 train_time:63881ms step_avg:52.97ms
+step:1207/1600 train_time:63969ms step_avg:53.00ms
+step:1208/1600 train_time:64055ms step_avg:53.03ms
+step:1209/1600 train_time:64144ms step_avg:53.06ms
+step:1210/1600 train_time:64231ms step_avg:53.08ms
+step:1211/1600 train_time:64319ms step_avg:53.11ms
+step:1212/1600 train_time:64405ms step_avg:53.14ms
+step:1213/1600 train_time:64494ms step_avg:53.17ms
+step:1214/1600 train_time:64580ms step_avg:53.20ms
+step:1215/1600 train_time:64669ms step_avg:53.23ms
+step:1216/1600 train_time:64755ms step_avg:53.25ms
+step:1217/1600 train_time:64844ms step_avg:53.28ms
+step:1218/1600 train_time:64929ms step_avg:53.31ms
+step:1219/1600 train_time:65018ms step_avg:53.34ms
+step:1220/1600 train_time:65103ms step_avg:53.36ms
+step:1221/1600 train_time:65191ms step_avg:53.39ms
+step:1222/1600 train_time:65277ms step_avg:53.42ms
+step:1223/1600 train_time:65365ms step_avg:53.45ms
+step:1224/1600 train_time:65452ms step_avg:53.47ms
+step:1225/1600 train_time:65540ms step_avg:53.50ms
+step:1226/1600 train_time:65628ms step_avg:53.53ms
+step:1227/1600 train_time:65717ms step_avg:53.56ms
+step:1228/1600 train_time:65803ms step_avg:53.59ms
+step:1229/1600 train_time:65891ms step_avg:53.61ms
+step:1230/1600 train_time:65977ms step_avg:53.64ms
+step:1231/1600 train_time:66065ms step_avg:53.67ms
+step:1232/1600 train_time:66150ms step_avg:53.69ms
+step:1233/1600 train_time:66239ms step_avg:53.72ms
+step:1234/1600 train_time:66325ms step_avg:53.75ms
+step:1235/1600 train_time:66413ms step_avg:53.78ms
+step:1236/1600 train_time:66499ms step_avg:53.80ms
+step:1237/1600 train_time:66588ms step_avg:53.83ms
+step:1238/1600 train_time:66674ms step_avg:53.86ms
+step:1239/1600 train_time:66762ms step_avg:53.88ms
+step:1240/1600 train_time:66847ms step_avg:53.91ms
+step:1241/1600 train_time:66936ms step_avg:53.94ms
+step:1242/1600 train_time:67021ms step_avg:53.96ms
+step:1243/1600 train_time:67111ms step_avg:53.99ms
+step:1244/1600 train_time:67196ms step_avg:54.02ms
+step:1245/1600 train_time:67286ms step_avg:54.04ms
+step:1246/1600 train_time:67371ms step_avg:54.07ms
+step:1247/1600 train_time:67460ms step_avg:54.10ms
+step:1248/1600 train_time:67545ms step_avg:54.12ms
+step:1249/1600 train_time:67634ms step_avg:54.15ms
+step:1250/1600 train_time:67719ms step_avg:54.18ms
+step:1250/1600 val_loss:3.4193 train_time:67791ms step_avg:54.23ms
+step:1251/1600 train_time:67809ms step_avg:54.20ms
+step:1252/1600 train_time:67897ms step_avg:54.23ms
+step:1253/1600 train_time:67987ms step_avg:54.26ms
+step:1254/1600 train_time:68073ms step_avg:54.28ms
+step:1255/1600 train_time:68161ms step_avg:54.31ms
+step:1256/1600 train_time:68247ms step_avg:54.34ms
+step:1257/1600 train_time:68334ms step_avg:54.36ms
+step:1258/1600 train_time:68419ms step_avg:54.39ms
+step:1259/1600 train_time:68507ms step_avg:54.41ms
+step:1260/1600 train_time:68593ms step_avg:54.44ms
+step:1261/1600 train_time:68680ms step_avg:54.47ms
+step:1262/1600 train_time:68769ms step_avg:54.49ms
+step:1263/1600 train_time:68859ms step_avg:54.52ms
+step:1264/1600 train_time:68947ms step_avg:54.55ms
+step:1265/1600 train_time:69035ms step_avg:54.57ms
+step:1266/1600 train_time:69121ms step_avg:54.60ms
+step:1267/1600 train_time:69209ms step_avg:54.62ms
+step:1268/1600 train_time:69295ms step_avg:54.65ms
+step:1269/1600 train_time:69382ms step_avg:54.67ms
+step:1270/1600 train_time:69467ms step_avg:54.70ms
+step:1271/1600 train_time:69555ms step_avg:54.72ms
+step:1272/1600 train_time:69641ms step_avg:54.75ms
+step:1273/1600 train_time:69729ms step_avg:54.78ms
+step:1274/1600 train_time:69817ms step_avg:54.80ms
+step:1275/1600 train_time:69906ms step_avg:54.83ms
+step:1276/1600 train_time:69993ms step_avg:54.85ms
+step:1277/1600 train_time:70082ms step_avg:54.88ms
+step:1278/1600 train_time:70168ms step_avg:54.90ms
+step:1279/1600 train_time:70256ms step_avg:54.93ms
+step:1280/1600 train_time:70341ms step_avg:54.95ms
+step:1281/1600 train_time:70429ms step_avg:54.98ms
+step:1282/1600 train_time:70514ms step_avg:55.00ms
+step:1283/1600 train_time:70602ms step_avg:55.03ms
+step:1284/1600 train_time:70689ms step_avg:55.05ms
+step:1285/1600 train_time:70778ms step_avg:55.08ms
+step:1286/1600 train_time:70865ms step_avg:55.10ms
+step:1287/1600 train_time:70955ms step_avg:55.13ms
+step:1288/1600 train_time:71040ms step_avg:55.16ms
+step:1289/1600 train_time:71129ms step_avg:55.18ms
+step:1290/1600 train_time:71214ms step_avg:55.20ms
+step:1291/1600 train_time:71303ms step_avg:55.23ms
+step:1292/1600 train_time:71388ms step_avg:55.25ms
+step:1293/1600 train_time:71475ms step_avg:55.28ms
+step:1294/1600 train_time:71561ms step_avg:55.30ms
+step:1295/1600 train_time:71650ms step_avg:55.33ms
+step:1296/1600 train_time:71735ms step_avg:55.35ms
+step:1297/1600 train_time:71823ms step_avg:55.38ms
+step:1298/1600 train_time:71910ms step_avg:55.40ms
+step:1299/1600 train_time:72000ms step_avg:55.43ms
+step:1300/1600 train_time:72087ms step_avg:55.45ms
+step:1301/1600 train_time:72175ms step_avg:55.48ms
+step:1302/1600 train_time:72261ms step_avg:55.50ms
+step:1303/1600 train_time:72349ms step_avg:55.53ms
+step:1304/1600 train_time:72435ms step_avg:55.55ms
+step:1305/1600 train_time:72523ms step_avg:55.57ms
+step:1306/1600 train_time:72608ms step_avg:55.60ms
+step:1307/1600 train_time:72697ms step_avg:55.62ms
+step:1308/1600 train_time:72783ms step_avg:55.64ms
+step:1309/1600 train_time:72871ms step_avg:55.67ms
+step:1310/1600 train_time:72958ms step_avg:55.69ms
+step:1311/1600 train_time:73046ms step_avg:55.72ms
+step:1312/1600 train_time:73131ms step_avg:55.74ms
+step:1313/1600 train_time:73221ms step_avg:55.77ms
+step:1314/1600 train_time:73307ms step_avg:55.79ms
+step:1315/1600 train_time:73395ms step_avg:55.81ms
+step:1316/1600 train_time:73481ms step_avg:55.84ms
+step:1317/1600 train_time:73569ms step_avg:55.86ms
+step:1318/1600 train_time:73655ms step_avg:55.88ms
+step:1319/1600 train_time:73743ms step_avg:55.91ms
+step:1320/1600 train_time:73830ms step_avg:55.93ms
+step:1321/1600 train_time:73920ms step_avg:55.96ms
+step:1322/1600 train_time:74005ms step_avg:55.98ms
+step:1323/1600 train_time:74094ms step_avg:56.00ms
+step:1324/1600 train_time:74180ms step_avg:56.03ms
+step:1325/1600 train_time:74268ms step_avg:56.05ms
+step:1326/1600 train_time:74355ms step_avg:56.07ms
+step:1327/1600 train_time:74443ms step_avg:56.10ms
+step:1328/1600 train_time:74528ms step_avg:56.12ms
+step:1329/1600 train_time:74616ms step_avg:56.14ms
+step:1330/1600 train_time:74703ms step_avg:56.17ms
+step:1331/1600 train_time:74791ms step_avg:56.19ms
+step:1332/1600 train_time:74878ms step_avg:56.21ms
+step:1333/1600 train_time:74966ms step_avg:56.24ms
+step:1334/1600 train_time:75052ms step_avg:56.26ms
+step:1335/1600 train_time:75141ms step_avg:56.29ms
+step:1336/1600 train_time:75226ms step_avg:56.31ms
+step:1337/1600 train_time:75315ms step_avg:56.33ms
+step:1338/1600 train_time:75401ms step_avg:56.35ms
+step:1339/1600 train_time:75489ms step_avg:56.38ms
+step:1340/1600 train_time:75575ms step_avg:56.40ms
+step:1341/1600 train_time:75664ms step_avg:56.42ms
+step:1342/1600 train_time:75750ms step_avg:56.45ms
+step:1343/1600 train_time:75838ms step_avg:56.47ms
+step:1344/1600 train_time:75924ms step_avg:56.49ms
+step:1345/1600 train_time:76013ms step_avg:56.52ms
+step:1346/1600 train_time:76099ms step_avg:56.54ms
+step:1347/1600 train_time:76188ms step_avg:56.56ms
+step:1348/1600 train_time:76273ms step_avg:56.58ms
+step:1349/1600 train_time:76362ms step_avg:56.61ms
+step:1350/1600 train_time:76447ms step_avg:56.63ms
+step:1351/1600 train_time:76536ms step_avg:56.65ms
+step:1352/1600 train_time:76622ms step_avg:56.67ms
+step:1353/1600 train_time:76711ms step_avg:56.70ms
+step:1354/1600 train_time:76797ms step_avg:56.72ms
+step:1355/1600 train_time:76886ms step_avg:56.74ms
+step:1356/1600 train_time:76972ms step_avg:56.76ms
+step:1357/1600 train_time:77062ms step_avg:56.79ms
+step:1358/1600 train_time:77147ms step_avg:56.81ms
+step:1359/1600 train_time:77236ms step_avg:56.83ms
+step:1360/1600 train_time:77322ms step_avg:56.85ms
+step:1361/1600 train_time:77410ms step_avg:56.88ms
+step:1362/1600 train_time:77496ms step_avg:56.90ms
+step:1363/1600 train_time:77584ms step_avg:56.92ms
+step:1364/1600 train_time:77670ms step_avg:56.94ms
+step:1365/1600 train_time:77759ms step_avg:56.97ms
+step:1366/1600 train_time:77845ms step_avg:56.99ms
+step:1367/1600 train_time:77933ms step_avg:57.01ms
+step:1368/1600 train_time:78019ms step_avg:57.03ms
+step:1369/1600 train_time:78108ms step_avg:57.05ms
+step:1370/1600 train_time:78194ms step_avg:57.08ms
+step:1371/1600 train_time:78282ms step_avg:57.10ms
+step:1372/1600 train_time:78368ms step_avg:57.12ms
+step:1373/1600 train_time:78457ms step_avg:57.14ms
+step:1374/1600 train_time:78542ms step_avg:57.16ms
+step:1375/1600 train_time:78631ms step_avg:57.19ms
+step:1376/1600 train_time:78716ms step_avg:57.21ms
+step:1377/1600 train_time:78805ms step_avg:57.23ms
+step:1378/1600 train_time:78892ms step_avg:57.25ms
+step:1379/1600 train_time:78982ms step_avg:57.28ms
+step:1380/1600 train_time:79068ms step_avg:57.30ms
+step:1381/1600 train_time:79156ms step_avg:57.32ms
+step:1382/1600 train_time:79242ms step_avg:57.34ms
+step:1383/1600 train_time:79331ms step_avg:57.36ms
+step:1384/1600 train_time:79417ms step_avg:57.38ms
+step:1385/1600 train_time:79506ms step_avg:57.40ms
+step:1386/1600 train_time:79592ms step_avg:57.43ms
+step:1387/1600 train_time:79681ms step_avg:57.45ms
+step:1388/1600 train_time:79766ms step_avg:57.47ms
+step:1389/1600 train_time:79854ms step_avg:57.49ms
+step:1390/1600 train_time:79940ms step_avg:57.51ms
+step:1391/1600 train_time:80029ms step_avg:57.53ms
+step:1392/1600 train_time:80115ms step_avg:57.55ms
+step:1393/1600 train_time:80203ms step_avg:57.58ms
+step:1394/1600 train_time:80289ms step_avg:57.60ms
+step:1395/1600 train_time:80377ms step_avg:57.62ms
+step:1396/1600 train_time:80463ms step_avg:57.64ms
+step:1397/1600 train_time:80551ms step_avg:57.66ms
+step:1398/1600 train_time:80636ms step_avg:57.68ms
+step:1399/1600 train_time:80725ms step_avg:57.70ms
+step:1400/1600 train_time:80811ms step_avg:57.72ms
+step:1401/1600 train_time:80900ms step_avg:57.74ms
+step:1402/1600 train_time:80986ms step_avg:57.76ms
+step:1403/1600 train_time:81075ms step_avg:57.79ms
+step:1404/1600 train_time:81161ms step_avg:57.81ms
+step:1405/1600 train_time:81250ms step_avg:57.83ms
+step:1406/1600 train_time:81336ms step_avg:57.85ms
+step:1407/1600 train_time:81424ms step_avg:57.87ms
+step:1408/1600 train_time:81509ms step_avg:57.89ms
+step:1409/1600 train_time:81598ms step_avg:57.91ms
+step:1410/1600 train_time:81683ms step_avg:57.93ms
+step:1411/1600 train_time:81772ms step_avg:57.95ms
+step:1412/1600 train_time:81858ms step_avg:57.97ms
+step:1413/1600 train_time:81946ms step_avg:57.99ms
+step:1414/1600 train_time:82032ms step_avg:58.01ms
+step:1415/1600 train_time:82122ms step_avg:58.04ms
+step:1416/1600 train_time:82207ms step_avg:58.06ms
+step:1417/1600 train_time:82295ms step_avg:58.08ms
+step:1418/1600 train_time:82381ms step_avg:58.10ms
+step:1419/1600 train_time:82469ms step_avg:58.12ms
+step:1420/1600 train_time:82554ms step_avg:58.14ms
+step:1421/1600 train_time:82642ms step_avg:58.16ms
+step:1422/1600 train_time:82728ms step_avg:58.18ms
+step:1423/1600 train_time:82816ms step_avg:58.20ms
+step:1424/1600 train_time:82902ms step_avg:58.22ms
+step:1425/1600 train_time:82991ms step_avg:58.24ms
+step:1426/1600 train_time:83077ms step_avg:58.26ms
+step:1427/1600 train_time:83165ms step_avg:58.28ms
+step:1428/1600 train_time:83250ms step_avg:58.30ms
+step:1429/1600 train_time:83339ms step_avg:58.32ms
+step:1430/1600 train_time:83424ms step_avg:58.34ms
+step:1431/1600 train_time:83513ms step_avg:58.36ms
+step:1432/1600 train_time:83598ms step_avg:58.38ms
+step:1433/1600 train_time:83687ms step_avg:58.40ms
+step:1434/1600 train_time:83772ms step_avg:58.42ms
+step:1435/1600 train_time:83860ms step_avg:58.44ms
+step:1436/1600 train_time:83947ms step_avg:58.46ms
+step:1437/1600 train_time:84035ms step_avg:58.48ms
+step:1438/1600 train_time:84121ms step_avg:58.50ms
+step:1439/1600 train_time:84211ms step_avg:58.52ms
+step:1440/1600 train_time:84296ms step_avg:58.54ms
+step:1441/1600 train_time:84385ms step_avg:58.56ms
+step:1442/1600 train_time:84471ms step_avg:58.58ms
+step:1443/1600 train_time:84559ms step_avg:58.60ms
+step:1444/1600 train_time:84645ms step_avg:58.62ms
+step:1445/1600 train_time:84734ms step_avg:58.64ms
+step:1446/1600 train_time:84819ms step_avg:58.66ms
+step:1447/1600 train_time:84907ms step_avg:58.68ms
+step:1448/1600 train_time:84994ms step_avg:58.70ms
+step:1449/1600 train_time:85082ms step_avg:58.72ms
+step:1450/1600 train_time:85168ms step_avg:58.74ms
+step:1451/1600 train_time:85256ms step_avg:58.76ms
+step:1452/1600 train_time:85342ms step_avg:58.78ms
+step:1453/1600 train_time:85430ms step_avg:58.80ms
+step:1454/1600 train_time:85516ms step_avg:58.81ms
+step:1455/1600 train_time:85604ms step_avg:58.83ms
+step:1456/1600 train_time:85690ms step_avg:58.85ms
+step:1457/1600 train_time:85779ms step_avg:58.87ms
+step:1458/1600 train_time:85864ms step_avg:58.89ms
+step:1459/1600 train_time:85953ms step_avg:58.91ms
+step:1460/1600 train_time:86038ms step_avg:58.93ms
+step:1461/1600 train_time:86128ms step_avg:58.95ms
+step:1462/1600 train_time:86214ms step_avg:58.97ms
+step:1463/1600 train_time:86303ms step_avg:58.99ms
+step:1464/1600 train_time:86388ms step_avg:59.01ms
+step:1465/1600 train_time:86476ms step_avg:59.03ms
+step:1466/1600 train_time:86562ms step_avg:59.05ms
+step:1467/1600 train_time:86651ms step_avg:59.07ms
+step:1468/1600 train_time:86736ms step_avg:59.08ms
+step:1469/1600 train_time:86825ms step_avg:59.10ms
+step:1470/1600 train_time:86910ms step_avg:59.12ms
+step:1471/1600 train_time:86998ms step_avg:59.14ms
+step:1472/1600 train_time:87084ms step_avg:59.16ms
+step:1473/1600 train_time:87173ms step_avg:59.18ms
+step:1474/1600 train_time:87258ms step_avg:59.20ms
+step:1475/1600 train_time:87347ms step_avg:59.22ms
+step:1476/1600 train_time:87433ms step_avg:59.24ms
+step:1477/1600 train_time:87521ms step_avg:59.26ms
+step:1478/1600 train_time:87608ms step_avg:59.27ms
+step:1479/1600 train_time:87696ms step_avg:59.29ms
+step:1480/1600 train_time:87781ms step_avg:59.31ms
+step:1481/1600 train_time:87870ms step_avg:59.33ms
+step:1482/1600 train_time:87955ms step_avg:59.35ms
+step:1483/1600 train_time:88043ms step_avg:59.37ms
+step:1484/1600 train_time:88129ms step_avg:59.39ms
+step:1485/1600 train_time:88218ms step_avg:59.41ms
+step:1486/1600 train_time:88304ms step_avg:59.42ms
+step:1487/1600 train_time:88393ms step_avg:59.44ms
+step:1488/1600 train_time:88478ms step_avg:59.46ms
+step:1489/1600 train_time:88567ms step_avg:59.48ms
+step:1490/1600 train_time:88652ms step_avg:59.50ms
+step:1491/1600 train_time:88741ms step_avg:59.52ms
+step:1492/1600 train_time:88826ms step_avg:59.54ms
+step:1493/1600 train_time:88915ms step_avg:59.55ms
+step:1494/1600 train_time:89000ms step_avg:59.57ms
+step:1495/1600 train_time:89090ms step_avg:59.59ms
+step:1496/1600 train_time:89175ms step_avg:59.61ms
+step:1497/1600 train_time:89264ms step_avg:59.63ms
+step:1498/1600 train_time:89350ms step_avg:59.65ms
+step:1499/1600 train_time:89439ms step_avg:59.67ms
+step:1500/1600 train_time:89525ms step_avg:59.68ms
+step:1500/1600 val_loss:3.3097 train_time:89597ms step_avg:59.73ms
+step:1501/1600 train_time:89615ms step_avg:59.70ms
+step:1502/1600 train_time:89701ms step_avg:59.72ms
+step:1503/1600 train_time:89791ms step_avg:59.74ms
+step:1504/1600 train_time:89878ms step_avg:59.76ms
+step:1505/1600 train_time:89965ms step_avg:59.78ms
+step:1506/1600 train_time:90050ms step_avg:59.79ms
+step:1507/1600 train_time:90137ms step_avg:59.81ms
+step:1508/1600 train_time:90223ms step_avg:59.83ms
+step:1509/1600 train_time:90310ms step_avg:59.85ms
+step:1510/1600 train_time:90396ms step_avg:59.86ms
+step:1511/1600 train_time:90484ms step_avg:59.88ms
+step:1512/1600 train_time:90572ms step_avg:59.90ms
+step:1513/1600 train_time:90663ms step_avg:59.92ms
+step:1514/1600 train_time:90750ms step_avg:59.94ms
+step:1515/1600 train_time:90839ms step_avg:59.96ms
+step:1516/1600 train_time:90925ms step_avg:59.98ms
+step:1517/1600 train_time:91013ms step_avg:60.00ms
+step:1518/1600 train_time:91097ms step_avg:60.01ms
+step:1519/1600 train_time:91186ms step_avg:60.03ms
+step:1520/1600 train_time:91271ms step_avg:60.05ms
+step:1521/1600 train_time:91359ms step_avg:60.06ms
+step:1522/1600 train_time:91444ms step_avg:60.08ms
+step:1523/1600 train_time:91534ms step_avg:60.10ms
+step:1524/1600 train_time:91621ms step_avg:60.12ms
+step:1525/1600 train_time:91711ms step_avg:60.14ms
+step:1526/1600 train_time:91796ms step_avg:60.15ms
+step:1527/1600 train_time:91886ms step_avg:60.17ms
+step:1528/1600 train_time:91971ms step_avg:60.19ms
+step:1529/1600 train_time:92060ms step_avg:60.21ms
+step:1530/1600 train_time:92145ms step_avg:60.23ms
+step:1531/1600 train_time:92233ms step_avg:60.24ms
+step:1532/1600 train_time:92317ms step_avg:60.26ms
+step:1533/1600 train_time:92406ms step_avg:60.28ms
+step:1534/1600 train_time:92492ms step_avg:60.29ms
+step:1535/1600 train_time:92581ms step_avg:60.31ms
+step:1536/1600 train_time:92667ms step_avg:60.33ms
+step:1537/1600 train_time:92757ms step_avg:60.35ms
+step:1538/1600 train_time:92844ms step_avg:60.37ms
+step:1539/1600 train_time:92932ms step_avg:60.38ms
+step:1540/1600 train_time:93018ms step_avg:60.40ms
+step:1541/1600 train_time:93106ms step_avg:60.42ms
+step:1542/1600 train_time:93191ms step_avg:60.44ms
+step:1543/1600 train_time:93280ms step_avg:60.45ms
+step:1544/1600 train_time:93366ms step_avg:60.47ms
+step:1545/1600 train_time:93455ms step_avg:60.49ms
+step:1546/1600 train_time:93541ms step_avg:60.50ms
+step:1547/1600 train_time:93630ms step_avg:60.52ms
+step:1548/1600 train_time:93717ms step_avg:60.54ms
+step:1549/1600 train_time:93807ms step_avg:60.56ms
+step:1550/1600 train_time:93893ms step_avg:60.58ms
+step:1551/1600 train_time:93981ms step_avg:60.59ms
+step:1552/1600 train_time:94067ms step_avg:60.61ms
+step:1553/1600 train_time:94156ms step_avg:60.63ms
+step:1554/1600 train_time:94241ms step_avg:60.64ms
+step:1555/1600 train_time:94329ms step_avg:60.66ms
+step:1556/1600 train_time:94414ms step_avg:60.68ms
+step:1557/1600 train_time:94503ms step_avg:60.70ms
+step:1558/1600 train_time:94589ms step_avg:60.71ms
+step:1559/1600 train_time:94678ms step_avg:60.73ms
+step:1560/1600 train_time:94764ms step_avg:60.75ms
+step:1561/1600 train_time:94858ms step_avg:60.77ms
+step:1562/1600 train_time:94944ms step_avg:60.78ms
+step:1563/1600 train_time:95032ms step_avg:60.80ms
+step:1564/1600 train_time:95118ms step_avg:60.82ms
+step:1565/1600 train_time:95206ms step_avg:60.83ms
+step:1566/1600 train_time:95293ms step_avg:60.85ms
+step:1567/1600 train_time:95381ms step_avg:60.87ms
+step:1568/1600 train_time:95468ms step_avg:60.89ms
+step:1569/1600 train_time:95557ms step_avg:60.90ms
+step:1570/1600 train_time:95643ms step_avg:60.92ms
+step:1571/1600 train_time:95732ms step_avg:60.94ms
+step:1572/1600 train_time:95819ms step_avg:60.95ms
+step:1573/1600 train_time:95909ms step_avg:60.97ms
+step:1574/1600 train_time:95995ms step_avg:60.99ms
+step:1575/1600 train_time:96084ms step_avg:61.01ms
+step:1576/1600 train_time:96169ms step_avg:61.02ms
+step:1577/1600 train_time:96258ms step_avg:61.04ms
+step:1578/1600 train_time:96343ms step_avg:61.05ms
+step:1579/1600 train_time:96432ms step_avg:61.07ms
+step:1580/1600 train_time:96518ms step_avg:61.09ms
+step:1581/1600 train_time:96607ms step_avg:61.11ms
+step:1582/1600 train_time:96694ms step_avg:61.12ms
+step:1583/1600 train_time:96783ms step_avg:61.14ms
+step:1584/1600 train_time:96870ms step_avg:61.16ms
+step:1585/1600 train_time:96959ms step_avg:61.17ms
+step:1586/1600 train_time:97045ms step_avg:61.19ms
+step:1587/1600 train_time:97134ms step_avg:61.21ms
+step:1588/1600 train_time:97219ms step_avg:61.22ms
+step:1589/1600 train_time:97308ms step_avg:61.24ms
+step:1590/1600 train_time:97394ms step_avg:61.25ms
+step:1591/1600 train_time:97483ms step_avg:61.27ms
+step:1592/1600 train_time:97569ms step_avg:61.29ms
+step:1593/1600 train_time:97659ms step_avg:61.30ms
+step:1594/1600 train_time:97744ms step_avg:61.32ms
+step:1595/1600 train_time:97833ms step_avg:61.34ms
+step:1596/1600 train_time:97918ms step_avg:61.35ms
+step:1597/1600 train_time:98009ms step_avg:61.37ms
+step:1598/1600 train_time:98095ms step_avg:61.39ms
+step:1599/1600 train_time:98184ms step_avg:61.40ms
+step:1600/1600 train_time:98270ms step_avg:61.42ms
+step:1600/1600 val_loss:3.2799 train_time:98342ms step_avg:61.46ms
+peak memory allocated: 30264 MiB reserved: 46238 MiB

--- a/records/track_1_short/2026-01-28_TieFirstLastVEs/baseline/83204699-b604-49cf-9321-1af422790aaf.txt
+++ b/records/track_1_short/2026-01-28_TieFirstLastVEs/baseline/83204699-b604-49cf-9321-1af422790aaf.txt
@@ -1,0 +1,4120 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.12.12 | packaged by conda-forge | (main, Jan 26 2026, 23:51:32) [GCC 14.3.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Thu Jan 29 02:13:53 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                  Off |
+| N/A   35C    P0            123W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:06:00.0 Off |                  Off |
+| N/A   33C    P0            124W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:07:00.0 Off |                  Off |
+| N/A   34C    P0            118W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:08:00.0 Off |                  Off |
+| N/A   33C    P0            123W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:09:00.0 Off |                  Off |
+| N/A   34C    P0            120W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                  Off |
+| N/A   33C    P0            120W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                  Off |
+| N/A   34C    P0            121W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:0C:00.0 Off |                  Off |
+| N/A   33C    P0            124W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A            6999      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    1   N/A  N/A            7000      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    2   N/A  N/A            7001      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    3   N/A  N/A            7002      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    4   N/A  N/A            7003      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    5   N/A  N/A            7004      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    6   N/A  N/A            7005      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    7   N/A  N/A            7006      C   .../envs/speedrun/bin/python3.12       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8303 train_time:0ms step_avg:0.03ms
+step:1/1600 train_time:50ms step_avg:50.37ms
+step:2/1600 train_time:67ms step_avg:33.35ms
+step:3/1600 train_time:90ms step_avg:29.94ms
+step:4/1600 train_time:126ms step_avg:31.58ms
+step:5/1600 train_time:157ms step_avg:31.40ms
+step:6/1600 train_time:245ms step_avg:40.87ms
+step:7/1600 train_time:260ms step_avg:37.15ms
+step:8/1600 train_time:287ms step_avg:35.87ms
+step:9/1600 train_time:318ms step_avg:35.29ms
+step:10/1600 train_time:354ms step_avg:35.44ms
+step:11/1600 train_time:385ms step_avg:35.02ms
+step:12/1600 train_time:422ms step_avg:35.21ms
+step:13/1600 train_time:453ms step_avg:34.85ms
+step:14/1600 train_time:490ms step_avg:35.01ms
+step:15/1600 train_time:521ms step_avg:34.72ms
+step:16/1600 train_time:558ms step_avg:34.87ms
+step:17/1600 train_time:589ms step_avg:34.62ms
+step:18/1600 train_time:626ms step_avg:34.78ms
+step:19/1600 train_time:657ms step_avg:34.57ms
+step:20/1600 train_time:694ms step_avg:34.70ms
+step:21/1600 train_time:725ms step_avg:34.51ms
+step:22/1600 train_time:762ms step_avg:34.63ms
+step:23/1600 train_time:793ms step_avg:34.46ms
+step:24/1600 train_time:829ms step_avg:34.55ms
+step:25/1600 train_time:860ms step_avg:34.39ms
+step:26/1600 train_time:897ms step_avg:34.51ms
+step:27/1600 train_time:928ms step_avg:34.36ms
+step:28/1600 train_time:964ms step_avg:34.45ms
+step:29/1600 train_time:995ms step_avg:34.32ms
+step:30/1600 train_time:1033ms step_avg:34.42ms
+step:31/1600 train_time:1063ms step_avg:34.31ms
+step:32/1600 train_time:1100ms step_avg:34.39ms
+step:33/1600 train_time:1131ms step_avg:34.28ms
+step:34/1600 train_time:1168ms step_avg:34.35ms
+step:35/1600 train_time:1199ms step_avg:34.27ms
+step:36/1600 train_time:1237ms step_avg:34.35ms
+step:37/1600 train_time:1268ms step_avg:34.26ms
+step:38/1600 train_time:1305ms step_avg:34.35ms
+step:39/1600 train_time:1336ms step_avg:34.26ms
+step:40/1600 train_time:1373ms step_avg:34.33ms
+step:41/1600 train_time:1404ms step_avg:34.25ms
+step:42/1600 train_time:1441ms step_avg:34.31ms
+step:43/1600 train_time:1473ms step_avg:34.25ms
+step:44/1600 train_time:1509ms step_avg:34.30ms
+step:45/1600 train_time:1540ms step_avg:34.23ms
+step:46/1600 train_time:1578ms step_avg:34.30ms
+step:47/1600 train_time:1609ms step_avg:34.24ms
+step:48/1600 train_time:1646ms step_avg:34.29ms
+step:49/1600 train_time:1677ms step_avg:34.23ms
+step:50/1600 train_time:1715ms step_avg:34.30ms
+step:51/1600 train_time:1745ms step_avg:34.22ms
+step:52/1600 train_time:1782ms step_avg:34.28ms
+step:53/1600 train_time:1813ms step_avg:34.21ms
+step:54/1600 train_time:1850ms step_avg:34.26ms
+step:55/1600 train_time:1881ms step_avg:34.20ms
+step:56/1600 train_time:1919ms step_avg:34.26ms
+step:57/1600 train_time:1949ms step_avg:34.20ms
+step:58/1600 train_time:1986ms step_avg:34.25ms
+step:59/1600 train_time:2017ms step_avg:34.19ms
+step:60/1600 train_time:2054ms step_avg:34.23ms
+step:61/1600 train_time:2085ms step_avg:34.17ms
+step:62/1600 train_time:2122ms step_avg:34.23ms
+step:63/1600 train_time:2153ms step_avg:34.17ms
+step:64/1600 train_time:2190ms step_avg:34.22ms
+step:65/1600 train_time:2221ms step_avg:34.18ms
+step:66/1600 train_time:2259ms step_avg:34.22ms
+step:67/1600 train_time:2290ms step_avg:34.17ms
+step:68/1600 train_time:2327ms step_avg:34.22ms
+step:69/1600 train_time:2358ms step_avg:34.17ms
+step:70/1600 train_time:2395ms step_avg:34.21ms
+step:71/1600 train_time:2426ms step_avg:34.16ms
+step:72/1600 train_time:2462ms step_avg:34.20ms
+step:73/1600 train_time:2493ms step_avg:34.16ms
+step:74/1600 train_time:2530ms step_avg:34.19ms
+step:75/1600 train_time:2561ms step_avg:34.15ms
+step:76/1600 train_time:2598ms step_avg:34.19ms
+step:77/1600 train_time:2629ms step_avg:34.14ms
+step:78/1600 train_time:2666ms step_avg:34.18ms
+step:79/1600 train_time:2697ms step_avg:34.14ms
+step:80/1600 train_time:2734ms step_avg:34.18ms
+step:81/1600 train_time:2765ms step_avg:34.14ms
+step:82/1600 train_time:2802ms step_avg:34.17ms
+step:83/1600 train_time:2833ms step_avg:34.13ms
+step:84/1600 train_time:2870ms step_avg:34.17ms
+step:85/1600 train_time:2901ms step_avg:34.13ms
+step:86/1600 train_time:2938ms step_avg:34.17ms
+step:87/1600 train_time:2969ms step_avg:34.13ms
+step:88/1600 train_time:3006ms step_avg:34.16ms
+step:89/1600 train_time:3037ms step_avg:34.12ms
+step:90/1600 train_time:3074ms step_avg:34.15ms
+step:91/1600 train_time:3104ms step_avg:34.11ms
+step:92/1600 train_time:3142ms step_avg:34.15ms
+step:93/1600 train_time:3173ms step_avg:34.12ms
+step:94/1600 train_time:3210ms step_avg:34.15ms
+step:95/1600 train_time:3241ms step_avg:34.12ms
+step:96/1600 train_time:3278ms step_avg:34.15ms
+step:97/1600 train_time:3309ms step_avg:34.11ms
+step:98/1600 train_time:3346ms step_avg:34.14ms
+step:99/1600 train_time:3378ms step_avg:34.12ms
+step:100/1600 train_time:3415ms step_avg:34.15ms
+step:101/1600 train_time:3446ms step_avg:34.12ms
+step:102/1600 train_time:3483ms step_avg:34.14ms
+step:103/1600 train_time:3513ms step_avg:34.11ms
+step:104/1600 train_time:3550ms step_avg:34.14ms
+step:105/1600 train_time:3581ms step_avg:34.11ms
+step:106/1600 train_time:3619ms step_avg:34.14ms
+step:107/1600 train_time:3650ms step_avg:34.11ms
+step:108/1600 train_time:3686ms step_avg:34.13ms
+step:109/1600 train_time:3717ms step_avg:34.10ms
+step:110/1600 train_time:3755ms step_avg:34.13ms
+step:111/1600 train_time:3785ms step_avg:34.10ms
+step:112/1600 train_time:3823ms step_avg:34.13ms
+step:113/1600 train_time:3853ms step_avg:34.10ms
+step:114/1600 train_time:3890ms step_avg:34.12ms
+step:115/1600 train_time:3920ms step_avg:34.09ms
+step:116/1600 train_time:3957ms step_avg:34.12ms
+step:117/1600 train_time:3988ms step_avg:34.09ms
+step:118/1600 train_time:4025ms step_avg:34.11ms
+step:119/1600 train_time:4056ms step_avg:34.08ms
+step:120/1600 train_time:4093ms step_avg:34.11ms
+step:121/1600 train_time:4124ms step_avg:34.08ms
+step:122/1600 train_time:4161ms step_avg:34.11ms
+step:123/1600 train_time:4192ms step_avg:34.08ms
+step:124/1600 train_time:4229ms step_avg:34.11ms
+step:125/1600 train_time:4260ms step_avg:34.08ms
+step:126/1600 train_time:4297ms step_avg:34.10ms
+step:127/1600 train_time:4328ms step_avg:34.08ms
+step:128/1600 train_time:4365ms step_avg:34.10ms
+step:129/1600 train_time:4396ms step_avg:34.08ms
+step:130/1600 train_time:4433ms step_avg:34.10ms
+step:131/1600 train_time:4463ms step_avg:34.07ms
+step:132/1600 train_time:4501ms step_avg:34.10ms
+step:133/1600 train_time:4532ms step_avg:34.07ms
+step:134/1600 train_time:4568ms step_avg:34.09ms
+step:135/1600 train_time:4600ms step_avg:34.07ms
+step:136/1600 train_time:4637ms step_avg:34.09ms
+step:137/1600 train_time:4668ms step_avg:34.07ms
+step:138/1600 train_time:4705ms step_avg:34.09ms
+step:139/1600 train_time:4736ms step_avg:34.07ms
+step:140/1600 train_time:4773ms step_avg:34.09ms
+step:141/1600 train_time:4804ms step_avg:34.07ms
+step:142/1600 train_time:4841ms step_avg:34.09ms
+step:143/1600 train_time:4872ms step_avg:34.07ms
+step:144/1600 train_time:4908ms step_avg:34.09ms
+step:145/1600 train_time:4939ms step_avg:34.06ms
+step:146/1600 train_time:4976ms step_avg:34.08ms
+step:147/1600 train_time:5007ms step_avg:34.06ms
+step:148/1600 train_time:5044ms step_avg:34.08ms
+step:149/1600 train_time:5075ms step_avg:34.06ms
+step:150/1600 train_time:5112ms step_avg:34.08ms
+step:151/1600 train_time:5143ms step_avg:34.06ms
+step:152/1600 train_time:5180ms step_avg:34.08ms
+step:153/1600 train_time:5211ms step_avg:34.06ms
+step:154/1600 train_time:5248ms step_avg:34.08ms
+step:155/1600 train_time:5279ms step_avg:34.06ms
+step:156/1600 train_time:5317ms step_avg:34.08ms
+step:157/1600 train_time:5347ms step_avg:34.06ms
+step:158/1600 train_time:5384ms step_avg:34.08ms
+step:159/1600 train_time:5415ms step_avg:34.06ms
+step:160/1600 train_time:5452ms step_avg:34.07ms
+step:161/1600 train_time:5483ms step_avg:34.05ms
+step:162/1600 train_time:5520ms step_avg:34.07ms
+step:163/1600 train_time:5551ms step_avg:34.05ms
+step:164/1600 train_time:5588ms step_avg:34.07ms
+step:165/1600 train_time:5619ms step_avg:34.05ms
+step:166/1600 train_time:5656ms step_avg:34.07ms
+step:167/1600 train_time:5687ms step_avg:34.05ms
+step:168/1600 train_time:5724ms step_avg:34.07ms
+step:169/1600 train_time:5755ms step_avg:34.06ms
+step:170/1600 train_time:5792ms step_avg:34.07ms
+step:171/1600 train_time:5823ms step_avg:34.06ms
+step:172/1600 train_time:5860ms step_avg:34.07ms
+step:173/1600 train_time:5891ms step_avg:34.05ms
+step:174/1600 train_time:5927ms step_avg:34.07ms
+step:175/1600 train_time:5958ms step_avg:34.04ms
+step:176/1600 train_time:5995ms step_avg:34.06ms
+step:177/1600 train_time:6026ms step_avg:34.04ms
+step:178/1600 train_time:6063ms step_avg:34.06ms
+step:179/1600 train_time:6094ms step_avg:34.04ms
+step:180/1600 train_time:6131ms step_avg:34.06ms
+step:181/1600 train_time:6161ms step_avg:34.04ms
+step:182/1600 train_time:6199ms step_avg:34.06ms
+step:183/1600 train_time:6230ms step_avg:34.04ms
+step:184/1600 train_time:6266ms step_avg:34.06ms
+step:185/1600 train_time:6298ms step_avg:34.04ms
+step:186/1600 train_time:6335ms step_avg:34.06ms
+step:187/1600 train_time:6366ms step_avg:34.04ms
+step:188/1600 train_time:6403ms step_avg:34.06ms
+step:189/1600 train_time:6433ms step_avg:34.04ms
+step:190/1600 train_time:6470ms step_avg:34.05ms
+step:191/1600 train_time:6501ms step_avg:34.03ms
+step:192/1600 train_time:6538ms step_avg:34.05ms
+step:193/1600 train_time:6568ms step_avg:34.03ms
+step:194/1600 train_time:6605ms step_avg:34.05ms
+step:195/1600 train_time:6637ms step_avg:34.04ms
+step:196/1600 train_time:6674ms step_avg:34.05ms
+step:197/1600 train_time:6705ms step_avg:34.04ms
+step:198/1600 train_time:6742ms step_avg:34.05ms
+step:199/1600 train_time:6773ms step_avg:34.03ms
+step:200/1600 train_time:6810ms step_avg:34.05ms
+step:201/1600 train_time:6841ms step_avg:34.03ms
+step:202/1600 train_time:6878ms step_avg:34.05ms
+step:203/1600 train_time:6909ms step_avg:34.03ms
+step:204/1600 train_time:6946ms step_avg:34.05ms
+step:205/1600 train_time:6977ms step_avg:34.03ms
+step:206/1600 train_time:7014ms step_avg:34.05ms
+step:207/1600 train_time:7045ms step_avg:34.03ms
+step:208/1600 train_time:7082ms step_avg:34.05ms
+step:209/1600 train_time:7112ms step_avg:34.03ms
+step:210/1600 train_time:7149ms step_avg:34.04ms
+step:211/1600 train_time:7180ms step_avg:34.03ms
+step:212/1600 train_time:7217ms step_avg:34.04ms
+step:213/1600 train_time:7247ms step_avg:34.02ms
+step:214/1600 train_time:7284ms step_avg:34.04ms
+step:215/1600 train_time:7315ms step_avg:34.02ms
+step:216/1600 train_time:7351ms step_avg:34.03ms
+step:217/1600 train_time:7382ms step_avg:34.02ms
+step:218/1600 train_time:7420ms step_avg:34.04ms
+step:219/1600 train_time:7451ms step_avg:34.02ms
+step:220/1600 train_time:7487ms step_avg:34.03ms
+step:221/1600 train_time:7518ms step_avg:34.02ms
+step:222/1600 train_time:7556ms step_avg:34.04ms
+step:223/1600 train_time:7587ms step_avg:34.02ms
+step:224/1600 train_time:7624ms step_avg:34.04ms
+step:225/1600 train_time:7654ms step_avg:34.02ms
+step:226/1600 train_time:7691ms step_avg:34.03ms
+step:227/1600 train_time:7722ms step_avg:34.02ms
+step:228/1600 train_time:7759ms step_avg:34.03ms
+step:229/1600 train_time:7790ms step_avg:34.02ms
+step:230/1600 train_time:7827ms step_avg:34.03ms
+step:231/1600 train_time:7857ms step_avg:34.01ms
+step:232/1600 train_time:7895ms step_avg:34.03ms
+step:233/1600 train_time:7925ms step_avg:34.01ms
+step:234/1600 train_time:7962ms step_avg:34.03ms
+step:235/1600 train_time:7993ms step_avg:34.01ms
+step:236/1600 train_time:8030ms step_avg:34.02ms
+step:237/1600 train_time:8060ms step_avg:34.01ms
+step:238/1600 train_time:8097ms step_avg:34.02ms
+step:239/1600 train_time:8128ms step_avg:34.01ms
+step:240/1600 train_time:8165ms step_avg:34.02ms
+step:241/1600 train_time:8196ms step_avg:34.01ms
+step:242/1600 train_time:8232ms step_avg:34.02ms
+step:243/1600 train_time:8263ms step_avg:34.01ms
+step:244/1600 train_time:8300ms step_avg:34.02ms
+step:245/1600 train_time:8331ms step_avg:34.01ms
+step:246/1600 train_time:8368ms step_avg:34.02ms
+step:247/1600 train_time:8399ms step_avg:34.00ms
+step:248/1600 train_time:8437ms step_avg:34.02ms
+step:249/1600 train_time:8467ms step_avg:34.01ms
+step:250/1600 train_time:8504ms step_avg:34.02ms
+step:250/1600 val_loss:4.5719 train_time:8552ms step_avg:34.21ms
+step:251/1600 train_time:8569ms step_avg:34.14ms
+step:252/1600 train_time:8585ms step_avg:34.07ms
+step:253/1600 train_time:8606ms step_avg:34.02ms
+step:254/1600 train_time:8643ms step_avg:34.03ms
+step:255/1600 train_time:8674ms step_avg:34.02ms
+step:256/1600 train_time:8712ms step_avg:34.03ms
+step:257/1600 train_time:8743ms step_avg:34.02ms
+step:258/1600 train_time:8780ms step_avg:34.03ms
+step:259/1600 train_time:8810ms step_avg:34.02ms
+step:260/1600 train_time:8847ms step_avg:34.03ms
+step:261/1600 train_time:8878ms step_avg:34.01ms
+step:262/1600 train_time:8915ms step_avg:34.02ms
+step:263/1600 train_time:8945ms step_avg:34.01ms
+step:264/1600 train_time:8982ms step_avg:34.02ms
+step:265/1600 train_time:9012ms step_avg:34.01ms
+step:266/1600 train_time:9049ms step_avg:34.02ms
+step:267/1600 train_time:9080ms step_avg:34.01ms
+step:268/1600 train_time:9116ms step_avg:34.02ms
+step:269/1600 train_time:9147ms step_avg:34.00ms
+step:270/1600 train_time:9184ms step_avg:34.02ms
+step:271/1600 train_time:9215ms step_avg:34.00ms
+step:272/1600 train_time:9252ms step_avg:34.01ms
+step:273/1600 train_time:9283ms step_avg:34.00ms
+step:274/1600 train_time:9319ms step_avg:34.01ms
+step:275/1600 train_time:9350ms step_avg:34.00ms
+step:276/1600 train_time:9387ms step_avg:34.01ms
+step:277/1600 train_time:9417ms step_avg:34.00ms
+step:278/1600 train_time:9454ms step_avg:34.01ms
+step:279/1600 train_time:9485ms step_avg:34.00ms
+step:280/1600 train_time:9522ms step_avg:34.01ms
+step:281/1600 train_time:9553ms step_avg:34.00ms
+step:282/1600 train_time:9591ms step_avg:34.01ms
+step:283/1600 train_time:9622ms step_avg:34.00ms
+step:284/1600 train_time:9659ms step_avg:34.01ms
+step:285/1600 train_time:9690ms step_avg:34.00ms
+step:286/1600 train_time:9728ms step_avg:34.01ms
+step:287/1600 train_time:9759ms step_avg:34.00ms
+step:288/1600 train_time:9796ms step_avg:34.01ms
+step:289/1600 train_time:9827ms step_avg:34.00ms
+step:290/1600 train_time:9864ms step_avg:34.01ms
+step:291/1600 train_time:9895ms step_avg:34.00ms
+step:292/1600 train_time:9931ms step_avg:34.01ms
+step:293/1600 train_time:9962ms step_avg:34.00ms
+step:294/1600 train_time:9999ms step_avg:34.01ms
+step:295/1600 train_time:10030ms step_avg:34.00ms
+step:296/1600 train_time:10067ms step_avg:34.01ms
+step:297/1600 train_time:10098ms step_avg:34.00ms
+step:298/1600 train_time:10135ms step_avg:34.01ms
+step:299/1600 train_time:10165ms step_avg:34.00ms
+step:300/1600 train_time:10202ms step_avg:34.01ms
+step:301/1600 train_time:10233ms step_avg:34.00ms
+step:302/1600 train_time:10270ms step_avg:34.01ms
+step:303/1600 train_time:10300ms step_avg:33.99ms
+step:304/1600 train_time:10337ms step_avg:34.00ms
+step:305/1600 train_time:10368ms step_avg:33.99ms
+step:306/1600 train_time:10404ms step_avg:34.00ms
+step:307/1600 train_time:10435ms step_avg:33.99ms
+step:308/1600 train_time:10472ms step_avg:34.00ms
+step:309/1600 train_time:10504ms step_avg:33.99ms
+step:310/1600 train_time:10541ms step_avg:34.00ms
+step:311/1600 train_time:10572ms step_avg:33.99ms
+step:312/1600 train_time:10609ms step_avg:34.00ms
+step:313/1600 train_time:10640ms step_avg:33.99ms
+step:314/1600 train_time:10677ms step_avg:34.00ms
+step:315/1600 train_time:10707ms step_avg:33.99ms
+step:316/1600 train_time:10744ms step_avg:34.00ms
+step:317/1600 train_time:10775ms step_avg:33.99ms
+step:318/1600 train_time:10812ms step_avg:34.00ms
+step:319/1600 train_time:10843ms step_avg:33.99ms
+step:320/1600 train_time:10880ms step_avg:34.00ms
+step:321/1600 train_time:10910ms step_avg:33.99ms
+step:322/1600 train_time:10947ms step_avg:34.00ms
+step:323/1600 train_time:10978ms step_avg:33.99ms
+step:324/1600 train_time:11015ms step_avg:34.00ms
+step:325/1600 train_time:11046ms step_avg:33.99ms
+step:326/1600 train_time:11083ms step_avg:34.00ms
+step:327/1600 train_time:11114ms step_avg:33.99ms
+step:328/1600 train_time:11151ms step_avg:34.00ms
+step:329/1600 train_time:11182ms step_avg:33.99ms
+step:330/1600 train_time:11218ms step_avg:33.99ms
+step:331/1600 train_time:11249ms step_avg:33.98ms
+step:332/1600 train_time:11286ms step_avg:34.00ms
+step:333/1600 train_time:11317ms step_avg:33.98ms
+step:334/1600 train_time:11354ms step_avg:33.99ms
+step:335/1600 train_time:11384ms step_avg:33.98ms
+step:336/1600 train_time:11421ms step_avg:33.99ms
+step:337/1600 train_time:11452ms step_avg:33.98ms
+step:338/1600 train_time:11489ms step_avg:33.99ms
+step:339/1600 train_time:11520ms step_avg:33.98ms
+step:340/1600 train_time:11557ms step_avg:33.99ms
+step:341/1600 train_time:11588ms step_avg:33.98ms
+step:342/1600 train_time:11625ms step_avg:33.99ms
+step:343/1600 train_time:11656ms step_avg:33.98ms
+step:344/1600 train_time:11694ms step_avg:33.99ms
+step:345/1600 train_time:11725ms step_avg:33.98ms
+step:346/1600 train_time:11761ms step_avg:33.99ms
+step:347/1600 train_time:11792ms step_avg:33.98ms
+step:348/1600 train_time:11830ms step_avg:33.99ms
+step:349/1600 train_time:11861ms step_avg:33.99ms
+step:350/1600 train_time:11898ms step_avg:33.99ms
+step:351/1600 train_time:11928ms step_avg:33.98ms
+step:352/1600 train_time:11965ms step_avg:33.99ms
+step:353/1600 train_time:11996ms step_avg:33.98ms
+step:354/1600 train_time:12033ms step_avg:33.99ms
+step:355/1600 train_time:12065ms step_avg:33.98ms
+step:356/1600 train_time:12101ms step_avg:33.99ms
+step:357/1600 train_time:12132ms step_avg:33.98ms
+step:358/1600 train_time:12169ms step_avg:33.99ms
+step:359/1600 train_time:12200ms step_avg:33.98ms
+step:360/1600 train_time:12237ms step_avg:33.99ms
+step:361/1600 train_time:12268ms step_avg:33.98ms
+step:362/1600 train_time:12305ms step_avg:33.99ms
+step:363/1600 train_time:12335ms step_avg:33.98ms
+step:364/1600 train_time:12372ms step_avg:33.99ms
+step:365/1600 train_time:12403ms step_avg:33.98ms
+step:366/1600 train_time:12440ms step_avg:33.99ms
+step:367/1600 train_time:12471ms step_avg:33.98ms
+step:368/1600 train_time:12508ms step_avg:33.99ms
+step:369/1600 train_time:12539ms step_avg:33.98ms
+step:370/1600 train_time:12576ms step_avg:33.99ms
+step:371/1600 train_time:12606ms step_avg:33.98ms
+step:372/1600 train_time:12643ms step_avg:33.99ms
+step:373/1600 train_time:12674ms step_avg:33.98ms
+step:374/1600 train_time:12711ms step_avg:33.99ms
+step:375/1600 train_time:12742ms step_avg:33.98ms
+step:376/1600 train_time:12778ms step_avg:33.98ms
+step:377/1600 train_time:12809ms step_avg:33.98ms
+step:378/1600 train_time:12846ms step_avg:33.98ms
+step:379/1600 train_time:12877ms step_avg:33.98ms
+step:380/1600 train_time:12914ms step_avg:33.98ms
+step:381/1600 train_time:12945ms step_avg:33.98ms
+step:382/1600 train_time:12981ms step_avg:33.98ms
+step:383/1600 train_time:13013ms step_avg:33.98ms
+step:384/1600 train_time:13050ms step_avg:33.98ms
+step:385/1600 train_time:13081ms step_avg:33.98ms
+step:386/1600 train_time:13118ms step_avg:33.98ms
+step:387/1600 train_time:13148ms step_avg:33.98ms
+step:388/1600 train_time:13186ms step_avg:33.98ms
+step:389/1600 train_time:13216ms step_avg:33.98ms
+step:390/1600 train_time:13254ms step_avg:33.98ms
+step:391/1600 train_time:13285ms step_avg:33.98ms
+step:392/1600 train_time:13321ms step_avg:33.98ms
+step:393/1600 train_time:13352ms step_avg:33.97ms
+step:394/1600 train_time:13390ms step_avg:33.98ms
+step:395/1600 train_time:13421ms step_avg:33.98ms
+step:396/1600 train_time:13457ms step_avg:33.98ms
+step:397/1600 train_time:13488ms step_avg:33.97ms
+step:398/1600 train_time:13525ms step_avg:33.98ms
+step:399/1600 train_time:13556ms step_avg:33.97ms
+step:400/1600 train_time:13593ms step_avg:33.98ms
+step:401/1600 train_time:13624ms step_avg:33.97ms
+step:402/1600 train_time:13660ms step_avg:33.98ms
+step:403/1600 train_time:13692ms step_avg:33.97ms
+step:404/1600 train_time:13729ms step_avg:33.98ms
+step:405/1600 train_time:13759ms step_avg:33.97ms
+step:406/1600 train_time:13796ms step_avg:33.98ms
+step:407/1600 train_time:13827ms step_avg:33.97ms
+step:408/1600 train_time:13864ms step_avg:33.98ms
+step:409/1600 train_time:13895ms step_avg:33.97ms
+step:410/1600 train_time:13932ms step_avg:33.98ms
+step:411/1600 train_time:13963ms step_avg:33.97ms
+step:412/1600 train_time:14000ms step_avg:33.98ms
+step:413/1600 train_time:14030ms step_avg:33.97ms
+step:414/1600 train_time:14067ms step_avg:33.98ms
+step:415/1600 train_time:14098ms step_avg:33.97ms
+step:416/1600 train_time:14135ms step_avg:33.98ms
+step:417/1600 train_time:14166ms step_avg:33.97ms
+step:418/1600 train_time:14203ms step_avg:33.98ms
+step:419/1600 train_time:14234ms step_avg:33.97ms
+step:420/1600 train_time:14271ms step_avg:33.98ms
+step:421/1600 train_time:14302ms step_avg:33.97ms
+step:422/1600 train_time:14338ms step_avg:33.98ms
+step:423/1600 train_time:14369ms step_avg:33.97ms
+step:424/1600 train_time:14406ms step_avg:33.98ms
+step:425/1600 train_time:14437ms step_avg:33.97ms
+step:426/1600 train_time:14474ms step_avg:33.98ms
+step:427/1600 train_time:14505ms step_avg:33.97ms
+step:428/1600 train_time:14542ms step_avg:33.98ms
+step:429/1600 train_time:14572ms step_avg:33.97ms
+step:430/1600 train_time:14610ms step_avg:33.98ms
+step:431/1600 train_time:14640ms step_avg:33.97ms
+step:432/1600 train_time:14677ms step_avg:33.98ms
+step:433/1600 train_time:14708ms step_avg:33.97ms
+step:434/1600 train_time:14744ms step_avg:33.97ms
+step:435/1600 train_time:14775ms step_avg:33.97ms
+step:436/1600 train_time:14812ms step_avg:33.97ms
+step:437/1600 train_time:14843ms step_avg:33.96ms
+step:438/1600 train_time:14879ms step_avg:33.97ms
+step:439/1600 train_time:14910ms step_avg:33.96ms
+step:440/1600 train_time:14947ms step_avg:33.97ms
+step:441/1600 train_time:14978ms step_avg:33.96ms
+step:442/1600 train_time:15015ms step_avg:33.97ms
+step:443/1600 train_time:15045ms step_avg:33.96ms
+step:444/1600 train_time:15082ms step_avg:33.97ms
+step:445/1600 train_time:15113ms step_avg:33.96ms
+step:446/1600 train_time:15149ms step_avg:33.97ms
+step:447/1600 train_time:15180ms step_avg:33.96ms
+step:448/1600 train_time:15217ms step_avg:33.97ms
+step:449/1600 train_time:15248ms step_avg:33.96ms
+step:450/1600 train_time:15285ms step_avg:33.97ms
+step:451/1600 train_time:15315ms step_avg:33.96ms
+step:452/1600 train_time:15352ms step_avg:33.96ms
+step:453/1600 train_time:15383ms step_avg:33.96ms
+step:454/1600 train_time:15420ms step_avg:33.96ms
+step:455/1600 train_time:15450ms step_avg:33.96ms
+step:456/1600 train_time:15487ms step_avg:33.96ms
+step:457/1600 train_time:15517ms step_avg:33.95ms
+step:458/1600 train_time:15555ms step_avg:33.96ms
+step:459/1600 train_time:15585ms step_avg:33.96ms
+step:460/1600 train_time:15622ms step_avg:33.96ms
+step:461/1600 train_time:15653ms step_avg:33.95ms
+step:462/1600 train_time:15690ms step_avg:33.96ms
+step:463/1600 train_time:15721ms step_avg:33.95ms
+step:464/1600 train_time:15758ms step_avg:33.96ms
+step:465/1600 train_time:15788ms step_avg:33.95ms
+step:466/1600 train_time:15826ms step_avg:33.96ms
+step:467/1600 train_time:15856ms step_avg:33.95ms
+step:468/1600 train_time:15893ms step_avg:33.96ms
+step:469/1600 train_time:15924ms step_avg:33.95ms
+step:470/1600 train_time:15961ms step_avg:33.96ms
+step:471/1600 train_time:15992ms step_avg:33.95ms
+step:472/1600 train_time:16029ms step_avg:33.96ms
+step:473/1600 train_time:16060ms step_avg:33.95ms
+step:474/1600 train_time:16097ms step_avg:33.96ms
+step:475/1600 train_time:16127ms step_avg:33.95ms
+step:476/1600 train_time:16165ms step_avg:33.96ms
+step:477/1600 train_time:16195ms step_avg:33.95ms
+step:478/1600 train_time:16232ms step_avg:33.96ms
+step:479/1600 train_time:16264ms step_avg:33.95ms
+step:480/1600 train_time:16301ms step_avg:33.96ms
+step:481/1600 train_time:16332ms step_avg:33.95ms
+step:482/1600 train_time:16368ms step_avg:33.96ms
+step:483/1600 train_time:16399ms step_avg:33.95ms
+step:484/1600 train_time:16436ms step_avg:33.96ms
+step:485/1600 train_time:16468ms step_avg:33.95ms
+step:486/1600 train_time:16504ms step_avg:33.96ms
+step:487/1600 train_time:16535ms step_avg:33.95ms
+step:488/1600 train_time:16572ms step_avg:33.96ms
+step:489/1600 train_time:16603ms step_avg:33.95ms
+step:490/1600 train_time:16640ms step_avg:33.96ms
+step:491/1600 train_time:16670ms step_avg:33.95ms
+step:492/1600 train_time:16708ms step_avg:33.96ms
+step:493/1600 train_time:16739ms step_avg:33.95ms
+step:494/1600 train_time:16776ms step_avg:33.96ms
+step:495/1600 train_time:16807ms step_avg:33.95ms
+step:496/1600 train_time:16844ms step_avg:33.96ms
+step:497/1600 train_time:16875ms step_avg:33.95ms
+step:498/1600 train_time:16912ms step_avg:33.96ms
+step:499/1600 train_time:16943ms step_avg:33.95ms
+step:500/1600 train_time:16980ms step_avg:33.96ms
+step:500/1600 val_loss:4.2498 train_time:17028ms step_avg:34.06ms
+step:501/1600 train_time:17045ms step_avg:34.02ms
+step:502/1600 train_time:17061ms step_avg:33.99ms
+step:503/1600 train_time:17082ms step_avg:33.96ms
+step:504/1600 train_time:17120ms step_avg:33.97ms
+step:505/1600 train_time:17151ms step_avg:33.96ms
+step:506/1600 train_time:17188ms step_avg:33.97ms
+step:507/1600 train_time:17220ms step_avg:33.96ms
+step:508/1600 train_time:17257ms step_avg:33.97ms
+step:509/1600 train_time:17287ms step_avg:33.96ms
+step:510/1600 train_time:17324ms step_avg:33.97ms
+step:511/1600 train_time:17355ms step_avg:33.96ms
+step:512/1600 train_time:17391ms step_avg:33.97ms
+step:513/1600 train_time:17422ms step_avg:33.96ms
+step:514/1600 train_time:17459ms step_avg:33.97ms
+step:515/1600 train_time:17489ms step_avg:33.96ms
+step:516/1600 train_time:17526ms step_avg:33.97ms
+step:517/1600 train_time:17556ms step_avg:33.96ms
+step:518/1600 train_time:17593ms step_avg:33.96ms
+step:519/1600 train_time:17624ms step_avg:33.96ms
+step:520/1600 train_time:17661ms step_avg:33.96ms
+step:521/1600 train_time:17730ms step_avg:34.03ms
+step:522/1600 train_time:17787ms step_avg:34.08ms
+step:523/1600 train_time:17849ms step_avg:34.13ms
+step:524/1600 train_time:17908ms step_avg:34.17ms
+step:525/1600 train_time:17970ms step_avg:34.23ms
+step:526/1600 train_time:18031ms step_avg:34.28ms
+step:527/1600 train_time:18094ms step_avg:34.33ms
+step:528/1600 train_time:18154ms step_avg:34.38ms
+step:529/1600 train_time:18217ms step_avg:34.44ms
+step:530/1600 train_time:18276ms step_avg:34.48ms
+step:531/1600 train_time:18339ms step_avg:34.54ms
+step:532/1600 train_time:18397ms step_avg:34.58ms
+step:533/1600 train_time:18460ms step_avg:34.63ms
+step:534/1600 train_time:18518ms step_avg:34.68ms
+step:535/1600 train_time:18581ms step_avg:34.73ms
+step:536/1600 train_time:18640ms step_avg:34.78ms
+step:537/1600 train_time:18702ms step_avg:34.83ms
+step:538/1600 train_time:18761ms step_avg:34.87ms
+step:539/1600 train_time:18823ms step_avg:34.92ms
+step:540/1600 train_time:18882ms step_avg:34.97ms
+step:541/1600 train_time:18945ms step_avg:35.02ms
+step:542/1600 train_time:19005ms step_avg:35.06ms
+step:543/1600 train_time:19069ms step_avg:35.12ms
+step:544/1600 train_time:19128ms step_avg:35.16ms
+step:545/1600 train_time:19191ms step_avg:35.21ms
+step:546/1600 train_time:19250ms step_avg:35.26ms
+step:547/1600 train_time:19312ms step_avg:35.31ms
+step:548/1600 train_time:19371ms step_avg:35.35ms
+step:549/1600 train_time:19434ms step_avg:35.40ms
+step:550/1600 train_time:19493ms step_avg:35.44ms
+step:551/1600 train_time:19556ms step_avg:35.49ms
+step:552/1600 train_time:19615ms step_avg:35.53ms
+step:553/1600 train_time:19677ms step_avg:35.58ms
+step:554/1600 train_time:19736ms step_avg:35.63ms
+step:555/1600 train_time:19799ms step_avg:35.67ms
+step:556/1600 train_time:19858ms step_avg:35.72ms
+step:557/1600 train_time:19921ms step_avg:35.76ms
+step:558/1600 train_time:19980ms step_avg:35.81ms
+step:559/1600 train_time:20044ms step_avg:35.86ms
+step:560/1600 train_time:20104ms step_avg:35.90ms
+step:561/1600 train_time:20167ms step_avg:35.95ms
+step:562/1600 train_time:20226ms step_avg:35.99ms
+step:563/1600 train_time:20289ms step_avg:36.04ms
+step:564/1600 train_time:20348ms step_avg:36.08ms
+step:565/1600 train_time:20411ms step_avg:36.13ms
+step:566/1600 train_time:20470ms step_avg:36.17ms
+step:567/1600 train_time:20532ms step_avg:36.21ms
+step:568/1600 train_time:20591ms step_avg:36.25ms
+step:569/1600 train_time:20653ms step_avg:36.30ms
+step:570/1600 train_time:20713ms step_avg:36.34ms
+step:571/1600 train_time:20776ms step_avg:36.38ms
+step:572/1600 train_time:20835ms step_avg:36.42ms
+step:573/1600 train_time:20899ms step_avg:36.47ms
+step:574/1600 train_time:20958ms step_avg:36.51ms
+step:575/1600 train_time:21020ms step_avg:36.56ms
+step:576/1600 train_time:21078ms step_avg:36.59ms
+step:577/1600 train_time:21141ms step_avg:36.64ms
+step:578/1600 train_time:21200ms step_avg:36.68ms
+step:579/1600 train_time:21263ms step_avg:36.72ms
+step:580/1600 train_time:21322ms step_avg:36.76ms
+step:581/1600 train_time:21386ms step_avg:36.81ms
+step:582/1600 train_time:21446ms step_avg:36.85ms
+step:583/1600 train_time:21510ms step_avg:36.89ms
+step:584/1600 train_time:21568ms step_avg:36.93ms
+step:585/1600 train_time:21631ms step_avg:36.98ms
+step:586/1600 train_time:21689ms step_avg:37.01ms
+step:587/1600 train_time:21752ms step_avg:37.06ms
+step:588/1600 train_time:21811ms step_avg:37.09ms
+step:589/1600 train_time:21874ms step_avg:37.14ms
+step:590/1600 train_time:21933ms step_avg:37.17ms
+step:591/1600 train_time:21996ms step_avg:37.22ms
+step:592/1600 train_time:22055ms step_avg:37.26ms
+step:593/1600 train_time:22118ms step_avg:37.30ms
+step:594/1600 train_time:22177ms step_avg:37.34ms
+step:595/1600 train_time:22240ms step_avg:37.38ms
+step:596/1600 train_time:22299ms step_avg:37.41ms
+step:597/1600 train_time:22361ms step_avg:37.46ms
+step:598/1600 train_time:22421ms step_avg:37.49ms
+step:599/1600 train_time:22484ms step_avg:37.54ms
+step:600/1600 train_time:22544ms step_avg:37.57ms
+step:601/1600 train_time:22607ms step_avg:37.61ms
+step:602/1600 train_time:22666ms step_avg:37.65ms
+step:603/1600 train_time:22729ms step_avg:37.69ms
+step:604/1600 train_time:22788ms step_avg:37.73ms
+step:605/1600 train_time:22851ms step_avg:37.77ms
+step:606/1600 train_time:22910ms step_avg:37.81ms
+step:607/1600 train_time:22973ms step_avg:37.85ms
+step:608/1600 train_time:23032ms step_avg:37.88ms
+step:609/1600 train_time:23094ms step_avg:37.92ms
+step:610/1600 train_time:23154ms step_avg:37.96ms
+step:611/1600 train_time:23217ms step_avg:38.00ms
+step:612/1600 train_time:23276ms step_avg:38.03ms
+step:613/1600 train_time:23339ms step_avg:38.07ms
+step:614/1600 train_time:23397ms step_avg:38.11ms
+step:615/1600 train_time:23459ms step_avg:38.15ms
+step:616/1600 train_time:23519ms step_avg:38.18ms
+step:617/1600 train_time:23582ms step_avg:38.22ms
+step:618/1600 train_time:23641ms step_avg:38.25ms
+step:619/1600 train_time:23705ms step_avg:38.30ms
+step:620/1600 train_time:23765ms step_avg:38.33ms
+step:621/1600 train_time:23828ms step_avg:38.37ms
+step:622/1600 train_time:23888ms step_avg:38.40ms
+step:623/1600 train_time:23951ms step_avg:38.44ms
+step:624/1600 train_time:24010ms step_avg:38.48ms
+step:625/1600 train_time:24073ms step_avg:38.52ms
+step:626/1600 train_time:24132ms step_avg:38.55ms
+step:627/1600 train_time:24194ms step_avg:38.59ms
+step:628/1600 train_time:24253ms step_avg:38.62ms
+step:629/1600 train_time:24316ms step_avg:38.66ms
+step:630/1600 train_time:24375ms step_avg:38.69ms
+step:631/1600 train_time:24437ms step_avg:38.73ms
+step:632/1600 train_time:24496ms step_avg:38.76ms
+step:633/1600 train_time:24559ms step_avg:38.80ms
+step:634/1600 train_time:24618ms step_avg:38.83ms
+step:635/1600 train_time:24681ms step_avg:38.87ms
+step:636/1600 train_time:24741ms step_avg:38.90ms
+step:637/1600 train_time:24804ms step_avg:38.94ms
+step:638/1600 train_time:24864ms step_avg:38.97ms
+step:639/1600 train_time:24927ms step_avg:39.01ms
+step:640/1600 train_time:24986ms step_avg:39.04ms
+step:641/1600 train_time:25049ms step_avg:39.08ms
+step:642/1600 train_time:25108ms step_avg:39.11ms
+step:643/1600 train_time:25171ms step_avg:39.15ms
+step:644/1600 train_time:25229ms step_avg:39.18ms
+step:645/1600 train_time:25292ms step_avg:39.21ms
+step:646/1600 train_time:25351ms step_avg:39.24ms
+step:647/1600 train_time:25414ms step_avg:39.28ms
+step:648/1600 train_time:25474ms step_avg:39.31ms
+step:649/1600 train_time:25537ms step_avg:39.35ms
+step:650/1600 train_time:25595ms step_avg:39.38ms
+step:651/1600 train_time:25658ms step_avg:39.41ms
+step:652/1600 train_time:25717ms step_avg:39.44ms
+step:653/1600 train_time:25780ms step_avg:39.48ms
+step:654/1600 train_time:25840ms step_avg:39.51ms
+step:655/1600 train_time:25903ms step_avg:39.55ms
+step:656/1600 train_time:25963ms step_avg:39.58ms
+step:657/1600 train_time:26026ms step_avg:39.61ms
+step:658/1600 train_time:26085ms step_avg:39.64ms
+step:659/1600 train_time:26149ms step_avg:39.68ms
+step:660/1600 train_time:26209ms step_avg:39.71ms
+step:661/1600 train_time:26271ms step_avg:39.74ms
+step:662/1600 train_time:26330ms step_avg:39.77ms
+step:663/1600 train_time:26393ms step_avg:39.81ms
+step:664/1600 train_time:26452ms step_avg:39.84ms
+step:665/1600 train_time:26516ms step_avg:39.87ms
+step:666/1600 train_time:26574ms step_avg:39.90ms
+step:667/1600 train_time:26637ms step_avg:39.94ms
+step:668/1600 train_time:26696ms step_avg:39.96ms
+step:669/1600 train_time:26758ms step_avg:40.00ms
+step:670/1600 train_time:26817ms step_avg:40.02ms
+step:671/1600 train_time:26880ms step_avg:40.06ms
+step:672/1600 train_time:26939ms step_avg:40.09ms
+step:673/1600 train_time:27002ms step_avg:40.12ms
+step:674/1600 train_time:27061ms step_avg:40.15ms
+step:675/1600 train_time:27124ms step_avg:40.18ms
+step:676/1600 train_time:27184ms step_avg:40.21ms
+step:677/1600 train_time:27247ms step_avg:40.25ms
+step:678/1600 train_time:27306ms step_avg:40.27ms
+step:679/1600 train_time:27369ms step_avg:40.31ms
+step:680/1600 train_time:27428ms step_avg:40.34ms
+step:681/1600 train_time:27492ms step_avg:40.37ms
+step:682/1600 train_time:27551ms step_avg:40.40ms
+step:683/1600 train_time:27613ms step_avg:40.43ms
+step:684/1600 train_time:27671ms step_avg:40.46ms
+step:685/1600 train_time:27734ms step_avg:40.49ms
+step:686/1600 train_time:27793ms step_avg:40.52ms
+step:687/1600 train_time:27857ms step_avg:40.55ms
+step:688/1600 train_time:27916ms step_avg:40.58ms
+step:689/1600 train_time:27979ms step_avg:40.61ms
+step:690/1600 train_time:28038ms step_avg:40.63ms
+step:691/1600 train_time:28101ms step_avg:40.67ms
+step:692/1600 train_time:28160ms step_avg:40.69ms
+step:693/1600 train_time:28224ms step_avg:40.73ms
+step:694/1600 train_time:28282ms step_avg:40.75ms
+step:695/1600 train_time:28345ms step_avg:40.78ms
+step:696/1600 train_time:28404ms step_avg:40.81ms
+step:697/1600 train_time:28468ms step_avg:40.84ms
+step:698/1600 train_time:28527ms step_avg:40.87ms
+step:699/1600 train_time:28590ms step_avg:40.90ms
+step:700/1600 train_time:28650ms step_avg:40.93ms
+step:701/1600 train_time:28712ms step_avg:40.96ms
+step:702/1600 train_time:28770ms step_avg:40.98ms
+step:703/1600 train_time:28834ms step_avg:41.02ms
+step:704/1600 train_time:28893ms step_avg:41.04ms
+step:705/1600 train_time:28956ms step_avg:41.07ms
+step:706/1600 train_time:29015ms step_avg:41.10ms
+step:707/1600 train_time:29078ms step_avg:41.13ms
+step:708/1600 train_time:29137ms step_avg:41.15ms
+step:709/1600 train_time:29200ms step_avg:41.19ms
+step:710/1600 train_time:29260ms step_avg:41.21ms
+step:711/1600 train_time:29323ms step_avg:41.24ms
+step:712/1600 train_time:29381ms step_avg:41.27ms
+step:713/1600 train_time:29444ms step_avg:41.30ms
+step:714/1600 train_time:29503ms step_avg:41.32ms
+step:715/1600 train_time:29565ms step_avg:41.35ms
+step:716/1600 train_time:29625ms step_avg:41.38ms
+step:717/1600 train_time:29689ms step_avg:41.41ms
+step:718/1600 train_time:29748ms step_avg:41.43ms
+step:719/1600 train_time:29811ms step_avg:41.46ms
+step:720/1600 train_time:29870ms step_avg:41.49ms
+step:721/1600 train_time:29932ms step_avg:41.51ms
+step:722/1600 train_time:29992ms step_avg:41.54ms
+step:723/1600 train_time:30055ms step_avg:41.57ms
+step:724/1600 train_time:30114ms step_avg:41.59ms
+step:725/1600 train_time:30177ms step_avg:41.62ms
+step:726/1600 train_time:30236ms step_avg:41.65ms
+step:727/1600 train_time:30298ms step_avg:41.68ms
+step:728/1600 train_time:30357ms step_avg:41.70ms
+step:729/1600 train_time:30420ms step_avg:41.73ms
+step:730/1600 train_time:30479ms step_avg:41.75ms
+step:731/1600 train_time:30543ms step_avg:41.78ms
+step:732/1600 train_time:30602ms step_avg:41.81ms
+step:733/1600 train_time:30665ms step_avg:41.83ms
+step:734/1600 train_time:30726ms step_avg:41.86ms
+step:735/1600 train_time:30789ms step_avg:41.89ms
+step:736/1600 train_time:30849ms step_avg:41.91ms
+step:737/1600 train_time:30912ms step_avg:41.94ms
+step:738/1600 train_time:30971ms step_avg:41.97ms
+step:739/1600 train_time:31033ms step_avg:41.99ms
+step:740/1600 train_time:31092ms step_avg:42.02ms
+step:741/1600 train_time:31155ms step_avg:42.04ms
+step:742/1600 train_time:31214ms step_avg:42.07ms
+step:743/1600 train_time:31277ms step_avg:42.10ms
+step:744/1600 train_time:31336ms step_avg:42.12ms
+step:745/1600 train_time:31398ms step_avg:42.15ms
+step:746/1600 train_time:31457ms step_avg:42.17ms
+step:747/1600 train_time:31520ms step_avg:42.20ms
+step:748/1600 train_time:31579ms step_avg:42.22ms
+step:749/1600 train_time:31642ms step_avg:42.25ms
+step:750/1600 train_time:31703ms step_avg:42.27ms
+step:750/1600 val_loss:3.9008 train_time:31750ms step_avg:42.33ms
+step:751/1600 train_time:31768ms step_avg:42.30ms
+step:752/1600 train_time:31826ms step_avg:42.32ms
+step:753/1600 train_time:31889ms step_avg:42.35ms
+step:754/1600 train_time:31949ms step_avg:42.37ms
+step:755/1600 train_time:32011ms step_avg:42.40ms
+step:756/1600 train_time:32071ms step_avg:42.42ms
+step:757/1600 train_time:32132ms step_avg:42.45ms
+step:758/1600 train_time:32191ms step_avg:42.47ms
+step:759/1600 train_time:32254ms step_avg:42.49ms
+step:760/1600 train_time:32312ms step_avg:42.52ms
+step:761/1600 train_time:32375ms step_avg:42.54ms
+step:762/1600 train_time:32435ms step_avg:42.57ms
+step:763/1600 train_time:32497ms step_avg:42.59ms
+step:764/1600 train_time:32557ms step_avg:42.61ms
+step:765/1600 train_time:32619ms step_avg:42.64ms
+step:766/1600 train_time:32678ms step_avg:42.66ms
+step:767/1600 train_time:32742ms step_avg:42.69ms
+step:768/1600 train_time:32801ms step_avg:42.71ms
+step:769/1600 train_time:32864ms step_avg:42.74ms
+step:770/1600 train_time:32923ms step_avg:42.76ms
+step:771/1600 train_time:32985ms step_avg:42.78ms
+step:772/1600 train_time:33044ms step_avg:42.80ms
+step:773/1600 train_time:33107ms step_avg:42.83ms
+step:774/1600 train_time:33166ms step_avg:42.85ms
+step:775/1600 train_time:33228ms step_avg:42.88ms
+step:776/1600 train_time:33287ms step_avg:42.90ms
+step:777/1600 train_time:33350ms step_avg:42.92ms
+step:778/1600 train_time:33408ms step_avg:42.94ms
+step:779/1600 train_time:33473ms step_avg:42.97ms
+step:780/1600 train_time:33532ms step_avg:42.99ms
+step:781/1600 train_time:33594ms step_avg:43.01ms
+step:782/1600 train_time:33653ms step_avg:43.03ms
+step:783/1600 train_time:33717ms step_avg:43.06ms
+step:784/1600 train_time:33776ms step_avg:43.08ms
+step:785/1600 train_time:33839ms step_avg:43.11ms
+step:786/1600 train_time:33899ms step_avg:43.13ms
+step:787/1600 train_time:33962ms step_avg:43.15ms
+step:788/1600 train_time:34021ms step_avg:43.17ms
+step:789/1600 train_time:34084ms step_avg:43.20ms
+step:790/1600 train_time:34144ms step_avg:43.22ms
+step:791/1600 train_time:34206ms step_avg:43.24ms
+step:792/1600 train_time:34265ms step_avg:43.26ms
+step:793/1600 train_time:34328ms step_avg:43.29ms
+step:794/1600 train_time:34388ms step_avg:43.31ms
+step:795/1600 train_time:34450ms step_avg:43.33ms
+step:796/1600 train_time:34509ms step_avg:43.35ms
+step:797/1600 train_time:34572ms step_avg:43.38ms
+step:798/1600 train_time:34630ms step_avg:43.40ms
+step:799/1600 train_time:34693ms step_avg:43.42ms
+step:800/1600 train_time:34753ms step_avg:43.44ms
+step:801/1600 train_time:34816ms step_avg:43.47ms
+step:802/1600 train_time:34875ms step_avg:43.48ms
+step:803/1600 train_time:34937ms step_avg:43.51ms
+step:804/1600 train_time:34997ms step_avg:43.53ms
+step:805/1600 train_time:35061ms step_avg:43.55ms
+step:806/1600 train_time:35120ms step_avg:43.57ms
+step:807/1600 train_time:35183ms step_avg:43.60ms
+step:808/1600 train_time:35243ms step_avg:43.62ms
+step:809/1600 train_time:35305ms step_avg:43.64ms
+step:810/1600 train_time:35365ms step_avg:43.66ms
+step:811/1600 train_time:35427ms step_avg:43.68ms
+step:812/1600 train_time:35487ms step_avg:43.70ms
+step:813/1600 train_time:35550ms step_avg:43.73ms
+step:814/1600 train_time:35609ms step_avg:43.75ms
+step:815/1600 train_time:35672ms step_avg:43.77ms
+step:816/1600 train_time:35731ms step_avg:43.79ms
+step:817/1600 train_time:35794ms step_avg:43.81ms
+step:818/1600 train_time:35853ms step_avg:43.83ms
+step:819/1600 train_time:35916ms step_avg:43.85ms
+step:820/1600 train_time:35975ms step_avg:43.87ms
+step:821/1600 train_time:36039ms step_avg:43.90ms
+step:822/1600 train_time:36099ms step_avg:43.92ms
+step:823/1600 train_time:36162ms step_avg:43.94ms
+step:824/1600 train_time:36221ms step_avg:43.96ms
+step:825/1600 train_time:36284ms step_avg:43.98ms
+step:826/1600 train_time:36344ms step_avg:44.00ms
+step:827/1600 train_time:36405ms step_avg:44.02ms
+step:828/1600 train_time:36465ms step_avg:44.04ms
+step:829/1600 train_time:36528ms step_avg:44.06ms
+step:830/1600 train_time:36587ms step_avg:44.08ms
+step:831/1600 train_time:36650ms step_avg:44.10ms
+step:832/1600 train_time:36709ms step_avg:44.12ms
+step:833/1600 train_time:36772ms step_avg:44.14ms
+step:834/1600 train_time:36830ms step_avg:44.16ms
+step:835/1600 train_time:36893ms step_avg:44.18ms
+step:836/1600 train_time:36953ms step_avg:44.20ms
+step:837/1600 train_time:37016ms step_avg:44.23ms
+step:838/1600 train_time:37076ms step_avg:44.24ms
+step:839/1600 train_time:37139ms step_avg:44.27ms
+step:840/1600 train_time:37199ms step_avg:44.28ms
+step:841/1600 train_time:37262ms step_avg:44.31ms
+step:842/1600 train_time:37321ms step_avg:44.32ms
+step:843/1600 train_time:37384ms step_avg:44.35ms
+step:844/1600 train_time:37444ms step_avg:44.36ms
+step:845/1600 train_time:37505ms step_avg:44.38ms
+step:846/1600 train_time:37564ms step_avg:44.40ms
+step:847/1600 train_time:37628ms step_avg:44.42ms
+step:848/1600 train_time:37687ms step_avg:44.44ms
+step:849/1600 train_time:37750ms step_avg:44.46ms
+step:850/1600 train_time:37809ms step_avg:44.48ms
+step:851/1600 train_time:37871ms step_avg:44.50ms
+step:852/1600 train_time:37930ms step_avg:44.52ms
+step:853/1600 train_time:37994ms step_avg:44.54ms
+step:854/1600 train_time:38053ms step_avg:44.56ms
+step:855/1600 train_time:38116ms step_avg:44.58ms
+step:856/1600 train_time:38176ms step_avg:44.60ms
+step:857/1600 train_time:38240ms step_avg:44.62ms
+step:858/1600 train_time:38298ms step_avg:44.64ms
+step:859/1600 train_time:38362ms step_avg:44.66ms
+step:860/1600 train_time:38421ms step_avg:44.68ms
+step:861/1600 train_time:38484ms step_avg:44.70ms
+step:862/1600 train_time:38543ms step_avg:44.71ms
+step:863/1600 train_time:38606ms step_avg:44.73ms
+step:864/1600 train_time:38664ms step_avg:44.75ms
+step:865/1600 train_time:38728ms step_avg:44.77ms
+step:866/1600 train_time:38787ms step_avg:44.79ms
+step:867/1600 train_time:38851ms step_avg:44.81ms
+step:868/1600 train_time:38910ms step_avg:44.83ms
+step:869/1600 train_time:38972ms step_avg:44.85ms
+step:870/1600 train_time:39032ms step_avg:44.86ms
+step:871/1600 train_time:39096ms step_avg:44.89ms
+step:872/1600 train_time:39154ms step_avg:44.90ms
+step:873/1600 train_time:39217ms step_avg:44.92ms
+step:874/1600 train_time:39277ms step_avg:44.94ms
+step:875/1600 train_time:39341ms step_avg:44.96ms
+step:876/1600 train_time:39400ms step_avg:44.98ms
+step:877/1600 train_time:39462ms step_avg:45.00ms
+step:878/1600 train_time:39521ms step_avg:45.01ms
+step:879/1600 train_time:39584ms step_avg:45.03ms
+step:880/1600 train_time:39643ms step_avg:45.05ms
+step:881/1600 train_time:39707ms step_avg:45.07ms
+step:882/1600 train_time:39766ms step_avg:45.09ms
+step:883/1600 train_time:39830ms step_avg:45.11ms
+step:884/1600 train_time:39890ms step_avg:45.12ms
+step:885/1600 train_time:39952ms step_avg:45.14ms
+step:886/1600 train_time:40011ms step_avg:45.16ms
+step:887/1600 train_time:40073ms step_avg:45.18ms
+step:888/1600 train_time:40132ms step_avg:45.19ms
+step:889/1600 train_time:40195ms step_avg:45.21ms
+step:890/1600 train_time:40255ms step_avg:45.23ms
+step:891/1600 train_time:40318ms step_avg:45.25ms
+step:892/1600 train_time:40377ms step_avg:45.27ms
+step:893/1600 train_time:40440ms step_avg:45.29ms
+step:894/1600 train_time:40499ms step_avg:45.30ms
+step:895/1600 train_time:40562ms step_avg:45.32ms
+step:896/1600 train_time:40622ms step_avg:45.34ms
+step:897/1600 train_time:40685ms step_avg:45.36ms
+step:898/1600 train_time:40744ms step_avg:45.37ms
+step:899/1600 train_time:40807ms step_avg:45.39ms
+step:900/1600 train_time:40866ms step_avg:45.41ms
+step:901/1600 train_time:40930ms step_avg:45.43ms
+step:902/1600 train_time:40988ms step_avg:45.44ms
+step:903/1600 train_time:41052ms step_avg:45.46ms
+step:904/1600 train_time:41111ms step_avg:45.48ms
+step:905/1600 train_time:41173ms step_avg:45.50ms
+step:906/1600 train_time:41232ms step_avg:45.51ms
+step:907/1600 train_time:41295ms step_avg:45.53ms
+step:908/1600 train_time:41354ms step_avg:45.54ms
+step:909/1600 train_time:41417ms step_avg:45.56ms
+step:910/1600 train_time:41477ms step_avg:45.58ms
+step:911/1600 train_time:41540ms step_avg:45.60ms
+step:912/1600 train_time:41601ms step_avg:45.61ms
+step:913/1600 train_time:41664ms step_avg:45.63ms
+step:914/1600 train_time:41723ms step_avg:45.65ms
+step:915/1600 train_time:41786ms step_avg:45.67ms
+step:916/1600 train_time:41845ms step_avg:45.68ms
+step:917/1600 train_time:41907ms step_avg:45.70ms
+step:918/1600 train_time:41966ms step_avg:45.71ms
+step:919/1600 train_time:42029ms step_avg:45.73ms
+step:920/1600 train_time:42088ms step_avg:45.75ms
+step:921/1600 train_time:42150ms step_avg:45.77ms
+step:922/1600 train_time:42209ms step_avg:45.78ms
+step:923/1600 train_time:42272ms step_avg:45.80ms
+step:924/1600 train_time:42331ms step_avg:45.81ms
+step:925/1600 train_time:42394ms step_avg:45.83ms
+step:926/1600 train_time:42454ms step_avg:45.85ms
+step:927/1600 train_time:42517ms step_avg:45.86ms
+step:928/1600 train_time:42576ms step_avg:45.88ms
+step:929/1600 train_time:42639ms step_avg:45.90ms
+step:930/1600 train_time:42699ms step_avg:45.91ms
+step:931/1600 train_time:42762ms step_avg:45.93ms
+step:932/1600 train_time:42822ms step_avg:45.95ms
+step:933/1600 train_time:42883ms step_avg:45.96ms
+step:934/1600 train_time:42942ms step_avg:45.98ms
+step:935/1600 train_time:43005ms step_avg:46.00ms
+step:936/1600 train_time:43065ms step_avg:46.01ms
+step:937/1600 train_time:43127ms step_avg:46.03ms
+step:938/1600 train_time:43187ms step_avg:46.04ms
+step:939/1600 train_time:43250ms step_avg:46.06ms
+step:940/1600 train_time:43309ms step_avg:46.07ms
+step:941/1600 train_time:43372ms step_avg:46.09ms
+step:942/1600 train_time:43431ms step_avg:46.10ms
+step:943/1600 train_time:43493ms step_avg:46.12ms
+step:944/1600 train_time:43552ms step_avg:46.14ms
+step:945/1600 train_time:43616ms step_avg:46.15ms
+step:946/1600 train_time:43676ms step_avg:46.17ms
+step:947/1600 train_time:43739ms step_avg:46.19ms
+step:948/1600 train_time:43798ms step_avg:46.20ms
+step:949/1600 train_time:43862ms step_avg:46.22ms
+step:950/1600 train_time:43920ms step_avg:46.23ms
+step:951/1600 train_time:43983ms step_avg:46.25ms
+step:952/1600 train_time:44042ms step_avg:46.26ms
+step:953/1600 train_time:44105ms step_avg:46.28ms
+step:954/1600 train_time:44164ms step_avg:46.29ms
+step:955/1600 train_time:44227ms step_avg:46.31ms
+step:956/1600 train_time:44287ms step_avg:46.33ms
+step:957/1600 train_time:44350ms step_avg:46.34ms
+step:958/1600 train_time:44409ms step_avg:46.36ms
+step:959/1600 train_time:44471ms step_avg:46.37ms
+step:960/1600 train_time:44530ms step_avg:46.39ms
+step:961/1600 train_time:44594ms step_avg:46.40ms
+step:962/1600 train_time:44653ms step_avg:46.42ms
+step:963/1600 train_time:44717ms step_avg:46.43ms
+step:964/1600 train_time:44777ms step_avg:46.45ms
+step:965/1600 train_time:44840ms step_avg:46.47ms
+step:966/1600 train_time:44899ms step_avg:46.48ms
+step:967/1600 train_time:44962ms step_avg:46.50ms
+step:968/1600 train_time:45022ms step_avg:46.51ms
+step:969/1600 train_time:45084ms step_avg:46.53ms
+step:970/1600 train_time:45143ms step_avg:46.54ms
+step:971/1600 train_time:45205ms step_avg:46.56ms
+step:972/1600 train_time:45264ms step_avg:46.57ms
+step:973/1600 train_time:45327ms step_avg:46.58ms
+step:974/1600 train_time:45387ms step_avg:46.60ms
+step:975/1600 train_time:45450ms step_avg:46.62ms
+step:976/1600 train_time:45509ms step_avg:46.63ms
+step:977/1600 train_time:45571ms step_avg:46.64ms
+step:978/1600 train_time:45630ms step_avg:46.66ms
+step:979/1600 train_time:45693ms step_avg:46.67ms
+step:980/1600 train_time:45753ms step_avg:46.69ms
+step:981/1600 train_time:45816ms step_avg:46.70ms
+step:982/1600 train_time:45876ms step_avg:46.72ms
+step:983/1600 train_time:45940ms step_avg:46.73ms
+step:984/1600 train_time:45999ms step_avg:46.75ms
+step:985/1600 train_time:46061ms step_avg:46.76ms
+step:986/1600 train_time:46120ms step_avg:46.77ms
+step:987/1600 train_time:46182ms step_avg:46.79ms
+step:988/1600 train_time:46241ms step_avg:46.80ms
+step:989/1600 train_time:46304ms step_avg:46.82ms
+step:990/1600 train_time:46363ms step_avg:46.83ms
+step:991/1600 train_time:46427ms step_avg:46.85ms
+step:992/1600 train_time:46486ms step_avg:46.86ms
+step:993/1600 train_time:46550ms step_avg:46.88ms
+step:994/1600 train_time:46608ms step_avg:46.89ms
+step:995/1600 train_time:46671ms step_avg:46.91ms
+step:996/1600 train_time:46730ms step_avg:46.92ms
+step:997/1600 train_time:46793ms step_avg:46.93ms
+step:998/1600 train_time:46852ms step_avg:46.95ms
+step:999/1600 train_time:46915ms step_avg:46.96ms
+step:1000/1600 train_time:46976ms step_avg:46.98ms
+step:1000/1600 val_loss:3.5991 train_time:47022ms step_avg:47.02ms
+step:1001/1600 train_time:47040ms step_avg:46.99ms
+step:1002/1600 train_time:47098ms step_avg:47.00ms
+step:1003/1600 train_time:47162ms step_avg:47.02ms
+step:1004/1600 train_time:47222ms step_avg:47.03ms
+step:1005/1600 train_time:47284ms step_avg:47.05ms
+step:1006/1600 train_time:47344ms step_avg:47.06ms
+step:1007/1600 train_time:47406ms step_avg:47.08ms
+step:1008/1600 train_time:47466ms step_avg:47.09ms
+step:1009/1600 train_time:47528ms step_avg:47.10ms
+step:1010/1600 train_time:47586ms step_avg:47.11ms
+step:1011/1600 train_time:47649ms step_avg:47.13ms
+step:1012/1600 train_time:47708ms step_avg:47.14ms
+step:1013/1600 train_time:47769ms step_avg:47.16ms
+step:1014/1600 train_time:47829ms step_avg:47.17ms
+step:1015/1600 train_time:47891ms step_avg:47.18ms
+step:1016/1600 train_time:47952ms step_avg:47.20ms
+step:1017/1600 train_time:48017ms step_avg:47.21ms
+step:1018/1600 train_time:48076ms step_avg:47.23ms
+step:1019/1600 train_time:48139ms step_avg:47.24ms
+step:1020/1600 train_time:48198ms step_avg:47.25ms
+step:1021/1600 train_time:48261ms step_avg:47.27ms
+step:1022/1600 train_time:48320ms step_avg:47.28ms
+step:1023/1600 train_time:48383ms step_avg:47.29ms
+step:1024/1600 train_time:48441ms step_avg:47.31ms
+step:1025/1600 train_time:48504ms step_avg:47.32ms
+step:1026/1600 train_time:48564ms step_avg:47.33ms
+step:1027/1600 train_time:48626ms step_avg:47.35ms
+step:1028/1600 train_time:48685ms step_avg:47.36ms
+step:1029/1600 train_time:48748ms step_avg:47.37ms
+step:1030/1600 train_time:48806ms step_avg:47.38ms
+step:1031/1600 train_time:48869ms step_avg:47.40ms
+step:1032/1600 train_time:48927ms step_avg:47.41ms
+step:1033/1600 train_time:48990ms step_avg:47.43ms
+step:1034/1600 train_time:49049ms step_avg:47.44ms
+step:1035/1600 train_time:49113ms step_avg:47.45ms
+step:1036/1600 train_time:49173ms step_avg:47.46ms
+step:1037/1600 train_time:49237ms step_avg:47.48ms
+step:1038/1600 train_time:49296ms step_avg:47.49ms
+step:1039/1600 train_time:49358ms step_avg:47.51ms
+step:1040/1600 train_time:49417ms step_avg:47.52ms
+step:1041/1600 train_time:49486ms step_avg:47.54ms
+step:1042/1600 train_time:49571ms step_avg:47.57ms
+step:1043/1600 train_time:49661ms step_avg:47.61ms
+step:1044/1600 train_time:49745ms step_avg:47.65ms
+step:1045/1600 train_time:49833ms step_avg:47.69ms
+step:1046/1600 train_time:49920ms step_avg:47.72ms
+step:1047/1600 train_time:50009ms step_avg:47.76ms
+step:1048/1600 train_time:50097ms step_avg:47.80ms
+step:1049/1600 train_time:50186ms step_avg:47.84ms
+step:1050/1600 train_time:50272ms step_avg:47.88ms
+step:1051/1600 train_time:50360ms step_avg:47.92ms
+step:1052/1600 train_time:50447ms step_avg:47.95ms
+step:1053/1600 train_time:50535ms step_avg:47.99ms
+step:1054/1600 train_time:50621ms step_avg:48.03ms
+step:1055/1600 train_time:50709ms step_avg:48.07ms
+step:1056/1600 train_time:50794ms step_avg:48.10ms
+step:1057/1600 train_time:50883ms step_avg:48.14ms
+step:1058/1600 train_time:50969ms step_avg:48.17ms
+step:1059/1600 train_time:51059ms step_avg:48.21ms
+step:1060/1600 train_time:51144ms step_avg:48.25ms
+step:1061/1600 train_time:51233ms step_avg:48.29ms
+step:1062/1600 train_time:51319ms step_avg:48.32ms
+step:1063/1600 train_time:51408ms step_avg:48.36ms
+step:1064/1600 train_time:51493ms step_avg:48.40ms
+step:1065/1600 train_time:51581ms step_avg:48.43ms
+step:1066/1600 train_time:51667ms step_avg:48.47ms
+step:1067/1600 train_time:51755ms step_avg:48.51ms
+step:1068/1600 train_time:51841ms step_avg:48.54ms
+step:1069/1600 train_time:51930ms step_avg:48.58ms
+step:1070/1600 train_time:52015ms step_avg:48.61ms
+step:1071/1600 train_time:52104ms step_avg:48.65ms
+step:1072/1600 train_time:52191ms step_avg:48.69ms
+step:1073/1600 train_time:52280ms step_avg:48.72ms
+step:1074/1600 train_time:52365ms step_avg:48.76ms
+step:1075/1600 train_time:52453ms step_avg:48.79ms
+step:1076/1600 train_time:52539ms step_avg:48.83ms
+step:1077/1600 train_time:52628ms step_avg:48.87ms
+step:1078/1600 train_time:52713ms step_avg:48.90ms
+step:1079/1600 train_time:52802ms step_avg:48.94ms
+step:1080/1600 train_time:52888ms step_avg:48.97ms
+step:1081/1600 train_time:52977ms step_avg:49.01ms
+step:1082/1600 train_time:53062ms step_avg:49.04ms
+step:1083/1600 train_time:53151ms step_avg:49.08ms
+step:1084/1600 train_time:53237ms step_avg:49.11ms
+step:1085/1600 train_time:53326ms step_avg:49.15ms
+step:1086/1600 train_time:53411ms step_avg:49.18ms
+step:1087/1600 train_time:53499ms step_avg:49.22ms
+step:1088/1600 train_time:53585ms step_avg:49.25ms
+step:1089/1600 train_time:53674ms step_avg:49.29ms
+step:1090/1600 train_time:53760ms step_avg:49.32ms
+step:1091/1600 train_time:53848ms step_avg:49.36ms
+step:1092/1600 train_time:53934ms step_avg:49.39ms
+step:1093/1600 train_time:54023ms step_avg:49.43ms
+step:1094/1600 train_time:54108ms step_avg:49.46ms
+step:1095/1600 train_time:54197ms step_avg:49.49ms
+step:1096/1600 train_time:54282ms step_avg:49.53ms
+step:1097/1600 train_time:54370ms step_avg:49.56ms
+step:1098/1600 train_time:54456ms step_avg:49.60ms
+step:1099/1600 train_time:54544ms step_avg:49.63ms
+step:1100/1600 train_time:54630ms step_avg:49.66ms
+step:1101/1600 train_time:54719ms step_avg:49.70ms
+step:1102/1600 train_time:54804ms step_avg:49.73ms
+step:1103/1600 train_time:54893ms step_avg:49.77ms
+step:1104/1600 train_time:54979ms step_avg:49.80ms
+step:1105/1600 train_time:55067ms step_avg:49.83ms
+step:1106/1600 train_time:55153ms step_avg:49.87ms
+step:1107/1600 train_time:55243ms step_avg:49.90ms
+step:1108/1600 train_time:55328ms step_avg:49.94ms
+step:1109/1600 train_time:55417ms step_avg:49.97ms
+step:1110/1600 train_time:55502ms step_avg:50.00ms
+step:1111/1600 train_time:55590ms step_avg:50.04ms
+step:1112/1600 train_time:55676ms step_avg:50.07ms
+step:1113/1600 train_time:55764ms step_avg:50.10ms
+step:1114/1600 train_time:55849ms step_avg:50.13ms
+step:1115/1600 train_time:55939ms step_avg:50.17ms
+step:1116/1600 train_time:56025ms step_avg:50.20ms
+step:1117/1600 train_time:56114ms step_avg:50.24ms
+step:1118/1600 train_time:56200ms step_avg:50.27ms
+step:1119/1600 train_time:56288ms step_avg:50.30ms
+step:1120/1600 train_time:56373ms step_avg:50.33ms
+step:1121/1600 train_time:56463ms step_avg:50.37ms
+step:1122/1600 train_time:56548ms step_avg:50.40ms
+step:1123/1600 train_time:56637ms step_avg:50.43ms
+step:1124/1600 train_time:56722ms step_avg:50.46ms
+step:1125/1600 train_time:56811ms step_avg:50.50ms
+step:1126/1600 train_time:56898ms step_avg:50.53ms
+step:1127/1600 train_time:56986ms step_avg:50.56ms
+step:1128/1600 train_time:57071ms step_avg:50.59ms
+step:1129/1600 train_time:57161ms step_avg:50.63ms
+step:1130/1600 train_time:57246ms step_avg:50.66ms
+step:1131/1600 train_time:57334ms step_avg:50.69ms
+step:1132/1600 train_time:57420ms step_avg:50.72ms
+step:1133/1600 train_time:57509ms step_avg:50.76ms
+step:1134/1600 train_time:57595ms step_avg:50.79ms
+step:1135/1600 train_time:57684ms step_avg:50.82ms
+step:1136/1600 train_time:57769ms step_avg:50.85ms
+step:1137/1600 train_time:57857ms step_avg:50.89ms
+step:1138/1600 train_time:57943ms step_avg:50.92ms
+step:1139/1600 train_time:58031ms step_avg:50.95ms
+step:1140/1600 train_time:58117ms step_avg:50.98ms
+step:1141/1600 train_time:58206ms step_avg:51.01ms
+step:1142/1600 train_time:58291ms step_avg:51.04ms
+step:1143/1600 train_time:58379ms step_avg:51.08ms
+step:1144/1600 train_time:58465ms step_avg:51.11ms
+step:1145/1600 train_time:58554ms step_avg:51.14ms
+step:1146/1600 train_time:58639ms step_avg:51.17ms
+step:1147/1600 train_time:58728ms step_avg:51.20ms
+step:1148/1600 train_time:58814ms step_avg:51.23ms
+step:1149/1600 train_time:58903ms step_avg:51.26ms
+step:1150/1600 train_time:58987ms step_avg:51.29ms
+step:1151/1600 train_time:59077ms step_avg:51.33ms
+step:1152/1600 train_time:59163ms step_avg:51.36ms
+step:1153/1600 train_time:59251ms step_avg:51.39ms
+step:1154/1600 train_time:59337ms step_avg:51.42ms
+step:1155/1600 train_time:59425ms step_avg:51.45ms
+step:1156/1600 train_time:59511ms step_avg:51.48ms
+step:1157/1600 train_time:59600ms step_avg:51.51ms
+step:1158/1600 train_time:59687ms step_avg:51.54ms
+step:1159/1600 train_time:59775ms step_avg:51.57ms
+step:1160/1600 train_time:59860ms step_avg:51.60ms
+step:1161/1600 train_time:59949ms step_avg:51.64ms
+step:1162/1600 train_time:60035ms step_avg:51.67ms
+step:1163/1600 train_time:60125ms step_avg:51.70ms
+step:1164/1600 train_time:60211ms step_avg:51.73ms
+step:1165/1600 train_time:60299ms step_avg:51.76ms
+step:1166/1600 train_time:60384ms step_avg:51.79ms
+step:1167/1600 train_time:60473ms step_avg:51.82ms
+step:1168/1600 train_time:60558ms step_avg:51.85ms
+step:1169/1600 train_time:60648ms step_avg:51.88ms
+step:1170/1600 train_time:60734ms step_avg:51.91ms
+step:1171/1600 train_time:60822ms step_avg:51.94ms
+step:1172/1600 train_time:60907ms step_avg:51.97ms
+step:1173/1600 train_time:60996ms step_avg:52.00ms
+step:1174/1600 train_time:61081ms step_avg:52.03ms
+step:1175/1600 train_time:61170ms step_avg:52.06ms
+step:1176/1600 train_time:61256ms step_avg:52.09ms
+step:1177/1600 train_time:61344ms step_avg:52.12ms
+step:1178/1600 train_time:61430ms step_avg:52.15ms
+step:1179/1600 train_time:61519ms step_avg:52.18ms
+step:1180/1600 train_time:61604ms step_avg:52.21ms
+step:1181/1600 train_time:61693ms step_avg:52.24ms
+step:1182/1600 train_time:61779ms step_avg:52.27ms
+step:1183/1600 train_time:61867ms step_avg:52.30ms
+step:1184/1600 train_time:61953ms step_avg:52.33ms
+step:1185/1600 train_time:62042ms step_avg:52.36ms
+step:1186/1600 train_time:62128ms step_avg:52.38ms
+step:1187/1600 train_time:62216ms step_avg:52.41ms
+step:1188/1600 train_time:62302ms step_avg:52.44ms
+step:1189/1600 train_time:62390ms step_avg:52.47ms
+step:1190/1600 train_time:62476ms step_avg:52.50ms
+step:1191/1600 train_time:62564ms step_avg:52.53ms
+step:1192/1600 train_time:62649ms step_avg:52.56ms
+step:1193/1600 train_time:62739ms step_avg:52.59ms
+step:1194/1600 train_time:62824ms step_avg:52.62ms
+step:1195/1600 train_time:62912ms step_avg:52.65ms
+step:1196/1600 train_time:62998ms step_avg:52.67ms
+step:1197/1600 train_time:63086ms step_avg:52.70ms
+step:1198/1600 train_time:63171ms step_avg:52.73ms
+step:1199/1600 train_time:63261ms step_avg:52.76ms
+step:1200/1600 train_time:63346ms step_avg:52.79ms
+step:1201/1600 train_time:63434ms step_avg:52.82ms
+step:1202/1600 train_time:63519ms step_avg:52.84ms
+step:1203/1600 train_time:63608ms step_avg:52.87ms
+step:1204/1600 train_time:63694ms step_avg:52.90ms
+step:1205/1600 train_time:63782ms step_avg:52.93ms
+step:1206/1600 train_time:63868ms step_avg:52.96ms
+step:1207/1600 train_time:63956ms step_avg:52.99ms
+step:1208/1600 train_time:64042ms step_avg:53.01ms
+step:1209/1600 train_time:64131ms step_avg:53.04ms
+step:1210/1600 train_time:64216ms step_avg:53.07ms
+step:1211/1600 train_time:64305ms step_avg:53.10ms
+step:1212/1600 train_time:64390ms step_avg:53.13ms
+step:1213/1600 train_time:64479ms step_avg:53.16ms
+step:1214/1600 train_time:64564ms step_avg:53.18ms
+step:1215/1600 train_time:64653ms step_avg:53.21ms
+step:1216/1600 train_time:64739ms step_avg:53.24ms
+step:1217/1600 train_time:64828ms step_avg:53.27ms
+step:1218/1600 train_time:64913ms step_avg:53.29ms
+step:1219/1600 train_time:65003ms step_avg:53.32ms
+step:1220/1600 train_time:65088ms step_avg:53.35ms
+step:1221/1600 train_time:65177ms step_avg:53.38ms
+step:1222/1600 train_time:65263ms step_avg:53.41ms
+step:1223/1600 train_time:65351ms step_avg:53.43ms
+step:1224/1600 train_time:65437ms step_avg:53.46ms
+step:1225/1600 train_time:65525ms step_avg:53.49ms
+step:1226/1600 train_time:65611ms step_avg:53.52ms
+step:1227/1600 train_time:65700ms step_avg:53.55ms
+step:1228/1600 train_time:65786ms step_avg:53.57ms
+step:1229/1600 train_time:65873ms step_avg:53.60ms
+step:1230/1600 train_time:65959ms step_avg:53.63ms
+step:1231/1600 train_time:66049ms step_avg:53.65ms
+step:1232/1600 train_time:66134ms step_avg:53.68ms
+step:1233/1600 train_time:66223ms step_avg:53.71ms
+step:1234/1600 train_time:66308ms step_avg:53.73ms
+step:1235/1600 train_time:66397ms step_avg:53.76ms
+step:1236/1600 train_time:66482ms step_avg:53.79ms
+step:1237/1600 train_time:66571ms step_avg:53.82ms
+step:1238/1600 train_time:66656ms step_avg:53.84ms
+step:1239/1600 train_time:66745ms step_avg:53.87ms
+step:1240/1600 train_time:66831ms step_avg:53.90ms
+step:1241/1600 train_time:66919ms step_avg:53.92ms
+step:1242/1600 train_time:67004ms step_avg:53.95ms
+step:1243/1600 train_time:67092ms step_avg:53.98ms
+step:1244/1600 train_time:67178ms step_avg:54.00ms
+step:1245/1600 train_time:67266ms step_avg:54.03ms
+step:1246/1600 train_time:67352ms step_avg:54.05ms
+step:1247/1600 train_time:67441ms step_avg:54.08ms
+step:1248/1600 train_time:67526ms step_avg:54.11ms
+step:1249/1600 train_time:67614ms step_avg:54.13ms
+step:1250/1600 train_time:67700ms step_avg:54.16ms
+step:1250/1600 val_loss:3.4165 train_time:67772ms step_avg:54.22ms
+step:1251/1600 train_time:67789ms step_avg:54.19ms
+step:1252/1600 train_time:67877ms step_avg:54.21ms
+step:1253/1600 train_time:67970ms step_avg:54.25ms
+step:1254/1600 train_time:68055ms step_avg:54.27ms
+step:1255/1600 train_time:68143ms step_avg:54.30ms
+step:1256/1600 train_time:68228ms step_avg:54.32ms
+step:1257/1600 train_time:68316ms step_avg:54.35ms
+step:1258/1600 train_time:68401ms step_avg:54.37ms
+step:1259/1600 train_time:68489ms step_avg:54.40ms
+step:1260/1600 train_time:68575ms step_avg:54.42ms
+step:1261/1600 train_time:68663ms step_avg:54.45ms
+step:1262/1600 train_time:68753ms step_avg:54.48ms
+step:1263/1600 train_time:68842ms step_avg:54.51ms
+step:1264/1600 train_time:68930ms step_avg:54.53ms
+step:1265/1600 train_time:69019ms step_avg:54.56ms
+step:1266/1600 train_time:69105ms step_avg:54.59ms
+step:1267/1600 train_time:69193ms step_avg:54.61ms
+step:1268/1600 train_time:69278ms step_avg:54.64ms
+step:1269/1600 train_time:69366ms step_avg:54.66ms
+step:1270/1600 train_time:69451ms step_avg:54.69ms
+step:1271/1600 train_time:69539ms step_avg:54.71ms
+step:1272/1600 train_time:69625ms step_avg:54.74ms
+step:1273/1600 train_time:69716ms step_avg:54.77ms
+step:1274/1600 train_time:69803ms step_avg:54.79ms
+step:1275/1600 train_time:69893ms step_avg:54.82ms
+step:1276/1600 train_time:69979ms step_avg:54.84ms
+step:1277/1600 train_time:70067ms step_avg:54.87ms
+step:1278/1600 train_time:70153ms step_avg:54.89ms
+step:1279/1600 train_time:70241ms step_avg:54.92ms
+step:1280/1600 train_time:70327ms step_avg:54.94ms
+step:1281/1600 train_time:70414ms step_avg:54.97ms
+step:1282/1600 train_time:70500ms step_avg:54.99ms
+step:1283/1600 train_time:70589ms step_avg:55.02ms
+step:1284/1600 train_time:70676ms step_avg:55.04ms
+step:1285/1600 train_time:70765ms step_avg:55.07ms
+step:1286/1600 train_time:70851ms step_avg:55.09ms
+step:1287/1600 train_time:70941ms step_avg:55.12ms
+step:1288/1600 train_time:71027ms step_avg:55.15ms
+step:1289/1600 train_time:71115ms step_avg:55.17ms
+step:1290/1600 train_time:71200ms step_avg:55.19ms
+step:1291/1600 train_time:71289ms step_avg:55.22ms
+step:1292/1600 train_time:71374ms step_avg:55.24ms
+step:1293/1600 train_time:71461ms step_avg:55.27ms
+step:1294/1600 train_time:71547ms step_avg:55.29ms
+step:1295/1600 train_time:71637ms step_avg:55.32ms
+step:1296/1600 train_time:71722ms step_avg:55.34ms
+step:1297/1600 train_time:71811ms step_avg:55.37ms
+step:1298/1600 train_time:71897ms step_avg:55.39ms
+step:1299/1600 train_time:71986ms step_avg:55.42ms
+step:1300/1600 train_time:72072ms step_avg:55.44ms
+step:1301/1600 train_time:72160ms step_avg:55.46ms
+step:1302/1600 train_time:72246ms step_avg:55.49ms
+step:1303/1600 train_time:72334ms step_avg:55.51ms
+step:1304/1600 train_time:72419ms step_avg:55.54ms
+step:1305/1600 train_time:72507ms step_avg:55.56ms
+step:1306/1600 train_time:72593ms step_avg:55.58ms
+step:1307/1600 train_time:72681ms step_avg:55.61ms
+step:1308/1600 train_time:72767ms step_avg:55.63ms
+step:1309/1600 train_time:72857ms step_avg:55.66ms
+step:1310/1600 train_time:72942ms step_avg:55.68ms
+step:1311/1600 train_time:73031ms step_avg:55.71ms
+step:1312/1600 train_time:73117ms step_avg:55.73ms
+step:1313/1600 train_time:73205ms step_avg:55.75ms
+step:1314/1600 train_time:73290ms step_avg:55.78ms
+step:1315/1600 train_time:73379ms step_avg:55.80ms
+step:1316/1600 train_time:73464ms step_avg:55.82ms
+step:1317/1600 train_time:73552ms step_avg:55.85ms
+step:1318/1600 train_time:73637ms step_avg:55.87ms
+step:1319/1600 train_time:73726ms step_avg:55.90ms
+step:1320/1600 train_time:73811ms step_avg:55.92ms
+step:1321/1600 train_time:73900ms step_avg:55.94ms
+step:1322/1600 train_time:73987ms step_avg:55.97ms
+step:1323/1600 train_time:74076ms step_avg:55.99ms
+step:1324/1600 train_time:74162ms step_avg:56.01ms
+step:1325/1600 train_time:74250ms step_avg:56.04ms
+step:1326/1600 train_time:74337ms step_avg:56.06ms
+step:1327/1600 train_time:74425ms step_avg:56.09ms
+step:1328/1600 train_time:74511ms step_avg:56.11ms
+step:1329/1600 train_time:74599ms step_avg:56.13ms
+step:1330/1600 train_time:74685ms step_avg:56.15ms
+step:1331/1600 train_time:74774ms step_avg:56.18ms
+step:1332/1600 train_time:74860ms step_avg:56.20ms
+step:1333/1600 train_time:74949ms step_avg:56.23ms
+step:1334/1600 train_time:75035ms step_avg:56.25ms
+step:1335/1600 train_time:75124ms step_avg:56.27ms
+step:1336/1600 train_time:75209ms step_avg:56.29ms
+step:1337/1600 train_time:75298ms step_avg:56.32ms
+step:1338/1600 train_time:75383ms step_avg:56.34ms
+step:1339/1600 train_time:75473ms step_avg:56.37ms
+step:1340/1600 train_time:75558ms step_avg:56.39ms
+step:1341/1600 train_time:75646ms step_avg:56.41ms
+step:1342/1600 train_time:75732ms step_avg:56.43ms
+step:1343/1600 train_time:75821ms step_avg:56.46ms
+step:1344/1600 train_time:75906ms step_avg:56.48ms
+step:1345/1600 train_time:75995ms step_avg:56.50ms
+step:1346/1600 train_time:76086ms step_avg:56.53ms
+step:1347/1600 train_time:76176ms step_avg:56.55ms
+step:1348/1600 train_time:76262ms step_avg:56.57ms
+step:1349/1600 train_time:76398ms step_avg:56.63ms
+step:1350/1600 train_time:76513ms step_avg:56.68ms
+step:1351/1600 train_time:76599ms step_avg:56.70ms
+step:1352/1600 train_time:76684ms step_avg:56.72ms
+step:1353/1600 train_time:76771ms step_avg:56.74ms
+step:1354/1600 train_time:76856ms step_avg:56.76ms
+step:1355/1600 train_time:76943ms step_avg:56.78ms
+step:1356/1600 train_time:77028ms step_avg:56.81ms
+step:1357/1600 train_time:77115ms step_avg:56.83ms
+step:1358/1600 train_time:77199ms step_avg:56.85ms
+step:1359/1600 train_time:77286ms step_avg:56.87ms
+step:1360/1600 train_time:77381ms step_avg:56.90ms
+step:1361/1600 train_time:77476ms step_avg:56.93ms
+step:1362/1600 train_time:77564ms step_avg:56.95ms
+step:1363/1600 train_time:77652ms step_avg:56.97ms
+step:1364/1600 train_time:77737ms step_avg:56.99ms
+step:1365/1600 train_time:77824ms step_avg:57.01ms
+step:1366/1600 train_time:77909ms step_avg:57.03ms
+step:1367/1600 train_time:77995ms step_avg:57.06ms
+step:1368/1600 train_time:78081ms step_avg:57.08ms
+step:1369/1600 train_time:78167ms step_avg:57.10ms
+step:1370/1600 train_time:78254ms step_avg:57.12ms
+step:1371/1600 train_time:78344ms step_avg:57.14ms
+step:1372/1600 train_time:78435ms step_avg:57.17ms
+step:1373/1600 train_time:78525ms step_avg:57.19ms
+step:1374/1600 train_time:78612ms step_avg:57.21ms
+step:1375/1600 train_time:78701ms step_avg:57.24ms
+step:1376/1600 train_time:78786ms step_avg:57.26ms
+step:1377/1600 train_time:78874ms step_avg:57.28ms
+step:1378/1600 train_time:78959ms step_avg:57.30ms
+step:1379/1600 train_time:79047ms step_avg:57.32ms
+step:1380/1600 train_time:79131ms step_avg:57.34ms
+step:1381/1600 train_time:79219ms step_avg:57.36ms
+step:1382/1600 train_time:79305ms step_avg:57.38ms
+step:1383/1600 train_time:79396ms step_avg:57.41ms
+step:1384/1600 train_time:79483ms step_avg:57.43ms
+step:1385/1600 train_time:79572ms step_avg:57.45ms
+step:1386/1600 train_time:79658ms step_avg:57.47ms
+step:1387/1600 train_time:79746ms step_avg:57.50ms
+step:1388/1600 train_time:79833ms step_avg:57.52ms
+step:1389/1600 train_time:79920ms step_avg:57.54ms
+step:1390/1600 train_time:80005ms step_avg:57.56ms
+step:1391/1600 train_time:80093ms step_avg:57.58ms
+step:1392/1600 train_time:80178ms step_avg:57.60ms
+step:1393/1600 train_time:80267ms step_avg:57.62ms
+step:1394/1600 train_time:80354ms step_avg:57.64ms
+step:1395/1600 train_time:80444ms step_avg:57.67ms
+step:1396/1600 train_time:80530ms step_avg:57.69ms
+step:1397/1600 train_time:80620ms step_avg:57.71ms
+step:1398/1600 train_time:80705ms step_avg:57.73ms
+step:1399/1600 train_time:80793ms step_avg:57.75ms
+step:1400/1600 train_time:80878ms step_avg:57.77ms
+step:1401/1600 train_time:80967ms step_avg:57.79ms
+step:1402/1600 train_time:81052ms step_avg:57.81ms
+step:1403/1600 train_time:81140ms step_avg:57.83ms
+step:1404/1600 train_time:81226ms step_avg:57.85ms
+step:1405/1600 train_time:81315ms step_avg:57.88ms
+step:1406/1600 train_time:81401ms step_avg:57.90ms
+step:1407/1600 train_time:81490ms step_avg:57.92ms
+step:1408/1600 train_time:81577ms step_avg:57.94ms
+step:1409/1600 train_time:81665ms step_avg:57.96ms
+step:1410/1600 train_time:81751ms step_avg:57.98ms
+step:1411/1600 train_time:81840ms step_avg:58.00ms
+step:1412/1600 train_time:81926ms step_avg:58.02ms
+step:1413/1600 train_time:82014ms step_avg:58.04ms
+step:1414/1600 train_time:82100ms step_avg:58.06ms
+step:1415/1600 train_time:82187ms step_avg:58.08ms
+step:1416/1600 train_time:82273ms step_avg:58.10ms
+step:1417/1600 train_time:82362ms step_avg:58.12ms
+step:1418/1600 train_time:82448ms step_avg:58.14ms
+step:1419/1600 train_time:82536ms step_avg:58.17ms
+step:1420/1600 train_time:82623ms step_avg:58.19ms
+step:1421/1600 train_time:82711ms step_avg:58.21ms
+step:1422/1600 train_time:82797ms step_avg:58.23ms
+step:1423/1600 train_time:82885ms step_avg:58.25ms
+step:1424/1600 train_time:82972ms step_avg:58.27ms
+step:1425/1600 train_time:83060ms step_avg:58.29ms
+step:1426/1600 train_time:83145ms step_avg:58.31ms
+step:1427/1600 train_time:83234ms step_avg:58.33ms
+step:1428/1600 train_time:83320ms step_avg:58.35ms
+step:1429/1600 train_time:83409ms step_avg:58.37ms
+step:1430/1600 train_time:83495ms step_avg:58.39ms
+step:1431/1600 train_time:83584ms step_avg:58.41ms
+step:1432/1600 train_time:83671ms step_avg:58.43ms
+step:1433/1600 train_time:83759ms step_avg:58.45ms
+step:1434/1600 train_time:83844ms step_avg:58.47ms
+step:1435/1600 train_time:83932ms step_avg:58.49ms
+step:1436/1600 train_time:84017ms step_avg:58.51ms
+step:1437/1600 train_time:84106ms step_avg:58.53ms
+step:1438/1600 train_time:84192ms step_avg:58.55ms
+step:1439/1600 train_time:84280ms step_avg:58.57ms
+step:1440/1600 train_time:84367ms step_avg:58.59ms
+step:1441/1600 train_time:84456ms step_avg:58.61ms
+step:1442/1600 train_time:84541ms step_avg:58.63ms
+step:1443/1600 train_time:84630ms step_avg:58.65ms
+step:1444/1600 train_time:84716ms step_avg:58.67ms
+step:1445/1600 train_time:84805ms step_avg:58.69ms
+step:1446/1600 train_time:84890ms step_avg:58.71ms
+step:1447/1600 train_time:84979ms step_avg:58.73ms
+step:1448/1600 train_time:85065ms step_avg:58.75ms
+step:1449/1600 train_time:85153ms step_avg:58.77ms
+step:1450/1600 train_time:85239ms step_avg:58.79ms
+step:1451/1600 train_time:85327ms step_avg:58.81ms
+step:1452/1600 train_time:85413ms step_avg:58.82ms
+step:1453/1600 train_time:85502ms step_avg:58.85ms
+step:1454/1600 train_time:85588ms step_avg:58.86ms
+step:1455/1600 train_time:85676ms step_avg:58.88ms
+step:1456/1600 train_time:85762ms step_avg:58.90ms
+step:1457/1600 train_time:85851ms step_avg:58.92ms
+step:1458/1600 train_time:85937ms step_avg:58.94ms
+step:1459/1600 train_time:86025ms step_avg:58.96ms
+step:1460/1600 train_time:86110ms step_avg:58.98ms
+step:1461/1600 train_time:86199ms step_avg:59.00ms
+step:1462/1600 train_time:86285ms step_avg:59.02ms
+step:1463/1600 train_time:86374ms step_avg:59.04ms
+step:1464/1600 train_time:86460ms step_avg:59.06ms
+step:1465/1600 train_time:86548ms step_avg:59.08ms
+step:1466/1600 train_time:86635ms step_avg:59.10ms
+step:1467/1600 train_time:86723ms step_avg:59.12ms
+step:1468/1600 train_time:86809ms step_avg:59.13ms
+step:1469/1600 train_time:86898ms step_avg:59.15ms
+step:1470/1600 train_time:86983ms step_avg:59.17ms
+step:1471/1600 train_time:87070ms step_avg:59.19ms
+step:1472/1600 train_time:87157ms step_avg:59.21ms
+step:1473/1600 train_time:87245ms step_avg:59.23ms
+step:1474/1600 train_time:87332ms step_avg:59.25ms
+step:1475/1600 train_time:87420ms step_avg:59.27ms
+step:1476/1600 train_time:87505ms step_avg:59.29ms
+step:1477/1600 train_time:87594ms step_avg:59.31ms
+step:1478/1600 train_time:87680ms step_avg:59.32ms
+step:1479/1600 train_time:87768ms step_avg:59.34ms
+step:1480/1600 train_time:87854ms step_avg:59.36ms
+step:1481/1600 train_time:87943ms step_avg:59.38ms
+step:1482/1600 train_time:88028ms step_avg:59.40ms
+step:1483/1600 train_time:88115ms step_avg:59.42ms
+step:1484/1600 train_time:88202ms step_avg:59.44ms
+step:1485/1600 train_time:88290ms step_avg:59.45ms
+step:1486/1600 train_time:88376ms step_avg:59.47ms
+step:1487/1600 train_time:88464ms step_avg:59.49ms
+step:1488/1600 train_time:88550ms step_avg:59.51ms
+step:1489/1600 train_time:88639ms step_avg:59.53ms
+step:1490/1600 train_time:88725ms step_avg:59.55ms
+step:1491/1600 train_time:88813ms step_avg:59.57ms
+step:1492/1600 train_time:88900ms step_avg:59.58ms
+step:1493/1600 train_time:88987ms step_avg:59.60ms
+step:1494/1600 train_time:89073ms step_avg:59.62ms
+step:1495/1600 train_time:89161ms step_avg:59.64ms
+step:1496/1600 train_time:89246ms step_avg:59.66ms
+step:1497/1600 train_time:89336ms step_avg:59.68ms
+step:1498/1600 train_time:89422ms step_avg:59.69ms
+step:1499/1600 train_time:89511ms step_avg:59.71ms
+step:1500/1600 train_time:89597ms step_avg:59.73ms
+step:1500/1600 val_loss:3.3071 train_time:89664ms step_avg:59.78ms
+step:1501/1600 train_time:89687ms step_avg:59.75ms
+step:1502/1600 train_time:89773ms step_avg:59.77ms
+step:1503/1600 train_time:89863ms step_avg:59.79ms
+step:1504/1600 train_time:89949ms step_avg:59.81ms
+step:1505/1600 train_time:90037ms step_avg:59.83ms
+step:1506/1600 train_time:90122ms step_avg:59.84ms
+step:1507/1600 train_time:90209ms step_avg:59.86ms
+step:1508/1600 train_time:90295ms step_avg:59.88ms
+step:1509/1600 train_time:90382ms step_avg:59.90ms
+step:1510/1600 train_time:90468ms step_avg:59.91ms
+step:1511/1600 train_time:90556ms step_avg:59.93ms
+step:1512/1600 train_time:90645ms step_avg:59.95ms
+step:1513/1600 train_time:90734ms step_avg:59.97ms
+step:1514/1600 train_time:90821ms step_avg:59.99ms
+step:1515/1600 train_time:90909ms step_avg:60.01ms
+step:1516/1600 train_time:90996ms step_avg:60.02ms
+step:1517/1600 train_time:91083ms step_avg:60.04ms
+step:1518/1600 train_time:91169ms step_avg:60.06ms
+step:1519/1600 train_time:91257ms step_avg:60.08ms
+step:1520/1600 train_time:91342ms step_avg:60.09ms
+step:1521/1600 train_time:91430ms step_avg:60.11ms
+step:1522/1600 train_time:91517ms step_avg:60.13ms
+step:1523/1600 train_time:91606ms step_avg:60.15ms
+step:1524/1600 train_time:91693ms step_avg:60.17ms
+step:1525/1600 train_time:91782ms step_avg:60.18ms
+step:1526/1600 train_time:91868ms step_avg:60.20ms
+step:1527/1600 train_time:91957ms step_avg:60.22ms
+step:1528/1600 train_time:92043ms step_avg:60.24ms
+step:1529/1600 train_time:92131ms step_avg:60.26ms
+step:1530/1600 train_time:92217ms step_avg:60.27ms
+step:1531/1600 train_time:92305ms step_avg:60.29ms
+step:1532/1600 train_time:92391ms step_avg:60.31ms
+step:1533/1600 train_time:92479ms step_avg:60.33ms
+step:1534/1600 train_time:92565ms step_avg:60.34ms
+step:1535/1600 train_time:92654ms step_avg:60.36ms
+step:1536/1600 train_time:92741ms step_avg:60.38ms
+step:1537/1600 train_time:92830ms step_avg:60.40ms
+step:1538/1600 train_time:92916ms step_avg:60.41ms
+step:1539/1600 train_time:93004ms step_avg:60.43ms
+step:1540/1600 train_time:93090ms step_avg:60.45ms
+step:1541/1600 train_time:93178ms step_avg:60.47ms
+step:1542/1600 train_time:93263ms step_avg:60.48ms
+step:1543/1600 train_time:93352ms step_avg:60.50ms
+step:1544/1600 train_time:93438ms step_avg:60.52ms
+step:1545/1600 train_time:93526ms step_avg:60.53ms
+step:1546/1600 train_time:93612ms step_avg:60.55ms
+step:1547/1600 train_time:93701ms step_avg:60.57ms
+step:1548/1600 train_time:93787ms step_avg:60.59ms
+step:1549/1600 train_time:93876ms step_avg:60.60ms
+step:1550/1600 train_time:93962ms step_avg:60.62ms
+step:1551/1600 train_time:94051ms step_avg:60.64ms
+step:1552/1600 train_time:94137ms step_avg:60.66ms
+step:1553/1600 train_time:94225ms step_avg:60.67ms
+step:1554/1600 train_time:94310ms step_avg:60.69ms
+step:1555/1600 train_time:94399ms step_avg:60.71ms
+step:1556/1600 train_time:94485ms step_avg:60.72ms
+step:1557/1600 train_time:94573ms step_avg:60.74ms
+step:1558/1600 train_time:94659ms step_avg:60.76ms
+step:1559/1600 train_time:94748ms step_avg:60.77ms
+step:1560/1600 train_time:94835ms step_avg:60.79ms
+step:1561/1600 train_time:94929ms step_avg:60.81ms
+step:1562/1600 train_time:95015ms step_avg:60.83ms
+step:1563/1600 train_time:95103ms step_avg:60.85ms
+step:1564/1600 train_time:95189ms step_avg:60.86ms
+step:1565/1600 train_time:95277ms step_avg:60.88ms
+step:1566/1600 train_time:95364ms step_avg:60.90ms
+step:1567/1600 train_time:95452ms step_avg:60.91ms
+step:1568/1600 train_time:95538ms step_avg:60.93ms
+step:1569/1600 train_time:95627ms step_avg:60.95ms
+step:1570/1600 train_time:95713ms step_avg:60.96ms
+step:1571/1600 train_time:95802ms step_avg:60.98ms
+step:1572/1600 train_time:95890ms step_avg:61.00ms
+step:1573/1600 train_time:95979ms step_avg:61.02ms
+step:1574/1600 train_time:96065ms step_avg:61.03ms
+step:1575/1600 train_time:96153ms step_avg:61.05ms
+step:1576/1600 train_time:96239ms step_avg:61.07ms
+step:1577/1600 train_time:96328ms step_avg:61.08ms
+step:1578/1600 train_time:96415ms step_avg:61.10ms
+step:1579/1600 train_time:96503ms step_avg:61.12ms
+step:1580/1600 train_time:96590ms step_avg:61.13ms
+step:1581/1600 train_time:96679ms step_avg:61.15ms
+step:1582/1600 train_time:96766ms step_avg:61.17ms
+step:1583/1600 train_time:96855ms step_avg:61.18ms
+step:1584/1600 train_time:96942ms step_avg:61.20ms
+step:1585/1600 train_time:97030ms step_avg:61.22ms
+step:1586/1600 train_time:97116ms step_avg:61.23ms
+step:1587/1600 train_time:97205ms step_avg:61.25ms
+step:1588/1600 train_time:97291ms step_avg:61.27ms
+step:1589/1600 train_time:97380ms step_avg:61.28ms
+step:1590/1600 train_time:97466ms step_avg:61.30ms
+step:1591/1600 train_time:97554ms step_avg:61.32ms
+step:1592/1600 train_time:97640ms step_avg:61.33ms
+step:1593/1600 train_time:97729ms step_avg:61.35ms
+step:1594/1600 train_time:97817ms step_avg:61.37ms
+step:1595/1600 train_time:97905ms step_avg:61.38ms
+step:1596/1600 train_time:97991ms step_avg:61.40ms
+step:1597/1600 train_time:98080ms step_avg:61.42ms
+step:1598/1600 train_time:98166ms step_avg:61.43ms
+step:1599/1600 train_time:98255ms step_avg:61.45ms
+step:1600/1600 train_time:98340ms step_avg:61.46ms
+step:1600/1600 val_loss:3.2778 train_time:98408ms step_avg:61.51ms
+peak memory allocated: 30181 MiB reserved: 46138 MiB

--- a/records/track_1_short/2026-01-28_TieFirstLastVEs/baseline/d9227b42-bb97-432c-94d0-131aaceea02b.txt
+++ b/records/track_1_short/2026-01-28_TieFirstLastVEs/baseline/d9227b42-bb97-432c-94d0-131aaceea02b.txt
@@ -1,0 +1,4120 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.12.12 | packaged by conda-forge | (main, Jan 26 2026, 23:51:32) [GCC 14.3.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Thu Jan 29 02:32:09 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                  Off |
+| N/A   38C    P0            132W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:06:00.0 Off |                  Off |
+| N/A   34C    P0            126W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:07:00.0 Off |                  Off |
+| N/A   38C    P0            122W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:08:00.0 Off |                  Off |
+| N/A   35C    P0            127W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:09:00.0 Off |                  Off |
+| N/A   37C    P0            125W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                  Off |
+| N/A   35C    P0            124W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                  Off |
+| N/A   37C    P0            125W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:0C:00.0 Off |                  Off |
+| N/A   35C    P0            125W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A           84842      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    1   N/A  N/A           84843      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    2   N/A  N/A           84844      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    3   N/A  N/A           84845      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    4   N/A  N/A           84846      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    5   N/A  N/A           84847      C   .../envs/speedrun/bin/python3.12       1552MiB |
+|    6   N/A  N/A           84848      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    7   N/A  N/A           84849      C   .../envs/speedrun/bin/python3.12       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8311 train_time:0ms step_avg:0.03ms
+step:1/1600 train_time:49ms step_avg:49.09ms
+step:2/1600 train_time:66ms step_avg:33.03ms
+step:3/1600 train_time:101ms step_avg:33.76ms
+step:4/1600 train_time:138ms step_avg:34.49ms
+step:5/1600 train_time:168ms step_avg:33.65ms
+step:6/1600 train_time:228ms step_avg:38.04ms
+step:7/1600 train_time:243ms step_avg:34.78ms
+step:8/1600 train_time:298ms step_avg:37.28ms
+step:9/1600 train_time:328ms step_avg:36.46ms
+step:10/1600 train_time:365ms step_avg:36.50ms
+step:11/1600 train_time:395ms step_avg:35.95ms
+step:12/1600 train_time:433ms step_avg:36.07ms
+step:13/1600 train_time:464ms step_avg:35.66ms
+step:14/1600 train_time:501ms step_avg:35.79ms
+step:15/1600 train_time:531ms step_avg:35.43ms
+step:16/1600 train_time:569ms step_avg:35.55ms
+step:17/1600 train_time:600ms step_avg:35.28ms
+step:18/1600 train_time:637ms step_avg:35.41ms
+step:19/1600 train_time:668ms step_avg:35.15ms
+step:20/1600 train_time:705ms step_avg:35.24ms
+step:21/1600 train_time:735ms step_avg:35.02ms
+step:22/1600 train_time:773ms step_avg:35.13ms
+step:23/1600 train_time:804ms step_avg:34.94ms
+step:24/1600 train_time:841ms step_avg:35.03ms
+step:25/1600 train_time:871ms step_avg:34.86ms
+step:26/1600 train_time:908ms step_avg:34.94ms
+step:27/1600 train_time:939ms step_avg:34.78ms
+step:28/1600 train_time:976ms step_avg:34.87ms
+step:29/1600 train_time:1007ms step_avg:34.72ms
+step:30/1600 train_time:1045ms step_avg:34.82ms
+step:31/1600 train_time:1075ms step_avg:34.68ms
+step:32/1600 train_time:1113ms step_avg:34.78ms
+step:33/1600 train_time:1143ms step_avg:34.65ms
+step:34/1600 train_time:1181ms step_avg:34.73ms
+step:35/1600 train_time:1212ms step_avg:34.62ms
+step:36/1600 train_time:1249ms step_avg:34.70ms
+step:37/1600 train_time:1280ms step_avg:34.60ms
+step:38/1600 train_time:1318ms step_avg:34.67ms
+step:39/1600 train_time:1349ms step_avg:34.58ms
+step:40/1600 train_time:1386ms step_avg:34.64ms
+step:41/1600 train_time:1417ms step_avg:34.55ms
+step:42/1600 train_time:1454ms step_avg:34.63ms
+step:43/1600 train_time:1485ms step_avg:34.53ms
+step:44/1600 train_time:1522ms step_avg:34.58ms
+step:45/1600 train_time:1553ms step_avg:34.50ms
+step:46/1600 train_time:1590ms step_avg:34.56ms
+step:47/1600 train_time:1620ms step_avg:34.47ms
+step:48/1600 train_time:1657ms step_avg:34.53ms
+step:49/1600 train_time:1688ms step_avg:34.46ms
+step:50/1600 train_time:1726ms step_avg:34.51ms
+step:51/1600 train_time:1756ms step_avg:34.44ms
+step:52/1600 train_time:1794ms step_avg:34.49ms
+step:53/1600 train_time:1824ms step_avg:34.42ms
+step:54/1600 train_time:1862ms step_avg:34.48ms
+step:55/1600 train_time:1892ms step_avg:34.40ms
+step:56/1600 train_time:1929ms step_avg:34.45ms
+step:57/1600 train_time:1960ms step_avg:34.39ms
+step:58/1600 train_time:1997ms step_avg:34.44ms
+step:59/1600 train_time:2028ms step_avg:34.38ms
+step:60/1600 train_time:2065ms step_avg:34.42ms
+step:61/1600 train_time:2096ms step_avg:34.36ms
+step:62/1600 train_time:2133ms step_avg:34.40ms
+step:63/1600 train_time:2163ms step_avg:34.34ms
+step:64/1600 train_time:2201ms step_avg:34.38ms
+step:65/1600 train_time:2231ms step_avg:34.33ms
+step:66/1600 train_time:2269ms step_avg:34.38ms
+step:67/1600 train_time:2299ms step_avg:34.32ms
+step:68/1600 train_time:2337ms step_avg:34.36ms
+step:69/1600 train_time:2367ms step_avg:34.31ms
+step:70/1600 train_time:2405ms step_avg:34.35ms
+step:71/1600 train_time:2435ms step_avg:34.30ms
+step:72/1600 train_time:2473ms step_avg:34.34ms
+step:73/1600 train_time:2503ms step_avg:34.29ms
+step:74/1600 train_time:2541ms step_avg:34.33ms
+step:75/1600 train_time:2571ms step_avg:34.28ms
+step:76/1600 train_time:2608ms step_avg:34.32ms
+step:77/1600 train_time:2639ms step_avg:34.27ms
+step:78/1600 train_time:2676ms step_avg:34.31ms
+step:79/1600 train_time:2707ms step_avg:34.27ms
+step:80/1600 train_time:2744ms step_avg:34.30ms
+step:81/1600 train_time:2775ms step_avg:34.26ms
+step:82/1600 train_time:2813ms step_avg:34.30ms
+step:83/1600 train_time:2843ms step_avg:34.25ms
+step:84/1600 train_time:2880ms step_avg:34.29ms
+step:85/1600 train_time:2911ms step_avg:34.25ms
+step:86/1600 train_time:2948ms step_avg:34.28ms
+step:87/1600 train_time:2979ms step_avg:34.24ms
+step:88/1600 train_time:3016ms step_avg:34.27ms
+step:89/1600 train_time:3047ms step_avg:34.23ms
+step:90/1600 train_time:3084ms step_avg:34.27ms
+step:91/1600 train_time:3115ms step_avg:34.23ms
+step:92/1600 train_time:3153ms step_avg:34.27ms
+step:93/1600 train_time:3183ms step_avg:34.23ms
+step:94/1600 train_time:3221ms step_avg:34.26ms
+step:95/1600 train_time:3252ms step_avg:34.23ms
+step:96/1600 train_time:3290ms step_avg:34.27ms
+step:97/1600 train_time:3320ms step_avg:34.23ms
+step:98/1600 train_time:3357ms step_avg:34.26ms
+step:99/1600 train_time:3388ms step_avg:34.22ms
+step:100/1600 train_time:3425ms step_avg:34.25ms
+step:101/1600 train_time:3456ms step_avg:34.22ms
+step:102/1600 train_time:3493ms step_avg:34.25ms
+step:103/1600 train_time:3524ms step_avg:34.21ms
+step:104/1600 train_time:3561ms step_avg:34.24ms
+step:105/1600 train_time:3592ms step_avg:34.21ms
+step:106/1600 train_time:3629ms step_avg:34.24ms
+step:107/1600 train_time:3661ms step_avg:34.21ms
+step:108/1600 train_time:3698ms step_avg:34.24ms
+step:109/1600 train_time:3728ms step_avg:34.20ms
+step:110/1600 train_time:3765ms step_avg:34.23ms
+step:111/1600 train_time:3796ms step_avg:34.20ms
+step:112/1600 train_time:3833ms step_avg:34.22ms
+step:113/1600 train_time:3863ms step_avg:34.19ms
+step:114/1600 train_time:3900ms step_avg:34.21ms
+step:115/1600 train_time:3931ms step_avg:34.18ms
+step:116/1600 train_time:3968ms step_avg:34.20ms
+step:117/1600 train_time:3998ms step_avg:34.17ms
+step:118/1600 train_time:4036ms step_avg:34.20ms
+step:119/1600 train_time:4066ms step_avg:34.17ms
+step:120/1600 train_time:4104ms step_avg:34.20ms
+step:121/1600 train_time:4134ms step_avg:34.17ms
+step:122/1600 train_time:4172ms step_avg:34.19ms
+step:123/1600 train_time:4202ms step_avg:34.16ms
+step:124/1600 train_time:4240ms step_avg:34.19ms
+step:125/1600 train_time:4270ms step_avg:34.16ms
+step:126/1600 train_time:4308ms step_avg:34.19ms
+step:127/1600 train_time:4338ms step_avg:34.16ms
+step:128/1600 train_time:4376ms step_avg:34.19ms
+step:129/1600 train_time:4407ms step_avg:34.16ms
+step:130/1600 train_time:4444ms step_avg:34.19ms
+step:131/1600 train_time:4475ms step_avg:34.16ms
+step:132/1600 train_time:4512ms step_avg:34.18ms
+step:133/1600 train_time:4543ms step_avg:34.16ms
+step:134/1600 train_time:4580ms step_avg:34.18ms
+step:135/1600 train_time:4611ms step_avg:34.15ms
+step:136/1600 train_time:4648ms step_avg:34.17ms
+step:137/1600 train_time:4678ms step_avg:34.15ms
+step:138/1600 train_time:4716ms step_avg:34.17ms
+step:139/1600 train_time:4746ms step_avg:34.15ms
+step:140/1600 train_time:4784ms step_avg:34.17ms
+step:141/1600 train_time:4814ms step_avg:34.14ms
+step:142/1600 train_time:4852ms step_avg:34.17ms
+step:143/1600 train_time:4882ms step_avg:34.14ms
+step:144/1600 train_time:4920ms step_avg:34.16ms
+step:145/1600 train_time:4950ms step_avg:34.14ms
+step:146/1600 train_time:4987ms step_avg:34.16ms
+step:147/1600 train_time:5018ms step_avg:34.14ms
+step:148/1600 train_time:5055ms step_avg:34.16ms
+step:149/1600 train_time:5086ms step_avg:34.13ms
+step:150/1600 train_time:5123ms step_avg:34.16ms
+step:151/1600 train_time:5154ms step_avg:34.13ms
+step:152/1600 train_time:5192ms step_avg:34.16ms
+step:153/1600 train_time:5222ms step_avg:34.13ms
+step:154/1600 train_time:5259ms step_avg:34.15ms
+step:155/1600 train_time:5290ms step_avg:34.13ms
+step:156/1600 train_time:5328ms step_avg:34.15ms
+step:157/1600 train_time:5359ms step_avg:34.13ms
+step:158/1600 train_time:5396ms step_avg:34.15ms
+step:159/1600 train_time:5427ms step_avg:34.13ms
+step:160/1600 train_time:5464ms step_avg:34.15ms
+step:161/1600 train_time:5494ms step_avg:34.13ms
+step:162/1600 train_time:5532ms step_avg:34.15ms
+step:163/1600 train_time:5563ms step_avg:34.13ms
+step:164/1600 train_time:5600ms step_avg:34.15ms
+step:165/1600 train_time:5630ms step_avg:34.12ms
+step:166/1600 train_time:5668ms step_avg:34.14ms
+step:167/1600 train_time:5698ms step_avg:34.12ms
+step:168/1600 train_time:5735ms step_avg:34.14ms
+step:169/1600 train_time:5766ms step_avg:34.12ms
+step:170/1600 train_time:5803ms step_avg:34.13ms
+step:171/1600 train_time:5833ms step_avg:34.11ms
+step:172/1600 train_time:5870ms step_avg:34.13ms
+step:173/1600 train_time:5901ms step_avg:34.11ms
+step:174/1600 train_time:5938ms step_avg:34.13ms
+step:175/1600 train_time:5969ms step_avg:34.11ms
+step:176/1600 train_time:6006ms step_avg:34.13ms
+step:177/1600 train_time:6037ms step_avg:34.10ms
+step:178/1600 train_time:6074ms step_avg:34.12ms
+step:179/1600 train_time:6104ms step_avg:34.10ms
+step:180/1600 train_time:6141ms step_avg:34.12ms
+step:181/1600 train_time:6173ms step_avg:34.10ms
+step:182/1600 train_time:6211ms step_avg:34.12ms
+step:183/1600 train_time:6241ms step_avg:34.10ms
+step:184/1600 train_time:6279ms step_avg:34.12ms
+step:185/1600 train_time:6310ms step_avg:34.11ms
+step:186/1600 train_time:6347ms step_avg:34.12ms
+step:187/1600 train_time:6377ms step_avg:34.10ms
+step:188/1600 train_time:6415ms step_avg:34.12ms
+step:189/1600 train_time:6445ms step_avg:34.10ms
+step:190/1600 train_time:6482ms step_avg:34.12ms
+step:191/1600 train_time:6513ms step_avg:34.10ms
+step:192/1600 train_time:6551ms step_avg:34.12ms
+step:193/1600 train_time:6581ms step_avg:34.10ms
+step:194/1600 train_time:6619ms step_avg:34.12ms
+step:195/1600 train_time:6649ms step_avg:34.10ms
+step:196/1600 train_time:6686ms step_avg:34.11ms
+step:197/1600 train_time:6717ms step_avg:34.10ms
+step:198/1600 train_time:6754ms step_avg:34.11ms
+step:199/1600 train_time:6785ms step_avg:34.10ms
+step:200/1600 train_time:6822ms step_avg:34.11ms
+step:201/1600 train_time:6853ms step_avg:34.09ms
+step:202/1600 train_time:6890ms step_avg:34.11ms
+step:203/1600 train_time:6920ms step_avg:34.09ms
+step:204/1600 train_time:6957ms step_avg:34.10ms
+step:205/1600 train_time:6988ms step_avg:34.09ms
+step:206/1600 train_time:7025ms step_avg:34.10ms
+step:207/1600 train_time:7056ms step_avg:34.09ms
+step:208/1600 train_time:7093ms step_avg:34.10ms
+step:209/1600 train_time:7124ms step_avg:34.08ms
+step:210/1600 train_time:7161ms step_avg:34.10ms
+step:211/1600 train_time:7191ms step_avg:34.08ms
+step:212/1600 train_time:7228ms step_avg:34.10ms
+step:213/1600 train_time:7259ms step_avg:34.08ms
+step:214/1600 train_time:7296ms step_avg:34.09ms
+step:215/1600 train_time:7326ms step_avg:34.08ms
+step:216/1600 train_time:7363ms step_avg:34.09ms
+step:217/1600 train_time:7394ms step_avg:34.07ms
+step:218/1600 train_time:7431ms step_avg:34.09ms
+step:219/1600 train_time:7461ms step_avg:34.07ms
+step:220/1600 train_time:7498ms step_avg:34.08ms
+step:221/1600 train_time:7529ms step_avg:34.07ms
+step:222/1600 train_time:7566ms step_avg:34.08ms
+step:223/1600 train_time:7596ms step_avg:34.06ms
+step:224/1600 train_time:7634ms step_avg:34.08ms
+step:225/1600 train_time:7664ms step_avg:34.06ms
+step:226/1600 train_time:7701ms step_avg:34.08ms
+step:227/1600 train_time:7732ms step_avg:34.06ms
+step:228/1600 train_time:7769ms step_avg:34.07ms
+step:229/1600 train_time:7799ms step_avg:34.06ms
+step:230/1600 train_time:7837ms step_avg:34.07ms
+step:231/1600 train_time:7868ms step_avg:34.06ms
+step:232/1600 train_time:7905ms step_avg:34.07ms
+step:233/1600 train_time:7936ms step_avg:34.06ms
+step:234/1600 train_time:7973ms step_avg:34.07ms
+step:235/1600 train_time:8004ms step_avg:34.06ms
+step:236/1600 train_time:8041ms step_avg:34.07ms
+step:237/1600 train_time:8071ms step_avg:34.06ms
+step:238/1600 train_time:8109ms step_avg:34.07ms
+step:239/1600 train_time:8139ms step_avg:34.06ms
+step:240/1600 train_time:8177ms step_avg:34.07ms
+step:241/1600 train_time:8207ms step_avg:34.06ms
+step:242/1600 train_time:8245ms step_avg:34.07ms
+step:243/1600 train_time:8275ms step_avg:34.05ms
+step:244/1600 train_time:8313ms step_avg:34.07ms
+step:245/1600 train_time:8343ms step_avg:34.05ms
+step:246/1600 train_time:8381ms step_avg:34.07ms
+step:247/1600 train_time:8411ms step_avg:34.05ms
+step:248/1600 train_time:8449ms step_avg:34.07ms
+step:249/1600 train_time:8479ms step_avg:34.05ms
+step:250/1600 train_time:8516ms step_avg:34.07ms
+step:250/1600 val_loss:4.5948 train_time:8564ms step_avg:34.26ms
+step:251/1600 train_time:8581ms step_avg:34.19ms
+step:252/1600 train_time:8598ms step_avg:34.12ms
+step:253/1600 train_time:8618ms step_avg:34.07ms
+step:254/1600 train_time:8656ms step_avg:34.08ms
+step:255/1600 train_time:8687ms step_avg:34.07ms
+step:256/1600 train_time:8725ms step_avg:34.08ms
+step:257/1600 train_time:8755ms step_avg:34.07ms
+step:258/1600 train_time:8792ms step_avg:34.08ms
+step:259/1600 train_time:8823ms step_avg:34.06ms
+step:260/1600 train_time:8860ms step_avg:34.08ms
+step:261/1600 train_time:8890ms step_avg:34.06ms
+step:262/1600 train_time:8927ms step_avg:34.07ms
+step:263/1600 train_time:8958ms step_avg:34.06ms
+step:264/1600 train_time:8995ms step_avg:34.07ms
+step:265/1600 train_time:9025ms step_avg:34.06ms
+step:266/1600 train_time:9063ms step_avg:34.07ms
+step:267/1600 train_time:9093ms step_avg:34.06ms
+step:268/1600 train_time:9130ms step_avg:34.07ms
+step:269/1600 train_time:9160ms step_avg:34.05ms
+step:270/1600 train_time:9197ms step_avg:34.06ms
+step:271/1600 train_time:9227ms step_avg:34.05ms
+step:272/1600 train_time:9264ms step_avg:34.06ms
+step:273/1600 train_time:9294ms step_avg:34.04ms
+step:274/1600 train_time:9331ms step_avg:34.06ms
+step:275/1600 train_time:9362ms step_avg:34.04ms
+step:276/1600 train_time:9398ms step_avg:34.05ms
+step:277/1600 train_time:9429ms step_avg:34.04ms
+step:278/1600 train_time:9466ms step_avg:34.05ms
+step:279/1600 train_time:9497ms step_avg:34.04ms
+step:280/1600 train_time:9535ms step_avg:34.05ms
+step:281/1600 train_time:9567ms step_avg:34.04ms
+step:282/1600 train_time:9604ms step_avg:34.06ms
+step:283/1600 train_time:9635ms step_avg:34.05ms
+step:284/1600 train_time:9673ms step_avg:34.06ms
+step:285/1600 train_time:9704ms step_avg:34.05ms
+step:286/1600 train_time:9742ms step_avg:34.06ms
+step:287/1600 train_time:9772ms step_avg:34.05ms
+step:288/1600 train_time:9809ms step_avg:34.06ms
+step:289/1600 train_time:9840ms step_avg:34.05ms
+step:290/1600 train_time:9877ms step_avg:34.06ms
+step:291/1600 train_time:9907ms step_avg:34.04ms
+step:292/1600 train_time:9944ms step_avg:34.05ms
+step:293/1600 train_time:9975ms step_avg:34.04ms
+step:294/1600 train_time:10012ms step_avg:34.05ms
+step:295/1600 train_time:10042ms step_avg:34.04ms
+step:296/1600 train_time:10079ms step_avg:34.05ms
+step:297/1600 train_time:10110ms step_avg:34.04ms
+step:298/1600 train_time:10147ms step_avg:34.05ms
+step:299/1600 train_time:10178ms step_avg:34.04ms
+step:300/1600 train_time:10214ms step_avg:34.05ms
+step:301/1600 train_time:10245ms step_avg:34.04ms
+step:302/1600 train_time:10282ms step_avg:34.05ms
+step:303/1600 train_time:10313ms step_avg:34.04ms
+step:304/1600 train_time:10350ms step_avg:34.05ms
+step:305/1600 train_time:10380ms step_avg:34.03ms
+step:306/1600 train_time:10418ms step_avg:34.05ms
+step:307/1600 train_time:10448ms step_avg:34.03ms
+step:308/1600 train_time:10486ms step_avg:34.04ms
+step:309/1600 train_time:10517ms step_avg:34.04ms
+step:310/1600 train_time:10554ms step_avg:34.04ms
+step:311/1600 train_time:10584ms step_avg:34.03ms
+step:312/1600 train_time:10622ms step_avg:34.04ms
+step:313/1600 train_time:10653ms step_avg:34.03ms
+step:314/1600 train_time:10690ms step_avg:34.04ms
+step:315/1600 train_time:10720ms step_avg:34.03ms
+step:316/1600 train_time:10757ms step_avg:34.04ms
+step:317/1600 train_time:10788ms step_avg:34.03ms
+step:318/1600 train_time:10825ms step_avg:34.04ms
+step:319/1600 train_time:10856ms step_avg:34.03ms
+step:320/1600 train_time:10893ms step_avg:34.04ms
+step:321/1600 train_time:10924ms step_avg:34.03ms
+step:322/1600 train_time:10962ms step_avg:34.04ms
+step:323/1600 train_time:10992ms step_avg:34.03ms
+step:324/1600 train_time:11029ms step_avg:34.04ms
+step:325/1600 train_time:11059ms step_avg:34.03ms
+step:326/1600 train_time:11096ms step_avg:34.04ms
+step:327/1600 train_time:11127ms step_avg:34.03ms
+step:328/1600 train_time:11165ms step_avg:34.04ms
+step:329/1600 train_time:11195ms step_avg:34.03ms
+step:330/1600 train_time:11232ms step_avg:34.04ms
+step:331/1600 train_time:11263ms step_avg:34.03ms
+step:332/1600 train_time:11300ms step_avg:34.04ms
+step:333/1600 train_time:11331ms step_avg:34.03ms
+step:334/1600 train_time:11368ms step_avg:34.04ms
+step:335/1600 train_time:11399ms step_avg:34.03ms
+step:336/1600 train_time:11436ms step_avg:34.04ms
+step:337/1600 train_time:11467ms step_avg:34.03ms
+step:338/1600 train_time:11504ms step_avg:34.04ms
+step:339/1600 train_time:11535ms step_avg:34.03ms
+step:340/1600 train_time:11572ms step_avg:34.04ms
+step:341/1600 train_time:11603ms step_avg:34.03ms
+step:342/1600 train_time:11640ms step_avg:34.04ms
+step:343/1600 train_time:11671ms step_avg:34.03ms
+step:344/1600 train_time:11708ms step_avg:34.03ms
+step:345/1600 train_time:11738ms step_avg:34.02ms
+step:346/1600 train_time:11775ms step_avg:34.03ms
+step:347/1600 train_time:11806ms step_avg:34.02ms
+step:348/1600 train_time:11843ms step_avg:34.03ms
+step:349/1600 train_time:11873ms step_avg:34.02ms
+step:350/1600 train_time:11910ms step_avg:34.03ms
+step:351/1600 train_time:11940ms step_avg:34.02ms
+step:352/1600 train_time:11977ms step_avg:34.03ms
+step:353/1600 train_time:12008ms step_avg:34.02ms
+step:354/1600 train_time:12045ms step_avg:34.03ms
+step:355/1600 train_time:12076ms step_avg:34.02ms
+step:356/1600 train_time:12112ms step_avg:34.02ms
+step:357/1600 train_time:12143ms step_avg:34.01ms
+step:358/1600 train_time:12180ms step_avg:34.02ms
+step:359/1600 train_time:12210ms step_avg:34.01ms
+step:360/1600 train_time:12247ms step_avg:34.02ms
+step:361/1600 train_time:12278ms step_avg:34.01ms
+step:362/1600 train_time:12315ms step_avg:34.02ms
+step:363/1600 train_time:12346ms step_avg:34.01ms
+step:364/1600 train_time:12383ms step_avg:34.02ms
+step:365/1600 train_time:12413ms step_avg:34.01ms
+step:366/1600 train_time:12451ms step_avg:34.02ms
+step:367/1600 train_time:12481ms step_avg:34.01ms
+step:368/1600 train_time:12518ms step_avg:34.02ms
+step:369/1600 train_time:12549ms step_avg:34.01ms
+step:370/1600 train_time:12586ms step_avg:34.02ms
+step:371/1600 train_time:12617ms step_avg:34.01ms
+step:372/1600 train_time:12654ms step_avg:34.02ms
+step:373/1600 train_time:12684ms step_avg:34.01ms
+step:374/1600 train_time:12722ms step_avg:34.02ms
+step:375/1600 train_time:12752ms step_avg:34.01ms
+step:376/1600 train_time:12789ms step_avg:34.01ms
+step:377/1600 train_time:12820ms step_avg:34.00ms
+step:378/1600 train_time:12857ms step_avg:34.01ms
+step:379/1600 train_time:12887ms step_avg:34.00ms
+step:380/1600 train_time:12925ms step_avg:34.01ms
+step:381/1600 train_time:12956ms step_avg:34.00ms
+step:382/1600 train_time:12993ms step_avg:34.01ms
+step:383/1600 train_time:13023ms step_avg:34.00ms
+step:384/1600 train_time:13061ms step_avg:34.01ms
+step:385/1600 train_time:13091ms step_avg:34.00ms
+step:386/1600 train_time:13128ms step_avg:34.01ms
+step:387/1600 train_time:13158ms step_avg:34.00ms
+step:388/1600 train_time:13196ms step_avg:34.01ms
+step:389/1600 train_time:13226ms step_avg:34.00ms
+step:390/1600 train_time:13263ms step_avg:34.01ms
+step:391/1600 train_time:13294ms step_avg:34.00ms
+step:392/1600 train_time:13331ms step_avg:34.01ms
+step:393/1600 train_time:13362ms step_avg:34.00ms
+step:394/1600 train_time:13400ms step_avg:34.01ms
+step:395/1600 train_time:13430ms step_avg:34.00ms
+step:396/1600 train_time:13467ms step_avg:34.01ms
+step:397/1600 train_time:13498ms step_avg:34.00ms
+step:398/1600 train_time:13535ms step_avg:34.01ms
+step:399/1600 train_time:13566ms step_avg:34.00ms
+step:400/1600 train_time:13603ms step_avg:34.01ms
+step:401/1600 train_time:13633ms step_avg:34.00ms
+step:402/1600 train_time:13671ms step_avg:34.01ms
+step:403/1600 train_time:13701ms step_avg:34.00ms
+step:404/1600 train_time:13738ms step_avg:34.01ms
+step:405/1600 train_time:13769ms step_avg:34.00ms
+step:406/1600 train_time:13806ms step_avg:34.00ms
+step:407/1600 train_time:13837ms step_avg:34.00ms
+step:408/1600 train_time:13874ms step_avg:34.00ms
+step:409/1600 train_time:13904ms step_avg:34.00ms
+step:410/1600 train_time:13941ms step_avg:34.00ms
+step:411/1600 train_time:13972ms step_avg:34.00ms
+step:412/1600 train_time:14010ms step_avg:34.00ms
+step:413/1600 train_time:14041ms step_avg:34.00ms
+step:414/1600 train_time:14078ms step_avg:34.00ms
+step:415/1600 train_time:14108ms step_avg:34.00ms
+step:416/1600 train_time:14145ms step_avg:34.00ms
+step:417/1600 train_time:14176ms step_avg:34.00ms
+step:418/1600 train_time:14213ms step_avg:34.00ms
+step:419/1600 train_time:14244ms step_avg:33.99ms
+step:420/1600 train_time:14281ms step_avg:34.00ms
+step:421/1600 train_time:14311ms step_avg:33.99ms
+step:422/1600 train_time:14348ms step_avg:34.00ms
+step:423/1600 train_time:14378ms step_avg:33.99ms
+step:424/1600 train_time:14416ms step_avg:34.00ms
+step:425/1600 train_time:14446ms step_avg:33.99ms
+step:426/1600 train_time:14483ms step_avg:34.00ms
+step:427/1600 train_time:14514ms step_avg:33.99ms
+step:428/1600 train_time:14551ms step_avg:34.00ms
+step:429/1600 train_time:14582ms step_avg:33.99ms
+step:430/1600 train_time:14619ms step_avg:34.00ms
+step:431/1600 train_time:14649ms step_avg:33.99ms
+step:432/1600 train_time:14687ms step_avg:34.00ms
+step:433/1600 train_time:14717ms step_avg:33.99ms
+step:434/1600 train_time:14754ms step_avg:34.00ms
+step:435/1600 train_time:14785ms step_avg:33.99ms
+step:436/1600 train_time:14822ms step_avg:34.00ms
+step:437/1600 train_time:14853ms step_avg:33.99ms
+step:438/1600 train_time:14890ms step_avg:34.00ms
+step:439/1600 train_time:14921ms step_avg:33.99ms
+step:440/1600 train_time:14958ms step_avg:34.00ms
+step:441/1600 train_time:14988ms step_avg:33.99ms
+step:442/1600 train_time:15026ms step_avg:34.00ms
+step:443/1600 train_time:15056ms step_avg:33.99ms
+step:444/1600 train_time:15094ms step_avg:34.00ms
+step:445/1600 train_time:15124ms step_avg:33.99ms
+step:446/1600 train_time:15162ms step_avg:33.99ms
+step:447/1600 train_time:15193ms step_avg:33.99ms
+step:448/1600 train_time:15230ms step_avg:34.00ms
+step:449/1600 train_time:15260ms step_avg:33.99ms
+step:450/1600 train_time:15298ms step_avg:34.00ms
+step:451/1600 train_time:15328ms step_avg:33.99ms
+step:452/1600 train_time:15365ms step_avg:33.99ms
+step:453/1600 train_time:15396ms step_avg:33.99ms
+step:454/1600 train_time:15433ms step_avg:33.99ms
+step:455/1600 train_time:15464ms step_avg:33.99ms
+step:456/1600 train_time:15501ms step_avg:33.99ms
+step:457/1600 train_time:15531ms step_avg:33.98ms
+step:458/1600 train_time:15568ms step_avg:33.99ms
+step:459/1600 train_time:15598ms step_avg:33.98ms
+step:460/1600 train_time:15635ms step_avg:33.99ms
+step:461/1600 train_time:15666ms step_avg:33.98ms
+step:462/1600 train_time:15703ms step_avg:33.99ms
+step:463/1600 train_time:15733ms step_avg:33.98ms
+step:464/1600 train_time:15770ms step_avg:33.99ms
+step:465/1600 train_time:15801ms step_avg:33.98ms
+step:466/1600 train_time:15838ms step_avg:33.99ms
+step:467/1600 train_time:15869ms step_avg:33.98ms
+step:468/1600 train_time:15907ms step_avg:33.99ms
+step:469/1600 train_time:15937ms step_avg:33.98ms
+step:470/1600 train_time:15974ms step_avg:33.99ms
+step:471/1600 train_time:16005ms step_avg:33.98ms
+step:472/1600 train_time:16042ms step_avg:33.99ms
+step:473/1600 train_time:16073ms step_avg:33.98ms
+step:474/1600 train_time:16110ms step_avg:33.99ms
+step:475/1600 train_time:16141ms step_avg:33.98ms
+step:476/1600 train_time:16178ms step_avg:33.99ms
+step:477/1600 train_time:16209ms step_avg:33.98ms
+step:478/1600 train_time:16246ms step_avg:33.99ms
+step:479/1600 train_time:16277ms step_avg:33.98ms
+step:480/1600 train_time:16313ms step_avg:33.99ms
+step:481/1600 train_time:16344ms step_avg:33.98ms
+step:482/1600 train_time:16381ms step_avg:33.99ms
+step:483/1600 train_time:16412ms step_avg:33.98ms
+step:484/1600 train_time:16448ms step_avg:33.98ms
+step:485/1600 train_time:16479ms step_avg:33.98ms
+step:486/1600 train_time:16516ms step_avg:33.98ms
+step:487/1600 train_time:16546ms step_avg:33.98ms
+step:488/1600 train_time:16584ms step_avg:33.98ms
+step:489/1600 train_time:16614ms step_avg:33.98ms
+step:490/1600 train_time:16651ms step_avg:33.98ms
+step:491/1600 train_time:16682ms step_avg:33.97ms
+step:492/1600 train_time:16719ms step_avg:33.98ms
+step:493/1600 train_time:16750ms step_avg:33.97ms
+step:494/1600 train_time:16787ms step_avg:33.98ms
+step:495/1600 train_time:16817ms step_avg:33.97ms
+step:496/1600 train_time:16854ms step_avg:33.98ms
+step:497/1600 train_time:16885ms step_avg:33.97ms
+step:498/1600 train_time:16922ms step_avg:33.98ms
+step:499/1600 train_time:16953ms step_avg:33.97ms
+step:500/1600 train_time:16990ms step_avg:33.98ms
+step:500/1600 val_loss:4.2384 train_time:17039ms step_avg:34.08ms
+step:501/1600 train_time:17056ms step_avg:34.04ms
+step:502/1600 train_time:17072ms step_avg:34.01ms
+step:503/1600 train_time:17093ms step_avg:33.98ms
+step:504/1600 train_time:17130ms step_avg:33.99ms
+step:505/1600 train_time:17161ms step_avg:33.98ms
+step:506/1600 train_time:17199ms step_avg:33.99ms
+step:507/1600 train_time:17230ms step_avg:33.98ms
+step:508/1600 train_time:17267ms step_avg:33.99ms
+step:509/1600 train_time:17297ms step_avg:33.98ms
+step:510/1600 train_time:17334ms step_avg:33.99ms
+step:511/1600 train_time:17365ms step_avg:33.98ms
+step:512/1600 train_time:17402ms step_avg:33.99ms
+step:513/1600 train_time:17432ms step_avg:33.98ms
+step:514/1600 train_time:17469ms step_avg:33.99ms
+step:515/1600 train_time:17499ms step_avg:33.98ms
+step:516/1600 train_time:17536ms step_avg:33.98ms
+step:517/1600 train_time:17566ms step_avg:33.98ms
+step:518/1600 train_time:17603ms step_avg:33.98ms
+step:519/1600 train_time:17634ms step_avg:33.98ms
+step:520/1600 train_time:17671ms step_avg:33.98ms
+step:521/1600 train_time:17740ms step_avg:34.05ms
+step:522/1600 train_time:17797ms step_avg:34.09ms
+step:523/1600 train_time:17859ms step_avg:34.15ms
+step:524/1600 train_time:17917ms step_avg:34.19ms
+step:525/1600 train_time:17980ms step_avg:34.25ms
+step:526/1600 train_time:18038ms step_avg:34.29ms
+step:527/1600 train_time:18101ms step_avg:34.35ms
+step:528/1600 train_time:18161ms step_avg:34.39ms
+step:529/1600 train_time:18223ms step_avg:34.45ms
+step:530/1600 train_time:18282ms step_avg:34.50ms
+step:531/1600 train_time:18346ms step_avg:34.55ms
+step:532/1600 train_time:18405ms step_avg:34.60ms
+step:533/1600 train_time:18468ms step_avg:34.65ms
+step:534/1600 train_time:18527ms step_avg:34.69ms
+step:535/1600 train_time:18590ms step_avg:34.75ms
+step:536/1600 train_time:18648ms step_avg:34.79ms
+step:537/1600 train_time:18711ms step_avg:34.84ms
+step:538/1600 train_time:18770ms step_avg:34.89ms
+step:539/1600 train_time:18833ms step_avg:34.94ms
+step:540/1600 train_time:18892ms step_avg:34.99ms
+step:541/1600 train_time:18955ms step_avg:35.04ms
+step:542/1600 train_time:19014ms step_avg:35.08ms
+step:543/1600 train_time:19077ms step_avg:35.13ms
+step:544/1600 train_time:19136ms step_avg:35.18ms
+step:545/1600 train_time:19199ms step_avg:35.23ms
+step:546/1600 train_time:19258ms step_avg:35.27ms
+step:547/1600 train_time:19320ms step_avg:35.32ms
+step:548/1600 train_time:19379ms step_avg:35.36ms
+step:549/1600 train_time:19442ms step_avg:35.41ms
+step:550/1600 train_time:19501ms step_avg:35.46ms
+step:551/1600 train_time:19564ms step_avg:35.51ms
+step:552/1600 train_time:19623ms step_avg:35.55ms
+step:553/1600 train_time:19686ms step_avg:35.60ms
+step:554/1600 train_time:19745ms step_avg:35.64ms
+step:555/1600 train_time:19808ms step_avg:35.69ms
+step:556/1600 train_time:19868ms step_avg:35.73ms
+step:557/1600 train_time:19931ms step_avg:35.78ms
+step:558/1600 train_time:19989ms step_avg:35.82ms
+step:559/1600 train_time:20053ms step_avg:35.87ms
+step:560/1600 train_time:20112ms step_avg:35.92ms
+step:561/1600 train_time:20176ms step_avg:35.96ms
+step:562/1600 train_time:20235ms step_avg:36.01ms
+step:563/1600 train_time:20298ms step_avg:36.05ms
+step:564/1600 train_time:20357ms step_avg:36.09ms
+step:565/1600 train_time:20419ms step_avg:36.14ms
+step:566/1600 train_time:20478ms step_avg:36.18ms
+step:567/1600 train_time:20541ms step_avg:36.23ms
+step:568/1600 train_time:20599ms step_avg:36.27ms
+step:569/1600 train_time:20663ms step_avg:36.31ms
+step:570/1600 train_time:20722ms step_avg:36.35ms
+step:571/1600 train_time:20784ms step_avg:36.40ms
+step:572/1600 train_time:20843ms step_avg:36.44ms
+step:573/1600 train_time:20906ms step_avg:36.49ms
+step:574/1600 train_time:20967ms step_avg:36.53ms
+step:575/1600 train_time:21030ms step_avg:36.57ms
+step:576/1600 train_time:21089ms step_avg:36.61ms
+step:577/1600 train_time:21151ms step_avg:36.66ms
+step:578/1600 train_time:21210ms step_avg:36.70ms
+step:579/1600 train_time:21273ms step_avg:36.74ms
+step:580/1600 train_time:21332ms step_avg:36.78ms
+step:581/1600 train_time:21395ms step_avg:36.82ms
+step:582/1600 train_time:21454ms step_avg:36.86ms
+step:583/1600 train_time:21517ms step_avg:36.91ms
+step:584/1600 train_time:21576ms step_avg:36.95ms
+step:585/1600 train_time:21639ms step_avg:36.99ms
+step:586/1600 train_time:21697ms step_avg:37.03ms
+step:587/1600 train_time:21760ms step_avg:37.07ms
+step:588/1600 train_time:21818ms step_avg:37.11ms
+step:589/1600 train_time:21882ms step_avg:37.15ms
+step:590/1600 train_time:21941ms step_avg:37.19ms
+step:591/1600 train_time:22004ms step_avg:37.23ms
+step:592/1600 train_time:22063ms step_avg:37.27ms
+step:593/1600 train_time:22126ms step_avg:37.31ms
+step:594/1600 train_time:22185ms step_avg:37.35ms
+step:595/1600 train_time:22248ms step_avg:37.39ms
+step:596/1600 train_time:22307ms step_avg:37.43ms
+step:597/1600 train_time:22370ms step_avg:37.47ms
+step:598/1600 train_time:22430ms step_avg:37.51ms
+step:599/1600 train_time:22492ms step_avg:37.55ms
+step:600/1600 train_time:22552ms step_avg:37.59ms
+step:601/1600 train_time:22614ms step_avg:37.63ms
+step:602/1600 train_time:22673ms step_avg:37.66ms
+step:603/1600 train_time:22737ms step_avg:37.71ms
+step:604/1600 train_time:22796ms step_avg:37.74ms
+step:605/1600 train_time:22859ms step_avg:37.78ms
+step:606/1600 train_time:22918ms step_avg:37.82ms
+step:607/1600 train_time:22980ms step_avg:37.86ms
+step:608/1600 train_time:23039ms step_avg:37.89ms
+step:609/1600 train_time:23102ms step_avg:37.93ms
+step:610/1600 train_time:23161ms step_avg:37.97ms
+step:611/1600 train_time:23224ms step_avg:38.01ms
+step:612/1600 train_time:23283ms step_avg:38.04ms
+step:613/1600 train_time:23346ms step_avg:38.09ms
+step:614/1600 train_time:23406ms step_avg:38.12ms
+step:615/1600 train_time:23470ms step_avg:38.16ms
+step:616/1600 train_time:23529ms step_avg:38.20ms
+step:617/1600 train_time:23593ms step_avg:38.24ms
+step:618/1600 train_time:23651ms step_avg:38.27ms
+step:619/1600 train_time:23714ms step_avg:38.31ms
+step:620/1600 train_time:23773ms step_avg:38.34ms
+step:621/1600 train_time:23837ms step_avg:38.38ms
+step:622/1600 train_time:23895ms step_avg:38.42ms
+step:623/1600 train_time:23958ms step_avg:38.46ms
+step:624/1600 train_time:24016ms step_avg:38.49ms
+step:625/1600 train_time:24079ms step_avg:38.53ms
+step:626/1600 train_time:24138ms step_avg:38.56ms
+step:627/1600 train_time:24201ms step_avg:38.60ms
+step:628/1600 train_time:24260ms step_avg:38.63ms
+step:629/1600 train_time:24323ms step_avg:38.67ms
+step:630/1600 train_time:24382ms step_avg:38.70ms
+step:631/1600 train_time:24446ms step_avg:38.74ms
+step:632/1600 train_time:24505ms step_avg:38.77ms
+step:633/1600 train_time:24567ms step_avg:38.81ms
+step:634/1600 train_time:24627ms step_avg:38.84ms
+step:635/1600 train_time:24690ms step_avg:38.88ms
+step:636/1600 train_time:24750ms step_avg:38.91ms
+step:637/1600 train_time:24813ms step_avg:38.95ms
+step:638/1600 train_time:24872ms step_avg:38.98ms
+step:639/1600 train_time:24935ms step_avg:39.02ms
+step:640/1600 train_time:24993ms step_avg:39.05ms
+step:641/1600 train_time:25056ms step_avg:39.09ms
+step:642/1600 train_time:25115ms step_avg:39.12ms
+step:643/1600 train_time:25178ms step_avg:39.16ms
+step:644/1600 train_time:25238ms step_avg:39.19ms
+step:645/1600 train_time:25301ms step_avg:39.23ms
+step:646/1600 train_time:25360ms step_avg:39.26ms
+step:647/1600 train_time:25424ms step_avg:39.29ms
+step:648/1600 train_time:25482ms step_avg:39.32ms
+step:649/1600 train_time:25545ms step_avg:39.36ms
+step:650/1600 train_time:25604ms step_avg:39.39ms
+step:651/1600 train_time:25667ms step_avg:39.43ms
+step:652/1600 train_time:25726ms step_avg:39.46ms
+step:653/1600 train_time:25790ms step_avg:39.49ms
+step:654/1600 train_time:25849ms step_avg:39.52ms
+step:655/1600 train_time:25913ms step_avg:39.56ms
+step:656/1600 train_time:25972ms step_avg:39.59ms
+step:657/1600 train_time:26034ms step_avg:39.63ms
+step:658/1600 train_time:26094ms step_avg:39.66ms
+step:659/1600 train_time:26157ms step_avg:39.69ms
+step:660/1600 train_time:26217ms step_avg:39.72ms
+step:661/1600 train_time:26281ms step_avg:39.76ms
+step:662/1600 train_time:26339ms step_avg:39.79ms
+step:663/1600 train_time:26401ms step_avg:39.82ms
+step:664/1600 train_time:26460ms step_avg:39.85ms
+step:665/1600 train_time:26523ms step_avg:39.88ms
+step:666/1600 train_time:26582ms step_avg:39.91ms
+step:667/1600 train_time:26645ms step_avg:39.95ms
+step:668/1600 train_time:26704ms step_avg:39.98ms
+step:669/1600 train_time:26767ms step_avg:40.01ms
+step:670/1600 train_time:26826ms step_avg:40.04ms
+step:671/1600 train_time:26889ms step_avg:40.07ms
+step:672/1600 train_time:26948ms step_avg:40.10ms
+step:673/1600 train_time:27011ms step_avg:40.14ms
+step:674/1600 train_time:27070ms step_avg:40.16ms
+step:675/1600 train_time:27133ms step_avg:40.20ms
+step:676/1600 train_time:27193ms step_avg:40.23ms
+step:677/1600 train_time:27257ms step_avg:40.26ms
+step:678/1600 train_time:27315ms step_avg:40.29ms
+step:679/1600 train_time:27377ms step_avg:40.32ms
+step:680/1600 train_time:27436ms step_avg:40.35ms
+step:681/1600 train_time:27499ms step_avg:40.38ms
+step:682/1600 train_time:27558ms step_avg:40.41ms
+step:683/1600 train_time:27620ms step_avg:40.44ms
+step:684/1600 train_time:27679ms step_avg:40.47ms
+step:685/1600 train_time:27742ms step_avg:40.50ms
+step:686/1600 train_time:27801ms step_avg:40.53ms
+step:687/1600 train_time:27864ms step_avg:40.56ms
+step:688/1600 train_time:27923ms step_avg:40.59ms
+step:689/1600 train_time:27986ms step_avg:40.62ms
+step:690/1600 train_time:28046ms step_avg:40.65ms
+step:691/1600 train_time:28109ms step_avg:40.68ms
+step:692/1600 train_time:28168ms step_avg:40.71ms
+step:693/1600 train_time:28232ms step_avg:40.74ms
+step:694/1600 train_time:28291ms step_avg:40.76ms
+step:695/1600 train_time:28353ms step_avg:40.80ms
+step:696/1600 train_time:28412ms step_avg:40.82ms
+step:697/1600 train_time:28476ms step_avg:40.85ms
+step:698/1600 train_time:28536ms step_avg:40.88ms
+step:699/1600 train_time:28598ms step_avg:40.91ms
+step:700/1600 train_time:28657ms step_avg:40.94ms
+step:701/1600 train_time:28720ms step_avg:40.97ms
+step:702/1600 train_time:28779ms step_avg:41.00ms
+step:703/1600 train_time:28842ms step_avg:41.03ms
+step:704/1600 train_time:28900ms step_avg:41.05ms
+step:705/1600 train_time:28963ms step_avg:41.08ms
+step:706/1600 train_time:29021ms step_avg:41.11ms
+step:707/1600 train_time:29084ms step_avg:41.14ms
+step:708/1600 train_time:29144ms step_avg:41.16ms
+step:709/1600 train_time:29207ms step_avg:41.19ms
+step:710/1600 train_time:29266ms step_avg:41.22ms
+step:711/1600 train_time:29329ms step_avg:41.25ms
+step:712/1600 train_time:29389ms step_avg:41.28ms
+step:713/1600 train_time:29452ms step_avg:41.31ms
+step:714/1600 train_time:29513ms step_avg:41.33ms
+step:715/1600 train_time:29576ms step_avg:41.37ms
+step:716/1600 train_time:29635ms step_avg:41.39ms
+step:717/1600 train_time:29697ms step_avg:41.42ms
+step:718/1600 train_time:29756ms step_avg:41.44ms
+step:719/1600 train_time:29819ms step_avg:41.47ms
+step:720/1600 train_time:29877ms step_avg:41.50ms
+step:721/1600 train_time:29940ms step_avg:41.53ms
+step:722/1600 train_time:29999ms step_avg:41.55ms
+step:723/1600 train_time:30062ms step_avg:41.58ms
+step:724/1600 train_time:30120ms step_avg:41.60ms
+step:725/1600 train_time:30183ms step_avg:41.63ms
+step:726/1600 train_time:30243ms step_avg:41.66ms
+step:727/1600 train_time:30306ms step_avg:41.69ms
+step:728/1600 train_time:30365ms step_avg:41.71ms
+step:729/1600 train_time:30428ms step_avg:41.74ms
+step:730/1600 train_time:30489ms step_avg:41.77ms
+step:731/1600 train_time:30551ms step_avg:41.79ms
+step:732/1600 train_time:30610ms step_avg:41.82ms
+step:733/1600 train_time:30673ms step_avg:41.85ms
+step:734/1600 train_time:30733ms step_avg:41.87ms
+step:735/1600 train_time:30796ms step_avg:41.90ms
+step:736/1600 train_time:30855ms step_avg:41.92ms
+step:737/1600 train_time:30918ms step_avg:41.95ms
+step:738/1600 train_time:30976ms step_avg:41.97ms
+step:739/1600 train_time:31039ms step_avg:42.00ms
+step:740/1600 train_time:31097ms step_avg:42.02ms
+step:741/1600 train_time:31160ms step_avg:42.05ms
+step:742/1600 train_time:31219ms step_avg:42.07ms
+step:743/1600 train_time:31283ms step_avg:42.10ms
+step:744/1600 train_time:31342ms step_avg:42.13ms
+step:745/1600 train_time:31405ms step_avg:42.15ms
+step:746/1600 train_time:31465ms step_avg:42.18ms
+step:747/1600 train_time:31527ms step_avg:42.21ms
+step:748/1600 train_time:31587ms step_avg:42.23ms
+step:749/1600 train_time:31650ms step_avg:42.26ms
+step:750/1600 train_time:31709ms step_avg:42.28ms
+step:750/1600 val_loss:3.8953 train_time:31755ms step_avg:42.34ms
+step:751/1600 train_time:31773ms step_avg:42.31ms
+step:752/1600 train_time:31832ms step_avg:42.33ms
+step:753/1600 train_time:31895ms step_avg:42.36ms
+step:754/1600 train_time:31954ms step_avg:42.38ms
+step:755/1600 train_time:32016ms step_avg:42.40ms
+step:756/1600 train_time:32075ms step_avg:42.43ms
+step:757/1600 train_time:32136ms step_avg:42.45ms
+step:758/1600 train_time:32195ms step_avg:42.47ms
+step:759/1600 train_time:32257ms step_avg:42.50ms
+step:760/1600 train_time:32315ms step_avg:42.52ms
+step:761/1600 train_time:32378ms step_avg:42.55ms
+step:762/1600 train_time:32436ms step_avg:42.57ms
+step:763/1600 train_time:32498ms step_avg:42.59ms
+step:764/1600 train_time:32557ms step_avg:42.61ms
+step:765/1600 train_time:32619ms step_avg:42.64ms
+step:766/1600 train_time:32679ms step_avg:42.66ms
+step:767/1600 train_time:32744ms step_avg:42.69ms
+step:768/1600 train_time:32804ms step_avg:42.71ms
+step:769/1600 train_time:32868ms step_avg:42.74ms
+step:770/1600 train_time:32927ms step_avg:42.76ms
+step:771/1600 train_time:32990ms step_avg:42.79ms
+step:772/1600 train_time:33048ms step_avg:42.81ms
+step:773/1600 train_time:33111ms step_avg:42.83ms
+step:774/1600 train_time:33170ms step_avg:42.86ms
+step:775/1600 train_time:33232ms step_avg:42.88ms
+step:776/1600 train_time:33290ms step_avg:42.90ms
+step:777/1600 train_time:33353ms step_avg:42.93ms
+step:778/1600 train_time:33412ms step_avg:42.95ms
+step:779/1600 train_time:33475ms step_avg:42.97ms
+step:780/1600 train_time:33534ms step_avg:42.99ms
+step:781/1600 train_time:33596ms step_avg:43.02ms
+step:782/1600 train_time:33655ms step_avg:43.04ms
+step:783/1600 train_time:33718ms step_avg:43.06ms
+step:784/1600 train_time:33777ms step_avg:43.08ms
+step:785/1600 train_time:33841ms step_avg:43.11ms
+step:786/1600 train_time:33901ms step_avg:43.13ms
+step:787/1600 train_time:33964ms step_avg:43.16ms
+step:788/1600 train_time:34023ms step_avg:43.18ms
+step:789/1600 train_time:34087ms step_avg:43.20ms
+step:790/1600 train_time:34146ms step_avg:43.22ms
+step:791/1600 train_time:34208ms step_avg:43.25ms
+step:792/1600 train_time:34267ms step_avg:43.27ms
+step:793/1600 train_time:34330ms step_avg:43.29ms
+step:794/1600 train_time:34389ms step_avg:43.31ms
+step:795/1600 train_time:34452ms step_avg:43.34ms
+step:796/1600 train_time:34511ms step_avg:43.36ms
+step:797/1600 train_time:34574ms step_avg:43.38ms
+step:798/1600 train_time:34633ms step_avg:43.40ms
+step:799/1600 train_time:34696ms step_avg:43.42ms
+step:800/1600 train_time:34755ms step_avg:43.44ms
+step:801/1600 train_time:34818ms step_avg:43.47ms
+step:802/1600 train_time:34877ms step_avg:43.49ms
+step:803/1600 train_time:34940ms step_avg:43.51ms
+step:804/1600 train_time:34999ms step_avg:43.53ms
+step:805/1600 train_time:35062ms step_avg:43.56ms
+step:806/1600 train_time:35121ms step_avg:43.57ms
+step:807/1600 train_time:35185ms step_avg:43.60ms
+step:808/1600 train_time:35244ms step_avg:43.62ms
+step:809/1600 train_time:35306ms step_avg:43.64ms
+step:810/1600 train_time:35365ms step_avg:43.66ms
+step:811/1600 train_time:35428ms step_avg:43.68ms
+step:812/1600 train_time:35487ms step_avg:43.70ms
+step:813/1600 train_time:35551ms step_avg:43.73ms
+step:814/1600 train_time:35610ms step_avg:43.75ms
+step:815/1600 train_time:35675ms step_avg:43.77ms
+step:816/1600 train_time:35733ms step_avg:43.79ms
+step:817/1600 train_time:35796ms step_avg:43.81ms
+step:818/1600 train_time:35854ms step_avg:43.83ms
+step:819/1600 train_time:35917ms step_avg:43.85ms
+step:820/1600 train_time:35976ms step_avg:43.87ms
+step:821/1600 train_time:36040ms step_avg:43.90ms
+step:822/1600 train_time:36099ms step_avg:43.92ms
+step:823/1600 train_time:36162ms step_avg:43.94ms
+step:824/1600 train_time:36222ms step_avg:43.96ms
+step:825/1600 train_time:36284ms step_avg:43.98ms
+step:826/1600 train_time:36344ms step_avg:44.00ms
+step:827/1600 train_time:36408ms step_avg:44.02ms
+step:828/1600 train_time:36467ms step_avg:44.04ms
+step:829/1600 train_time:36529ms step_avg:44.06ms
+step:830/1600 train_time:36589ms step_avg:44.08ms
+step:831/1600 train_time:36652ms step_avg:44.11ms
+step:832/1600 train_time:36710ms step_avg:44.12ms
+step:833/1600 train_time:36774ms step_avg:44.15ms
+step:834/1600 train_time:36833ms step_avg:44.16ms
+step:835/1600 train_time:36896ms step_avg:44.19ms
+step:836/1600 train_time:36955ms step_avg:44.20ms
+step:837/1600 train_time:37017ms step_avg:44.23ms
+step:838/1600 train_time:37076ms step_avg:44.24ms
+step:839/1600 train_time:37139ms step_avg:44.27ms
+step:840/1600 train_time:37198ms step_avg:44.28ms
+step:841/1600 train_time:37261ms step_avg:44.31ms
+step:842/1600 train_time:37320ms step_avg:44.32ms
+step:843/1600 train_time:37383ms step_avg:44.34ms
+step:844/1600 train_time:37442ms step_avg:44.36ms
+step:845/1600 train_time:37506ms step_avg:44.39ms
+step:846/1600 train_time:37565ms step_avg:44.40ms
+step:847/1600 train_time:37629ms step_avg:44.43ms
+step:848/1600 train_time:37687ms step_avg:44.44ms
+step:849/1600 train_time:37750ms step_avg:44.46ms
+step:850/1600 train_time:37810ms step_avg:44.48ms
+step:851/1600 train_time:37873ms step_avg:44.50ms
+step:852/1600 train_time:37933ms step_avg:44.52ms
+step:853/1600 train_time:37996ms step_avg:44.54ms
+step:854/1600 train_time:38054ms step_avg:44.56ms
+step:855/1600 train_time:38116ms step_avg:44.58ms
+step:856/1600 train_time:38176ms step_avg:44.60ms
+step:857/1600 train_time:38239ms step_avg:44.62ms
+step:858/1600 train_time:38298ms step_avg:44.64ms
+step:859/1600 train_time:38360ms step_avg:44.66ms
+step:860/1600 train_time:38419ms step_avg:44.67ms
+step:861/1600 train_time:38483ms step_avg:44.70ms
+step:862/1600 train_time:38542ms step_avg:44.71ms
+step:863/1600 train_time:38605ms step_avg:44.73ms
+step:864/1600 train_time:38664ms step_avg:44.75ms
+step:865/1600 train_time:38727ms step_avg:44.77ms
+step:866/1600 train_time:38786ms step_avg:44.79ms
+step:867/1600 train_time:38849ms step_avg:44.81ms
+step:868/1600 train_time:38908ms step_avg:44.83ms
+step:869/1600 train_time:38972ms step_avg:44.85ms
+step:870/1600 train_time:39031ms step_avg:44.86ms
+step:871/1600 train_time:39094ms step_avg:44.88ms
+step:872/1600 train_time:39153ms step_avg:44.90ms
+step:873/1600 train_time:39216ms step_avg:44.92ms
+step:874/1600 train_time:39275ms step_avg:44.94ms
+step:875/1600 train_time:39337ms step_avg:44.96ms
+step:876/1600 train_time:39396ms step_avg:44.97ms
+step:877/1600 train_time:39459ms step_avg:44.99ms
+step:878/1600 train_time:39518ms step_avg:45.01ms
+step:879/1600 train_time:39581ms step_avg:45.03ms
+step:880/1600 train_time:39640ms step_avg:45.05ms
+step:881/1600 train_time:39703ms step_avg:45.07ms
+step:882/1600 train_time:39762ms step_avg:45.08ms
+step:883/1600 train_time:39825ms step_avg:45.10ms
+step:884/1600 train_time:39885ms step_avg:45.12ms
+step:885/1600 train_time:39949ms step_avg:45.14ms
+step:886/1600 train_time:40008ms step_avg:45.16ms
+step:887/1600 train_time:40071ms step_avg:45.18ms
+step:888/1600 train_time:40131ms step_avg:45.19ms
+step:889/1600 train_time:40194ms step_avg:45.21ms
+step:890/1600 train_time:40256ms step_avg:45.23ms
+step:891/1600 train_time:40318ms step_avg:45.25ms
+step:892/1600 train_time:40377ms step_avg:45.27ms
+step:893/1600 train_time:40438ms step_avg:45.28ms
+step:894/1600 train_time:40497ms step_avg:45.30ms
+step:895/1600 train_time:40560ms step_avg:45.32ms
+step:896/1600 train_time:40619ms step_avg:45.33ms
+step:897/1600 train_time:40681ms step_avg:45.35ms
+step:898/1600 train_time:40740ms step_avg:45.37ms
+step:899/1600 train_time:40804ms step_avg:45.39ms
+step:900/1600 train_time:40862ms step_avg:45.40ms
+step:901/1600 train_time:40925ms step_avg:45.42ms
+step:902/1600 train_time:40985ms step_avg:45.44ms
+step:903/1600 train_time:41048ms step_avg:45.46ms
+step:904/1600 train_time:41107ms step_avg:45.47ms
+step:905/1600 train_time:41170ms step_avg:45.49ms
+step:906/1600 train_time:41230ms step_avg:45.51ms
+step:907/1600 train_time:41292ms step_avg:45.53ms
+step:908/1600 train_time:41353ms step_avg:45.54ms
+step:909/1600 train_time:41415ms step_avg:45.56ms
+step:910/1600 train_time:41474ms step_avg:45.58ms
+step:911/1600 train_time:41537ms step_avg:45.59ms
+step:912/1600 train_time:41596ms step_avg:45.61ms
+step:913/1600 train_time:41658ms step_avg:45.63ms
+step:914/1600 train_time:41717ms step_avg:45.64ms
+step:915/1600 train_time:41780ms step_avg:45.66ms
+step:916/1600 train_time:41839ms step_avg:45.68ms
+step:917/1600 train_time:41902ms step_avg:45.69ms
+step:918/1600 train_time:41962ms step_avg:45.71ms
+step:919/1600 train_time:42026ms step_avg:45.73ms
+step:920/1600 train_time:42085ms step_avg:45.74ms
+step:921/1600 train_time:42148ms step_avg:45.76ms
+step:922/1600 train_time:42208ms step_avg:45.78ms
+step:923/1600 train_time:42270ms step_avg:45.80ms
+step:924/1600 train_time:42329ms step_avg:45.81ms
+step:925/1600 train_time:42392ms step_avg:45.83ms
+step:926/1600 train_time:42452ms step_avg:45.84ms
+step:927/1600 train_time:42514ms step_avg:45.86ms
+step:928/1600 train_time:42574ms step_avg:45.88ms
+step:929/1600 train_time:42637ms step_avg:45.90ms
+step:930/1600 train_time:42695ms step_avg:45.91ms
+step:931/1600 train_time:42758ms step_avg:45.93ms
+step:932/1600 train_time:42817ms step_avg:45.94ms
+step:933/1600 train_time:42879ms step_avg:45.96ms
+step:934/1600 train_time:42938ms step_avg:45.97ms
+step:935/1600 train_time:43002ms step_avg:45.99ms
+step:936/1600 train_time:43061ms step_avg:46.01ms
+step:937/1600 train_time:43125ms step_avg:46.02ms
+step:938/1600 train_time:43184ms step_avg:46.04ms
+step:939/1600 train_time:43247ms step_avg:46.06ms
+step:940/1600 train_time:43306ms step_avg:46.07ms
+step:941/1600 train_time:43369ms step_avg:46.09ms
+step:942/1600 train_time:43428ms step_avg:46.10ms
+step:943/1600 train_time:43491ms step_avg:46.12ms
+step:944/1600 train_time:43550ms step_avg:46.13ms
+step:945/1600 train_time:43613ms step_avg:46.15ms
+step:946/1600 train_time:43672ms step_avg:46.16ms
+step:947/1600 train_time:43735ms step_avg:46.18ms
+step:948/1600 train_time:43793ms step_avg:46.20ms
+step:949/1600 train_time:43857ms step_avg:46.21ms
+step:950/1600 train_time:43916ms step_avg:46.23ms
+step:951/1600 train_time:43978ms step_avg:46.24ms
+step:952/1600 train_time:44037ms step_avg:46.26ms
+step:953/1600 train_time:44100ms step_avg:46.28ms
+step:954/1600 train_time:44160ms step_avg:46.29ms
+step:955/1600 train_time:44223ms step_avg:46.31ms
+step:956/1600 train_time:44282ms step_avg:46.32ms
+step:957/1600 train_time:44345ms step_avg:46.34ms
+step:958/1600 train_time:44405ms step_avg:46.35ms
+step:959/1600 train_time:44469ms step_avg:46.37ms
+step:960/1600 train_time:44528ms step_avg:46.38ms
+step:961/1600 train_time:44591ms step_avg:46.40ms
+step:962/1600 train_time:44650ms step_avg:46.41ms
+step:963/1600 train_time:44713ms step_avg:46.43ms
+step:964/1600 train_time:44771ms step_avg:46.44ms
+step:965/1600 train_time:44834ms step_avg:46.46ms
+step:966/1600 train_time:44893ms step_avg:46.47ms
+step:967/1600 train_time:44956ms step_avg:46.49ms
+step:968/1600 train_time:45016ms step_avg:46.50ms
+step:969/1600 train_time:45079ms step_avg:46.52ms
+step:970/1600 train_time:45138ms step_avg:46.53ms
+step:971/1600 train_time:45200ms step_avg:46.55ms
+step:972/1600 train_time:45259ms step_avg:46.56ms
+step:973/1600 train_time:45323ms step_avg:46.58ms
+step:974/1600 train_time:45382ms step_avg:46.59ms
+step:975/1600 train_time:45445ms step_avg:46.61ms
+step:976/1600 train_time:45504ms step_avg:46.62ms
+step:977/1600 train_time:45567ms step_avg:46.64ms
+step:978/1600 train_time:45626ms step_avg:46.65ms
+step:979/1600 train_time:45689ms step_avg:46.67ms
+step:980/1600 train_time:45748ms step_avg:46.68ms
+step:981/1600 train_time:45812ms step_avg:46.70ms
+step:982/1600 train_time:45871ms step_avg:46.71ms
+step:983/1600 train_time:45934ms step_avg:46.73ms
+step:984/1600 train_time:45993ms step_avg:46.74ms
+step:985/1600 train_time:46056ms step_avg:46.76ms
+step:986/1600 train_time:46114ms step_avg:46.77ms
+step:987/1600 train_time:46178ms step_avg:46.79ms
+step:988/1600 train_time:46237ms step_avg:46.80ms
+step:989/1600 train_time:46300ms step_avg:46.81ms
+step:990/1600 train_time:46359ms step_avg:46.83ms
+step:991/1600 train_time:46421ms step_avg:46.84ms
+step:992/1600 train_time:46480ms step_avg:46.85ms
+step:993/1600 train_time:46544ms step_avg:46.87ms
+step:994/1600 train_time:46603ms step_avg:46.88ms
+step:995/1600 train_time:46666ms step_avg:46.90ms
+step:996/1600 train_time:46725ms step_avg:46.91ms
+step:997/1600 train_time:46788ms step_avg:46.93ms
+step:998/1600 train_time:46847ms step_avg:46.94ms
+step:999/1600 train_time:46910ms step_avg:46.96ms
+step:1000/1600 train_time:46971ms step_avg:46.97ms
+step:1000/1600 val_loss:3.5966 train_time:47017ms step_avg:47.02ms
+step:1001/1600 train_time:47035ms step_avg:46.99ms
+step:1002/1600 train_time:47095ms step_avg:47.00ms
+step:1003/1600 train_time:47158ms step_avg:47.02ms
+step:1004/1600 train_time:47217ms step_avg:47.03ms
+step:1005/1600 train_time:47280ms step_avg:47.04ms
+step:1006/1600 train_time:47340ms step_avg:47.06ms
+step:1007/1600 train_time:47402ms step_avg:47.07ms
+step:1008/1600 train_time:47461ms step_avg:47.08ms
+step:1009/1600 train_time:47523ms step_avg:47.10ms
+step:1010/1600 train_time:47581ms step_avg:47.11ms
+step:1011/1600 train_time:47643ms step_avg:47.13ms
+step:1012/1600 train_time:47702ms step_avg:47.14ms
+step:1013/1600 train_time:47764ms step_avg:47.15ms
+step:1014/1600 train_time:47822ms step_avg:47.16ms
+step:1015/1600 train_time:47885ms step_avg:47.18ms
+step:1016/1600 train_time:47944ms step_avg:47.19ms
+step:1017/1600 train_time:48008ms step_avg:47.21ms
+step:1018/1600 train_time:48068ms step_avg:47.22ms
+step:1019/1600 train_time:48132ms step_avg:47.23ms
+step:1020/1600 train_time:48192ms step_avg:47.25ms
+step:1021/1600 train_time:48254ms step_avg:47.26ms
+step:1022/1600 train_time:48313ms step_avg:47.27ms
+step:1023/1600 train_time:48376ms step_avg:47.29ms
+step:1024/1600 train_time:48434ms step_avg:47.30ms
+step:1025/1600 train_time:48497ms step_avg:47.31ms
+step:1026/1600 train_time:48555ms step_avg:47.32ms
+step:1027/1600 train_time:48618ms step_avg:47.34ms
+step:1028/1600 train_time:48677ms step_avg:47.35ms
+step:1029/1600 train_time:48739ms step_avg:47.37ms
+step:1030/1600 train_time:48798ms step_avg:47.38ms
+step:1031/1600 train_time:48860ms step_avg:47.39ms
+step:1032/1600 train_time:48920ms step_avg:47.40ms
+step:1033/1600 train_time:48984ms step_avg:47.42ms
+step:1034/1600 train_time:49043ms step_avg:47.43ms
+step:1035/1600 train_time:49107ms step_avg:47.45ms
+step:1036/1600 train_time:49166ms step_avg:47.46ms
+step:1037/1600 train_time:49229ms step_avg:47.47ms
+step:1038/1600 train_time:49288ms step_avg:47.48ms
+step:1039/1600 train_time:49350ms step_avg:47.50ms
+step:1040/1600 train_time:49409ms step_avg:47.51ms
+step:1041/1600 train_time:49479ms step_avg:47.53ms
+step:1042/1600 train_time:49564ms step_avg:47.57ms
+step:1043/1600 train_time:49653ms step_avg:47.61ms
+step:1044/1600 train_time:49739ms step_avg:47.64ms
+step:1045/1600 train_time:49827ms step_avg:47.68ms
+step:1046/1600 train_time:49912ms step_avg:47.72ms
+step:1047/1600 train_time:50001ms step_avg:47.76ms
+step:1048/1600 train_time:50088ms step_avg:47.79ms
+step:1049/1600 train_time:50179ms step_avg:47.83ms
+step:1050/1600 train_time:50264ms step_avg:47.87ms
+step:1051/1600 train_time:50353ms step_avg:47.91ms
+step:1052/1600 train_time:50438ms step_avg:47.94ms
+step:1053/1600 train_time:50527ms step_avg:47.98ms
+step:1054/1600 train_time:50612ms step_avg:48.02ms
+step:1055/1600 train_time:50700ms step_avg:48.06ms
+step:1056/1600 train_time:50785ms step_avg:48.09ms
+step:1057/1600 train_time:50874ms step_avg:48.13ms
+step:1058/1600 train_time:50959ms step_avg:48.17ms
+step:1059/1600 train_time:51048ms step_avg:48.20ms
+step:1060/1600 train_time:51134ms step_avg:48.24ms
+step:1061/1600 train_time:51223ms step_avg:48.28ms
+step:1062/1600 train_time:51309ms step_avg:48.31ms
+step:1063/1600 train_time:51397ms step_avg:48.35ms
+step:1064/1600 train_time:51483ms step_avg:48.39ms
+step:1065/1600 train_time:51571ms step_avg:48.42ms
+step:1066/1600 train_time:51657ms step_avg:48.46ms
+step:1067/1600 train_time:51745ms step_avg:48.50ms
+step:1068/1600 train_time:51830ms step_avg:48.53ms
+step:1069/1600 train_time:51919ms step_avg:48.57ms
+step:1070/1600 train_time:52005ms step_avg:48.60ms
+step:1071/1600 train_time:52094ms step_avg:48.64ms
+step:1072/1600 train_time:52181ms step_avg:48.68ms
+step:1073/1600 train_time:52269ms step_avg:48.71ms
+step:1074/1600 train_time:52355ms step_avg:48.75ms
+step:1075/1600 train_time:52444ms step_avg:48.79ms
+step:1076/1600 train_time:52530ms step_avg:48.82ms
+step:1077/1600 train_time:52618ms step_avg:48.86ms
+step:1078/1600 train_time:52703ms step_avg:48.89ms
+step:1079/1600 train_time:52795ms step_avg:48.93ms
+step:1080/1600 train_time:52880ms step_avg:48.96ms
+step:1081/1600 train_time:52969ms step_avg:49.00ms
+step:1082/1600 train_time:53054ms step_avg:49.03ms
+step:1083/1600 train_time:53143ms step_avg:49.07ms
+step:1084/1600 train_time:53228ms step_avg:49.10ms
+step:1085/1600 train_time:53317ms step_avg:49.14ms
+step:1086/1600 train_time:53403ms step_avg:49.17ms
+step:1087/1600 train_time:53491ms step_avg:49.21ms
+step:1088/1600 train_time:53577ms step_avg:49.24ms
+step:1089/1600 train_time:53665ms step_avg:49.28ms
+step:1090/1600 train_time:53751ms step_avg:49.31ms
+step:1091/1600 train_time:53839ms step_avg:49.35ms
+step:1092/1600 train_time:53924ms step_avg:49.38ms
+step:1093/1600 train_time:54013ms step_avg:49.42ms
+step:1094/1600 train_time:54099ms step_avg:49.45ms
+step:1095/1600 train_time:54188ms step_avg:49.49ms
+step:1096/1600 train_time:54273ms step_avg:49.52ms
+step:1097/1600 train_time:54362ms step_avg:49.55ms
+step:1098/1600 train_time:54447ms step_avg:49.59ms
+step:1099/1600 train_time:54535ms step_avg:49.62ms
+step:1100/1600 train_time:54620ms step_avg:49.65ms
+step:1101/1600 train_time:54709ms step_avg:49.69ms
+step:1102/1600 train_time:54793ms step_avg:49.72ms
+step:1103/1600 train_time:54882ms step_avg:49.76ms
+step:1104/1600 train_time:54967ms step_avg:49.79ms
+step:1105/1600 train_time:55056ms step_avg:49.82ms
+step:1106/1600 train_time:55141ms step_avg:49.86ms
+step:1107/1600 train_time:55230ms step_avg:49.89ms
+step:1108/1600 train_time:55316ms step_avg:49.92ms
+step:1109/1600 train_time:55405ms step_avg:49.96ms
+step:1110/1600 train_time:55490ms step_avg:49.99ms
+step:1111/1600 train_time:55579ms step_avg:50.03ms
+step:1112/1600 train_time:55663ms step_avg:50.06ms
+step:1113/1600 train_time:55752ms step_avg:50.09ms
+step:1114/1600 train_time:55838ms step_avg:50.12ms
+step:1115/1600 train_time:55926ms step_avg:50.16ms
+step:1116/1600 train_time:56011ms step_avg:50.19ms
+step:1117/1600 train_time:56101ms step_avg:50.22ms
+step:1118/1600 train_time:56186ms step_avg:50.26ms
+step:1119/1600 train_time:56274ms step_avg:50.29ms
+step:1120/1600 train_time:56361ms step_avg:50.32ms
+step:1121/1600 train_time:56449ms step_avg:50.36ms
+step:1122/1600 train_time:56534ms step_avg:50.39ms
+step:1123/1600 train_time:56622ms step_avg:50.42ms
+step:1124/1600 train_time:56708ms step_avg:50.45ms
+step:1125/1600 train_time:56796ms step_avg:50.49ms
+step:1126/1600 train_time:56882ms step_avg:50.52ms
+step:1127/1600 train_time:56970ms step_avg:50.55ms
+step:1128/1600 train_time:57055ms step_avg:50.58ms
+step:1129/1600 train_time:57144ms step_avg:50.61ms
+step:1130/1600 train_time:57230ms step_avg:50.65ms
+step:1131/1600 train_time:57319ms step_avg:50.68ms
+step:1132/1600 train_time:57404ms step_avg:50.71ms
+step:1133/1600 train_time:57492ms step_avg:50.74ms
+step:1134/1600 train_time:57578ms step_avg:50.77ms
+step:1135/1600 train_time:57666ms step_avg:50.81ms
+step:1136/1600 train_time:57753ms step_avg:50.84ms
+step:1137/1600 train_time:57841ms step_avg:50.87ms
+step:1138/1600 train_time:57927ms step_avg:50.90ms
+step:1139/1600 train_time:58015ms step_avg:50.93ms
+step:1140/1600 train_time:58100ms step_avg:50.97ms
+step:1141/1600 train_time:58189ms step_avg:51.00ms
+step:1142/1600 train_time:58274ms step_avg:51.03ms
+step:1143/1600 train_time:58362ms step_avg:51.06ms
+step:1144/1600 train_time:58447ms step_avg:51.09ms
+step:1145/1600 train_time:58535ms step_avg:51.12ms
+step:1146/1600 train_time:58621ms step_avg:51.15ms
+step:1147/1600 train_time:58709ms step_avg:51.19ms
+step:1148/1600 train_time:58795ms step_avg:51.22ms
+step:1149/1600 train_time:58883ms step_avg:51.25ms
+step:1150/1600 train_time:58969ms step_avg:51.28ms
+step:1151/1600 train_time:59056ms step_avg:51.31ms
+step:1152/1600 train_time:59141ms step_avg:51.34ms
+step:1153/1600 train_time:59231ms step_avg:51.37ms
+step:1154/1600 train_time:59319ms step_avg:51.40ms
+step:1155/1600 train_time:59407ms step_avg:51.43ms
+step:1156/1600 train_time:59491ms step_avg:51.46ms
+step:1157/1600 train_time:59581ms step_avg:51.50ms
+step:1158/1600 train_time:59666ms step_avg:51.53ms
+step:1159/1600 train_time:59754ms step_avg:51.56ms
+step:1160/1600 train_time:59840ms step_avg:51.59ms
+step:1161/1600 train_time:59929ms step_avg:51.62ms
+step:1162/1600 train_time:60014ms step_avg:51.65ms
+step:1163/1600 train_time:60102ms step_avg:51.68ms
+step:1164/1600 train_time:60188ms step_avg:51.71ms
+step:1165/1600 train_time:60276ms step_avg:51.74ms
+step:1166/1600 train_time:60361ms step_avg:51.77ms
+step:1167/1600 train_time:60449ms step_avg:51.80ms
+step:1168/1600 train_time:60536ms step_avg:51.83ms
+step:1169/1600 train_time:60624ms step_avg:51.86ms
+step:1170/1600 train_time:60710ms step_avg:51.89ms
+step:1171/1600 train_time:60799ms step_avg:51.92ms
+step:1172/1600 train_time:60885ms step_avg:51.95ms
+step:1173/1600 train_time:60973ms step_avg:51.98ms
+step:1174/1600 train_time:61058ms step_avg:52.01ms
+step:1175/1600 train_time:61147ms step_avg:52.04ms
+step:1176/1600 train_time:61233ms step_avg:52.07ms
+step:1177/1600 train_time:61321ms step_avg:52.10ms
+step:1178/1600 train_time:61407ms step_avg:52.13ms
+step:1179/1600 train_time:61495ms step_avg:52.16ms
+step:1180/1600 train_time:61580ms step_avg:52.19ms
+step:1181/1600 train_time:61670ms step_avg:52.22ms
+step:1182/1600 train_time:61755ms step_avg:52.25ms
+step:1183/1600 train_time:61844ms step_avg:52.28ms
+step:1184/1600 train_time:61929ms step_avg:52.31ms
+step:1185/1600 train_time:62017ms step_avg:52.34ms
+step:1186/1600 train_time:62104ms step_avg:52.36ms
+step:1187/1600 train_time:62192ms step_avg:52.39ms
+step:1188/1600 train_time:62278ms step_avg:52.42ms
+step:1189/1600 train_time:62367ms step_avg:52.45ms
+step:1190/1600 train_time:62452ms step_avg:52.48ms
+step:1191/1600 train_time:62541ms step_avg:52.51ms
+step:1192/1600 train_time:62625ms step_avg:52.54ms
+step:1193/1600 train_time:62713ms step_avg:52.57ms
+step:1194/1600 train_time:62798ms step_avg:52.59ms
+step:1195/1600 train_time:62887ms step_avg:52.63ms
+step:1196/1600 train_time:62972ms step_avg:52.65ms
+step:1197/1600 train_time:63060ms step_avg:52.68ms
+step:1198/1600 train_time:63146ms step_avg:52.71ms
+step:1199/1600 train_time:63234ms step_avg:52.74ms
+step:1200/1600 train_time:63319ms step_avg:52.77ms
+step:1201/1600 train_time:63408ms step_avg:52.80ms
+step:1202/1600 train_time:63494ms step_avg:52.82ms
+step:1203/1600 train_time:63582ms step_avg:52.85ms
+step:1204/1600 train_time:63668ms step_avg:52.88ms
+step:1205/1600 train_time:63756ms step_avg:52.91ms
+step:1206/1600 train_time:63842ms step_avg:52.94ms
+step:1207/1600 train_time:63930ms step_avg:52.97ms
+step:1208/1600 train_time:64016ms step_avg:52.99ms
+step:1209/1600 train_time:64106ms step_avg:53.02ms
+step:1210/1600 train_time:64192ms step_avg:53.05ms
+step:1211/1600 train_time:64282ms step_avg:53.08ms
+step:1212/1600 train_time:64366ms step_avg:53.11ms
+step:1213/1600 train_time:64455ms step_avg:53.14ms
+step:1214/1600 train_time:64542ms step_avg:53.16ms
+step:1215/1600 train_time:64629ms step_avg:53.19ms
+step:1216/1600 train_time:64715ms step_avg:53.22ms
+step:1217/1600 train_time:64804ms step_avg:53.25ms
+step:1218/1600 train_time:64890ms step_avg:53.28ms
+step:1219/1600 train_time:64979ms step_avg:53.31ms
+step:1220/1600 train_time:65065ms step_avg:53.33ms
+step:1221/1600 train_time:65154ms step_avg:53.36ms
+step:1222/1600 train_time:65239ms step_avg:53.39ms
+step:1223/1600 train_time:65327ms step_avg:53.42ms
+step:1224/1600 train_time:65413ms step_avg:53.44ms
+step:1225/1600 train_time:65501ms step_avg:53.47ms
+step:1226/1600 train_time:65588ms step_avg:53.50ms
+step:1227/1600 train_time:65677ms step_avg:53.53ms
+step:1228/1600 train_time:65762ms step_avg:53.55ms
+step:1229/1600 train_time:65851ms step_avg:53.58ms
+step:1230/1600 train_time:65937ms step_avg:53.61ms
+step:1231/1600 train_time:66025ms step_avg:53.64ms
+step:1232/1600 train_time:66111ms step_avg:53.66ms
+step:1233/1600 train_time:66200ms step_avg:53.69ms
+step:1234/1600 train_time:66285ms step_avg:53.72ms
+step:1235/1600 train_time:66373ms step_avg:53.74ms
+step:1236/1600 train_time:66458ms step_avg:53.77ms
+step:1237/1600 train_time:66547ms step_avg:53.80ms
+step:1238/1600 train_time:66633ms step_avg:53.82ms
+step:1239/1600 train_time:66722ms step_avg:53.85ms
+step:1240/1600 train_time:66808ms step_avg:53.88ms
+step:1241/1600 train_time:66898ms step_avg:53.91ms
+step:1242/1600 train_time:66984ms step_avg:53.93ms
+step:1243/1600 train_time:67072ms step_avg:53.96ms
+step:1244/1600 train_time:67157ms step_avg:53.99ms
+step:1245/1600 train_time:67246ms step_avg:54.01ms
+step:1246/1600 train_time:67331ms step_avg:54.04ms
+step:1247/1600 train_time:67420ms step_avg:54.07ms
+step:1248/1600 train_time:67505ms step_avg:54.09ms
+step:1249/1600 train_time:67593ms step_avg:54.12ms
+step:1250/1600 train_time:67679ms step_avg:54.14ms
+step:1250/1600 val_loss:3.4172 train_time:67749ms step_avg:54.20ms
+step:1251/1600 train_time:67770ms step_avg:54.17ms
+step:1252/1600 train_time:67857ms step_avg:54.20ms
+step:1253/1600 train_time:67947ms step_avg:54.23ms
+step:1254/1600 train_time:68032ms step_avg:54.25ms
+step:1255/1600 train_time:68120ms step_avg:54.28ms
+step:1256/1600 train_time:68205ms step_avg:54.30ms
+step:1257/1600 train_time:68293ms step_avg:54.33ms
+step:1258/1600 train_time:68378ms step_avg:54.35ms
+step:1259/1600 train_time:68466ms step_avg:54.38ms
+step:1260/1600 train_time:68552ms step_avg:54.41ms
+step:1261/1600 train_time:68640ms step_avg:54.43ms
+step:1262/1600 train_time:68728ms step_avg:54.46ms
+step:1263/1600 train_time:68818ms step_avg:54.49ms
+step:1264/1600 train_time:68905ms step_avg:54.51ms
+step:1265/1600 train_time:68993ms step_avg:54.54ms
+step:1266/1600 train_time:69079ms step_avg:54.56ms
+step:1267/1600 train_time:69167ms step_avg:54.59ms
+step:1268/1600 train_time:69252ms step_avg:54.62ms
+step:1269/1600 train_time:69340ms step_avg:54.64ms
+step:1270/1600 train_time:69426ms step_avg:54.67ms
+step:1271/1600 train_time:69514ms step_avg:54.69ms
+step:1272/1600 train_time:69599ms step_avg:54.72ms
+step:1273/1600 train_time:69689ms step_avg:54.74ms
+step:1274/1600 train_time:69776ms step_avg:54.77ms
+step:1275/1600 train_time:69865ms step_avg:54.80ms
+step:1276/1600 train_time:69951ms step_avg:54.82ms
+step:1277/1600 train_time:70039ms step_avg:54.85ms
+step:1278/1600 train_time:70124ms step_avg:54.87ms
+step:1279/1600 train_time:70212ms step_avg:54.90ms
+step:1280/1600 train_time:70297ms step_avg:54.92ms
+step:1281/1600 train_time:70385ms step_avg:54.95ms
+step:1282/1600 train_time:70470ms step_avg:54.97ms
+step:1283/1600 train_time:70558ms step_avg:54.99ms
+step:1284/1600 train_time:70644ms step_avg:55.02ms
+step:1285/1600 train_time:70733ms step_avg:55.05ms
+step:1286/1600 train_time:70819ms step_avg:55.07ms
+step:1287/1600 train_time:70908ms step_avg:55.10ms
+step:1288/1600 train_time:70994ms step_avg:55.12ms
+step:1289/1600 train_time:71082ms step_avg:55.15ms
+step:1290/1600 train_time:71167ms step_avg:55.17ms
+step:1291/1600 train_time:71255ms step_avg:55.19ms
+step:1292/1600 train_time:71341ms step_avg:55.22ms
+step:1293/1600 train_time:71429ms step_avg:55.24ms
+step:1294/1600 train_time:71514ms step_avg:55.27ms
+step:1295/1600 train_time:71603ms step_avg:55.29ms
+step:1296/1600 train_time:71689ms step_avg:55.32ms
+step:1297/1600 train_time:71778ms step_avg:55.34ms
+step:1298/1600 train_time:71863ms step_avg:55.36ms
+step:1299/1600 train_time:71952ms step_avg:55.39ms
+step:1300/1600 train_time:72038ms step_avg:55.41ms
+step:1301/1600 train_time:72126ms step_avg:55.44ms
+step:1302/1600 train_time:72212ms step_avg:55.46ms
+step:1303/1600 train_time:72301ms step_avg:55.49ms
+step:1304/1600 train_time:72387ms step_avg:55.51ms
+step:1305/1600 train_time:72475ms step_avg:55.54ms
+step:1306/1600 train_time:72560ms step_avg:55.56ms
+step:1307/1600 train_time:72649ms step_avg:55.58ms
+step:1308/1600 train_time:72735ms step_avg:55.61ms
+step:1309/1600 train_time:72823ms step_avg:55.63ms
+step:1310/1600 train_time:72909ms step_avg:55.66ms
+step:1311/1600 train_time:72997ms step_avg:55.68ms
+step:1312/1600 train_time:73082ms step_avg:55.70ms
+step:1313/1600 train_time:73171ms step_avg:55.73ms
+step:1314/1600 train_time:73256ms step_avg:55.75ms
+step:1315/1600 train_time:73344ms step_avg:55.77ms
+step:1316/1600 train_time:73430ms step_avg:55.80ms
+step:1317/1600 train_time:73518ms step_avg:55.82ms
+step:1318/1600 train_time:73604ms step_avg:55.85ms
+step:1319/1600 train_time:73692ms step_avg:55.87ms
+step:1320/1600 train_time:73778ms step_avg:55.89ms
+step:1321/1600 train_time:73866ms step_avg:55.92ms
+step:1322/1600 train_time:73951ms step_avg:55.94ms
+step:1323/1600 train_time:74040ms step_avg:55.96ms
+step:1324/1600 train_time:74126ms step_avg:55.99ms
+step:1325/1600 train_time:74214ms step_avg:56.01ms
+step:1326/1600 train_time:74301ms step_avg:56.03ms
+step:1327/1600 train_time:74390ms step_avg:56.06ms
+step:1328/1600 train_time:74475ms step_avg:56.08ms
+step:1329/1600 train_time:74563ms step_avg:56.10ms
+step:1330/1600 train_time:74649ms step_avg:56.13ms
+step:1331/1600 train_time:74738ms step_avg:56.15ms
+step:1332/1600 train_time:74823ms step_avg:56.17ms
+step:1333/1600 train_time:74912ms step_avg:56.20ms
+step:1334/1600 train_time:74998ms step_avg:56.22ms
+step:1335/1600 train_time:75086ms step_avg:56.24ms
+step:1336/1600 train_time:75172ms step_avg:56.27ms
+step:1337/1600 train_time:75260ms step_avg:56.29ms
+step:1338/1600 train_time:75347ms step_avg:56.31ms
+step:1339/1600 train_time:75435ms step_avg:56.34ms
+step:1340/1600 train_time:75521ms step_avg:56.36ms
+step:1341/1600 train_time:75608ms step_avg:56.38ms
+step:1342/1600 train_time:75694ms step_avg:56.40ms
+step:1343/1600 train_time:75783ms step_avg:56.43ms
+step:1344/1600 train_time:75868ms step_avg:56.45ms
+step:1345/1600 train_time:75956ms step_avg:56.47ms
+step:1346/1600 train_time:76042ms step_avg:56.49ms
+step:1347/1600 train_time:76131ms step_avg:56.52ms
+step:1348/1600 train_time:76216ms step_avg:56.54ms
+step:1349/1600 train_time:76304ms step_avg:56.56ms
+step:1350/1600 train_time:76389ms step_avg:56.58ms
+step:1351/1600 train_time:76478ms step_avg:56.61ms
+step:1352/1600 train_time:76563ms step_avg:56.63ms
+step:1353/1600 train_time:76652ms step_avg:56.65ms
+step:1354/1600 train_time:76737ms step_avg:56.67ms
+step:1355/1600 train_time:76826ms step_avg:56.70ms
+step:1356/1600 train_time:76912ms step_avg:56.72ms
+step:1357/1600 train_time:77000ms step_avg:56.74ms
+step:1358/1600 train_time:77086ms step_avg:56.76ms
+step:1359/1600 train_time:77175ms step_avg:56.79ms
+step:1360/1600 train_time:77260ms step_avg:56.81ms
+step:1361/1600 train_time:77349ms step_avg:56.83ms
+step:1362/1600 train_time:77435ms step_avg:56.85ms
+step:1363/1600 train_time:77523ms step_avg:56.88ms
+step:1364/1600 train_time:77609ms step_avg:56.90ms
+step:1365/1600 train_time:77697ms step_avg:56.92ms
+step:1366/1600 train_time:77782ms step_avg:56.94ms
+step:1367/1600 train_time:77871ms step_avg:56.96ms
+step:1368/1600 train_time:77956ms step_avg:56.99ms
+step:1369/1600 train_time:78044ms step_avg:57.01ms
+step:1370/1600 train_time:78130ms step_avg:57.03ms
+step:1371/1600 train_time:78219ms step_avg:57.05ms
+step:1372/1600 train_time:78305ms step_avg:57.07ms
+step:1373/1600 train_time:78393ms step_avg:57.10ms
+step:1374/1600 train_time:78478ms step_avg:57.12ms
+step:1375/1600 train_time:78567ms step_avg:57.14ms
+step:1376/1600 train_time:78653ms step_avg:57.16ms
+step:1377/1600 train_time:78741ms step_avg:57.18ms
+step:1378/1600 train_time:78827ms step_avg:57.20ms
+step:1379/1600 train_time:78916ms step_avg:57.23ms
+step:1380/1600 train_time:79001ms step_avg:57.25ms
+step:1381/1600 train_time:79090ms step_avg:57.27ms
+step:1382/1600 train_time:79175ms step_avg:57.29ms
+step:1383/1600 train_time:79264ms step_avg:57.31ms
+step:1384/1600 train_time:79349ms step_avg:57.33ms
+step:1385/1600 train_time:79437ms step_avg:57.36ms
+step:1386/1600 train_time:79524ms step_avg:57.38ms
+step:1387/1600 train_time:79613ms step_avg:57.40ms
+step:1388/1600 train_time:79698ms step_avg:57.42ms
+step:1389/1600 train_time:79787ms step_avg:57.44ms
+step:1390/1600 train_time:79873ms step_avg:57.46ms
+step:1391/1600 train_time:79961ms step_avg:57.48ms
+step:1392/1600 train_time:80049ms step_avg:57.51ms
+step:1393/1600 train_time:80138ms step_avg:57.53ms
+step:1394/1600 train_time:80224ms step_avg:57.55ms
+step:1395/1600 train_time:80312ms step_avg:57.57ms
+step:1396/1600 train_time:80397ms step_avg:57.59ms
+step:1397/1600 train_time:80485ms step_avg:57.61ms
+step:1398/1600 train_time:80572ms step_avg:57.63ms
+step:1399/1600 train_time:80659ms step_avg:57.65ms
+step:1400/1600 train_time:80744ms step_avg:57.67ms
+step:1401/1600 train_time:80832ms step_avg:57.70ms
+step:1402/1600 train_time:80918ms step_avg:57.72ms
+step:1403/1600 train_time:81006ms step_avg:57.74ms
+step:1404/1600 train_time:81092ms step_avg:57.76ms
+step:1405/1600 train_time:81181ms step_avg:57.78ms
+step:1406/1600 train_time:81267ms step_avg:57.80ms
+step:1407/1600 train_time:81355ms step_avg:57.82ms
+step:1408/1600 train_time:81440ms step_avg:57.84ms
+step:1409/1600 train_time:81529ms step_avg:57.86ms
+step:1410/1600 train_time:81614ms step_avg:57.88ms
+step:1411/1600 train_time:81703ms step_avg:57.90ms
+step:1412/1600 train_time:81789ms step_avg:57.92ms
+step:1413/1600 train_time:81877ms step_avg:57.95ms
+step:1414/1600 train_time:81963ms step_avg:57.97ms
+step:1415/1600 train_time:82051ms step_avg:57.99ms
+step:1416/1600 train_time:82137ms step_avg:58.01ms
+step:1417/1600 train_time:82225ms step_avg:58.03ms
+step:1418/1600 train_time:82310ms step_avg:58.05ms
+step:1419/1600 train_time:82398ms step_avg:58.07ms
+step:1420/1600 train_time:82484ms step_avg:58.09ms
+step:1421/1600 train_time:82573ms step_avg:58.11ms
+step:1422/1600 train_time:82657ms step_avg:58.13ms
+step:1423/1600 train_time:82746ms step_avg:58.15ms
+step:1424/1600 train_time:82831ms step_avg:58.17ms
+step:1425/1600 train_time:82921ms step_avg:58.19ms
+step:1426/1600 train_time:83006ms step_avg:58.21ms
+step:1427/1600 train_time:83094ms step_avg:58.23ms
+step:1428/1600 train_time:83179ms step_avg:58.25ms
+step:1429/1600 train_time:83268ms step_avg:58.27ms
+step:1430/1600 train_time:83354ms step_avg:58.29ms
+step:1431/1600 train_time:83442ms step_avg:58.31ms
+step:1432/1600 train_time:83528ms step_avg:58.33ms
+step:1433/1600 train_time:83617ms step_avg:58.35ms
+step:1434/1600 train_time:83702ms step_avg:58.37ms
+step:1435/1600 train_time:83791ms step_avg:58.39ms
+step:1436/1600 train_time:83876ms step_avg:58.41ms
+step:1437/1600 train_time:83964ms step_avg:58.43ms
+step:1438/1600 train_time:84050ms step_avg:58.45ms
+step:1439/1600 train_time:84138ms step_avg:58.47ms
+step:1440/1600 train_time:84224ms step_avg:58.49ms
+step:1441/1600 train_time:84312ms step_avg:58.51ms
+step:1442/1600 train_time:84398ms step_avg:58.53ms
+step:1443/1600 train_time:84487ms step_avg:58.55ms
+step:1444/1600 train_time:84573ms step_avg:58.57ms
+step:1445/1600 train_time:84661ms step_avg:58.59ms
+step:1446/1600 train_time:84746ms step_avg:58.61ms
+step:1447/1600 train_time:84835ms step_avg:58.63ms
+step:1448/1600 train_time:84920ms step_avg:58.65ms
+step:1449/1600 train_time:85009ms step_avg:58.67ms
+step:1450/1600 train_time:85094ms step_avg:58.69ms
+step:1451/1600 train_time:85183ms step_avg:58.71ms
+step:1452/1600 train_time:85267ms step_avg:58.72ms
+step:1453/1600 train_time:85356ms step_avg:58.74ms
+step:1454/1600 train_time:85442ms step_avg:58.76ms
+step:1455/1600 train_time:85530ms step_avg:58.78ms
+step:1456/1600 train_time:85616ms step_avg:58.80ms
+step:1457/1600 train_time:85703ms step_avg:58.82ms
+step:1458/1600 train_time:85789ms step_avg:58.84ms
+step:1459/1600 train_time:85878ms step_avg:58.86ms
+step:1460/1600 train_time:85963ms step_avg:58.88ms
+step:1461/1600 train_time:86051ms step_avg:58.90ms
+step:1462/1600 train_time:86137ms step_avg:58.92ms
+step:1463/1600 train_time:86226ms step_avg:58.94ms
+step:1464/1600 train_time:86311ms step_avg:58.96ms
+step:1465/1600 train_time:86399ms step_avg:58.98ms
+step:1466/1600 train_time:86486ms step_avg:58.99ms
+step:1467/1600 train_time:86574ms step_avg:59.01ms
+step:1468/1600 train_time:86660ms step_avg:59.03ms
+step:1469/1600 train_time:86748ms step_avg:59.05ms
+step:1470/1600 train_time:86833ms step_avg:59.07ms
+step:1471/1600 train_time:86921ms step_avg:59.09ms
+step:1472/1600 train_time:87008ms step_avg:59.11ms
+step:1473/1600 train_time:87097ms step_avg:59.13ms
+step:1474/1600 train_time:87182ms step_avg:59.15ms
+step:1475/1600 train_time:87271ms step_avg:59.17ms
+step:1476/1600 train_time:87355ms step_avg:59.18ms
+step:1477/1600 train_time:87444ms step_avg:59.20ms
+step:1478/1600 train_time:87529ms step_avg:59.22ms
+step:1479/1600 train_time:87618ms step_avg:59.24ms
+step:1480/1600 train_time:87704ms step_avg:59.26ms
+step:1481/1600 train_time:87793ms step_avg:59.28ms
+step:1482/1600 train_time:87878ms step_avg:59.30ms
+step:1483/1600 train_time:87968ms step_avg:59.32ms
+step:1484/1600 train_time:88053ms step_avg:59.33ms
+step:1485/1600 train_time:88142ms step_avg:59.35ms
+step:1486/1600 train_time:88228ms step_avg:59.37ms
+step:1487/1600 train_time:88316ms step_avg:59.39ms
+step:1488/1600 train_time:88401ms step_avg:59.41ms
+step:1489/1600 train_time:88491ms step_avg:59.43ms
+step:1490/1600 train_time:88576ms step_avg:59.45ms
+step:1491/1600 train_time:88663ms step_avg:59.47ms
+step:1492/1600 train_time:88749ms step_avg:59.48ms
+step:1493/1600 train_time:88838ms step_avg:59.50ms
+step:1494/1600 train_time:88924ms step_avg:59.52ms
+step:1495/1600 train_time:89013ms step_avg:59.54ms
+step:1496/1600 train_time:89098ms step_avg:59.56ms
+step:1497/1600 train_time:89188ms step_avg:59.58ms
+step:1498/1600 train_time:89275ms step_avg:59.60ms
+step:1499/1600 train_time:89362ms step_avg:59.61ms
+step:1500/1600 train_time:89448ms step_avg:59.63ms
+step:1500/1600 val_loss:3.3081 train_time:89517ms step_avg:59.68ms
+step:1501/1600 train_time:89537ms step_avg:59.65ms
+step:1502/1600 train_time:89625ms step_avg:59.67ms
+step:1503/1600 train_time:89715ms step_avg:59.69ms
+step:1504/1600 train_time:89801ms step_avg:59.71ms
+step:1505/1600 train_time:89888ms step_avg:59.73ms
+step:1506/1600 train_time:89973ms step_avg:59.74ms
+step:1507/1600 train_time:90062ms step_avg:59.76ms
+step:1508/1600 train_time:90147ms step_avg:59.78ms
+step:1509/1600 train_time:90234ms step_avg:59.80ms
+step:1510/1600 train_time:90320ms step_avg:59.81ms
+step:1511/1600 train_time:90408ms step_avg:59.83ms
+step:1512/1600 train_time:90495ms step_avg:59.85ms
+step:1513/1600 train_time:90585ms step_avg:59.87ms
+step:1514/1600 train_time:90672ms step_avg:59.89ms
+step:1515/1600 train_time:90761ms step_avg:59.91ms
+step:1516/1600 train_time:90846ms step_avg:59.92ms
+step:1517/1600 train_time:90935ms step_avg:59.94ms
+step:1518/1600 train_time:91020ms step_avg:59.96ms
+step:1519/1600 train_time:91108ms step_avg:59.98ms
+step:1520/1600 train_time:91193ms step_avg:60.00ms
+step:1521/1600 train_time:91281ms step_avg:60.01ms
+step:1522/1600 train_time:91366ms step_avg:60.03ms
+step:1523/1600 train_time:91456ms step_avg:60.05ms
+step:1524/1600 train_time:91541ms step_avg:60.07ms
+step:1525/1600 train_time:91631ms step_avg:60.09ms
+step:1526/1600 train_time:91717ms step_avg:60.10ms
+step:1527/1600 train_time:91806ms step_avg:60.12ms
+step:1528/1600 train_time:91891ms step_avg:60.14ms
+step:1529/1600 train_time:91980ms step_avg:60.16ms
+step:1530/1600 train_time:92064ms step_avg:60.17ms
+step:1531/1600 train_time:92152ms step_avg:60.19ms
+step:1532/1600 train_time:92237ms step_avg:60.21ms
+step:1533/1600 train_time:92326ms step_avg:60.23ms
+step:1534/1600 train_time:92411ms step_avg:60.24ms
+step:1535/1600 train_time:92501ms step_avg:60.26ms
+step:1536/1600 train_time:92587ms step_avg:60.28ms
+step:1537/1600 train_time:92676ms step_avg:60.30ms
+step:1538/1600 train_time:92762ms step_avg:60.31ms
+step:1539/1600 train_time:92850ms step_avg:60.33ms
+step:1540/1600 train_time:92936ms step_avg:60.35ms
+step:1541/1600 train_time:93024ms step_avg:60.37ms
+step:1542/1600 train_time:93109ms step_avg:60.38ms
+step:1543/1600 train_time:93197ms step_avg:60.40ms
+step:1544/1600 train_time:93282ms step_avg:60.42ms
+step:1545/1600 train_time:93370ms step_avg:60.43ms
+step:1546/1600 train_time:93456ms step_avg:60.45ms
+step:1547/1600 train_time:93545ms step_avg:60.47ms
+step:1548/1600 train_time:93631ms step_avg:60.49ms
+step:1549/1600 train_time:93720ms step_avg:60.50ms
+step:1550/1600 train_time:93806ms step_avg:60.52ms
+step:1551/1600 train_time:93895ms step_avg:60.54ms
+step:1552/1600 train_time:93980ms step_avg:60.55ms
+step:1553/1600 train_time:94069ms step_avg:60.57ms
+step:1554/1600 train_time:94154ms step_avg:60.59ms
+step:1555/1600 train_time:94242ms step_avg:60.61ms
+step:1556/1600 train_time:94328ms step_avg:60.62ms
+step:1557/1600 train_time:94416ms step_avg:60.64ms
+step:1558/1600 train_time:94502ms step_avg:60.66ms
+step:1559/1600 train_time:94590ms step_avg:60.67ms
+step:1560/1600 train_time:94677ms step_avg:60.69ms
+step:1561/1600 train_time:94771ms step_avg:60.71ms
+step:1562/1600 train_time:94857ms step_avg:60.73ms
+step:1563/1600 train_time:94945ms step_avg:60.75ms
+step:1564/1600 train_time:95031ms step_avg:60.76ms
+step:1565/1600 train_time:95119ms step_avg:60.78ms
+step:1566/1600 train_time:95205ms step_avg:60.80ms
+step:1567/1600 train_time:95294ms step_avg:60.81ms
+step:1568/1600 train_time:95380ms step_avg:60.83ms
+step:1569/1600 train_time:95469ms step_avg:60.85ms
+step:1570/1600 train_time:95555ms step_avg:60.86ms
+step:1571/1600 train_time:95644ms step_avg:60.88ms
+step:1572/1600 train_time:95730ms step_avg:60.90ms
+step:1573/1600 train_time:95819ms step_avg:60.91ms
+step:1574/1600 train_time:95904ms step_avg:60.93ms
+step:1575/1600 train_time:95993ms step_avg:60.95ms
+step:1576/1600 train_time:96079ms step_avg:60.96ms
+step:1577/1600 train_time:96169ms step_avg:60.98ms
+step:1578/1600 train_time:96253ms step_avg:61.00ms
+step:1579/1600 train_time:96342ms step_avg:61.01ms
+step:1580/1600 train_time:96428ms step_avg:61.03ms
+step:1581/1600 train_time:96517ms step_avg:61.05ms
+step:1582/1600 train_time:96604ms step_avg:61.06ms
+step:1583/1600 train_time:96693ms step_avg:61.08ms
+step:1584/1600 train_time:96779ms step_avg:61.10ms
+step:1585/1600 train_time:96868ms step_avg:61.12ms
+step:1586/1600 train_time:96954ms step_avg:61.13ms
+step:1587/1600 train_time:97042ms step_avg:61.15ms
+step:1588/1600 train_time:97128ms step_avg:61.16ms
+step:1589/1600 train_time:97216ms step_avg:61.18ms
+step:1590/1600 train_time:97302ms step_avg:61.20ms
+step:1591/1600 train_time:97390ms step_avg:61.21ms
+step:1592/1600 train_time:97477ms step_avg:61.23ms
+step:1593/1600 train_time:97566ms step_avg:61.25ms
+step:1594/1600 train_time:97652ms step_avg:61.26ms
+step:1595/1600 train_time:97741ms step_avg:61.28ms
+step:1596/1600 train_time:97827ms step_avg:61.29ms
+step:1597/1600 train_time:97915ms step_avg:61.31ms
+step:1598/1600 train_time:98001ms step_avg:61.33ms
+step:1599/1600 train_time:98090ms step_avg:61.34ms
+step:1600/1600 train_time:98175ms step_avg:61.36ms
+step:1600/1600 val_loss:3.2787 train_time:98245ms step_avg:61.40ms
+peak memory allocated: 30181 MiB reserved: 46138 MiB

--- a/records/track_1_short/2026-01-28_TieFirstLastVEs/baseline/f1110311-fe75-483b-8c4d-017c553da194.txt
+++ b/records/track_1_short/2026-01-28_TieFirstLastVEs/baseline/f1110311-fe75-483b-8c4d-017c553da194.txt
@@ -1,0 +1,4120 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.12.12 | packaged by conda-forge | (main, Jan 26 2026, 23:51:32) [GCC 14.3.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Thu Jan 29 02:35:33 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                  Off |
+| N/A   45C    P0            139W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:06:00.0 Off |                  Off |
+| N/A   38C    P0            130W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:07:00.0 Off |                  Off |
+| N/A   45C    P0            127W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:08:00.0 Off |                  Off |
+| N/A   38C    P0            130W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:09:00.0 Off |                  Off |
+| N/A   44C    P0            130W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                  Off |
+| N/A   38C    P0            128W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                  Off |
+| N/A   44C    P0            131W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:0C:00.0 Off |                  Off |
+| N/A   38C    P0            129W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          102506      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    1   N/A  N/A          102507      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    2   N/A  N/A          102508      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    3   N/A  N/A          102509      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    4   N/A  N/A          102510      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    5   N/A  N/A          102511      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    6   N/A  N/A          102512      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    7   N/A  N/A          102513      C   .../envs/speedrun/bin/python3.12       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8299 train_time:0ms step_avg:0.03ms
+step:1/1600 train_time:57ms step_avg:57.16ms
+step:2/1600 train_time:78ms step_avg:39.18ms
+step:3/1600 train_time:96ms step_avg:32.11ms
+step:4/1600 train_time:126ms step_avg:31.59ms
+step:5/1600 train_time:156ms step_avg:31.27ms
+step:6/1600 train_time:255ms step_avg:42.42ms
+step:7/1600 train_time:270ms step_avg:38.53ms
+step:8/1600 train_time:293ms step_avg:36.61ms
+step:9/1600 train_time:323ms step_avg:35.93ms
+step:10/1600 train_time:360ms step_avg:36.04ms
+step:11/1600 train_time:391ms step_avg:35.59ms
+step:12/1600 train_time:429ms step_avg:35.71ms
+step:13/1600 train_time:459ms step_avg:35.32ms
+step:14/1600 train_time:497ms step_avg:35.48ms
+step:15/1600 train_time:527ms step_avg:35.16ms
+step:16/1600 train_time:565ms step_avg:35.29ms
+step:17/1600 train_time:595ms step_avg:35.02ms
+step:18/1600 train_time:632ms step_avg:35.12ms
+step:19/1600 train_time:663ms step_avg:34.88ms
+step:20/1600 train_time:700ms step_avg:35.02ms
+step:21/1600 train_time:731ms step_avg:34.82ms
+step:22/1600 train_time:768ms step_avg:34.93ms
+step:23/1600 train_time:799ms step_avg:34.74ms
+step:24/1600 train_time:836ms step_avg:34.85ms
+step:25/1600 train_time:867ms step_avg:34.67ms
+step:26/1600 train_time:904ms step_avg:34.78ms
+step:27/1600 train_time:935ms step_avg:34.64ms
+step:28/1600 train_time:972ms step_avg:34.72ms
+step:29/1600 train_time:1003ms step_avg:34.58ms
+step:30/1600 train_time:1040ms step_avg:34.67ms
+step:31/1600 train_time:1071ms step_avg:34.54ms
+step:32/1600 train_time:1108ms step_avg:34.62ms
+step:33/1600 train_time:1138ms step_avg:34.50ms
+step:34/1600 train_time:1176ms step_avg:34.59ms
+step:35/1600 train_time:1208ms step_avg:34.52ms
+step:36/1600 train_time:1246ms step_avg:34.61ms
+step:37/1600 train_time:1277ms step_avg:34.52ms
+step:38/1600 train_time:1315ms step_avg:34.60ms
+step:39/1600 train_time:1346ms step_avg:34.52ms
+step:40/1600 train_time:1384ms step_avg:34.59ms
+step:41/1600 train_time:1415ms step_avg:34.51ms
+step:42/1600 train_time:1452ms step_avg:34.57ms
+step:43/1600 train_time:1482ms step_avg:34.47ms
+step:44/1600 train_time:1520ms step_avg:34.54ms
+step:45/1600 train_time:1550ms step_avg:34.45ms
+step:46/1600 train_time:1588ms step_avg:34.51ms
+step:47/1600 train_time:1619ms step_avg:34.44ms
+step:48/1600 train_time:1657ms step_avg:34.51ms
+step:49/1600 train_time:1687ms step_avg:34.43ms
+step:50/1600 train_time:1725ms step_avg:34.50ms
+step:51/1600 train_time:1756ms step_avg:34.42ms
+step:52/1600 train_time:1792ms step_avg:34.47ms
+step:53/1600 train_time:1823ms step_avg:34.40ms
+step:54/1600 train_time:1861ms step_avg:34.46ms
+step:55/1600 train_time:1892ms step_avg:34.40ms
+step:56/1600 train_time:1929ms step_avg:34.44ms
+step:57/1600 train_time:1960ms step_avg:34.38ms
+step:58/1600 train_time:1997ms step_avg:34.44ms
+step:59/1600 train_time:2028ms step_avg:34.37ms
+step:60/1600 train_time:2065ms step_avg:34.42ms
+step:61/1600 train_time:2096ms step_avg:34.36ms
+step:62/1600 train_time:2133ms step_avg:34.41ms
+step:63/1600 train_time:2164ms step_avg:34.35ms
+step:64/1600 train_time:2202ms step_avg:34.41ms
+step:65/1600 train_time:2233ms step_avg:34.36ms
+step:66/1600 train_time:2270ms step_avg:34.40ms
+step:67/1600 train_time:2301ms step_avg:34.34ms
+step:68/1600 train_time:2339ms step_avg:34.39ms
+step:69/1600 train_time:2370ms step_avg:34.34ms
+step:70/1600 train_time:2407ms step_avg:34.39ms
+step:71/1600 train_time:2438ms step_avg:34.34ms
+step:72/1600 train_time:2475ms step_avg:34.38ms
+step:73/1600 train_time:2506ms step_avg:34.33ms
+step:74/1600 train_time:2544ms step_avg:34.38ms
+step:75/1600 train_time:2574ms step_avg:34.33ms
+step:76/1600 train_time:2612ms step_avg:34.36ms
+step:77/1600 train_time:2642ms step_avg:34.32ms
+step:78/1600 train_time:2679ms step_avg:34.35ms
+step:79/1600 train_time:2710ms step_avg:34.31ms
+step:80/1600 train_time:2748ms step_avg:34.35ms
+step:81/1600 train_time:2778ms step_avg:34.30ms
+step:82/1600 train_time:2815ms step_avg:34.33ms
+step:83/1600 train_time:2846ms step_avg:34.29ms
+step:84/1600 train_time:2883ms step_avg:34.33ms
+step:85/1600 train_time:2914ms step_avg:34.28ms
+step:86/1600 train_time:2951ms step_avg:34.32ms
+step:87/1600 train_time:2982ms step_avg:34.27ms
+step:88/1600 train_time:3019ms step_avg:34.31ms
+step:89/1600 train_time:3050ms step_avg:34.27ms
+step:90/1600 train_time:3087ms step_avg:34.31ms
+step:91/1600 train_time:3119ms step_avg:34.27ms
+step:92/1600 train_time:3156ms step_avg:34.31ms
+step:93/1600 train_time:3187ms step_avg:34.27ms
+step:94/1600 train_time:3225ms step_avg:34.31ms
+step:95/1600 train_time:3256ms step_avg:34.27ms
+step:96/1600 train_time:3293ms step_avg:34.31ms
+step:97/1600 train_time:3324ms step_avg:34.27ms
+step:98/1600 train_time:3361ms step_avg:34.30ms
+step:99/1600 train_time:3393ms step_avg:34.27ms
+step:100/1600 train_time:3430ms step_avg:34.30ms
+step:101/1600 train_time:3461ms step_avg:34.26ms
+step:102/1600 train_time:3498ms step_avg:34.30ms
+step:103/1600 train_time:3529ms step_avg:34.26ms
+step:104/1600 train_time:3566ms step_avg:34.29ms
+step:105/1600 train_time:3597ms step_avg:34.26ms
+step:106/1600 train_time:3634ms step_avg:34.29ms
+step:107/1600 train_time:3665ms step_avg:34.25ms
+step:108/1600 train_time:3702ms step_avg:34.28ms
+step:109/1600 train_time:3733ms step_avg:34.25ms
+step:110/1600 train_time:3771ms step_avg:34.28ms
+step:111/1600 train_time:3802ms step_avg:34.25ms
+step:112/1600 train_time:3839ms step_avg:34.28ms
+step:113/1600 train_time:3870ms step_avg:34.25ms
+step:114/1600 train_time:3908ms step_avg:34.28ms
+step:115/1600 train_time:3938ms step_avg:34.25ms
+step:116/1600 train_time:3975ms step_avg:34.27ms
+step:117/1600 train_time:4006ms step_avg:34.24ms
+step:118/1600 train_time:4043ms step_avg:34.27ms
+step:119/1600 train_time:4074ms step_avg:34.24ms
+step:120/1600 train_time:4112ms step_avg:34.26ms
+step:121/1600 train_time:4142ms step_avg:34.23ms
+step:122/1600 train_time:4180ms step_avg:34.26ms
+step:123/1600 train_time:4211ms step_avg:34.23ms
+step:124/1600 train_time:4249ms step_avg:34.26ms
+step:125/1600 train_time:4279ms step_avg:34.23ms
+step:126/1600 train_time:4317ms step_avg:34.26ms
+step:127/1600 train_time:4347ms step_avg:34.23ms
+step:128/1600 train_time:4384ms step_avg:34.25ms
+step:129/1600 train_time:4415ms step_avg:34.22ms
+step:130/1600 train_time:4452ms step_avg:34.25ms
+step:131/1600 train_time:4483ms step_avg:34.22ms
+step:132/1600 train_time:4520ms step_avg:34.24ms
+step:133/1600 train_time:4551ms step_avg:34.22ms
+step:134/1600 train_time:4589ms step_avg:34.24ms
+step:135/1600 train_time:4619ms step_avg:34.22ms
+step:136/1600 train_time:4657ms step_avg:34.24ms
+step:137/1600 train_time:4687ms step_avg:34.21ms
+step:138/1600 train_time:4725ms step_avg:34.24ms
+step:139/1600 train_time:4755ms step_avg:34.21ms
+step:140/1600 train_time:4792ms step_avg:34.23ms
+step:141/1600 train_time:4822ms step_avg:34.20ms
+step:142/1600 train_time:4860ms step_avg:34.22ms
+step:143/1600 train_time:4891ms step_avg:34.20ms
+step:144/1600 train_time:4929ms step_avg:34.23ms
+step:145/1600 train_time:4959ms step_avg:34.20ms
+step:146/1600 train_time:4997ms step_avg:34.23ms
+step:147/1600 train_time:5028ms step_avg:34.20ms
+step:148/1600 train_time:5065ms step_avg:34.22ms
+step:149/1600 train_time:5096ms step_avg:34.20ms
+step:150/1600 train_time:5133ms step_avg:34.22ms
+step:151/1600 train_time:5164ms step_avg:34.20ms
+step:152/1600 train_time:5201ms step_avg:34.22ms
+step:153/1600 train_time:5232ms step_avg:34.20ms
+step:154/1600 train_time:5269ms step_avg:34.22ms
+step:155/1600 train_time:5300ms step_avg:34.19ms
+step:156/1600 train_time:5338ms step_avg:34.22ms
+step:157/1600 train_time:5368ms step_avg:34.19ms
+step:158/1600 train_time:5405ms step_avg:34.21ms
+step:159/1600 train_time:5436ms step_avg:34.19ms
+step:160/1600 train_time:5473ms step_avg:34.21ms
+step:161/1600 train_time:5504ms step_avg:34.19ms
+step:162/1600 train_time:5541ms step_avg:34.20ms
+step:163/1600 train_time:5572ms step_avg:34.18ms
+step:164/1600 train_time:5610ms step_avg:34.20ms
+step:165/1600 train_time:5640ms step_avg:34.18ms
+step:166/1600 train_time:5677ms step_avg:34.20ms
+step:167/1600 train_time:5708ms step_avg:34.18ms
+step:168/1600 train_time:5746ms step_avg:34.20ms
+step:169/1600 train_time:5776ms step_avg:34.18ms
+step:170/1600 train_time:5814ms step_avg:34.20ms
+step:171/1600 train_time:5844ms step_avg:34.18ms
+step:172/1600 train_time:5881ms step_avg:34.19ms
+step:173/1600 train_time:5912ms step_avg:34.17ms
+step:174/1600 train_time:5949ms step_avg:34.19ms
+step:175/1600 train_time:5979ms step_avg:34.17ms
+step:176/1600 train_time:6017ms step_avg:34.19ms
+step:177/1600 train_time:6047ms step_avg:34.16ms
+step:178/1600 train_time:6084ms step_avg:34.18ms
+step:179/1600 train_time:6115ms step_avg:34.16ms
+step:180/1600 train_time:6152ms step_avg:34.18ms
+step:181/1600 train_time:6183ms step_avg:34.16ms
+step:182/1600 train_time:6220ms step_avg:34.18ms
+step:183/1600 train_time:6251ms step_avg:34.16ms
+step:184/1600 train_time:6288ms step_avg:34.17ms
+step:185/1600 train_time:6319ms step_avg:34.15ms
+step:186/1600 train_time:6357ms step_avg:34.18ms
+step:187/1600 train_time:6387ms step_avg:34.16ms
+step:188/1600 train_time:6425ms step_avg:34.17ms
+step:189/1600 train_time:6455ms step_avg:34.15ms
+step:190/1600 train_time:6492ms step_avg:34.17ms
+step:191/1600 train_time:6523ms step_avg:34.15ms
+step:192/1600 train_time:6561ms step_avg:34.17ms
+step:193/1600 train_time:6591ms step_avg:34.15ms
+step:194/1600 train_time:6628ms step_avg:34.17ms
+step:195/1600 train_time:6659ms step_avg:34.15ms
+step:196/1600 train_time:6697ms step_avg:34.17ms
+step:197/1600 train_time:6727ms step_avg:34.15ms
+step:198/1600 train_time:6764ms step_avg:34.16ms
+step:199/1600 train_time:6795ms step_avg:34.14ms
+step:200/1600 train_time:6832ms step_avg:34.16ms
+step:201/1600 train_time:6862ms step_avg:34.14ms
+step:202/1600 train_time:6899ms step_avg:34.15ms
+step:203/1600 train_time:6929ms step_avg:34.14ms
+step:204/1600 train_time:6966ms step_avg:34.15ms
+step:205/1600 train_time:6997ms step_avg:34.13ms
+step:206/1600 train_time:7034ms step_avg:34.15ms
+step:207/1600 train_time:7065ms step_avg:34.13ms
+step:208/1600 train_time:7102ms step_avg:34.14ms
+step:209/1600 train_time:7133ms step_avg:34.13ms
+step:210/1600 train_time:7170ms step_avg:34.14ms
+step:211/1600 train_time:7201ms step_avg:34.13ms
+step:212/1600 train_time:7238ms step_avg:34.14ms
+step:213/1600 train_time:7269ms step_avg:34.12ms
+step:214/1600 train_time:7306ms step_avg:34.14ms
+step:215/1600 train_time:7336ms step_avg:34.12ms
+step:216/1600 train_time:7374ms step_avg:34.14ms
+step:217/1600 train_time:7405ms step_avg:34.12ms
+step:218/1600 train_time:7442ms step_avg:34.14ms
+step:219/1600 train_time:7473ms step_avg:34.12ms
+step:220/1600 train_time:7510ms step_avg:34.14ms
+step:221/1600 train_time:7540ms step_avg:34.12ms
+step:222/1600 train_time:7578ms step_avg:34.13ms
+step:223/1600 train_time:7608ms step_avg:34.12ms
+step:224/1600 train_time:7646ms step_avg:34.13ms
+step:225/1600 train_time:7676ms step_avg:34.12ms
+step:226/1600 train_time:7713ms step_avg:34.13ms
+step:227/1600 train_time:7744ms step_avg:34.12ms
+step:228/1600 train_time:7782ms step_avg:34.13ms
+step:229/1600 train_time:7813ms step_avg:34.12ms
+step:230/1600 train_time:7850ms step_avg:34.13ms
+step:231/1600 train_time:7880ms step_avg:34.11ms
+step:232/1600 train_time:7917ms step_avg:34.13ms
+step:233/1600 train_time:7948ms step_avg:34.11ms
+step:234/1600 train_time:7985ms step_avg:34.12ms
+step:235/1600 train_time:8015ms step_avg:34.11ms
+step:236/1600 train_time:8052ms step_avg:34.12ms
+step:237/1600 train_time:8083ms step_avg:34.10ms
+step:238/1600 train_time:8120ms step_avg:34.12ms
+step:239/1600 train_time:8151ms step_avg:34.10ms
+step:240/1600 train_time:8188ms step_avg:34.12ms
+step:241/1600 train_time:8218ms step_avg:34.10ms
+step:242/1600 train_time:8256ms step_avg:34.11ms
+step:243/1600 train_time:8286ms step_avg:34.10ms
+step:244/1600 train_time:8323ms step_avg:34.11ms
+step:245/1600 train_time:8354ms step_avg:34.10ms
+step:246/1600 train_time:8391ms step_avg:34.11ms
+step:247/1600 train_time:8422ms step_avg:34.10ms
+step:248/1600 train_time:8459ms step_avg:34.11ms
+step:249/1600 train_time:8490ms step_avg:34.10ms
+step:250/1600 train_time:8527ms step_avg:34.11ms
+step:250/1600 val_loss:4.5875 train_time:8575ms step_avg:34.30ms
+step:251/1600 train_time:8593ms step_avg:34.23ms
+step:252/1600 train_time:8609ms step_avg:34.16ms
+step:253/1600 train_time:8632ms step_avg:34.12ms
+step:254/1600 train_time:8670ms step_avg:34.13ms
+step:255/1600 train_time:8701ms step_avg:34.12ms
+step:256/1600 train_time:8739ms step_avg:34.14ms
+step:257/1600 train_time:8769ms step_avg:34.12ms
+step:258/1600 train_time:8807ms step_avg:34.13ms
+step:259/1600 train_time:8837ms step_avg:34.12ms
+step:260/1600 train_time:8875ms step_avg:34.13ms
+step:261/1600 train_time:8905ms step_avg:34.12ms
+step:262/1600 train_time:8942ms step_avg:34.13ms
+step:263/1600 train_time:8972ms step_avg:34.12ms
+step:264/1600 train_time:9010ms step_avg:34.13ms
+step:265/1600 train_time:9041ms step_avg:34.12ms
+step:266/1600 train_time:9078ms step_avg:34.13ms
+step:267/1600 train_time:9108ms step_avg:34.11ms
+step:268/1600 train_time:9145ms step_avg:34.12ms
+step:269/1600 train_time:9175ms step_avg:34.11ms
+step:270/1600 train_time:9213ms step_avg:34.12ms
+step:271/1600 train_time:9243ms step_avg:34.11ms
+step:272/1600 train_time:9280ms step_avg:34.12ms
+step:273/1600 train_time:9310ms step_avg:34.10ms
+step:274/1600 train_time:9347ms step_avg:34.11ms
+step:275/1600 train_time:9378ms step_avg:34.10ms
+step:276/1600 train_time:9415ms step_avg:34.11ms
+step:277/1600 train_time:9445ms step_avg:34.10ms
+step:278/1600 train_time:9482ms step_avg:34.11ms
+step:279/1600 train_time:9513ms step_avg:34.10ms
+step:280/1600 train_time:9552ms step_avg:34.11ms
+step:281/1600 train_time:9583ms step_avg:34.10ms
+step:282/1600 train_time:9620ms step_avg:34.11ms
+step:283/1600 train_time:9651ms step_avg:34.10ms
+step:284/1600 train_time:9689ms step_avg:34.11ms
+step:285/1600 train_time:9719ms step_avg:34.10ms
+step:286/1600 train_time:9757ms step_avg:34.11ms
+step:287/1600 train_time:9787ms step_avg:34.10ms
+step:288/1600 train_time:9824ms step_avg:34.11ms
+step:289/1600 train_time:9855ms step_avg:34.10ms
+step:290/1600 train_time:9892ms step_avg:34.11ms
+step:291/1600 train_time:9923ms step_avg:34.10ms
+step:292/1600 train_time:9960ms step_avg:34.11ms
+step:293/1600 train_time:9991ms step_avg:34.10ms
+step:294/1600 train_time:10028ms step_avg:34.11ms
+step:295/1600 train_time:10058ms step_avg:34.09ms
+step:296/1600 train_time:10095ms step_avg:34.10ms
+step:297/1600 train_time:10125ms step_avg:34.09ms
+step:298/1600 train_time:10163ms step_avg:34.10ms
+step:299/1600 train_time:10193ms step_avg:34.09ms
+step:300/1600 train_time:10230ms step_avg:34.10ms
+step:301/1600 train_time:10261ms step_avg:34.09ms
+step:302/1600 train_time:10298ms step_avg:34.10ms
+step:303/1600 train_time:10328ms step_avg:34.09ms
+step:304/1600 train_time:10365ms step_avg:34.10ms
+step:305/1600 train_time:10396ms step_avg:34.09ms
+step:306/1600 train_time:10433ms step_avg:34.09ms
+step:307/1600 train_time:10463ms step_avg:34.08ms
+step:308/1600 train_time:10501ms step_avg:34.09ms
+step:309/1600 train_time:10531ms step_avg:34.08ms
+step:310/1600 train_time:10568ms step_avg:34.09ms
+step:311/1600 train_time:10599ms step_avg:34.08ms
+step:312/1600 train_time:10636ms step_avg:34.09ms
+step:313/1600 train_time:10667ms step_avg:34.08ms
+step:314/1600 train_time:10704ms step_avg:34.09ms
+step:315/1600 train_time:10735ms step_avg:34.08ms
+step:316/1600 train_time:10772ms step_avg:34.09ms
+step:317/1600 train_time:10803ms step_avg:34.08ms
+step:318/1600 train_time:10840ms step_avg:34.09ms
+step:319/1600 train_time:10870ms step_avg:34.08ms
+step:320/1600 train_time:10907ms step_avg:34.09ms
+step:321/1600 train_time:10938ms step_avg:34.07ms
+step:322/1600 train_time:10975ms step_avg:34.08ms
+step:323/1600 train_time:11005ms step_avg:34.07ms
+step:324/1600 train_time:11042ms step_avg:34.08ms
+step:325/1600 train_time:11073ms step_avg:34.07ms
+step:326/1600 train_time:11110ms step_avg:34.08ms
+step:327/1600 train_time:11140ms step_avg:34.07ms
+step:328/1600 train_time:11177ms step_avg:34.08ms
+step:329/1600 train_time:11208ms step_avg:34.07ms
+step:330/1600 train_time:11245ms step_avg:34.08ms
+step:331/1600 train_time:11276ms step_avg:34.07ms
+step:332/1600 train_time:11313ms step_avg:34.07ms
+step:333/1600 train_time:11343ms step_avg:34.06ms
+step:334/1600 train_time:11380ms step_avg:34.07ms
+step:335/1600 train_time:11411ms step_avg:34.06ms
+step:336/1600 train_time:11448ms step_avg:34.07ms
+step:337/1600 train_time:11479ms step_avg:34.06ms
+step:338/1600 train_time:11516ms step_avg:34.07ms
+step:339/1600 train_time:11546ms step_avg:34.06ms
+step:340/1600 train_time:11584ms step_avg:34.07ms
+step:341/1600 train_time:11614ms step_avg:34.06ms
+step:342/1600 train_time:11652ms step_avg:34.07ms
+step:343/1600 train_time:11682ms step_avg:34.06ms
+step:344/1600 train_time:11720ms step_avg:34.07ms
+step:345/1600 train_time:11750ms step_avg:34.06ms
+step:346/1600 train_time:11788ms step_avg:34.07ms
+step:347/1600 train_time:11818ms step_avg:34.06ms
+step:348/1600 train_time:11856ms step_avg:34.07ms
+step:349/1600 train_time:11886ms step_avg:34.06ms
+step:350/1600 train_time:11923ms step_avg:34.07ms
+step:351/1600 train_time:11954ms step_avg:34.06ms
+step:352/1600 train_time:11991ms step_avg:34.07ms
+step:353/1600 train_time:12022ms step_avg:34.06ms
+step:354/1600 train_time:12059ms step_avg:34.06ms
+step:355/1600 train_time:12090ms step_avg:34.06ms
+step:356/1600 train_time:12126ms step_avg:34.06ms
+step:357/1600 train_time:12157ms step_avg:34.05ms
+step:358/1600 train_time:12194ms step_avg:34.06ms
+step:359/1600 train_time:12225ms step_avg:34.05ms
+step:360/1600 train_time:12262ms step_avg:34.06ms
+step:361/1600 train_time:12292ms step_avg:34.05ms
+step:362/1600 train_time:12330ms step_avg:34.06ms
+step:363/1600 train_time:12360ms step_avg:34.05ms
+step:364/1600 train_time:12397ms step_avg:34.06ms
+step:365/1600 train_time:12428ms step_avg:34.05ms
+step:366/1600 train_time:12465ms step_avg:34.06ms
+step:367/1600 train_time:12496ms step_avg:34.05ms
+step:368/1600 train_time:12533ms step_avg:34.06ms
+step:369/1600 train_time:12563ms step_avg:34.05ms
+step:370/1600 train_time:12600ms step_avg:34.05ms
+step:371/1600 train_time:12630ms step_avg:34.04ms
+step:372/1600 train_time:12667ms step_avg:34.05ms
+step:373/1600 train_time:12698ms step_avg:34.04ms
+step:374/1600 train_time:12735ms step_avg:34.05ms
+step:375/1600 train_time:12766ms step_avg:34.04ms
+step:376/1600 train_time:12803ms step_avg:34.05ms
+step:377/1600 train_time:12834ms step_avg:34.04ms
+step:378/1600 train_time:12870ms step_avg:34.05ms
+step:379/1600 train_time:12901ms step_avg:34.04ms
+step:380/1600 train_time:12939ms step_avg:34.05ms
+step:381/1600 train_time:12969ms step_avg:34.04ms
+step:382/1600 train_time:13007ms step_avg:34.05ms
+step:383/1600 train_time:13037ms step_avg:34.04ms
+step:384/1600 train_time:13074ms step_avg:34.05ms
+step:385/1600 train_time:13105ms step_avg:34.04ms
+step:386/1600 train_time:13142ms step_avg:34.05ms
+step:387/1600 train_time:13173ms step_avg:34.04ms
+step:388/1600 train_time:13210ms step_avg:34.05ms
+step:389/1600 train_time:13241ms step_avg:34.04ms
+step:390/1600 train_time:13278ms step_avg:34.05ms
+step:391/1600 train_time:13309ms step_avg:34.04ms
+step:392/1600 train_time:13347ms step_avg:34.05ms
+step:393/1600 train_time:13377ms step_avg:34.04ms
+step:394/1600 train_time:13414ms step_avg:34.05ms
+step:395/1600 train_time:13445ms step_avg:34.04ms
+step:396/1600 train_time:13481ms step_avg:34.04ms
+step:397/1600 train_time:13512ms step_avg:34.04ms
+step:398/1600 train_time:13549ms step_avg:34.04ms
+step:399/1600 train_time:13580ms step_avg:34.03ms
+step:400/1600 train_time:13617ms step_avg:34.04ms
+step:401/1600 train_time:13648ms step_avg:34.03ms
+step:402/1600 train_time:13685ms step_avg:34.04ms
+step:403/1600 train_time:13715ms step_avg:34.03ms
+step:404/1600 train_time:13752ms step_avg:34.04ms
+step:405/1600 train_time:13783ms step_avg:34.03ms
+step:406/1600 train_time:13820ms step_avg:34.04ms
+step:407/1600 train_time:13851ms step_avg:34.03ms
+step:408/1600 train_time:13887ms step_avg:34.04ms
+step:409/1600 train_time:13918ms step_avg:34.03ms
+step:410/1600 train_time:13955ms step_avg:34.04ms
+step:411/1600 train_time:13986ms step_avg:34.03ms
+step:412/1600 train_time:14023ms step_avg:34.04ms
+step:413/1600 train_time:14054ms step_avg:34.03ms
+step:414/1600 train_time:14091ms step_avg:34.04ms
+step:415/1600 train_time:14121ms step_avg:34.03ms
+step:416/1600 train_time:14159ms step_avg:34.04ms
+step:417/1600 train_time:14189ms step_avg:34.03ms
+step:418/1600 train_time:14226ms step_avg:34.03ms
+step:419/1600 train_time:14257ms step_avg:34.03ms
+step:420/1600 train_time:14294ms step_avg:34.03ms
+step:421/1600 train_time:14324ms step_avg:34.02ms
+step:422/1600 train_time:14361ms step_avg:34.03ms
+step:423/1600 train_time:14392ms step_avg:34.02ms
+step:424/1600 train_time:14431ms step_avg:34.03ms
+step:425/1600 train_time:14460ms step_avg:34.02ms
+step:426/1600 train_time:14498ms step_avg:34.03ms
+step:427/1600 train_time:14527ms step_avg:34.02ms
+step:428/1600 train_time:14565ms step_avg:34.03ms
+step:429/1600 train_time:14595ms step_avg:34.02ms
+step:430/1600 train_time:14633ms step_avg:34.03ms
+step:431/1600 train_time:14663ms step_avg:34.02ms
+step:432/1600 train_time:14701ms step_avg:34.03ms
+step:433/1600 train_time:14730ms step_avg:34.02ms
+step:434/1600 train_time:14768ms step_avg:34.03ms
+step:435/1600 train_time:14798ms step_avg:34.02ms
+step:436/1600 train_time:14836ms step_avg:34.03ms
+step:437/1600 train_time:14865ms step_avg:34.02ms
+step:438/1600 train_time:14903ms step_avg:34.02ms
+step:439/1600 train_time:14933ms step_avg:34.02ms
+step:440/1600 train_time:14970ms step_avg:34.02ms
+step:441/1600 train_time:15000ms step_avg:34.01ms
+step:442/1600 train_time:15038ms step_avg:34.02ms
+step:443/1600 train_time:15068ms step_avg:34.01ms
+step:444/1600 train_time:15106ms step_avg:34.02ms
+step:445/1600 train_time:15136ms step_avg:34.01ms
+step:446/1600 train_time:15174ms step_avg:34.02ms
+step:447/1600 train_time:15203ms step_avg:34.01ms
+step:448/1600 train_time:15241ms step_avg:34.02ms
+step:449/1600 train_time:15271ms step_avg:34.01ms
+step:450/1600 train_time:15309ms step_avg:34.02ms
+step:451/1600 train_time:15339ms step_avg:34.01ms
+step:452/1600 train_time:15377ms step_avg:34.02ms
+step:453/1600 train_time:15407ms step_avg:34.01ms
+step:454/1600 train_time:15445ms step_avg:34.02ms
+step:455/1600 train_time:15475ms step_avg:34.01ms
+step:456/1600 train_time:15514ms step_avg:34.02ms
+step:457/1600 train_time:15544ms step_avg:34.01ms
+step:458/1600 train_time:15581ms step_avg:34.02ms
+step:459/1600 train_time:15611ms step_avg:34.01ms
+step:460/1600 train_time:15649ms step_avg:34.02ms
+step:461/1600 train_time:15679ms step_avg:34.01ms
+step:462/1600 train_time:15717ms step_avg:34.02ms
+step:463/1600 train_time:15747ms step_avg:34.01ms
+step:464/1600 train_time:15785ms step_avg:34.02ms
+step:465/1600 train_time:15815ms step_avg:34.01ms
+step:466/1600 train_time:15853ms step_avg:34.02ms
+step:467/1600 train_time:15883ms step_avg:34.01ms
+step:468/1600 train_time:15921ms step_avg:34.02ms
+step:469/1600 train_time:15951ms step_avg:34.01ms
+step:470/1600 train_time:15989ms step_avg:34.02ms
+step:471/1600 train_time:16018ms step_avg:34.01ms
+step:472/1600 train_time:16056ms step_avg:34.02ms
+step:473/1600 train_time:16086ms step_avg:34.01ms
+step:474/1600 train_time:16124ms step_avg:34.02ms
+step:475/1600 train_time:16154ms step_avg:34.01ms
+step:476/1600 train_time:16191ms step_avg:34.01ms
+step:477/1600 train_time:16221ms step_avg:34.01ms
+step:478/1600 train_time:16258ms step_avg:34.01ms
+step:479/1600 train_time:16288ms step_avg:34.00ms
+step:480/1600 train_time:16326ms step_avg:34.01ms
+step:481/1600 train_time:16357ms step_avg:34.01ms
+step:482/1600 train_time:16395ms step_avg:34.01ms
+step:483/1600 train_time:16425ms step_avg:34.01ms
+step:484/1600 train_time:16462ms step_avg:34.01ms
+step:485/1600 train_time:16492ms step_avg:34.00ms
+step:486/1600 train_time:16530ms step_avg:34.01ms
+step:487/1600 train_time:16560ms step_avg:34.00ms
+step:488/1600 train_time:16598ms step_avg:34.01ms
+step:489/1600 train_time:16627ms step_avg:34.00ms
+step:490/1600 train_time:16665ms step_avg:34.01ms
+step:491/1600 train_time:16695ms step_avg:34.00ms
+step:492/1600 train_time:16733ms step_avg:34.01ms
+step:493/1600 train_time:16763ms step_avg:34.00ms
+step:494/1600 train_time:16801ms step_avg:34.01ms
+step:495/1600 train_time:16831ms step_avg:34.00ms
+step:496/1600 train_time:16869ms step_avg:34.01ms
+step:497/1600 train_time:16899ms step_avg:34.00ms
+step:498/1600 train_time:16937ms step_avg:34.01ms
+step:499/1600 train_time:16966ms step_avg:34.00ms
+step:500/1600 train_time:17004ms step_avg:34.01ms
+step:500/1600 val_loss:4.2339 train_time:17052ms step_avg:34.10ms
+step:501/1600 train_time:17073ms step_avg:34.08ms
+step:502/1600 train_time:17093ms step_avg:34.05ms
+step:503/1600 train_time:17110ms step_avg:34.02ms
+step:504/1600 train_time:17144ms step_avg:34.02ms
+step:505/1600 train_time:17175ms step_avg:34.01ms
+step:506/1600 train_time:17213ms step_avg:34.02ms
+step:507/1600 train_time:17244ms step_avg:34.01ms
+step:508/1600 train_time:17283ms step_avg:34.02ms
+step:509/1600 train_time:17313ms step_avg:34.01ms
+step:510/1600 train_time:17351ms step_avg:34.02ms
+step:511/1600 train_time:17380ms step_avg:34.01ms
+step:512/1600 train_time:17418ms step_avg:34.02ms
+step:513/1600 train_time:17447ms step_avg:34.01ms
+step:514/1600 train_time:17486ms step_avg:34.02ms
+step:515/1600 train_time:17515ms step_avg:34.01ms
+step:516/1600 train_time:17553ms step_avg:34.02ms
+step:517/1600 train_time:17583ms step_avg:34.01ms
+step:518/1600 train_time:17621ms step_avg:34.02ms
+step:519/1600 train_time:17650ms step_avg:34.01ms
+step:520/1600 train_time:17688ms step_avg:34.02ms
+step:521/1600 train_time:17760ms step_avg:34.09ms
+step:522/1600 train_time:17817ms step_avg:34.13ms
+step:523/1600 train_time:17878ms step_avg:34.18ms
+step:524/1600 train_time:17936ms step_avg:34.23ms
+step:525/1600 train_time:17999ms step_avg:34.28ms
+step:526/1600 train_time:18059ms step_avg:34.33ms
+step:527/1600 train_time:18123ms step_avg:34.39ms
+step:528/1600 train_time:18183ms step_avg:34.44ms
+step:529/1600 train_time:18245ms step_avg:34.49ms
+step:530/1600 train_time:18305ms step_avg:34.54ms
+step:531/1600 train_time:18368ms step_avg:34.59ms
+step:532/1600 train_time:18427ms step_avg:34.64ms
+step:533/1600 train_time:18490ms step_avg:34.69ms
+step:534/1600 train_time:18549ms step_avg:34.74ms
+step:535/1600 train_time:18612ms step_avg:34.79ms
+step:536/1600 train_time:18671ms step_avg:34.83ms
+step:537/1600 train_time:18734ms step_avg:34.89ms
+step:538/1600 train_time:18793ms step_avg:34.93ms
+step:539/1600 train_time:18855ms step_avg:34.98ms
+step:540/1600 train_time:18914ms step_avg:35.03ms
+step:541/1600 train_time:18977ms step_avg:35.08ms
+step:542/1600 train_time:19036ms step_avg:35.12ms
+step:543/1600 train_time:19099ms step_avg:35.17ms
+step:544/1600 train_time:19158ms step_avg:35.22ms
+step:545/1600 train_time:19221ms step_avg:35.27ms
+step:546/1600 train_time:19281ms step_avg:35.31ms
+step:547/1600 train_time:19344ms step_avg:35.36ms
+step:548/1600 train_time:19404ms step_avg:35.41ms
+step:549/1600 train_time:19466ms step_avg:35.46ms
+step:550/1600 train_time:19525ms step_avg:35.50ms
+step:551/1600 train_time:19588ms step_avg:35.55ms
+step:552/1600 train_time:19648ms step_avg:35.59ms
+step:553/1600 train_time:19710ms step_avg:35.64ms
+step:554/1600 train_time:19770ms step_avg:35.69ms
+step:555/1600 train_time:19833ms step_avg:35.73ms
+step:556/1600 train_time:19892ms step_avg:35.78ms
+step:557/1600 train_time:19955ms step_avg:35.83ms
+step:558/1600 train_time:20014ms step_avg:35.87ms
+step:559/1600 train_time:20077ms step_avg:35.92ms
+step:560/1600 train_time:20137ms step_avg:35.96ms
+step:561/1600 train_time:20199ms step_avg:36.00ms
+step:562/1600 train_time:20258ms step_avg:36.05ms
+step:563/1600 train_time:20320ms step_avg:36.09ms
+step:564/1600 train_time:20379ms step_avg:36.13ms
+step:565/1600 train_time:20442ms step_avg:36.18ms
+step:566/1600 train_time:20502ms step_avg:36.22ms
+step:567/1600 train_time:20565ms step_avg:36.27ms
+step:568/1600 train_time:20624ms step_avg:36.31ms
+step:569/1600 train_time:20687ms step_avg:36.36ms
+step:570/1600 train_time:20746ms step_avg:36.40ms
+step:571/1600 train_time:20809ms step_avg:36.44ms
+step:572/1600 train_time:20869ms step_avg:36.48ms
+step:573/1600 train_time:20932ms step_avg:36.53ms
+step:574/1600 train_time:20992ms step_avg:36.57ms
+step:575/1600 train_time:21054ms step_avg:36.62ms
+step:576/1600 train_time:21114ms step_avg:36.66ms
+step:577/1600 train_time:21177ms step_avg:36.70ms
+step:578/1600 train_time:21236ms step_avg:36.74ms
+step:579/1600 train_time:21299ms step_avg:36.79ms
+step:580/1600 train_time:21358ms step_avg:36.82ms
+step:581/1600 train_time:21421ms step_avg:36.87ms
+step:582/1600 train_time:21480ms step_avg:36.91ms
+step:583/1600 train_time:21543ms step_avg:36.95ms
+step:584/1600 train_time:21602ms step_avg:36.99ms
+step:585/1600 train_time:21665ms step_avg:37.03ms
+step:586/1600 train_time:21724ms step_avg:37.07ms
+step:587/1600 train_time:21788ms step_avg:37.12ms
+step:588/1600 train_time:21846ms step_avg:37.15ms
+step:589/1600 train_time:21909ms step_avg:37.20ms
+step:590/1600 train_time:21970ms step_avg:37.24ms
+step:591/1600 train_time:22032ms step_avg:37.28ms
+step:592/1600 train_time:22092ms step_avg:37.32ms
+step:593/1600 train_time:22155ms step_avg:37.36ms
+step:594/1600 train_time:22214ms step_avg:37.40ms
+step:595/1600 train_time:22277ms step_avg:37.44ms
+step:596/1600 train_time:22336ms step_avg:37.48ms
+step:597/1600 train_time:22399ms step_avg:37.52ms
+step:598/1600 train_time:22457ms step_avg:37.55ms
+step:599/1600 train_time:22521ms step_avg:37.60ms
+step:600/1600 train_time:22580ms step_avg:37.63ms
+step:601/1600 train_time:22642ms step_avg:37.67ms
+step:602/1600 train_time:22702ms step_avg:37.71ms
+step:603/1600 train_time:22765ms step_avg:37.75ms
+step:604/1600 train_time:22824ms step_avg:37.79ms
+step:605/1600 train_time:22887ms step_avg:37.83ms
+step:606/1600 train_time:22946ms step_avg:37.86ms
+step:607/1600 train_time:23009ms step_avg:37.91ms
+step:608/1600 train_time:23069ms step_avg:37.94ms
+step:609/1600 train_time:23132ms step_avg:37.98ms
+step:610/1600 train_time:23192ms step_avg:38.02ms
+step:611/1600 train_time:23255ms step_avg:38.06ms
+step:612/1600 train_time:23315ms step_avg:38.10ms
+step:613/1600 train_time:23376ms step_avg:38.13ms
+step:614/1600 train_time:23434ms step_avg:38.17ms
+step:615/1600 train_time:23497ms step_avg:38.21ms
+step:616/1600 train_time:23556ms step_avg:38.24ms
+step:617/1600 train_time:23619ms step_avg:38.28ms
+step:618/1600 train_time:23677ms step_avg:38.31ms
+step:619/1600 train_time:23741ms step_avg:38.35ms
+step:620/1600 train_time:23800ms step_avg:38.39ms
+step:621/1600 train_time:23863ms step_avg:38.43ms
+step:622/1600 train_time:23922ms step_avg:38.46ms
+step:623/1600 train_time:23986ms step_avg:38.50ms
+step:624/1600 train_time:24044ms step_avg:38.53ms
+step:625/1600 train_time:24107ms step_avg:38.57ms
+step:626/1600 train_time:24167ms step_avg:38.60ms
+step:627/1600 train_time:24230ms step_avg:38.64ms
+step:628/1600 train_time:24289ms step_avg:38.68ms
+step:629/1600 train_time:24352ms step_avg:38.72ms
+step:630/1600 train_time:24412ms step_avg:38.75ms
+step:631/1600 train_time:24474ms step_avg:38.79ms
+step:632/1600 train_time:24534ms step_avg:38.82ms
+step:633/1600 train_time:24596ms step_avg:38.86ms
+step:634/1600 train_time:24655ms step_avg:38.89ms
+step:635/1600 train_time:24719ms step_avg:38.93ms
+step:636/1600 train_time:24778ms step_avg:38.96ms
+step:637/1600 train_time:24841ms step_avg:39.00ms
+step:638/1600 train_time:24900ms step_avg:39.03ms
+step:639/1600 train_time:24963ms step_avg:39.07ms
+step:640/1600 train_time:25022ms step_avg:39.10ms
+step:641/1600 train_time:25085ms step_avg:39.13ms
+step:642/1600 train_time:25144ms step_avg:39.17ms
+step:643/1600 train_time:25208ms step_avg:39.20ms
+step:644/1600 train_time:25267ms step_avg:39.24ms
+step:645/1600 train_time:25331ms step_avg:39.27ms
+step:646/1600 train_time:25390ms step_avg:39.30ms
+step:647/1600 train_time:25454ms step_avg:39.34ms
+step:648/1600 train_time:25513ms step_avg:39.37ms
+step:649/1600 train_time:25575ms step_avg:39.41ms
+step:650/1600 train_time:25634ms step_avg:39.44ms
+step:651/1600 train_time:25696ms step_avg:39.47ms
+step:652/1600 train_time:25756ms step_avg:39.50ms
+step:653/1600 train_time:25819ms step_avg:39.54ms
+step:654/1600 train_time:25879ms step_avg:39.57ms
+step:655/1600 train_time:25941ms step_avg:39.60ms
+step:656/1600 train_time:26001ms step_avg:39.64ms
+step:657/1600 train_time:26063ms step_avg:39.67ms
+step:658/1600 train_time:26122ms step_avg:39.70ms
+step:659/1600 train_time:26185ms step_avg:39.74ms
+step:660/1600 train_time:26245ms step_avg:39.77ms
+step:661/1600 train_time:26308ms step_avg:39.80ms
+step:662/1600 train_time:26368ms step_avg:39.83ms
+step:663/1600 train_time:26431ms step_avg:39.87ms
+step:664/1600 train_time:26492ms step_avg:39.90ms
+step:665/1600 train_time:26553ms step_avg:39.93ms
+step:666/1600 train_time:26612ms step_avg:39.96ms
+step:667/1600 train_time:26675ms step_avg:39.99ms
+step:668/1600 train_time:26734ms step_avg:40.02ms
+step:669/1600 train_time:26798ms step_avg:40.06ms
+step:670/1600 train_time:26856ms step_avg:40.08ms
+step:671/1600 train_time:26919ms step_avg:40.12ms
+step:672/1600 train_time:26979ms step_avg:40.15ms
+step:673/1600 train_time:27041ms step_avg:40.18ms
+step:674/1600 train_time:27101ms step_avg:40.21ms
+step:675/1600 train_time:27164ms step_avg:40.24ms
+step:676/1600 train_time:27223ms step_avg:40.27ms
+step:677/1600 train_time:27287ms step_avg:40.31ms
+step:678/1600 train_time:27345ms step_avg:40.33ms
+step:679/1600 train_time:27409ms step_avg:40.37ms
+step:680/1600 train_time:27468ms step_avg:40.39ms
+step:681/1600 train_time:27531ms step_avg:40.43ms
+step:682/1600 train_time:27590ms step_avg:40.46ms
+step:683/1600 train_time:27654ms step_avg:40.49ms
+step:684/1600 train_time:27713ms step_avg:40.52ms
+step:685/1600 train_time:27776ms step_avg:40.55ms
+step:686/1600 train_time:27835ms step_avg:40.58ms
+step:687/1600 train_time:27899ms step_avg:40.61ms
+step:688/1600 train_time:27958ms step_avg:40.64ms
+step:689/1600 train_time:28021ms step_avg:40.67ms
+step:690/1600 train_time:28080ms step_avg:40.70ms
+step:691/1600 train_time:28142ms step_avg:40.73ms
+step:692/1600 train_time:28202ms step_avg:40.75ms
+step:693/1600 train_time:28266ms step_avg:40.79ms
+step:694/1600 train_time:28325ms step_avg:40.81ms
+step:695/1600 train_time:28388ms step_avg:40.85ms
+step:696/1600 train_time:28447ms step_avg:40.87ms
+step:697/1600 train_time:28510ms step_avg:40.90ms
+step:698/1600 train_time:28569ms step_avg:40.93ms
+step:699/1600 train_time:28632ms step_avg:40.96ms
+step:700/1600 train_time:28691ms step_avg:40.99ms
+step:701/1600 train_time:28754ms step_avg:41.02ms
+step:702/1600 train_time:28813ms step_avg:41.04ms
+step:703/1600 train_time:28876ms step_avg:41.08ms
+step:704/1600 train_time:28936ms step_avg:41.10ms
+step:705/1600 train_time:28999ms step_avg:41.13ms
+step:706/1600 train_time:29059ms step_avg:41.16ms
+step:707/1600 train_time:29122ms step_avg:41.19ms
+step:708/1600 train_time:29181ms step_avg:41.22ms
+step:709/1600 train_time:29244ms step_avg:41.25ms
+step:710/1600 train_time:29303ms step_avg:41.27ms
+step:711/1600 train_time:29366ms step_avg:41.30ms
+step:712/1600 train_time:29425ms step_avg:41.33ms
+step:713/1600 train_time:29487ms step_avg:41.36ms
+step:714/1600 train_time:29547ms step_avg:41.38ms
+step:715/1600 train_time:29610ms step_avg:41.41ms
+step:716/1600 train_time:29671ms step_avg:41.44ms
+step:717/1600 train_time:29733ms step_avg:41.47ms
+step:718/1600 train_time:29791ms step_avg:41.49ms
+step:719/1600 train_time:29854ms step_avg:41.52ms
+step:720/1600 train_time:29913ms step_avg:41.55ms
+step:721/1600 train_time:29977ms step_avg:41.58ms
+step:722/1600 train_time:30037ms step_avg:41.60ms
+step:723/1600 train_time:30100ms step_avg:41.63ms
+step:724/1600 train_time:30159ms step_avg:41.66ms
+step:725/1600 train_time:30222ms step_avg:41.69ms
+step:726/1600 train_time:30281ms step_avg:41.71ms
+step:727/1600 train_time:30345ms step_avg:41.74ms
+step:728/1600 train_time:30404ms step_avg:41.76ms
+step:729/1600 train_time:30466ms step_avg:41.79ms
+step:730/1600 train_time:30526ms step_avg:41.82ms
+step:731/1600 train_time:30588ms step_avg:41.84ms
+step:732/1600 train_time:30648ms step_avg:41.87ms
+step:733/1600 train_time:30712ms step_avg:41.90ms
+step:734/1600 train_time:30771ms step_avg:41.92ms
+step:735/1600 train_time:30834ms step_avg:41.95ms
+step:736/1600 train_time:30893ms step_avg:41.97ms
+step:737/1600 train_time:30956ms step_avg:42.00ms
+step:738/1600 train_time:31015ms step_avg:42.03ms
+step:739/1600 train_time:31078ms step_avg:42.05ms
+step:740/1600 train_time:31137ms step_avg:42.08ms
+step:741/1600 train_time:31201ms step_avg:42.11ms
+step:742/1600 train_time:31259ms step_avg:42.13ms
+step:743/1600 train_time:31322ms step_avg:42.16ms
+step:744/1600 train_time:31382ms step_avg:42.18ms
+step:745/1600 train_time:31445ms step_avg:42.21ms
+step:746/1600 train_time:31504ms step_avg:42.23ms
+step:747/1600 train_time:31567ms step_avg:42.26ms
+step:748/1600 train_time:31627ms step_avg:42.28ms
+step:749/1600 train_time:31690ms step_avg:42.31ms
+step:750/1600 train_time:31750ms step_avg:42.33ms
+step:750/1600 val_loss:3.8916 train_time:31797ms step_avg:42.40ms
+step:751/1600 train_time:31815ms step_avg:42.36ms
+step:752/1600 train_time:31874ms step_avg:42.39ms
+step:753/1600 train_time:31938ms step_avg:42.41ms
+step:754/1600 train_time:31998ms step_avg:42.44ms
+step:755/1600 train_time:32060ms step_avg:42.46ms
+step:756/1600 train_time:32119ms step_avg:42.49ms
+step:757/1600 train_time:32182ms step_avg:42.51ms
+step:758/1600 train_time:32241ms step_avg:42.53ms
+step:759/1600 train_time:32305ms step_avg:42.56ms
+step:760/1600 train_time:32364ms step_avg:42.58ms
+step:761/1600 train_time:32426ms step_avg:42.61ms
+step:762/1600 train_time:32485ms step_avg:42.63ms
+step:763/1600 train_time:32547ms step_avg:42.66ms
+step:764/1600 train_time:32606ms step_avg:42.68ms
+step:765/1600 train_time:32668ms step_avg:42.70ms
+step:766/1600 train_time:32727ms step_avg:42.72ms
+step:767/1600 train_time:32791ms step_avg:42.75ms
+step:768/1600 train_time:32851ms step_avg:42.78ms
+step:769/1600 train_time:32915ms step_avg:42.80ms
+step:770/1600 train_time:32974ms step_avg:42.82ms
+step:771/1600 train_time:33038ms step_avg:42.85ms
+step:772/1600 train_time:33096ms step_avg:42.87ms
+step:773/1600 train_time:33159ms step_avg:42.90ms
+step:774/1600 train_time:33218ms step_avg:42.92ms
+step:775/1600 train_time:33280ms step_avg:42.94ms
+step:776/1600 train_time:33339ms step_avg:42.96ms
+step:777/1600 train_time:33402ms step_avg:42.99ms
+step:778/1600 train_time:33461ms step_avg:43.01ms
+step:779/1600 train_time:33523ms step_avg:43.03ms
+step:780/1600 train_time:33582ms step_avg:43.05ms
+step:781/1600 train_time:33644ms step_avg:43.08ms
+step:782/1600 train_time:33704ms step_avg:43.10ms
+step:783/1600 train_time:33768ms step_avg:43.13ms
+step:784/1600 train_time:33828ms step_avg:43.15ms
+step:785/1600 train_time:33891ms step_avg:43.17ms
+step:786/1600 train_time:33951ms step_avg:43.19ms
+step:787/1600 train_time:34013ms step_avg:43.22ms
+step:788/1600 train_time:34073ms step_avg:43.24ms
+step:789/1600 train_time:34136ms step_avg:43.26ms
+step:790/1600 train_time:34195ms step_avg:43.28ms
+step:791/1600 train_time:34258ms step_avg:43.31ms
+step:792/1600 train_time:34317ms step_avg:43.33ms
+step:793/1600 train_time:34380ms step_avg:43.35ms
+step:794/1600 train_time:34439ms step_avg:43.37ms
+step:795/1600 train_time:34502ms step_avg:43.40ms
+step:796/1600 train_time:34561ms step_avg:43.42ms
+step:797/1600 train_time:34624ms step_avg:43.44ms
+step:798/1600 train_time:34683ms step_avg:43.46ms
+step:799/1600 train_time:34747ms step_avg:43.49ms
+step:800/1600 train_time:34807ms step_avg:43.51ms
+step:801/1600 train_time:34870ms step_avg:43.53ms
+step:802/1600 train_time:34929ms step_avg:43.55ms
+step:803/1600 train_time:34993ms step_avg:43.58ms
+step:804/1600 train_time:35052ms step_avg:43.60ms
+step:805/1600 train_time:35115ms step_avg:43.62ms
+step:806/1600 train_time:35174ms step_avg:43.64ms
+step:807/1600 train_time:35237ms step_avg:43.66ms
+step:808/1600 train_time:35296ms step_avg:43.68ms
+step:809/1600 train_time:35358ms step_avg:43.71ms
+step:810/1600 train_time:35418ms step_avg:43.73ms
+step:811/1600 train_time:35481ms step_avg:43.75ms
+step:812/1600 train_time:35541ms step_avg:43.77ms
+step:813/1600 train_time:35604ms step_avg:43.79ms
+step:814/1600 train_time:35662ms step_avg:43.81ms
+step:815/1600 train_time:35725ms step_avg:43.83ms
+step:816/1600 train_time:35785ms step_avg:43.85ms
+step:817/1600 train_time:35848ms step_avg:43.88ms
+step:818/1600 train_time:35907ms step_avg:43.90ms
+step:819/1600 train_time:35971ms step_avg:43.92ms
+step:820/1600 train_time:36030ms step_avg:43.94ms
+step:821/1600 train_time:36093ms step_avg:43.96ms
+step:822/1600 train_time:36152ms step_avg:43.98ms
+step:823/1600 train_time:36215ms step_avg:44.00ms
+step:824/1600 train_time:36274ms step_avg:44.02ms
+step:825/1600 train_time:36337ms step_avg:44.05ms
+step:826/1600 train_time:36397ms step_avg:44.06ms
+step:827/1600 train_time:36460ms step_avg:44.09ms
+step:828/1600 train_time:36519ms step_avg:44.10ms
+step:829/1600 train_time:36582ms step_avg:44.13ms
+step:830/1600 train_time:36641ms step_avg:44.15ms
+step:831/1600 train_time:36704ms step_avg:44.17ms
+step:832/1600 train_time:36763ms step_avg:44.19ms
+step:833/1600 train_time:36826ms step_avg:44.21ms
+step:834/1600 train_time:36886ms step_avg:44.23ms
+step:835/1600 train_time:36950ms step_avg:44.25ms
+step:836/1600 train_time:37009ms step_avg:44.27ms
+step:837/1600 train_time:37072ms step_avg:44.29ms
+step:838/1600 train_time:37130ms step_avg:44.31ms
+step:839/1600 train_time:37193ms step_avg:44.33ms
+step:840/1600 train_time:37252ms step_avg:44.35ms
+step:841/1600 train_time:37315ms step_avg:44.37ms
+step:842/1600 train_time:37375ms step_avg:44.39ms
+step:843/1600 train_time:37438ms step_avg:44.41ms
+step:844/1600 train_time:37498ms step_avg:44.43ms
+step:845/1600 train_time:37561ms step_avg:44.45ms
+step:846/1600 train_time:37620ms step_avg:44.47ms
+step:847/1600 train_time:37683ms step_avg:44.49ms
+step:848/1600 train_time:37742ms step_avg:44.51ms
+step:849/1600 train_time:37805ms step_avg:44.53ms
+step:850/1600 train_time:37865ms step_avg:44.55ms
+step:851/1600 train_time:37927ms step_avg:44.57ms
+step:852/1600 train_time:37987ms step_avg:44.59ms
+step:853/1600 train_time:38050ms step_avg:44.61ms
+step:854/1600 train_time:38110ms step_avg:44.62ms
+step:855/1600 train_time:38173ms step_avg:44.65ms
+step:856/1600 train_time:38231ms step_avg:44.66ms
+step:857/1600 train_time:38293ms step_avg:44.68ms
+step:858/1600 train_time:38353ms step_avg:44.70ms
+step:859/1600 train_time:38416ms step_avg:44.72ms
+step:860/1600 train_time:38475ms step_avg:44.74ms
+step:861/1600 train_time:38538ms step_avg:44.76ms
+step:862/1600 train_time:38598ms step_avg:44.78ms
+step:863/1600 train_time:38660ms step_avg:44.80ms
+step:864/1600 train_time:38720ms step_avg:44.82ms
+step:865/1600 train_time:38783ms step_avg:44.84ms
+step:866/1600 train_time:38842ms step_avg:44.85ms
+step:867/1600 train_time:38906ms step_avg:44.87ms
+step:868/1600 train_time:38966ms step_avg:44.89ms
+step:869/1600 train_time:39029ms step_avg:44.91ms
+step:870/1600 train_time:39088ms step_avg:44.93ms
+step:871/1600 train_time:39152ms step_avg:44.95ms
+step:872/1600 train_time:39211ms step_avg:44.97ms
+step:873/1600 train_time:39274ms step_avg:44.99ms
+step:874/1600 train_time:39332ms step_avg:45.00ms
+step:875/1600 train_time:39395ms step_avg:45.02ms
+step:876/1600 train_time:39454ms step_avg:45.04ms
+step:877/1600 train_time:39517ms step_avg:45.06ms
+step:878/1600 train_time:39576ms step_avg:45.07ms
+step:879/1600 train_time:39639ms step_avg:45.10ms
+step:880/1600 train_time:39698ms step_avg:45.11ms
+step:881/1600 train_time:39762ms step_avg:45.13ms
+step:882/1600 train_time:39821ms step_avg:45.15ms
+step:883/1600 train_time:39884ms step_avg:45.17ms
+step:884/1600 train_time:39943ms step_avg:45.18ms
+step:885/1600 train_time:40006ms step_avg:45.20ms
+step:886/1600 train_time:40065ms step_avg:45.22ms
+step:887/1600 train_time:40129ms step_avg:45.24ms
+step:888/1600 train_time:40188ms step_avg:45.26ms
+step:889/1600 train_time:40251ms step_avg:45.28ms
+step:890/1600 train_time:40311ms step_avg:45.29ms
+step:891/1600 train_time:40374ms step_avg:45.31ms
+step:892/1600 train_time:40433ms step_avg:45.33ms
+step:893/1600 train_time:40495ms step_avg:45.35ms
+step:894/1600 train_time:40554ms step_avg:45.36ms
+step:895/1600 train_time:40617ms step_avg:45.38ms
+step:896/1600 train_time:40677ms step_avg:45.40ms
+step:897/1600 train_time:40739ms step_avg:45.42ms
+step:898/1600 train_time:40799ms step_avg:45.43ms
+step:899/1600 train_time:40861ms step_avg:45.45ms
+step:900/1600 train_time:40921ms step_avg:45.47ms
+step:901/1600 train_time:40984ms step_avg:45.49ms
+step:902/1600 train_time:41043ms step_avg:45.50ms
+step:903/1600 train_time:41107ms step_avg:45.52ms
+step:904/1600 train_time:41166ms step_avg:45.54ms
+step:905/1600 train_time:41229ms step_avg:45.56ms
+step:906/1600 train_time:41288ms step_avg:45.57ms
+step:907/1600 train_time:41352ms step_avg:45.59ms
+step:908/1600 train_time:41411ms step_avg:45.61ms
+step:909/1600 train_time:41474ms step_avg:45.63ms
+step:910/1600 train_time:41533ms step_avg:45.64ms
+step:911/1600 train_time:41597ms step_avg:45.66ms
+step:912/1600 train_time:41656ms step_avg:45.68ms
+step:913/1600 train_time:41718ms step_avg:45.69ms
+step:914/1600 train_time:41778ms step_avg:45.71ms
+step:915/1600 train_time:41840ms step_avg:45.73ms
+step:916/1600 train_time:41900ms step_avg:45.74ms
+step:917/1600 train_time:41963ms step_avg:45.76ms
+step:918/1600 train_time:42023ms step_avg:45.78ms
+step:919/1600 train_time:42086ms step_avg:45.80ms
+step:920/1600 train_time:42145ms step_avg:45.81ms
+step:921/1600 train_time:42208ms step_avg:45.83ms
+step:922/1600 train_time:42267ms step_avg:45.84ms
+step:923/1600 train_time:42330ms step_avg:45.86ms
+step:924/1600 train_time:42390ms step_avg:45.88ms
+step:925/1600 train_time:42453ms step_avg:45.90ms
+step:926/1600 train_time:42512ms step_avg:45.91ms
+step:927/1600 train_time:42574ms step_avg:45.93ms
+step:928/1600 train_time:42633ms step_avg:45.94ms
+step:929/1600 train_time:42696ms step_avg:45.96ms
+step:930/1600 train_time:42755ms step_avg:45.97ms
+step:931/1600 train_time:42818ms step_avg:45.99ms
+step:932/1600 train_time:42877ms step_avg:46.01ms
+step:933/1600 train_time:42940ms step_avg:46.02ms
+step:934/1600 train_time:42999ms step_avg:46.04ms
+step:935/1600 train_time:43062ms step_avg:46.06ms
+step:936/1600 train_time:43121ms step_avg:46.07ms
+step:937/1600 train_time:43184ms step_avg:46.09ms
+step:938/1600 train_time:43244ms step_avg:46.10ms
+step:939/1600 train_time:43307ms step_avg:46.12ms
+step:940/1600 train_time:43367ms step_avg:46.14ms
+step:941/1600 train_time:43430ms step_avg:46.15ms
+step:942/1600 train_time:43490ms step_avg:46.17ms
+step:943/1600 train_time:43553ms step_avg:46.19ms
+step:944/1600 train_time:43612ms step_avg:46.20ms
+step:945/1600 train_time:43674ms step_avg:46.22ms
+step:946/1600 train_time:43733ms step_avg:46.23ms
+step:947/1600 train_time:43796ms step_avg:46.25ms
+step:948/1600 train_time:43855ms step_avg:46.26ms
+step:949/1600 train_time:43919ms step_avg:46.28ms
+step:950/1600 train_time:43978ms step_avg:46.29ms
+step:951/1600 train_time:44042ms step_avg:46.31ms
+step:952/1600 train_time:44101ms step_avg:46.32ms
+step:953/1600 train_time:44164ms step_avg:46.34ms
+step:954/1600 train_time:44223ms step_avg:46.36ms
+step:955/1600 train_time:44287ms step_avg:46.37ms
+step:956/1600 train_time:44346ms step_avg:46.39ms
+step:957/1600 train_time:44409ms step_avg:46.40ms
+step:958/1600 train_time:44470ms step_avg:46.42ms
+step:959/1600 train_time:44532ms step_avg:46.44ms
+step:960/1600 train_time:44591ms step_avg:46.45ms
+step:961/1600 train_time:44654ms step_avg:46.47ms
+step:962/1600 train_time:44713ms step_avg:46.48ms
+step:963/1600 train_time:44776ms step_avg:46.50ms
+step:964/1600 train_time:44834ms step_avg:46.51ms
+step:965/1600 train_time:44897ms step_avg:46.53ms
+step:966/1600 train_time:44956ms step_avg:46.54ms
+step:967/1600 train_time:45020ms step_avg:46.56ms
+step:968/1600 train_time:45079ms step_avg:46.57ms
+step:969/1600 train_time:45142ms step_avg:46.59ms
+step:970/1600 train_time:45201ms step_avg:46.60ms
+step:971/1600 train_time:45264ms step_avg:46.62ms
+step:972/1600 train_time:45324ms step_avg:46.63ms
+step:973/1600 train_time:45387ms step_avg:46.65ms
+step:974/1600 train_time:45446ms step_avg:46.66ms
+step:975/1600 train_time:45510ms step_avg:46.68ms
+step:976/1600 train_time:45569ms step_avg:46.69ms
+step:977/1600 train_time:45632ms step_avg:46.71ms
+step:978/1600 train_time:45691ms step_avg:46.72ms
+step:979/1600 train_time:45754ms step_avg:46.74ms
+step:980/1600 train_time:45813ms step_avg:46.75ms
+step:981/1600 train_time:45876ms step_avg:46.76ms
+step:982/1600 train_time:45935ms step_avg:46.78ms
+step:983/1600 train_time:45999ms step_avg:46.79ms
+step:984/1600 train_time:46057ms step_avg:46.81ms
+step:985/1600 train_time:46121ms step_avg:46.82ms
+step:986/1600 train_time:46181ms step_avg:46.84ms
+step:987/1600 train_time:46243ms step_avg:46.85ms
+step:988/1600 train_time:46303ms step_avg:46.87ms
+step:989/1600 train_time:46366ms step_avg:46.88ms
+step:990/1600 train_time:46426ms step_avg:46.89ms
+step:991/1600 train_time:46489ms step_avg:46.91ms
+step:992/1600 train_time:46548ms step_avg:46.92ms
+step:993/1600 train_time:46611ms step_avg:46.94ms
+step:994/1600 train_time:46670ms step_avg:46.95ms
+step:995/1600 train_time:46732ms step_avg:46.97ms
+step:996/1600 train_time:46791ms step_avg:46.98ms
+step:997/1600 train_time:46854ms step_avg:46.99ms
+step:998/1600 train_time:46913ms step_avg:47.01ms
+step:999/1600 train_time:46976ms step_avg:47.02ms
+step:1000/1600 train_time:47035ms step_avg:47.03ms
+step:1000/1600 val_loss:3.5995 train_time:47082ms step_avg:47.08ms
+step:1001/1600 train_time:47100ms step_avg:47.05ms
+step:1002/1600 train_time:47159ms step_avg:47.07ms
+step:1003/1600 train_time:47223ms step_avg:47.08ms
+step:1004/1600 train_time:47282ms step_avg:47.09ms
+step:1005/1600 train_time:47345ms step_avg:47.11ms
+step:1006/1600 train_time:47404ms step_avg:47.12ms
+step:1007/1600 train_time:47466ms step_avg:47.14ms
+step:1008/1600 train_time:47526ms step_avg:47.15ms
+step:1009/1600 train_time:47588ms step_avg:47.16ms
+step:1010/1600 train_time:47646ms step_avg:47.17ms
+step:1011/1600 train_time:47709ms step_avg:47.19ms
+step:1012/1600 train_time:47767ms step_avg:47.20ms
+step:1013/1600 train_time:47830ms step_avg:47.22ms
+step:1014/1600 train_time:47889ms step_avg:47.23ms
+step:1015/1600 train_time:47951ms step_avg:47.24ms
+step:1016/1600 train_time:48010ms step_avg:47.25ms
+step:1017/1600 train_time:48074ms step_avg:47.27ms
+step:1018/1600 train_time:48134ms step_avg:47.28ms
+step:1019/1600 train_time:48197ms step_avg:47.30ms
+step:1020/1600 train_time:48257ms step_avg:47.31ms
+step:1021/1600 train_time:48320ms step_avg:47.33ms
+step:1022/1600 train_time:48378ms step_avg:47.34ms
+step:1023/1600 train_time:48441ms step_avg:47.35ms
+step:1024/1600 train_time:48501ms step_avg:47.36ms
+step:1025/1600 train_time:48563ms step_avg:47.38ms
+step:1026/1600 train_time:48622ms step_avg:47.39ms
+step:1027/1600 train_time:48684ms step_avg:47.40ms
+step:1028/1600 train_time:48744ms step_avg:47.42ms
+step:1029/1600 train_time:48807ms step_avg:47.43ms
+step:1030/1600 train_time:48865ms step_avg:47.44ms
+step:1031/1600 train_time:48927ms step_avg:47.46ms
+step:1032/1600 train_time:48986ms step_avg:47.47ms
+step:1033/1600 train_time:49050ms step_avg:47.48ms
+step:1034/1600 train_time:49110ms step_avg:47.50ms
+step:1035/1600 train_time:49173ms step_avg:47.51ms
+step:1036/1600 train_time:49233ms step_avg:47.52ms
+step:1037/1600 train_time:49296ms step_avg:47.54ms
+step:1038/1600 train_time:49356ms step_avg:47.55ms
+step:1039/1600 train_time:49418ms step_avg:47.56ms
+step:1040/1600 train_time:49477ms step_avg:47.57ms
+step:1041/1600 train_time:49546ms step_avg:47.59ms
+step:1042/1600 train_time:49631ms step_avg:47.63ms
+step:1043/1600 train_time:49721ms step_avg:47.67ms
+step:1044/1600 train_time:49806ms step_avg:47.71ms
+step:1045/1600 train_time:49894ms step_avg:47.75ms
+step:1046/1600 train_time:49979ms step_avg:47.78ms
+step:1047/1600 train_time:50069ms step_avg:47.82ms
+step:1048/1600 train_time:50156ms step_avg:47.86ms
+step:1049/1600 train_time:50246ms step_avg:47.90ms
+step:1050/1600 train_time:50331ms step_avg:47.93ms
+step:1051/1600 train_time:50421ms step_avg:47.97ms
+step:1052/1600 train_time:50506ms step_avg:48.01ms
+step:1053/1600 train_time:50595ms step_avg:48.05ms
+step:1054/1600 train_time:50680ms step_avg:48.08ms
+step:1055/1600 train_time:50769ms step_avg:48.12ms
+step:1056/1600 train_time:50854ms step_avg:48.16ms
+step:1057/1600 train_time:50942ms step_avg:48.19ms
+step:1058/1600 train_time:51029ms step_avg:48.23ms
+step:1059/1600 train_time:51118ms step_avg:48.27ms
+step:1060/1600 train_time:51204ms step_avg:48.31ms
+step:1061/1600 train_time:51292ms step_avg:48.34ms
+step:1062/1600 train_time:51379ms step_avg:48.38ms
+step:1063/1600 train_time:51467ms step_avg:48.42ms
+step:1064/1600 train_time:51552ms step_avg:48.45ms
+step:1065/1600 train_time:51641ms step_avg:48.49ms
+step:1066/1600 train_time:51726ms step_avg:48.52ms
+step:1067/1600 train_time:51814ms step_avg:48.56ms
+step:1068/1600 train_time:51900ms step_avg:48.60ms
+step:1069/1600 train_time:51989ms step_avg:48.63ms
+step:1070/1600 train_time:52076ms step_avg:48.67ms
+step:1071/1600 train_time:52165ms step_avg:48.71ms
+step:1072/1600 train_time:52250ms step_avg:48.74ms
+step:1073/1600 train_time:52338ms step_avg:48.78ms
+step:1074/1600 train_time:52424ms step_avg:48.81ms
+step:1075/1600 train_time:52512ms step_avg:48.85ms
+step:1076/1600 train_time:52597ms step_avg:48.88ms
+step:1077/1600 train_time:52685ms step_avg:48.92ms
+step:1078/1600 train_time:52770ms step_avg:48.95ms
+step:1079/1600 train_time:52871ms step_avg:49.00ms
+step:1080/1600 train_time:52952ms step_avg:49.03ms
+step:1081/1600 train_time:53032ms step_avg:49.06ms
+step:1082/1600 train_time:53118ms step_avg:49.09ms
+step:1083/1600 train_time:53207ms step_avg:49.13ms
+step:1084/1600 train_time:53293ms step_avg:49.16ms
+step:1085/1600 train_time:53381ms step_avg:49.20ms
+step:1086/1600 train_time:53467ms step_avg:49.23ms
+step:1087/1600 train_time:53555ms step_avg:49.27ms
+step:1088/1600 train_time:53640ms step_avg:49.30ms
+step:1089/1600 train_time:53728ms step_avg:49.34ms
+step:1090/1600 train_time:53814ms step_avg:49.37ms
+step:1091/1600 train_time:53903ms step_avg:49.41ms
+step:1092/1600 train_time:53989ms step_avg:49.44ms
+step:1093/1600 train_time:54078ms step_avg:49.48ms
+step:1094/1600 train_time:54164ms step_avg:49.51ms
+step:1095/1600 train_time:54252ms step_avg:49.55ms
+step:1096/1600 train_time:54352ms step_avg:49.59ms
+step:1097/1600 train_time:54425ms step_avg:49.61ms
+step:1098/1600 train_time:54511ms step_avg:49.65ms
+step:1099/1600 train_time:54599ms step_avg:49.68ms
+step:1100/1600 train_time:54685ms step_avg:49.71ms
+step:1101/1600 train_time:54774ms step_avg:49.75ms
+step:1102/1600 train_time:54859ms step_avg:49.78ms
+step:1103/1600 train_time:54948ms step_avg:49.82ms
+step:1104/1600 train_time:55034ms step_avg:49.85ms
+step:1105/1600 train_time:55122ms step_avg:49.88ms
+step:1106/1600 train_time:55209ms step_avg:49.92ms
+step:1107/1600 train_time:55298ms step_avg:49.95ms
+step:1108/1600 train_time:55383ms step_avg:49.98ms
+step:1109/1600 train_time:55472ms step_avg:50.02ms
+step:1110/1600 train_time:55558ms step_avg:50.05ms
+step:1111/1600 train_time:55646ms step_avg:50.09ms
+step:1112/1600 train_time:55731ms step_avg:50.12ms
+step:1113/1600 train_time:55820ms step_avg:50.15ms
+step:1114/1600 train_time:55906ms step_avg:50.18ms
+step:1115/1600 train_time:55994ms step_avg:50.22ms
+step:1116/1600 train_time:56079ms step_avg:50.25ms
+step:1117/1600 train_time:56168ms step_avg:50.28ms
+step:1118/1600 train_time:56255ms step_avg:50.32ms
+step:1119/1600 train_time:56343ms step_avg:50.35ms
+step:1120/1600 train_time:56429ms step_avg:50.38ms
+step:1121/1600 train_time:56517ms step_avg:50.42ms
+step:1122/1600 train_time:56603ms step_avg:50.45ms
+step:1123/1600 train_time:56691ms step_avg:50.48ms
+step:1124/1600 train_time:56777ms step_avg:50.51ms
+step:1125/1600 train_time:56865ms step_avg:50.55ms
+step:1126/1600 train_time:56951ms step_avg:50.58ms
+step:1127/1600 train_time:57039ms step_avg:50.61ms
+step:1128/1600 train_time:57126ms step_avg:50.64ms
+step:1129/1600 train_time:57214ms step_avg:50.68ms
+step:1130/1600 train_time:57299ms step_avg:50.71ms
+step:1131/1600 train_time:57388ms step_avg:50.74ms
+step:1132/1600 train_time:57474ms step_avg:50.77ms
+step:1133/1600 train_time:57561ms step_avg:50.80ms
+step:1134/1600 train_time:57648ms step_avg:50.84ms
+step:1135/1600 train_time:57737ms step_avg:50.87ms
+step:1136/1600 train_time:57822ms step_avg:50.90ms
+step:1137/1600 train_time:57911ms step_avg:50.93ms
+step:1138/1600 train_time:57996ms step_avg:50.96ms
+step:1139/1600 train_time:58084ms step_avg:51.00ms
+step:1140/1600 train_time:58169ms step_avg:51.03ms
+step:1141/1600 train_time:58258ms step_avg:51.06ms
+step:1142/1600 train_time:58344ms step_avg:51.09ms
+step:1143/1600 train_time:58433ms step_avg:51.12ms
+step:1144/1600 train_time:58518ms step_avg:51.15ms
+step:1145/1600 train_time:58607ms step_avg:51.18ms
+step:1146/1600 train_time:58692ms step_avg:51.21ms
+step:1147/1600 train_time:58780ms step_avg:51.25ms
+step:1148/1600 train_time:58867ms step_avg:51.28ms
+step:1149/1600 train_time:58955ms step_avg:51.31ms
+step:1150/1600 train_time:59040ms step_avg:51.34ms
+step:1151/1600 train_time:59128ms step_avg:51.37ms
+step:1152/1600 train_time:59213ms step_avg:51.40ms
+step:1153/1600 train_time:59302ms step_avg:51.43ms
+step:1154/1600 train_time:59388ms step_avg:51.46ms
+step:1155/1600 train_time:59476ms step_avg:51.49ms
+step:1156/1600 train_time:59562ms step_avg:51.52ms
+step:1157/1600 train_time:59651ms step_avg:51.56ms
+step:1158/1600 train_time:59737ms step_avg:51.59ms
+step:1159/1600 train_time:59825ms step_avg:51.62ms
+step:1160/1600 train_time:59910ms step_avg:51.65ms
+step:1161/1600 train_time:59999ms step_avg:51.68ms
+step:1162/1600 train_time:60084ms step_avg:51.71ms
+step:1163/1600 train_time:60173ms step_avg:51.74ms
+step:1164/1600 train_time:60258ms step_avg:51.77ms
+step:1165/1600 train_time:60346ms step_avg:51.80ms
+step:1166/1600 train_time:60432ms step_avg:51.83ms
+step:1167/1600 train_time:60521ms step_avg:51.86ms
+step:1168/1600 train_time:60607ms step_avg:51.89ms
+step:1169/1600 train_time:60695ms step_avg:51.92ms
+step:1170/1600 train_time:60781ms step_avg:51.95ms
+step:1171/1600 train_time:60870ms step_avg:51.98ms
+step:1172/1600 train_time:60955ms step_avg:52.01ms
+step:1173/1600 train_time:61043ms step_avg:52.04ms
+step:1174/1600 train_time:61129ms step_avg:52.07ms
+step:1175/1600 train_time:61217ms step_avg:52.10ms
+step:1176/1600 train_time:61303ms step_avg:52.13ms
+step:1177/1600 train_time:61392ms step_avg:52.16ms
+step:1178/1600 train_time:61478ms step_avg:52.19ms
+step:1179/1600 train_time:61566ms step_avg:52.22ms
+step:1180/1600 train_time:61652ms step_avg:52.25ms
+step:1181/1600 train_time:61741ms step_avg:52.28ms
+step:1182/1600 train_time:61827ms step_avg:52.31ms
+step:1183/1600 train_time:61915ms step_avg:52.34ms
+step:1184/1600 train_time:62001ms step_avg:52.37ms
+step:1185/1600 train_time:62090ms step_avg:52.40ms
+step:1186/1600 train_time:62176ms step_avg:52.42ms
+step:1187/1600 train_time:62265ms step_avg:52.46ms
+step:1188/1600 train_time:62351ms step_avg:52.48ms
+step:1189/1600 train_time:62440ms step_avg:52.51ms
+step:1190/1600 train_time:62526ms step_avg:52.54ms
+step:1191/1600 train_time:62614ms step_avg:52.57ms
+step:1192/1600 train_time:62699ms step_avg:52.60ms
+step:1193/1600 train_time:62788ms step_avg:52.63ms
+step:1194/1600 train_time:62873ms step_avg:52.66ms
+step:1195/1600 train_time:62962ms step_avg:52.69ms
+step:1196/1600 train_time:63048ms step_avg:52.72ms
+step:1197/1600 train_time:63137ms step_avg:52.75ms
+step:1198/1600 train_time:63222ms step_avg:52.77ms
+step:1199/1600 train_time:63312ms step_avg:52.80ms
+step:1200/1600 train_time:63398ms step_avg:52.83ms
+step:1201/1600 train_time:63486ms step_avg:52.86ms
+step:1202/1600 train_time:63572ms step_avg:52.89ms
+step:1203/1600 train_time:63661ms step_avg:52.92ms
+step:1204/1600 train_time:63746ms step_avg:52.95ms
+step:1205/1600 train_time:63835ms step_avg:52.97ms
+step:1206/1600 train_time:63920ms step_avg:53.00ms
+step:1207/1600 train_time:64009ms step_avg:53.03ms
+step:1208/1600 train_time:64095ms step_avg:53.06ms
+step:1209/1600 train_time:64184ms step_avg:53.09ms
+step:1210/1600 train_time:64269ms step_avg:53.12ms
+step:1211/1600 train_time:64358ms step_avg:53.14ms
+step:1212/1600 train_time:64444ms step_avg:53.17ms
+step:1213/1600 train_time:64533ms step_avg:53.20ms
+step:1214/1600 train_time:64618ms step_avg:53.23ms
+step:1215/1600 train_time:64707ms step_avg:53.26ms
+step:1216/1600 train_time:64792ms step_avg:53.28ms
+step:1217/1600 train_time:64880ms step_avg:53.31ms
+step:1218/1600 train_time:64966ms step_avg:53.34ms
+step:1219/1600 train_time:65055ms step_avg:53.37ms
+step:1220/1600 train_time:65141ms step_avg:53.39ms
+step:1221/1600 train_time:65229ms step_avg:53.42ms
+step:1222/1600 train_time:65315ms step_avg:53.45ms
+step:1223/1600 train_time:65404ms step_avg:53.48ms
+step:1224/1600 train_time:65490ms step_avg:53.50ms
+step:1225/1600 train_time:65578ms step_avg:53.53ms
+step:1226/1600 train_time:65664ms step_avg:53.56ms
+step:1227/1600 train_time:65752ms step_avg:53.59ms
+step:1228/1600 train_time:65837ms step_avg:53.61ms
+step:1229/1600 train_time:65926ms step_avg:53.64ms
+step:1230/1600 train_time:66012ms step_avg:53.67ms
+step:1231/1600 train_time:66100ms step_avg:53.70ms
+step:1232/1600 train_time:66187ms step_avg:53.72ms
+step:1233/1600 train_time:66274ms step_avg:53.75ms
+step:1234/1600 train_time:66360ms step_avg:53.78ms
+step:1235/1600 train_time:66448ms step_avg:53.80ms
+step:1236/1600 train_time:66534ms step_avg:53.83ms
+step:1237/1600 train_time:66622ms step_avg:53.86ms
+step:1238/1600 train_time:66709ms step_avg:53.88ms
+step:1239/1600 train_time:66798ms step_avg:53.91ms
+step:1240/1600 train_time:66883ms step_avg:53.94ms
+step:1241/1600 train_time:66973ms step_avg:53.97ms
+step:1242/1600 train_time:67059ms step_avg:53.99ms
+step:1243/1600 train_time:67146ms step_avg:54.02ms
+step:1244/1600 train_time:67232ms step_avg:54.04ms
+step:1245/1600 train_time:67320ms step_avg:54.07ms
+step:1246/1600 train_time:67405ms step_avg:54.10ms
+step:1247/1600 train_time:67494ms step_avg:54.13ms
+step:1248/1600 train_time:67580ms step_avg:54.15ms
+step:1249/1600 train_time:67669ms step_avg:54.18ms
+step:1250/1600 train_time:67755ms step_avg:54.20ms
+step:1250/1600 val_loss:3.4181 train_time:67827ms step_avg:54.26ms
+step:1251/1600 train_time:67845ms step_avg:54.23ms
+step:1252/1600 train_time:67933ms step_avg:54.26ms
+step:1253/1600 train_time:68023ms step_avg:54.29ms
+step:1254/1600 train_time:68109ms step_avg:54.31ms
+step:1255/1600 train_time:68197ms step_avg:54.34ms
+step:1256/1600 train_time:68282ms step_avg:54.36ms
+step:1257/1600 train_time:68370ms step_avg:54.39ms
+step:1258/1600 train_time:68455ms step_avg:54.42ms
+step:1259/1600 train_time:68543ms step_avg:54.44ms
+step:1260/1600 train_time:68628ms step_avg:54.47ms
+step:1261/1600 train_time:68716ms step_avg:54.49ms
+step:1262/1600 train_time:68803ms step_avg:54.52ms
+step:1263/1600 train_time:68892ms step_avg:54.55ms
+step:1264/1600 train_time:68979ms step_avg:54.57ms
+step:1265/1600 train_time:69068ms step_avg:54.60ms
+step:1266/1600 train_time:69153ms step_avg:54.62ms
+step:1267/1600 train_time:69242ms step_avg:54.65ms
+step:1268/1600 train_time:69326ms step_avg:54.67ms
+step:1269/1600 train_time:69415ms step_avg:54.70ms
+step:1270/1600 train_time:69500ms step_avg:54.72ms
+step:1271/1600 train_time:69588ms step_avg:54.75ms
+step:1272/1600 train_time:69674ms step_avg:54.77ms
+step:1273/1600 train_time:69763ms step_avg:54.80ms
+step:1274/1600 train_time:69849ms step_avg:54.83ms
+step:1275/1600 train_time:69939ms step_avg:54.85ms
+step:1276/1600 train_time:70024ms step_avg:54.88ms
+step:1277/1600 train_time:70113ms step_avg:54.90ms
+step:1278/1600 train_time:70198ms step_avg:54.93ms
+step:1279/1600 train_time:70286ms step_avg:54.95ms
+step:1280/1600 train_time:70371ms step_avg:54.98ms
+step:1281/1600 train_time:70459ms step_avg:55.00ms
+step:1282/1600 train_time:70544ms step_avg:55.03ms
+step:1283/1600 train_time:70632ms step_avg:55.05ms
+step:1284/1600 train_time:70717ms step_avg:55.08ms
+step:1285/1600 train_time:70807ms step_avg:55.10ms
+step:1286/1600 train_time:70893ms step_avg:55.13ms
+step:1287/1600 train_time:70982ms step_avg:55.15ms
+step:1288/1600 train_time:71068ms step_avg:55.18ms
+step:1289/1600 train_time:71157ms step_avg:55.20ms
+step:1290/1600 train_time:71242ms step_avg:55.23ms
+step:1291/1600 train_time:71331ms step_avg:55.25ms
+step:1292/1600 train_time:71416ms step_avg:55.28ms
+step:1293/1600 train_time:71504ms step_avg:55.30ms
+step:1294/1600 train_time:71589ms step_avg:55.32ms
+step:1295/1600 train_time:71677ms step_avg:55.35ms
+step:1296/1600 train_time:71764ms step_avg:55.37ms
+step:1297/1600 train_time:71853ms step_avg:55.40ms
+step:1298/1600 train_time:71939ms step_avg:55.42ms
+step:1299/1600 train_time:72029ms step_avg:55.45ms
+step:1300/1600 train_time:72114ms step_avg:55.47ms
+step:1301/1600 train_time:72203ms step_avg:55.50ms
+step:1302/1600 train_time:72290ms step_avg:55.52ms
+step:1303/1600 train_time:72378ms step_avg:55.55ms
+step:1304/1600 train_time:72464ms step_avg:55.57ms
+step:1305/1600 train_time:72551ms step_avg:55.59ms
+step:1306/1600 train_time:72637ms step_avg:55.62ms
+step:1307/1600 train_time:72726ms step_avg:55.64ms
+step:1308/1600 train_time:72812ms step_avg:55.67ms
+step:1309/1600 train_time:72901ms step_avg:55.69ms
+step:1310/1600 train_time:72986ms step_avg:55.71ms
+step:1311/1600 train_time:73075ms step_avg:55.74ms
+step:1312/1600 train_time:73161ms step_avg:55.76ms
+step:1313/1600 train_time:73249ms step_avg:55.79ms
+step:1314/1600 train_time:73334ms step_avg:55.81ms
+step:1315/1600 train_time:73422ms step_avg:55.83ms
+step:1316/1600 train_time:73507ms step_avg:55.86ms
+step:1317/1600 train_time:73596ms step_avg:55.88ms
+step:1318/1600 train_time:73681ms step_avg:55.90ms
+step:1319/1600 train_time:73770ms step_avg:55.93ms
+step:1320/1600 train_time:73856ms step_avg:55.95ms
+step:1321/1600 train_time:73946ms step_avg:55.98ms
+step:1322/1600 train_time:74031ms step_avg:56.00ms
+step:1323/1600 train_time:74119ms step_avg:56.02ms
+step:1324/1600 train_time:74205ms step_avg:56.05ms
+step:1325/1600 train_time:74293ms step_avg:56.07ms
+step:1326/1600 train_time:74380ms step_avg:56.09ms
+step:1327/1600 train_time:74469ms step_avg:56.12ms
+step:1328/1600 train_time:74554ms step_avg:56.14ms
+step:1329/1600 train_time:74643ms step_avg:56.16ms
+step:1330/1600 train_time:74729ms step_avg:56.19ms
+step:1331/1600 train_time:74817ms step_avg:56.21ms
+step:1332/1600 train_time:74903ms step_avg:56.23ms
+step:1333/1600 train_time:74992ms step_avg:56.26ms
+step:1334/1600 train_time:75077ms step_avg:56.28ms
+step:1335/1600 train_time:75165ms step_avg:56.30ms
+step:1336/1600 train_time:75250ms step_avg:56.33ms
+step:1337/1600 train_time:75339ms step_avg:56.35ms
+step:1338/1600 train_time:75424ms step_avg:56.37ms
+step:1339/1600 train_time:75513ms step_avg:56.40ms
+step:1340/1600 train_time:75598ms step_avg:56.42ms
+step:1341/1600 train_time:75687ms step_avg:56.44ms
+step:1342/1600 train_time:75773ms step_avg:56.46ms
+step:1343/1600 train_time:75861ms step_avg:56.49ms
+step:1344/1600 train_time:75947ms step_avg:56.51ms
+step:1345/1600 train_time:76035ms step_avg:56.53ms
+step:1346/1600 train_time:76120ms step_avg:56.55ms
+step:1347/1600 train_time:76209ms step_avg:56.58ms
+step:1348/1600 train_time:76294ms step_avg:56.60ms
+step:1349/1600 train_time:76383ms step_avg:56.62ms
+step:1350/1600 train_time:76468ms step_avg:56.64ms
+step:1351/1600 train_time:76557ms step_avg:56.67ms
+step:1352/1600 train_time:76642ms step_avg:56.69ms
+step:1353/1600 train_time:76730ms step_avg:56.71ms
+step:1354/1600 train_time:76816ms step_avg:56.73ms
+step:1355/1600 train_time:76905ms step_avg:56.76ms
+step:1356/1600 train_time:76990ms step_avg:56.78ms
+step:1357/1600 train_time:77078ms step_avg:56.80ms
+step:1358/1600 train_time:77164ms step_avg:56.82ms
+step:1359/1600 train_time:77252ms step_avg:56.84ms
+step:1360/1600 train_time:77338ms step_avg:56.87ms
+step:1361/1600 train_time:77427ms step_avg:56.89ms
+step:1362/1600 train_time:77513ms step_avg:56.91ms
+step:1363/1600 train_time:77601ms step_avg:56.93ms
+step:1364/1600 train_time:77687ms step_avg:56.96ms
+step:1365/1600 train_time:77776ms step_avg:56.98ms
+step:1366/1600 train_time:77862ms step_avg:57.00ms
+step:1367/1600 train_time:77950ms step_avg:57.02ms
+step:1368/1600 train_time:78034ms step_avg:57.04ms
+step:1369/1600 train_time:78123ms step_avg:57.07ms
+step:1370/1600 train_time:78208ms step_avg:57.09ms
+step:1371/1600 train_time:78296ms step_avg:57.11ms
+step:1372/1600 train_time:78382ms step_avg:57.13ms
+step:1373/1600 train_time:78471ms step_avg:57.15ms
+step:1374/1600 train_time:78557ms step_avg:57.17ms
+step:1375/1600 train_time:78646ms step_avg:57.20ms
+step:1376/1600 train_time:78732ms step_avg:57.22ms
+step:1377/1600 train_time:78820ms step_avg:57.24ms
+step:1378/1600 train_time:78905ms step_avg:57.26ms
+step:1379/1600 train_time:78994ms step_avg:57.28ms
+step:1380/1600 train_time:79080ms step_avg:57.30ms
+step:1381/1600 train_time:79170ms step_avg:57.33ms
+step:1382/1600 train_time:79254ms step_avg:57.35ms
+step:1383/1600 train_time:79344ms step_avg:57.37ms
+step:1384/1600 train_time:79431ms step_avg:57.39ms
+step:1385/1600 train_time:79519ms step_avg:57.41ms
+step:1386/1600 train_time:79605ms step_avg:57.44ms
+step:1387/1600 train_time:79694ms step_avg:57.46ms
+step:1388/1600 train_time:79779ms step_avg:57.48ms
+step:1389/1600 train_time:79868ms step_avg:57.50ms
+step:1390/1600 train_time:79953ms step_avg:57.52ms
+step:1391/1600 train_time:80042ms step_avg:57.54ms
+step:1392/1600 train_time:80127ms step_avg:57.56ms
+step:1393/1600 train_time:80216ms step_avg:57.59ms
+step:1394/1600 train_time:80303ms step_avg:57.61ms
+step:1395/1600 train_time:80391ms step_avg:57.63ms
+step:1396/1600 train_time:80476ms step_avg:57.65ms
+step:1397/1600 train_time:80565ms step_avg:57.67ms
+step:1398/1600 train_time:80650ms step_avg:57.69ms
+step:1399/1600 train_time:80739ms step_avg:57.71ms
+step:1400/1600 train_time:80825ms step_avg:57.73ms
+step:1401/1600 train_time:80913ms step_avg:57.75ms
+step:1402/1600 train_time:80999ms step_avg:57.77ms
+step:1403/1600 train_time:81088ms step_avg:57.80ms
+step:1404/1600 train_time:81174ms step_avg:57.82ms
+step:1405/1600 train_time:81262ms step_avg:57.84ms
+step:1406/1600 train_time:81347ms step_avg:57.86ms
+step:1407/1600 train_time:81436ms step_avg:57.88ms
+step:1408/1600 train_time:81521ms step_avg:57.90ms
+step:1409/1600 train_time:81611ms step_avg:57.92ms
+step:1410/1600 train_time:81696ms step_avg:57.94ms
+step:1411/1600 train_time:81784ms step_avg:57.96ms
+step:1412/1600 train_time:81870ms step_avg:57.98ms
+step:1413/1600 train_time:81958ms step_avg:58.00ms
+step:1414/1600 train_time:82043ms step_avg:58.02ms
+step:1415/1600 train_time:82133ms step_avg:58.04ms
+step:1416/1600 train_time:82219ms step_avg:58.06ms
+step:1417/1600 train_time:82306ms step_avg:58.08ms
+step:1418/1600 train_time:82392ms step_avg:58.10ms
+step:1419/1600 train_time:82480ms step_avg:58.13ms
+step:1420/1600 train_time:82570ms step_avg:58.15ms
+step:1421/1600 train_time:82657ms step_avg:58.17ms
+step:1422/1600 train_time:82743ms step_avg:58.19ms
+step:1423/1600 train_time:82832ms step_avg:58.21ms
+step:1424/1600 train_time:82917ms step_avg:58.23ms
+step:1425/1600 train_time:83007ms step_avg:58.25ms
+step:1426/1600 train_time:83092ms step_avg:58.27ms
+step:1427/1600 train_time:83181ms step_avg:58.29ms
+step:1428/1600 train_time:83266ms step_avg:58.31ms
+step:1429/1600 train_time:83354ms step_avg:58.33ms
+step:1430/1600 train_time:83440ms step_avg:58.35ms
+step:1431/1600 train_time:83528ms step_avg:58.37ms
+step:1432/1600 train_time:83614ms step_avg:58.39ms
+step:1433/1600 train_time:83702ms step_avg:58.41ms
+step:1434/1600 train_time:83787ms step_avg:58.43ms
+step:1435/1600 train_time:83875ms step_avg:58.45ms
+step:1436/1600 train_time:83961ms step_avg:58.47ms
+step:1437/1600 train_time:84049ms step_avg:58.49ms
+step:1438/1600 train_time:84135ms step_avg:58.51ms
+step:1439/1600 train_time:84224ms step_avg:58.53ms
+step:1440/1600 train_time:84309ms step_avg:58.55ms
+step:1441/1600 train_time:84398ms step_avg:58.57ms
+step:1442/1600 train_time:84483ms step_avg:58.59ms
+step:1443/1600 train_time:84572ms step_avg:58.61ms
+step:1444/1600 train_time:84657ms step_avg:58.63ms
+step:1445/1600 train_time:84746ms step_avg:58.65ms
+step:1446/1600 train_time:84831ms step_avg:58.67ms
+step:1447/1600 train_time:84919ms step_avg:58.69ms
+step:1448/1600 train_time:85004ms step_avg:58.70ms
+step:1449/1600 train_time:85093ms step_avg:58.73ms
+step:1450/1600 train_time:85179ms step_avg:58.74ms
+step:1451/1600 train_time:85268ms step_avg:58.77ms
+step:1452/1600 train_time:85354ms step_avg:58.78ms
+step:1453/1600 train_time:85442ms step_avg:58.80ms
+step:1454/1600 train_time:85528ms step_avg:58.82ms
+step:1455/1600 train_time:85616ms step_avg:58.84ms
+step:1456/1600 train_time:85703ms step_avg:58.86ms
+step:1457/1600 train_time:85792ms step_avg:58.88ms
+step:1458/1600 train_time:85877ms step_avg:58.90ms
+step:1459/1600 train_time:85966ms step_avg:58.92ms
+step:1460/1600 train_time:86051ms step_avg:58.94ms
+step:1461/1600 train_time:86140ms step_avg:58.96ms
+step:1462/1600 train_time:86225ms step_avg:58.98ms
+step:1463/1600 train_time:86314ms step_avg:59.00ms
+step:1464/1600 train_time:86399ms step_avg:59.02ms
+step:1465/1600 train_time:86487ms step_avg:59.04ms
+step:1466/1600 train_time:86573ms step_avg:59.05ms
+step:1467/1600 train_time:86661ms step_avg:59.07ms
+step:1468/1600 train_time:86747ms step_avg:59.09ms
+step:1469/1600 train_time:86834ms step_avg:59.11ms
+step:1470/1600 train_time:86920ms step_avg:59.13ms
+step:1471/1600 train_time:87008ms step_avg:59.15ms
+step:1472/1600 train_time:87094ms step_avg:59.17ms
+step:1473/1600 train_time:87183ms step_avg:59.19ms
+step:1474/1600 train_time:87269ms step_avg:59.21ms
+step:1475/1600 train_time:87358ms step_avg:59.23ms
+step:1476/1600 train_time:87443ms step_avg:59.24ms
+step:1477/1600 train_time:87532ms step_avg:59.26ms
+step:1478/1600 train_time:87618ms step_avg:59.28ms
+step:1479/1600 train_time:87707ms step_avg:59.30ms
+step:1480/1600 train_time:87792ms step_avg:59.32ms
+step:1481/1600 train_time:87880ms step_avg:59.34ms
+step:1482/1600 train_time:87965ms step_avg:59.36ms
+step:1483/1600 train_time:88053ms step_avg:59.38ms
+step:1484/1600 train_time:88139ms step_avg:59.39ms
+step:1485/1600 train_time:88228ms step_avg:59.41ms
+step:1486/1600 train_time:88314ms step_avg:59.43ms
+step:1487/1600 train_time:88402ms step_avg:59.45ms
+step:1488/1600 train_time:88487ms step_avg:59.47ms
+step:1489/1600 train_time:88576ms step_avg:59.49ms
+step:1490/1600 train_time:88662ms step_avg:59.50ms
+step:1491/1600 train_time:88751ms step_avg:59.52ms
+step:1492/1600 train_time:88836ms step_avg:59.54ms
+step:1493/1600 train_time:88924ms step_avg:59.56ms
+step:1494/1600 train_time:89010ms step_avg:59.58ms
+step:1495/1600 train_time:89098ms step_avg:59.60ms
+step:1496/1600 train_time:89184ms step_avg:59.61ms
+step:1497/1600 train_time:89273ms step_avg:59.63ms
+step:1498/1600 train_time:89358ms step_avg:59.65ms
+step:1499/1600 train_time:89447ms step_avg:59.67ms
+step:1500/1600 train_time:89532ms step_avg:59.69ms
+step:1500/1600 val_loss:3.3086 train_time:89601ms step_avg:59.73ms
+step:1501/1600 train_time:89621ms step_avg:59.71ms
+step:1502/1600 train_time:89709ms step_avg:59.73ms
+step:1503/1600 train_time:89799ms step_avg:59.75ms
+step:1504/1600 train_time:89884ms step_avg:59.76ms
+step:1505/1600 train_time:89973ms step_avg:59.78ms
+step:1506/1600 train_time:90057ms step_avg:59.80ms
+step:1507/1600 train_time:90144ms step_avg:59.82ms
+step:1508/1600 train_time:90230ms step_avg:59.83ms
+step:1509/1600 train_time:90318ms step_avg:59.85ms
+step:1510/1600 train_time:90403ms step_avg:59.87ms
+step:1511/1600 train_time:90491ms step_avg:59.89ms
+step:1512/1600 train_time:90577ms step_avg:59.91ms
+step:1513/1600 train_time:90667ms step_avg:59.93ms
+step:1514/1600 train_time:90754ms step_avg:59.94ms
+step:1515/1600 train_time:90843ms step_avg:59.96ms
+step:1516/1600 train_time:90930ms step_avg:59.98ms
+step:1517/1600 train_time:91018ms step_avg:60.00ms
+step:1518/1600 train_time:91102ms step_avg:60.01ms
+step:1519/1600 train_time:91190ms step_avg:60.03ms
+step:1520/1600 train_time:91275ms step_avg:60.05ms
+step:1521/1600 train_time:91363ms step_avg:60.07ms
+step:1522/1600 train_time:91449ms step_avg:60.08ms
+step:1523/1600 train_time:91538ms step_avg:60.10ms
+step:1524/1600 train_time:91624ms step_avg:60.12ms
+step:1525/1600 train_time:91713ms step_avg:60.14ms
+step:1526/1600 train_time:91799ms step_avg:60.16ms
+step:1527/1600 train_time:91887ms step_avg:60.18ms
+step:1528/1600 train_time:91973ms step_avg:60.19ms
+step:1529/1600 train_time:92062ms step_avg:60.21ms
+step:1530/1600 train_time:92146ms step_avg:60.23ms
+step:1531/1600 train_time:92235ms step_avg:60.24ms
+step:1532/1600 train_time:92320ms step_avg:60.26ms
+step:1533/1600 train_time:92408ms step_avg:60.28ms
+step:1534/1600 train_time:92494ms step_avg:60.30ms
+step:1535/1600 train_time:92583ms step_avg:60.31ms
+step:1536/1600 train_time:92669ms step_avg:60.33ms
+step:1537/1600 train_time:92757ms step_avg:60.35ms
+step:1538/1600 train_time:92843ms step_avg:60.37ms
+step:1539/1600 train_time:92932ms step_avg:60.38ms
+step:1540/1600 train_time:93017ms step_avg:60.40ms
+step:1541/1600 train_time:93106ms step_avg:60.42ms
+step:1542/1600 train_time:93191ms step_avg:60.44ms
+step:1543/1600 train_time:93278ms step_avg:60.45ms
+step:1544/1600 train_time:93363ms step_avg:60.47ms
+step:1545/1600 train_time:93452ms step_avg:60.49ms
+step:1546/1600 train_time:93538ms step_avg:60.50ms
+step:1547/1600 train_time:93626ms step_avg:60.52ms
+step:1548/1600 train_time:93712ms step_avg:60.54ms
+step:1549/1600 train_time:93801ms step_avg:60.56ms
+step:1550/1600 train_time:93887ms step_avg:60.57ms
+step:1551/1600 train_time:93976ms step_avg:60.59ms
+step:1552/1600 train_time:94062ms step_avg:60.61ms
+step:1553/1600 train_time:94151ms step_avg:60.62ms
+step:1554/1600 train_time:94236ms step_avg:60.64ms
+step:1555/1600 train_time:94324ms step_avg:60.66ms
+step:1556/1600 train_time:94409ms step_avg:60.67ms
+step:1557/1600 train_time:94499ms step_avg:60.69ms
+step:1558/1600 train_time:94585ms step_avg:60.71ms
+step:1559/1600 train_time:94675ms step_avg:60.73ms
+step:1560/1600 train_time:94760ms step_avg:60.74ms
+step:1561/1600 train_time:94854ms step_avg:60.76ms
+step:1562/1600 train_time:94939ms step_avg:60.78ms
+step:1563/1600 train_time:95028ms step_avg:60.80ms
+step:1564/1600 train_time:95114ms step_avg:60.81ms
+step:1565/1600 train_time:95202ms step_avg:60.83ms
+step:1566/1600 train_time:95288ms step_avg:60.85ms
+step:1567/1600 train_time:95377ms step_avg:60.87ms
+step:1568/1600 train_time:95463ms step_avg:60.88ms
+step:1569/1600 train_time:95553ms step_avg:60.90ms
+step:1570/1600 train_time:95639ms step_avg:60.92ms
+step:1571/1600 train_time:95727ms step_avg:60.93ms
+step:1572/1600 train_time:95813ms step_avg:60.95ms
+step:1573/1600 train_time:95902ms step_avg:60.97ms
+step:1574/1600 train_time:95989ms step_avg:60.98ms
+step:1575/1600 train_time:96077ms step_avg:61.00ms
+step:1576/1600 train_time:96163ms step_avg:61.02ms
+step:1577/1600 train_time:96253ms step_avg:61.04ms
+step:1578/1600 train_time:96339ms step_avg:61.05ms
+step:1579/1600 train_time:96427ms step_avg:61.07ms
+step:1580/1600 train_time:96513ms step_avg:61.08ms
+step:1581/1600 train_time:96602ms step_avg:61.10ms
+step:1582/1600 train_time:96688ms step_avg:61.12ms
+step:1583/1600 train_time:96777ms step_avg:61.14ms
+step:1584/1600 train_time:96863ms step_avg:61.15ms
+step:1585/1600 train_time:96953ms step_avg:61.17ms
+step:1586/1600 train_time:97038ms step_avg:61.18ms
+step:1587/1600 train_time:97127ms step_avg:61.20ms
+step:1588/1600 train_time:97213ms step_avg:61.22ms
+step:1589/1600 train_time:97302ms step_avg:61.23ms
+step:1590/1600 train_time:97387ms step_avg:61.25ms
+step:1591/1600 train_time:97476ms step_avg:61.27ms
+step:1592/1600 train_time:97561ms step_avg:61.28ms
+step:1593/1600 train_time:97650ms step_avg:61.30ms
+step:1594/1600 train_time:97737ms step_avg:61.32ms
+step:1595/1600 train_time:97826ms step_avg:61.33ms
+step:1596/1600 train_time:97912ms step_avg:61.35ms
+step:1597/1600 train_time:98002ms step_avg:61.37ms
+step:1598/1600 train_time:98088ms step_avg:61.38ms
+step:1599/1600 train_time:98177ms step_avg:61.40ms
+step:1600/1600 train_time:98263ms step_avg:61.41ms
+step:1600/1600 val_loss:3.2791 train_time:98333ms step_avg:61.46ms
+peak memory allocated: 30368 MiB reserved: 46238 MiB

--- a/records/track_1_short/2026-01-28_TieFirstLastVEs/ve01_230-15stps/643551f4-99ac-4f71-826e-de0dce3ca4f3.txt
+++ b/records/track_1_short/2026-01-28_TieFirstLastVEs/ve01_230-15stps/643551f4-99ac-4f71-826e-de0dce3ca4f3.txt
@@ -1,0 +1,4301 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    is_tall = G.size(-2) > G.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall matrices: use X^T @ X (small K×K) and right multiplication
+        # This avoids the transpose overhead that slows down Nesterov momentum
+        K = X.size(-1)
+        A = torch.empty((*X.shape[:-2], K, K), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched matmul for X @ B
+        XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.mT @ X 
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            # Right multiplication: C = a * X + X @ B
+            XB_matmul(X, B, out=C)  # C = X @ B
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place)
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide matrices: use X @ X^T and left multiplication (original approach)
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+major, _ = torch.cuda.get_device_capability()
+if major >= 9:
+    flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+else:
+    flash_attn_interface = get_kernel('kernels-community/flash-attn2').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(4)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = (major >= 9) # FP8 requires Hopper (SM90+)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # new layout: 01 ... 230 (ve0 shared at start and end)
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[0]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1545  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+
+# Check compute capability for Hopper-specific features
+_major, _ = torch.cuda.get_device_capability()
+_USE_TMA = _major >= 9
+
+if _USE_TMA:
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+# Note: This kernel was AI-written. It's been tested for numerical equivalence, 
+#       but not otherwised reviewed.
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < M - m * BLOCK_SIZE_K, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < M - m * BLOCK_SIZE_K, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(K, meta["BLOCK_SIZE_M"]) * triton.cdiv(K, meta["BLOCK_SIZE_N"]),
+    )
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+# Uses TMA (Tensor Memory Accelerator) which requires Hopper (SM90+)
+
+if _USE_TMA:
+    @triton.jit
+    def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                     M, N, K,
+                                     BLOCK_SIZE_M: tl.constexpr,
+                                     BLOCK_SIZE_N: tl.constexpr,
+                                     BLOCK_SIZE_K: tl.constexpr,
+                                     GROUP_SIZE_M: tl.constexpr,
+                                     NUM_SMS: tl.constexpr,
+                                     FORWARD: tl.constexpr,
+                                     ):
+        dtype = tl.bfloat16
+        start_pid = tl.program_id(axis=0)
+        num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+        num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+        k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+        num_tiles = num_pid_m * num_pid_n
+
+        tile_id_c = start_pid - NUM_SMS
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+        for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+            pid_m = tile_id // num_pid_n
+            pid_n = tile_id % num_pid_n
+            offs_am = pid_m * BLOCK_SIZE_M
+            offs_bn = pid_n * BLOCK_SIZE_N
+
+            accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+            for ki in range(k_tiles):
+                offs_k = ki * BLOCK_SIZE_K
+                a = a_desc.load([offs_am, offs_k])
+                b = b_desc.load([offs_bn, offs_k])
+                accumulator = tl.dot(a, b.T, accumulator)
+
+            tile_id_c += NUM_SMS
+            pid_m = tile_id // num_pid_n
+            pid_n = tile_id % num_pid_n
+            offs_am_c = pid_m * BLOCK_SIZE_M
+            offs_bn_c = pid_n * BLOCK_SIZE_N
+
+            acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+            acc = tl.permute(acc, (0, 2, 1))
+            acc0, acc1 = tl.split(acc)
+
+            c0 = acc0.to(dtype)
+            if not FORWARD:
+                c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+                c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+            c_desc.store([offs_am_c, offs_bn_c], c0)
+
+            if FORWARD:
+                c0_post = tl.maximum(c0, 0)
+                c0_post = c0_post * c0_post
+                aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+            c1 = acc1.to(dtype)
+            if not FORWARD:
+                c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+                c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+            c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+            if FORWARD:
+                c1_post = tl.maximum(c1, 0)
+                c1_post = c1_post * c1_post
+                aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+    def linear_relu_square(a, b, aux=None):
+        M, K = a.shape
+        N, K = b.shape
+        dtype = a.dtype
+
+        c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+        FORWARD = False
+        if aux is None:
+            FORWARD = True
+            aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+        BLOCK_SIZE_M = 128
+        BLOCK_SIZE_N = 256
+        BLOCK_SIZE_K = 64
+        num_stages = 4 if FORWARD else 3
+        num_warps = 8
+
+        a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+        b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+        c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+        aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+        def grid(META):
+            return (min(
+                NUM_SMS,
+                triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+            ), )
+
+        linear_relu_square_kernel[grid](
+            a_desc, b_desc, c_desc, aux_desc,
+            M, N, K,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_K=BLOCK_SIZE_K,
+            GROUP_SIZE_M=1,
+            NUM_SMS=NUM_SMS,
+            FORWARD=FORWARD,
+            num_stages=num_stages,
+            num_warps=num_warps
+        )
+
+        if FORWARD:
+            return c, aux
+        else:
+            return c
+
+    class FusedLinearReLUSquareFunction(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x, W1, W2):
+            pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+            x3 = post @ W2
+            ctx.save_for_backward(x, W1, W2, pre, post)
+            return x3.view(x.shape)
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            x, W1, W2, pre, post = ctx.saved_tensors
+            dW2 = post.T @ grad_output
+            dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+            dW1 = dpre.T @ x
+            dx = dpre @ W1
+            return dx.view(x.shape), dW1, dW2
+
+else:
+    # Fallback for Ampere (A100) and earlier - uses standard PyTorch ops
+    class FusedLinearReLUSquareFunction(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x, W1, W2):
+            # relu(x @ W1.T)^2 @ W2
+            x_flat = x.view(-1, x.shape[-1])
+            pre = x_flat @ W1.T  # (M, N)
+            post = torch.relu(pre).square()  # relu(...)^2
+            out = post @ W2
+            ctx.save_for_backward(x, W1, W2, pre, post)
+            return out.view(x.shape)
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            x, W1, W2, pre, post = ctx.saved_tensors
+            x_flat = x.view(-1, x.shape[-1])
+            grad_flat = grad_output.view(-1, grad_output.shape[-1])
+            
+            # grad w.r.t. W2: post.T @ grad_output
+            dW2 = post.T @ grad_flat
+            
+            # grad w.r.t. post: grad_output @ W2.T
+            dpost = grad_flat @ W2.T
+            
+            # grad through relu(pre)^2: d/dpre[relu(pre)^2] = 2*relu(pre) * (pre > 0)
+            dpre = 2 * dpost * torch.where(pre > 0, pre, pre.new_zeros(()))
+            
+            # grad w.r.t. W1: dpre.T @ x
+            dW1 = dpre.T @ x_flat
+            
+            # grad w.r.t. x: dpre @ W1
+            dx = dpre @ W1
+            return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.12.12 | packaged by conda-forge | (main, Jan 26 2026, 23:51:32) [GCC 14.3.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Thu Jan 29 06:02:59 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                  Off |
+| N/A   42C    P0            156W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:06:00.0 Off |                  Off |
+| N/A   37C    P0            132W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:07:00.0 Off |                  Off |
+| N/A   42C    P0            135W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:08:00.0 Off |                  Off |
+| N/A   37C    P0            137W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:09:00.0 Off |                  Off |
+| N/A   42C    P0            143W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                  Off |
+| N/A   37C    P0            133W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                  Off |
+| N/A   42C    P0            139W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:0C:00.0 Off |                  Off |
+| N/A   39C    P0            150W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          804929      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    1   N/A  N/A          804930      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    2   N/A  N/A          804931      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    3   N/A  N/A          804932      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    4   N/A  N/A          804933      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    5   N/A  N/A          804934      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    6   N/A  N/A          804935      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    7   N/A  N/A          804936      C   .../envs/speedrun/bin/python3.12       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 514, 515, 516, 1029, 1030, 1031, 1544, 1545, 1546] for warmup
+Resetting Model
+step:0/1585 val_loss:10.8279 train_time:0ms step_avg:0.03ms
+step:1/1585 train_time:49ms step_avg:49.17ms
+step:2/1585 train_time:77ms step_avg:38.65ms
+step:3/1585 train_time:109ms step_avg:36.38ms
+step:4/1585 train_time:147ms step_avg:36.83ms
+step:5/1585 train_time:178ms step_avg:35.50ms
+step:6/1585 train_time:227ms step_avg:37.85ms
+step:7/1585 train_time:246ms step_avg:35.10ms
+step:8/1585 train_time:330ms step_avg:41.23ms
+step:9/1585 train_time:360ms step_avg:39.96ms
+step:10/1585 train_time:398ms step_avg:39.78ms
+step:11/1585 train_time:428ms step_avg:38.92ms
+step:12/1585 train_time:466ms step_avg:38.83ms
+step:13/1585 train_time:497ms step_avg:38.20ms
+step:14/1585 train_time:535ms step_avg:38.22ms
+step:15/1585 train_time:566ms step_avg:37.72ms
+step:16/1585 train_time:604ms step_avg:37.74ms
+step:17/1585 train_time:634ms step_avg:37.31ms
+step:18/1585 train_time:672ms step_avg:37.35ms
+step:19/1585 train_time:703ms step_avg:36.99ms
+step:20/1585 train_time:741ms step_avg:37.05ms
+step:21/1585 train_time:772ms step_avg:36.74ms
+step:22/1585 train_time:810ms step_avg:36.81ms
+step:23/1585 train_time:840ms step_avg:36.53ms
+step:24/1585 train_time:879ms step_avg:36.61ms
+step:25/1585 train_time:910ms step_avg:36.38ms
+step:26/1585 train_time:948ms step_avg:36.45ms
+step:27/1585 train_time:979ms step_avg:36.24ms
+step:28/1585 train_time:1017ms step_avg:36.32ms
+step:29/1585 train_time:1047ms step_avg:36.12ms
+step:30/1585 train_time:1086ms step_avg:36.21ms
+step:31/1585 train_time:1116ms step_avg:36.01ms
+step:32/1585 train_time:1154ms step_avg:36.06ms
+step:33/1585 train_time:1185ms step_avg:35.90ms
+step:34/1585 train_time:1223ms step_avg:35.97ms
+step:35/1585 train_time:1254ms step_avg:35.84ms
+step:36/1585 train_time:1293ms step_avg:35.91ms
+step:37/1585 train_time:1323ms step_avg:35.76ms
+step:38/1585 train_time:1361ms step_avg:35.82ms
+step:39/1585 train_time:1392ms step_avg:35.70ms
+step:40/1585 train_time:1430ms step_avg:35.75ms
+step:41/1585 train_time:1461ms step_avg:35.62ms
+step:42/1585 train_time:1499ms step_avg:35.69ms
+step:43/1585 train_time:1529ms step_avg:35.56ms
+step:44/1585 train_time:1567ms step_avg:35.62ms
+step:45/1585 train_time:1598ms step_avg:35.52ms
+step:46/1585 train_time:1637ms step_avg:35.59ms
+step:47/1585 train_time:1668ms step_avg:35.48ms
+step:48/1585 train_time:1706ms step_avg:35.55ms
+step:49/1585 train_time:1737ms step_avg:35.45ms
+step:50/1585 train_time:1775ms step_avg:35.50ms
+step:51/1585 train_time:1806ms step_avg:35.42ms
+step:52/1585 train_time:1844ms step_avg:35.47ms
+step:53/1585 train_time:1875ms step_avg:35.38ms
+step:54/1585 train_time:1914ms step_avg:35.44ms
+step:55/1585 train_time:1944ms step_avg:35.35ms
+step:56/1585 train_time:1982ms step_avg:35.40ms
+step:57/1585 train_time:2013ms step_avg:35.32ms
+step:58/1585 train_time:2051ms step_avg:35.36ms
+step:59/1585 train_time:2081ms step_avg:35.28ms
+step:60/1585 train_time:2120ms step_avg:35.33ms
+step:61/1585 train_time:2150ms step_avg:35.25ms
+step:62/1585 train_time:2188ms step_avg:35.29ms
+step:63/1585 train_time:2219ms step_avg:35.22ms
+step:64/1585 train_time:2257ms step_avg:35.27ms
+step:65/1585 train_time:2288ms step_avg:35.20ms
+step:66/1585 train_time:2326ms step_avg:35.25ms
+step:67/1585 train_time:2357ms step_avg:35.18ms
+step:68/1585 train_time:2395ms step_avg:35.23ms
+step:69/1585 train_time:2426ms step_avg:35.16ms
+step:70/1585 train_time:2463ms step_avg:35.19ms
+step:71/1585 train_time:2494ms step_avg:35.13ms
+step:72/1585 train_time:2533ms step_avg:35.18ms
+step:73/1585 train_time:2564ms step_avg:35.12ms
+step:74/1585 train_time:2601ms step_avg:35.15ms
+step:75/1585 train_time:2632ms step_avg:35.10ms
+step:76/1585 train_time:2670ms step_avg:35.13ms
+step:77/1585 train_time:2701ms step_avg:35.07ms
+step:78/1585 train_time:2739ms step_avg:35.12ms
+step:79/1585 train_time:2770ms step_avg:35.06ms
+step:80/1585 train_time:2808ms step_avg:35.09ms
+step:81/1585 train_time:2838ms step_avg:35.04ms
+step:82/1585 train_time:2876ms step_avg:35.08ms
+step:83/1585 train_time:2907ms step_avg:35.02ms
+step:84/1585 train_time:2945ms step_avg:35.06ms
+step:85/1585 train_time:2975ms step_avg:35.01ms
+step:86/1585 train_time:3013ms step_avg:35.04ms
+step:87/1585 train_time:3044ms step_avg:34.99ms
+step:88/1585 train_time:3082ms step_avg:35.02ms
+step:89/1585 train_time:3113ms step_avg:34.98ms
+step:90/1585 train_time:3151ms step_avg:35.01ms
+step:91/1585 train_time:3181ms step_avg:34.96ms
+step:92/1585 train_time:3220ms step_avg:35.00ms
+step:93/1585 train_time:3251ms step_avg:34.95ms
+step:94/1585 train_time:3289ms step_avg:34.99ms
+step:95/1585 train_time:3319ms step_avg:34.94ms
+step:96/1585 train_time:3357ms step_avg:34.97ms
+step:97/1585 train_time:3388ms step_avg:34.93ms
+step:98/1585 train_time:3426ms step_avg:34.96ms
+step:99/1585 train_time:3457ms step_avg:34.92ms
+step:100/1585 train_time:3496ms step_avg:34.96ms
+step:101/1585 train_time:3527ms step_avg:34.92ms
+step:102/1585 train_time:3565ms step_avg:34.95ms
+step:103/1585 train_time:3595ms step_avg:34.90ms
+step:104/1585 train_time:3634ms step_avg:34.94ms
+step:105/1585 train_time:3664ms step_avg:34.90ms
+step:106/1585 train_time:3702ms step_avg:34.93ms
+step:107/1585 train_time:3733ms step_avg:34.88ms
+step:108/1585 train_time:3770ms step_avg:34.91ms
+step:109/1585 train_time:3801ms step_avg:34.87ms
+step:110/1585 train_time:3839ms step_avg:34.90ms
+step:111/1585 train_time:3870ms step_avg:34.87ms
+step:112/1585 train_time:3908ms step_avg:34.90ms
+step:113/1585 train_time:3939ms step_avg:34.86ms
+step:114/1585 train_time:3977ms step_avg:34.88ms
+step:115/1585 train_time:4008ms step_avg:34.86ms
+step:116/1585 train_time:4047ms step_avg:34.88ms
+step:117/1585 train_time:4077ms step_avg:34.85ms
+step:118/1585 train_time:4115ms step_avg:34.87ms
+step:119/1585 train_time:4146ms step_avg:34.84ms
+step:120/1585 train_time:4183ms step_avg:34.86ms
+step:121/1585 train_time:4214ms step_avg:34.83ms
+step:122/1585 train_time:4252ms step_avg:34.85ms
+step:123/1585 train_time:4283ms step_avg:34.82ms
+step:124/1585 train_time:4321ms step_avg:34.84ms
+step:125/1585 train_time:4351ms step_avg:34.81ms
+step:126/1585 train_time:4389ms step_avg:34.83ms
+step:127/1585 train_time:4420ms step_avg:34.80ms
+step:128/1585 train_time:4458ms step_avg:34.83ms
+step:129/1585 train_time:4488ms step_avg:34.79ms
+step:130/1585 train_time:4526ms step_avg:34.82ms
+step:131/1585 train_time:4556ms step_avg:34.78ms
+step:132/1585 train_time:4594ms step_avg:34.80ms
+step:133/1585 train_time:4624ms step_avg:34.77ms
+step:134/1585 train_time:4662ms step_avg:34.79ms
+step:135/1585 train_time:4693ms step_avg:34.76ms
+step:136/1585 train_time:4731ms step_avg:34.79ms
+step:137/1585 train_time:4762ms step_avg:34.76ms
+step:138/1585 train_time:4800ms step_avg:34.78ms
+step:139/1585 train_time:4831ms step_avg:34.76ms
+step:140/1585 train_time:4869ms step_avg:34.78ms
+step:141/1585 train_time:4899ms step_avg:34.75ms
+step:142/1585 train_time:4938ms step_avg:34.77ms
+step:143/1585 train_time:4968ms step_avg:34.74ms
+step:144/1585 train_time:5007ms step_avg:34.77ms
+step:145/1585 train_time:5037ms step_avg:34.74ms
+step:146/1585 train_time:5075ms step_avg:34.76ms
+step:147/1585 train_time:5106ms step_avg:34.74ms
+step:148/1585 train_time:5144ms step_avg:34.76ms
+step:149/1585 train_time:5175ms step_avg:34.73ms
+step:150/1585 train_time:5213ms step_avg:34.75ms
+step:151/1585 train_time:5243ms step_avg:34.72ms
+step:152/1585 train_time:5281ms step_avg:34.74ms
+step:153/1585 train_time:5312ms step_avg:34.72ms
+step:154/1585 train_time:5350ms step_avg:34.74ms
+step:155/1585 train_time:5380ms step_avg:34.71ms
+step:156/1585 train_time:5419ms step_avg:34.74ms
+step:157/1585 train_time:5449ms step_avg:34.71ms
+step:158/1585 train_time:5487ms step_avg:34.73ms
+step:159/1585 train_time:5518ms step_avg:34.70ms
+step:160/1585 train_time:5556ms step_avg:34.73ms
+step:161/1585 train_time:5586ms step_avg:34.70ms
+step:162/1585 train_time:5624ms step_avg:34.72ms
+step:163/1585 train_time:5655ms step_avg:34.69ms
+step:164/1585 train_time:5693ms step_avg:34.71ms
+step:165/1585 train_time:5723ms step_avg:34.69ms
+step:166/1585 train_time:5762ms step_avg:34.71ms
+step:167/1585 train_time:5792ms step_avg:34.68ms
+step:168/1585 train_time:5830ms step_avg:34.70ms
+step:169/1585 train_time:5860ms step_avg:34.68ms
+step:170/1585 train_time:5899ms step_avg:34.70ms
+step:171/1585 train_time:5929ms step_avg:34.67ms
+step:172/1585 train_time:5967ms step_avg:34.69ms
+step:173/1585 train_time:5998ms step_avg:34.67ms
+step:174/1585 train_time:6036ms step_avg:34.69ms
+step:175/1585 train_time:6066ms step_avg:34.66ms
+step:176/1585 train_time:6104ms step_avg:34.68ms
+step:177/1585 train_time:6135ms step_avg:34.66ms
+step:178/1585 train_time:6173ms step_avg:34.68ms
+step:179/1585 train_time:6203ms step_avg:34.66ms
+step:180/1585 train_time:6242ms step_avg:34.68ms
+step:181/1585 train_time:6272ms step_avg:34.65ms
+step:182/1585 train_time:6311ms step_avg:34.68ms
+step:183/1585 train_time:6341ms step_avg:34.65ms
+step:184/1585 train_time:6379ms step_avg:34.67ms
+step:185/1585 train_time:6410ms step_avg:34.65ms
+step:186/1585 train_time:6448ms step_avg:34.67ms
+step:187/1585 train_time:6478ms step_avg:34.64ms
+step:188/1585 train_time:6516ms step_avg:34.66ms
+step:189/1585 train_time:6546ms step_avg:34.64ms
+step:190/1585 train_time:6585ms step_avg:34.66ms
+step:191/1585 train_time:6615ms step_avg:34.63ms
+step:192/1585 train_time:6653ms step_avg:34.65ms
+step:193/1585 train_time:6683ms step_avg:34.63ms
+step:194/1585 train_time:6722ms step_avg:34.65ms
+step:195/1585 train_time:6752ms step_avg:34.63ms
+step:196/1585 train_time:6790ms step_avg:34.64ms
+step:197/1585 train_time:6821ms step_avg:34.62ms
+step:198/1585 train_time:6860ms step_avg:34.64ms
+step:199/1585 train_time:6890ms step_avg:34.62ms
+step:200/1585 train_time:6928ms step_avg:34.64ms
+step:201/1585 train_time:6959ms step_avg:34.62ms
+step:202/1585 train_time:6998ms step_avg:34.64ms
+step:203/1585 train_time:7028ms step_avg:34.62ms
+step:204/1585 train_time:7066ms step_avg:34.64ms
+step:205/1585 train_time:7096ms step_avg:34.62ms
+step:206/1585 train_time:7134ms step_avg:34.63ms
+step:207/1585 train_time:7165ms step_avg:34.61ms
+step:208/1585 train_time:7203ms step_avg:34.63ms
+step:209/1585 train_time:7233ms step_avg:34.61ms
+step:210/1585 train_time:7271ms step_avg:34.63ms
+step:211/1585 train_time:7302ms step_avg:34.60ms
+step:212/1585 train_time:7340ms step_avg:34.62ms
+step:213/1585 train_time:7370ms step_avg:34.60ms
+step:214/1585 train_time:7408ms step_avg:34.62ms
+step:215/1585 train_time:7438ms step_avg:34.60ms
+step:216/1585 train_time:7476ms step_avg:34.61ms
+step:217/1585 train_time:7507ms step_avg:34.59ms
+step:218/1585 train_time:7545ms step_avg:34.61ms
+step:219/1585 train_time:7575ms step_avg:34.59ms
+step:220/1585 train_time:7614ms step_avg:34.61ms
+step:221/1585 train_time:7644ms step_avg:34.59ms
+step:222/1585 train_time:7682ms step_avg:34.61ms
+step:223/1585 train_time:7712ms step_avg:34.59ms
+step:224/1585 train_time:7751ms step_avg:34.60ms
+step:225/1585 train_time:7781ms step_avg:34.58ms
+step:226/1585 train_time:7820ms step_avg:34.60ms
+step:227/1585 train_time:7849ms step_avg:34.58ms
+step:228/1585 train_time:7887ms step_avg:34.59ms
+step:229/1585 train_time:7918ms step_avg:34.58ms
+step:230/1585 train_time:7957ms step_avg:34.60ms
+step:231/1585 train_time:7988ms step_avg:34.58ms
+step:232/1585 train_time:8026ms step_avg:34.59ms
+step:233/1585 train_time:8056ms step_avg:34.57ms
+step:234/1585 train_time:8094ms step_avg:34.59ms
+step:235/1585 train_time:8125ms step_avg:34.57ms
+step:236/1585 train_time:8163ms step_avg:34.59ms
+step:237/1585 train_time:8193ms step_avg:34.57ms
+step:238/1585 train_time:8231ms step_avg:34.58ms
+step:239/1585 train_time:8262ms step_avg:34.57ms
+step:240/1585 train_time:8300ms step_avg:34.58ms
+step:241/1585 train_time:8330ms step_avg:34.56ms
+step:242/1585 train_time:8368ms step_avg:34.58ms
+step:243/1585 train_time:8399ms step_avg:34.56ms
+step:244/1585 train_time:8437ms step_avg:34.58ms
+step:245/1585 train_time:8467ms step_avg:34.56ms
+step:246/1585 train_time:8506ms step_avg:34.58ms
+step:247/1585 train_time:8536ms step_avg:34.56ms
+step:248/1585 train_time:8574ms step_avg:34.57ms
+step:249/1585 train_time:8605ms step_avg:34.56ms
+step:250/1585 train_time:8643ms step_avg:34.57ms
+step:250/1585 val_loss:4.5904 train_time:8691ms step_avg:34.76ms
+step:251/1585 train_time:8710ms step_avg:34.70ms
+step:252/1585 train_time:8729ms step_avg:34.64ms
+step:253/1585 train_time:8746ms step_avg:34.57ms
+step:254/1585 train_time:8783ms step_avg:34.58ms
+step:255/1585 train_time:8815ms step_avg:34.57ms
+step:256/1585 train_time:8855ms step_avg:34.59ms
+step:257/1585 train_time:8886ms step_avg:34.57ms
+step:258/1585 train_time:8924ms step_avg:34.59ms
+step:259/1585 train_time:8954ms step_avg:34.57ms
+step:260/1585 train_time:8993ms step_avg:34.59ms
+step:261/1585 train_time:9023ms step_avg:34.57ms
+step:262/1585 train_time:9061ms step_avg:34.58ms
+step:263/1585 train_time:9091ms step_avg:34.57ms
+step:264/1585 train_time:9129ms step_avg:34.58ms
+step:265/1585 train_time:9160ms step_avg:34.57ms
+step:266/1585 train_time:9198ms step_avg:34.58ms
+step:267/1585 train_time:9228ms step_avg:34.56ms
+step:268/1585 train_time:9266ms step_avg:34.58ms
+step:269/1585 train_time:9296ms step_avg:34.56ms
+step:270/1585 train_time:9334ms step_avg:34.57ms
+step:271/1585 train_time:9365ms step_avg:34.56ms
+step:272/1585 train_time:9402ms step_avg:34.57ms
+step:273/1585 train_time:9433ms step_avg:34.55ms
+step:274/1585 train_time:9471ms step_avg:34.57ms
+step:275/1585 train_time:9501ms step_avg:34.55ms
+step:276/1585 train_time:9539ms step_avg:34.56ms
+step:277/1585 train_time:9569ms step_avg:34.55ms
+step:278/1585 train_time:9608ms step_avg:34.56ms
+step:279/1585 train_time:9638ms step_avg:34.55ms
+step:280/1585 train_time:9676ms step_avg:34.56ms
+step:281/1585 train_time:9707ms step_avg:34.54ms
+step:282/1585 train_time:9746ms step_avg:34.56ms
+step:283/1585 train_time:9777ms step_avg:34.55ms
+step:284/1585 train_time:9815ms step_avg:34.56ms
+step:285/1585 train_time:9846ms step_avg:34.55ms
+step:286/1585 train_time:9885ms step_avg:34.56ms
+step:287/1585 train_time:9914ms step_avg:34.54ms
+step:288/1585 train_time:9953ms step_avg:34.56ms
+step:289/1585 train_time:9983ms step_avg:34.54ms
+step:290/1585 train_time:10021ms step_avg:34.56ms
+step:291/1585 train_time:10052ms step_avg:34.54ms
+step:292/1585 train_time:10090ms step_avg:34.56ms
+step:293/1585 train_time:10121ms step_avg:34.54ms
+step:294/1585 train_time:10159ms step_avg:34.55ms
+step:295/1585 train_time:10189ms step_avg:34.54ms
+step:296/1585 train_time:10227ms step_avg:34.55ms
+step:297/1585 train_time:10257ms step_avg:34.53ms
+step:298/1585 train_time:10295ms step_avg:34.55ms
+step:299/1585 train_time:10325ms step_avg:34.53ms
+step:300/1585 train_time:10363ms step_avg:34.54ms
+step:301/1585 train_time:10393ms step_avg:34.53ms
+step:302/1585 train_time:10431ms step_avg:34.54ms
+step:303/1585 train_time:10462ms step_avg:34.53ms
+step:304/1585 train_time:10500ms step_avg:34.54ms
+step:305/1585 train_time:10530ms step_avg:34.52ms
+step:306/1585 train_time:10568ms step_avg:34.54ms
+step:307/1585 train_time:10598ms step_avg:34.52ms
+step:308/1585 train_time:10636ms step_avg:34.53ms
+step:309/1585 train_time:10667ms step_avg:34.52ms
+step:310/1585 train_time:10705ms step_avg:34.53ms
+step:311/1585 train_time:10735ms step_avg:34.52ms
+step:312/1585 train_time:10773ms step_avg:34.53ms
+step:313/1585 train_time:10804ms step_avg:34.52ms
+step:314/1585 train_time:10842ms step_avg:34.53ms
+step:315/1585 train_time:10873ms step_avg:34.52ms
+step:316/1585 train_time:10911ms step_avg:34.53ms
+step:317/1585 train_time:10942ms step_avg:34.52ms
+step:318/1585 train_time:10980ms step_avg:34.53ms
+step:319/1585 train_time:11010ms step_avg:34.51ms
+step:320/1585 train_time:11048ms step_avg:34.53ms
+step:321/1585 train_time:11079ms step_avg:34.51ms
+step:322/1585 train_time:11117ms step_avg:34.52ms
+step:323/1585 train_time:11147ms step_avg:34.51ms
+step:324/1585 train_time:11186ms step_avg:34.52ms
+step:325/1585 train_time:11216ms step_avg:34.51ms
+step:326/1585 train_time:11254ms step_avg:34.52ms
+step:327/1585 train_time:11284ms step_avg:34.51ms
+step:328/1585 train_time:11322ms step_avg:34.52ms
+step:329/1585 train_time:11353ms step_avg:34.51ms
+step:330/1585 train_time:11392ms step_avg:34.52ms
+step:331/1585 train_time:11422ms step_avg:34.51ms
+step:332/1585 train_time:11460ms step_avg:34.52ms
+step:333/1585 train_time:11490ms step_avg:34.50ms
+step:334/1585 train_time:11528ms step_avg:34.51ms
+step:335/1585 train_time:11558ms step_avg:34.50ms
+step:336/1585 train_time:11596ms step_avg:34.51ms
+step:337/1585 train_time:11626ms step_avg:34.50ms
+step:338/1585 train_time:11664ms step_avg:34.51ms
+step:339/1585 train_time:11695ms step_avg:34.50ms
+step:340/1585 train_time:11733ms step_avg:34.51ms
+step:341/1585 train_time:11763ms step_avg:34.50ms
+step:342/1585 train_time:11801ms step_avg:34.51ms
+step:343/1585 train_time:11831ms step_avg:34.49ms
+step:344/1585 train_time:11870ms step_avg:34.50ms
+step:345/1585 train_time:11900ms step_avg:34.49ms
+step:346/1585 train_time:11938ms step_avg:34.50ms
+step:347/1585 train_time:11968ms step_avg:34.49ms
+step:348/1585 train_time:12007ms step_avg:34.50ms
+step:349/1585 train_time:12038ms step_avg:34.49ms
+step:350/1585 train_time:12076ms step_avg:34.50ms
+step:351/1585 train_time:12106ms step_avg:34.49ms
+step:352/1585 train_time:12144ms step_avg:34.50ms
+step:353/1585 train_time:12174ms step_avg:34.49ms
+step:354/1585 train_time:12212ms step_avg:34.50ms
+step:355/1585 train_time:12243ms step_avg:34.49ms
+step:356/1585 train_time:12281ms step_avg:34.50ms
+step:357/1585 train_time:12311ms step_avg:34.49ms
+step:358/1585 train_time:12349ms step_avg:34.49ms
+step:359/1585 train_time:12380ms step_avg:34.48ms
+step:360/1585 train_time:12418ms step_avg:34.49ms
+step:361/1585 train_time:12448ms step_avg:34.48ms
+step:362/1585 train_time:12487ms step_avg:34.49ms
+step:363/1585 train_time:12516ms step_avg:34.48ms
+step:364/1585 train_time:12555ms step_avg:34.49ms
+step:365/1585 train_time:12585ms step_avg:34.48ms
+step:366/1585 train_time:12623ms step_avg:34.49ms
+step:367/1585 train_time:12653ms step_avg:34.48ms
+step:368/1585 train_time:12692ms step_avg:34.49ms
+step:369/1585 train_time:12722ms step_avg:34.48ms
+step:370/1585 train_time:12760ms step_avg:34.49ms
+step:371/1585 train_time:12790ms step_avg:34.47ms
+step:372/1585 train_time:12828ms step_avg:34.48ms
+step:373/1585 train_time:12859ms step_avg:34.47ms
+step:374/1585 train_time:12897ms step_avg:34.48ms
+step:375/1585 train_time:12927ms step_avg:34.47ms
+step:376/1585 train_time:12966ms step_avg:34.48ms
+step:377/1585 train_time:12996ms step_avg:34.47ms
+step:378/1585 train_time:13034ms step_avg:34.48ms
+step:379/1585 train_time:13064ms step_avg:34.47ms
+step:380/1585 train_time:13103ms step_avg:34.48ms
+step:381/1585 train_time:13133ms step_avg:34.47ms
+step:382/1585 train_time:13172ms step_avg:34.48ms
+step:383/1585 train_time:13202ms step_avg:34.47ms
+step:384/1585 train_time:13241ms step_avg:34.48ms
+step:385/1585 train_time:13271ms step_avg:34.47ms
+step:386/1585 train_time:13309ms step_avg:34.48ms
+step:387/1585 train_time:13341ms step_avg:34.47ms
+step:388/1585 train_time:13379ms step_avg:34.48ms
+step:389/1585 train_time:13409ms step_avg:34.47ms
+step:390/1585 train_time:13447ms step_avg:34.48ms
+step:391/1585 train_time:13477ms step_avg:34.47ms
+step:392/1585 train_time:13515ms step_avg:34.48ms
+step:393/1585 train_time:13546ms step_avg:34.47ms
+step:394/1585 train_time:13584ms step_avg:34.48ms
+step:395/1585 train_time:13614ms step_avg:34.47ms
+step:396/1585 train_time:13652ms step_avg:34.48ms
+step:397/1585 train_time:13683ms step_avg:34.47ms
+step:398/1585 train_time:13720ms step_avg:34.47ms
+step:399/1585 train_time:13751ms step_avg:34.46ms
+step:400/1585 train_time:13789ms step_avg:34.47ms
+step:401/1585 train_time:13819ms step_avg:34.46ms
+step:402/1585 train_time:13857ms step_avg:34.47ms
+step:403/1585 train_time:13887ms step_avg:34.46ms
+step:404/1585 train_time:13925ms step_avg:34.47ms
+step:405/1585 train_time:13955ms step_avg:34.46ms
+step:406/1585 train_time:13993ms step_avg:34.47ms
+step:407/1585 train_time:14024ms step_avg:34.46ms
+step:408/1585 train_time:14062ms step_avg:34.46ms
+step:409/1585 train_time:14092ms step_avg:34.45ms
+step:410/1585 train_time:14131ms step_avg:34.47ms
+step:411/1585 train_time:14161ms step_avg:34.46ms
+step:412/1585 train_time:14200ms step_avg:34.46ms
+step:413/1585 train_time:14230ms step_avg:34.45ms
+step:414/1585 train_time:14268ms step_avg:34.46ms
+step:415/1585 train_time:14298ms step_avg:34.45ms
+step:416/1585 train_time:14337ms step_avg:34.46ms
+step:417/1585 train_time:14367ms step_avg:34.45ms
+step:418/1585 train_time:14406ms step_avg:34.46ms
+step:419/1585 train_time:14435ms step_avg:34.45ms
+step:420/1585 train_time:14474ms step_avg:34.46ms
+step:421/1585 train_time:14504ms step_avg:34.45ms
+step:422/1585 train_time:14543ms step_avg:34.46ms
+step:423/1585 train_time:14573ms step_avg:34.45ms
+step:424/1585 train_time:14611ms step_avg:34.46ms
+step:425/1585 train_time:14641ms step_avg:34.45ms
+step:426/1585 train_time:14679ms step_avg:34.46ms
+step:427/1585 train_time:14710ms step_avg:34.45ms
+step:428/1585 train_time:14748ms step_avg:34.46ms
+step:429/1585 train_time:14778ms step_avg:34.45ms
+step:430/1585 train_time:14816ms step_avg:34.46ms
+step:431/1585 train_time:14847ms step_avg:34.45ms
+step:432/1585 train_time:14885ms step_avg:34.46ms
+step:433/1585 train_time:14915ms step_avg:34.45ms
+step:434/1585 train_time:14953ms step_avg:34.45ms
+step:435/1585 train_time:14983ms step_avg:34.44ms
+step:436/1585 train_time:15021ms step_avg:34.45ms
+step:437/1585 train_time:15051ms step_avg:34.44ms
+step:438/1585 train_time:15090ms step_avg:34.45ms
+step:439/1585 train_time:15120ms step_avg:34.44ms
+step:440/1585 train_time:15158ms step_avg:34.45ms
+step:441/1585 train_time:15188ms step_avg:34.44ms
+step:442/1585 train_time:15226ms step_avg:34.45ms
+step:443/1585 train_time:15257ms step_avg:34.44ms
+step:444/1585 train_time:15295ms step_avg:34.45ms
+step:445/1585 train_time:15326ms step_avg:34.44ms
+step:446/1585 train_time:15364ms step_avg:34.45ms
+step:447/1585 train_time:15394ms step_avg:34.44ms
+step:448/1585 train_time:15433ms step_avg:34.45ms
+step:449/1585 train_time:15463ms step_avg:34.44ms
+step:450/1585 train_time:15501ms step_avg:34.45ms
+step:451/1585 train_time:15531ms step_avg:34.44ms
+step:452/1585 train_time:15570ms step_avg:34.45ms
+step:453/1585 train_time:15600ms step_avg:34.44ms
+step:454/1585 train_time:15639ms step_avg:34.45ms
+step:455/1585 train_time:15669ms step_avg:34.44ms
+step:456/1585 train_time:15708ms step_avg:34.45ms
+step:457/1585 train_time:15738ms step_avg:34.44ms
+step:458/1585 train_time:15776ms step_avg:34.45ms
+step:459/1585 train_time:15806ms step_avg:34.44ms
+step:460/1585 train_time:15844ms step_avg:34.44ms
+step:461/1585 train_time:15875ms step_avg:34.43ms
+step:462/1585 train_time:15913ms step_avg:34.44ms
+step:463/1585 train_time:15943ms step_avg:34.43ms
+step:464/1585 train_time:15981ms step_avg:34.44ms
+step:465/1585 train_time:16012ms step_avg:34.43ms
+step:466/1585 train_time:16050ms step_avg:34.44ms
+step:467/1585 train_time:16080ms step_avg:34.43ms
+step:468/1585 train_time:16118ms step_avg:34.44ms
+step:469/1585 train_time:16148ms step_avg:34.43ms
+step:470/1585 train_time:16186ms step_avg:34.44ms
+step:471/1585 train_time:16216ms step_avg:34.43ms
+step:472/1585 train_time:16255ms step_avg:34.44ms
+step:473/1585 train_time:16285ms step_avg:34.43ms
+step:474/1585 train_time:16323ms step_avg:34.44ms
+step:475/1585 train_time:16354ms step_avg:34.43ms
+step:476/1585 train_time:16393ms step_avg:34.44ms
+step:477/1585 train_time:16423ms step_avg:34.43ms
+step:478/1585 train_time:16461ms step_avg:34.44ms
+step:479/1585 train_time:16492ms step_avg:34.43ms
+step:480/1585 train_time:16531ms step_avg:34.44ms
+step:481/1585 train_time:16561ms step_avg:34.43ms
+step:482/1585 train_time:16599ms step_avg:34.44ms
+step:483/1585 train_time:16629ms step_avg:34.43ms
+step:484/1585 train_time:16667ms step_avg:34.43ms
+step:485/1585 train_time:16697ms step_avg:34.43ms
+step:486/1585 train_time:16735ms step_avg:34.43ms
+step:487/1585 train_time:16766ms step_avg:34.43ms
+step:488/1585 train_time:16804ms step_avg:34.43ms
+step:489/1585 train_time:16834ms step_avg:34.43ms
+step:490/1585 train_time:16873ms step_avg:34.43ms
+step:491/1585 train_time:16903ms step_avg:34.43ms
+step:492/1585 train_time:16941ms step_avg:34.43ms
+step:493/1585 train_time:16972ms step_avg:34.42ms
+step:494/1585 train_time:17010ms step_avg:34.43ms
+step:495/1585 train_time:17040ms step_avg:34.43ms
+step:496/1585 train_time:17078ms step_avg:34.43ms
+step:497/1585 train_time:17108ms step_avg:34.42ms
+step:498/1585 train_time:17146ms step_avg:34.43ms
+step:499/1585 train_time:17177ms step_avg:34.42ms
+step:500/1585 train_time:17215ms step_avg:34.43ms
+step:500/1585 val_loss:4.2357 train_time:17262ms step_avg:34.52ms
+step:501/1585 train_time:17282ms step_avg:34.49ms
+step:502/1585 train_time:17300ms step_avg:34.46ms
+step:503/1585 train_time:17317ms step_avg:34.43ms
+step:504/1585 train_time:17356ms step_avg:34.44ms
+step:505/1585 train_time:17387ms step_avg:34.43ms
+step:506/1585 train_time:17427ms step_avg:34.44ms
+step:507/1585 train_time:17458ms step_avg:34.43ms
+step:508/1585 train_time:17496ms step_avg:34.44ms
+step:509/1585 train_time:17527ms step_avg:34.43ms
+step:510/1585 train_time:17566ms step_avg:34.44ms
+step:511/1585 train_time:17596ms step_avg:34.43ms
+step:512/1585 train_time:17635ms step_avg:34.44ms
+step:513/1585 train_time:17664ms step_avg:34.43ms
+step:514/1585 train_time:17702ms step_avg:34.44ms
+step:515/1585 train_time:17733ms step_avg:34.43ms
+step:516/1585 train_time:17807ms step_avg:34.51ms
+step:517/1585 train_time:17868ms step_avg:34.56ms
+step:518/1585 train_time:17926ms step_avg:34.61ms
+step:519/1585 train_time:17988ms step_avg:34.66ms
+step:520/1585 train_time:18047ms step_avg:34.71ms
+step:521/1585 train_time:18109ms step_avg:34.76ms
+step:522/1585 train_time:18167ms step_avg:34.80ms
+step:523/1585 train_time:18234ms step_avg:34.86ms
+step:524/1585 train_time:18295ms step_avg:34.91ms
+step:525/1585 train_time:18358ms step_avg:34.97ms
+step:526/1585 train_time:18418ms step_avg:35.02ms
+step:527/1585 train_time:18482ms step_avg:35.07ms
+step:528/1585 train_time:18542ms step_avg:35.12ms
+step:529/1585 train_time:18605ms step_avg:35.17ms
+step:530/1585 train_time:18665ms step_avg:35.22ms
+step:531/1585 train_time:18728ms step_avg:35.27ms
+step:532/1585 train_time:18787ms step_avg:35.31ms
+step:533/1585 train_time:18850ms step_avg:35.37ms
+step:534/1585 train_time:18909ms step_avg:35.41ms
+step:535/1585 train_time:18971ms step_avg:35.46ms
+step:536/1585 train_time:19030ms step_avg:35.50ms
+step:537/1585 train_time:19093ms step_avg:35.55ms
+step:538/1585 train_time:19152ms step_avg:35.60ms
+step:539/1585 train_time:19215ms step_avg:35.65ms
+step:540/1585 train_time:19274ms step_avg:35.69ms
+step:541/1585 train_time:19338ms step_avg:35.74ms
+step:542/1585 train_time:19398ms step_avg:35.79ms
+step:543/1585 train_time:19462ms step_avg:35.84ms
+step:544/1585 train_time:19522ms step_avg:35.89ms
+step:545/1585 train_time:19586ms step_avg:35.94ms
+step:546/1585 train_time:19645ms step_avg:35.98ms
+step:547/1585 train_time:19708ms step_avg:36.03ms
+step:548/1585 train_time:19767ms step_avg:36.07ms
+step:549/1585 train_time:19830ms step_avg:36.12ms
+step:550/1585 train_time:19889ms step_avg:36.16ms
+step:551/1585 train_time:19952ms step_avg:36.21ms
+step:552/1585 train_time:20011ms step_avg:36.25ms
+step:553/1585 train_time:20073ms step_avg:36.30ms
+step:554/1585 train_time:20132ms step_avg:36.34ms
+step:555/1585 train_time:20195ms step_avg:36.39ms
+step:556/1585 train_time:20254ms step_avg:36.43ms
+step:557/1585 train_time:20318ms step_avg:36.48ms
+step:558/1585 train_time:20377ms step_avg:36.52ms
+step:559/1585 train_time:20442ms step_avg:36.57ms
+step:560/1585 train_time:20501ms step_avg:36.61ms
+step:561/1585 train_time:20565ms step_avg:36.66ms
+step:562/1585 train_time:20625ms step_avg:36.70ms
+step:563/1585 train_time:20689ms step_avg:36.75ms
+step:564/1585 train_time:20748ms step_avg:36.79ms
+step:565/1585 train_time:20810ms step_avg:36.83ms
+step:566/1585 train_time:20869ms step_avg:36.87ms
+step:567/1585 train_time:20932ms step_avg:36.92ms
+step:568/1585 train_time:20991ms step_avg:36.96ms
+step:569/1585 train_time:21054ms step_avg:37.00ms
+step:570/1585 train_time:21115ms step_avg:37.04ms
+step:571/1585 train_time:21178ms step_avg:37.09ms
+step:572/1585 train_time:21237ms step_avg:37.13ms
+step:573/1585 train_time:21299ms step_avg:37.17ms
+step:574/1585 train_time:21359ms step_avg:37.21ms
+step:575/1585 train_time:21422ms step_avg:37.26ms
+step:576/1585 train_time:21481ms step_avg:37.29ms
+step:577/1585 train_time:21545ms step_avg:37.34ms
+step:578/1585 train_time:21604ms step_avg:37.38ms
+step:579/1585 train_time:21667ms step_avg:37.42ms
+step:580/1585 train_time:21727ms step_avg:37.46ms
+step:581/1585 train_time:21790ms step_avg:37.50ms
+step:582/1585 train_time:21849ms step_avg:37.54ms
+step:583/1585 train_time:21912ms step_avg:37.58ms
+step:584/1585 train_time:21970ms step_avg:37.62ms
+step:585/1585 train_time:22033ms step_avg:37.66ms
+step:586/1585 train_time:22093ms step_avg:37.70ms
+step:587/1585 train_time:22156ms step_avg:37.74ms
+step:588/1585 train_time:22214ms step_avg:37.78ms
+step:589/1585 train_time:22277ms step_avg:37.82ms
+step:590/1585 train_time:22337ms step_avg:37.86ms
+step:591/1585 train_time:22400ms step_avg:37.90ms
+step:592/1585 train_time:22460ms step_avg:37.94ms
+step:593/1585 train_time:22524ms step_avg:37.98ms
+step:594/1585 train_time:22583ms step_avg:38.02ms
+step:595/1585 train_time:22647ms step_avg:38.06ms
+step:596/1585 train_time:22707ms step_avg:38.10ms
+step:597/1585 train_time:22769ms step_avg:38.14ms
+step:598/1585 train_time:22829ms step_avg:38.18ms
+step:599/1585 train_time:22892ms step_avg:38.22ms
+step:600/1585 train_time:22952ms step_avg:38.25ms
+step:601/1585 train_time:23014ms step_avg:38.29ms
+step:602/1585 train_time:23073ms step_avg:38.33ms
+step:603/1585 train_time:23136ms step_avg:38.37ms
+step:604/1585 train_time:23195ms step_avg:38.40ms
+step:605/1585 train_time:23260ms step_avg:38.45ms
+step:606/1585 train_time:23318ms step_avg:38.48ms
+step:607/1585 train_time:23383ms step_avg:38.52ms
+step:608/1585 train_time:23442ms step_avg:38.56ms
+step:609/1585 train_time:23507ms step_avg:38.60ms
+step:610/1585 train_time:23565ms step_avg:38.63ms
+step:611/1585 train_time:23629ms step_avg:38.67ms
+step:612/1585 train_time:23689ms step_avg:38.71ms
+step:613/1585 train_time:23753ms step_avg:38.75ms
+step:614/1585 train_time:23812ms step_avg:38.78ms
+step:615/1585 train_time:23876ms step_avg:38.82ms
+step:616/1585 train_time:23936ms step_avg:38.86ms
+step:617/1585 train_time:23999ms step_avg:38.90ms
+step:618/1585 train_time:24058ms step_avg:38.93ms
+step:619/1585 train_time:24121ms step_avg:38.97ms
+step:620/1585 train_time:24181ms step_avg:39.00ms
+step:621/1585 train_time:24244ms step_avg:39.04ms
+step:622/1585 train_time:24304ms step_avg:39.07ms
+step:623/1585 train_time:24368ms step_avg:39.11ms
+step:624/1585 train_time:24427ms step_avg:39.15ms
+step:625/1585 train_time:24490ms step_avg:39.18ms
+step:626/1585 train_time:24550ms step_avg:39.22ms
+step:627/1585 train_time:24614ms step_avg:39.26ms
+step:628/1585 train_time:24673ms step_avg:39.29ms
+step:629/1585 train_time:24737ms step_avg:39.33ms
+step:630/1585 train_time:24797ms step_avg:39.36ms
+step:631/1585 train_time:24861ms step_avg:39.40ms
+step:632/1585 train_time:24919ms step_avg:39.43ms
+step:633/1585 train_time:24983ms step_avg:39.47ms
+step:634/1585 train_time:25041ms step_avg:39.50ms
+step:635/1585 train_time:25105ms step_avg:39.54ms
+step:636/1585 train_time:25164ms step_avg:39.57ms
+step:637/1585 train_time:25228ms step_avg:39.60ms
+step:638/1585 train_time:25287ms step_avg:39.64ms
+step:639/1585 train_time:25351ms step_avg:39.67ms
+step:640/1585 train_time:25411ms step_avg:39.70ms
+step:641/1585 train_time:25473ms step_avg:39.74ms
+step:642/1585 train_time:25532ms step_avg:39.77ms
+step:643/1585 train_time:25595ms step_avg:39.81ms
+step:644/1585 train_time:25655ms step_avg:39.84ms
+step:645/1585 train_time:25719ms step_avg:39.87ms
+step:646/1585 train_time:25779ms step_avg:39.91ms
+step:647/1585 train_time:25843ms step_avg:39.94ms
+step:648/1585 train_time:25904ms step_avg:39.97ms
+step:649/1585 train_time:25966ms step_avg:40.01ms
+step:650/1585 train_time:26025ms step_avg:40.04ms
+step:651/1585 train_time:26087ms step_avg:40.07ms
+step:652/1585 train_time:26146ms step_avg:40.10ms
+step:653/1585 train_time:26209ms step_avg:40.14ms
+step:654/1585 train_time:26269ms step_avg:40.17ms
+step:655/1585 train_time:26332ms step_avg:40.20ms
+step:656/1585 train_time:26391ms step_avg:40.23ms
+step:657/1585 train_time:26454ms step_avg:40.27ms
+step:658/1585 train_time:26513ms step_avg:40.29ms
+step:659/1585 train_time:26576ms step_avg:40.33ms
+step:660/1585 train_time:26636ms step_avg:40.36ms
+step:661/1585 train_time:26700ms step_avg:40.39ms
+step:662/1585 train_time:26759ms step_avg:40.42ms
+step:663/1585 train_time:26823ms step_avg:40.46ms
+step:664/1585 train_time:26883ms step_avg:40.49ms
+step:665/1585 train_time:26946ms step_avg:40.52ms
+step:666/1585 train_time:27005ms step_avg:40.55ms
+step:667/1585 train_time:27068ms step_avg:40.58ms
+step:668/1585 train_time:27127ms step_avg:40.61ms
+step:669/1585 train_time:27190ms step_avg:40.64ms
+step:670/1585 train_time:27249ms step_avg:40.67ms
+step:671/1585 train_time:27312ms step_avg:40.70ms
+step:672/1585 train_time:27371ms step_avg:40.73ms
+step:673/1585 train_time:27434ms step_avg:40.76ms
+step:674/1585 train_time:27493ms step_avg:40.79ms
+step:675/1585 train_time:27556ms step_avg:40.82ms
+step:676/1585 train_time:27616ms step_avg:40.85ms
+step:677/1585 train_time:27679ms step_avg:40.89ms
+step:678/1585 train_time:27739ms step_avg:40.91ms
+step:679/1585 train_time:27803ms step_avg:40.95ms
+step:680/1585 train_time:27862ms step_avg:40.97ms
+step:681/1585 train_time:27926ms step_avg:41.01ms
+step:682/1585 train_time:27985ms step_avg:41.03ms
+step:683/1585 train_time:28048ms step_avg:41.07ms
+step:684/1585 train_time:28107ms step_avg:41.09ms
+step:685/1585 train_time:28170ms step_avg:41.12ms
+step:686/1585 train_time:28229ms step_avg:41.15ms
+step:687/1585 train_time:28292ms step_avg:41.18ms
+step:688/1585 train_time:28352ms step_avg:41.21ms
+step:689/1585 train_time:28415ms step_avg:41.24ms
+step:690/1585 train_time:28474ms step_avg:41.27ms
+step:691/1585 train_time:28537ms step_avg:41.30ms
+step:692/1585 train_time:28596ms step_avg:41.32ms
+step:693/1585 train_time:28660ms step_avg:41.36ms
+step:694/1585 train_time:28720ms step_avg:41.38ms
+step:695/1585 train_time:28784ms step_avg:41.42ms
+step:696/1585 train_time:28843ms step_avg:41.44ms
+step:697/1585 train_time:28907ms step_avg:41.47ms
+step:698/1585 train_time:28966ms step_avg:41.50ms
+step:699/1585 train_time:29029ms step_avg:41.53ms
+step:700/1585 train_time:29089ms step_avg:41.56ms
+step:701/1585 train_time:29151ms step_avg:41.59ms
+step:702/1585 train_time:29211ms step_avg:41.61ms
+step:703/1585 train_time:29274ms step_avg:41.64ms
+step:704/1585 train_time:29333ms step_avg:41.67ms
+step:705/1585 train_time:29397ms step_avg:41.70ms
+step:706/1585 train_time:29456ms step_avg:41.72ms
+step:707/1585 train_time:29519ms step_avg:41.75ms
+step:708/1585 train_time:29579ms step_avg:41.78ms
+step:709/1585 train_time:29642ms step_avg:41.81ms
+step:710/1585 train_time:29703ms step_avg:41.83ms
+step:711/1585 train_time:29766ms step_avg:41.87ms
+step:712/1585 train_time:29826ms step_avg:41.89ms
+step:713/1585 train_time:29889ms step_avg:41.92ms
+step:714/1585 train_time:29948ms step_avg:41.94ms
+step:715/1585 train_time:30011ms step_avg:41.97ms
+step:716/1585 train_time:30070ms step_avg:42.00ms
+step:717/1585 train_time:30133ms step_avg:42.03ms
+step:718/1585 train_time:30192ms step_avg:42.05ms
+step:719/1585 train_time:30254ms step_avg:42.08ms
+step:720/1585 train_time:30313ms step_avg:42.10ms
+step:721/1585 train_time:30376ms step_avg:42.13ms
+step:722/1585 train_time:30435ms step_avg:42.15ms
+step:723/1585 train_time:30499ms step_avg:42.18ms
+step:724/1585 train_time:30558ms step_avg:42.21ms
+step:725/1585 train_time:30622ms step_avg:42.24ms
+step:726/1585 train_time:30681ms step_avg:42.26ms
+step:727/1585 train_time:30745ms step_avg:42.29ms
+step:728/1585 train_time:30805ms step_avg:42.32ms
+step:729/1585 train_time:30868ms step_avg:42.34ms
+step:730/1585 train_time:30927ms step_avg:42.37ms
+step:731/1585 train_time:30991ms step_avg:42.39ms
+step:732/1585 train_time:31050ms step_avg:42.42ms
+step:733/1585 train_time:31113ms step_avg:42.45ms
+step:734/1585 train_time:31171ms step_avg:42.47ms
+step:735/1585 train_time:31235ms step_avg:42.50ms
+step:736/1585 train_time:31293ms step_avg:42.52ms
+step:737/1585 train_time:31356ms step_avg:42.55ms
+step:738/1585 train_time:31416ms step_avg:42.57ms
+step:739/1585 train_time:31479ms step_avg:42.60ms
+step:740/1585 train_time:31538ms step_avg:42.62ms
+step:741/1585 train_time:31602ms step_avg:42.65ms
+step:742/1585 train_time:31661ms step_avg:42.67ms
+step:743/1585 train_time:31725ms step_avg:42.70ms
+step:744/1585 train_time:31784ms step_avg:42.72ms
+step:745/1585 train_time:31847ms step_avg:42.75ms
+step:746/1585 train_time:31907ms step_avg:42.77ms
+step:747/1585 train_time:31970ms step_avg:42.80ms
+step:748/1585 train_time:32030ms step_avg:42.82ms
+step:749/1585 train_time:32093ms step_avg:42.85ms
+step:750/1585 train_time:32152ms step_avg:42.87ms
+step:750/1585 val_loss:3.8769 train_time:32197ms step_avg:42.93ms
+step:751/1585 train_time:32217ms step_avg:42.90ms
+step:752/1585 train_time:32278ms step_avg:42.92ms
+step:753/1585 train_time:32345ms step_avg:42.96ms
+step:754/1585 train_time:32405ms step_avg:42.98ms
+step:755/1585 train_time:32467ms step_avg:43.00ms
+step:756/1585 train_time:32526ms step_avg:43.02ms
+step:757/1585 train_time:32588ms step_avg:43.05ms
+step:758/1585 train_time:32648ms step_avg:43.07ms
+step:759/1585 train_time:32710ms step_avg:43.10ms
+step:760/1585 train_time:32769ms step_avg:43.12ms
+step:761/1585 train_time:32832ms step_avg:43.14ms
+step:762/1585 train_time:32891ms step_avg:43.16ms
+step:763/1585 train_time:32954ms step_avg:43.19ms
+step:764/1585 train_time:33014ms step_avg:43.21ms
+step:765/1585 train_time:33076ms step_avg:43.24ms
+step:766/1585 train_time:33137ms step_avg:43.26ms
+step:767/1585 train_time:33202ms step_avg:43.29ms
+step:768/1585 train_time:33262ms step_avg:43.31ms
+step:769/1585 train_time:33325ms step_avg:43.34ms
+step:770/1585 train_time:33385ms step_avg:43.36ms
+step:771/1585 train_time:33448ms step_avg:43.38ms
+step:772/1585 train_time:33507ms step_avg:43.40ms
+step:773/1585 train_time:33570ms step_avg:43.43ms
+step:774/1585 train_time:33629ms step_avg:43.45ms
+step:775/1585 train_time:33691ms step_avg:43.47ms
+step:776/1585 train_time:33750ms step_avg:43.49ms
+step:777/1585 train_time:33812ms step_avg:43.52ms
+step:778/1585 train_time:33871ms step_avg:43.54ms
+step:779/1585 train_time:33934ms step_avg:43.56ms
+step:780/1585 train_time:33993ms step_avg:43.58ms
+step:781/1585 train_time:34057ms step_avg:43.61ms
+step:782/1585 train_time:34118ms step_avg:43.63ms
+step:783/1585 train_time:34181ms step_avg:43.65ms
+step:784/1585 train_time:34241ms step_avg:43.68ms
+step:785/1585 train_time:34304ms step_avg:43.70ms
+step:786/1585 train_time:34364ms step_avg:43.72ms
+step:787/1585 train_time:34427ms step_avg:43.75ms
+step:788/1585 train_time:34486ms step_avg:43.76ms
+step:789/1585 train_time:34549ms step_avg:43.79ms
+step:790/1585 train_time:34608ms step_avg:43.81ms
+step:791/1585 train_time:34671ms step_avg:43.83ms
+step:792/1585 train_time:34731ms step_avg:43.85ms
+step:793/1585 train_time:34793ms step_avg:43.87ms
+step:794/1585 train_time:34852ms step_avg:43.89ms
+step:795/1585 train_time:34915ms step_avg:43.92ms
+step:796/1585 train_time:34973ms step_avg:43.94ms
+step:797/1585 train_time:35038ms step_avg:43.96ms
+step:798/1585 train_time:35096ms step_avg:43.98ms
+step:799/1585 train_time:35161ms step_avg:44.01ms
+step:800/1585 train_time:35220ms step_avg:44.03ms
+step:801/1585 train_time:35283ms step_avg:44.05ms
+step:802/1585 train_time:35342ms step_avg:44.07ms
+step:803/1585 train_time:35405ms step_avg:44.09ms
+step:804/1585 train_time:35464ms step_avg:44.11ms
+step:805/1585 train_time:35528ms step_avg:44.13ms
+step:806/1585 train_time:35587ms step_avg:44.15ms
+step:807/1585 train_time:35650ms step_avg:44.18ms
+step:808/1585 train_time:35709ms step_avg:44.19ms
+step:809/1585 train_time:35772ms step_avg:44.22ms
+step:810/1585 train_time:35831ms step_avg:44.24ms
+step:811/1585 train_time:35894ms step_avg:44.26ms
+step:812/1585 train_time:35953ms step_avg:44.28ms
+step:813/1585 train_time:36017ms step_avg:44.30ms
+step:814/1585 train_time:36076ms step_avg:44.32ms
+step:815/1585 train_time:36140ms step_avg:44.34ms
+step:816/1585 train_time:36200ms step_avg:44.36ms
+step:817/1585 train_time:36263ms step_avg:44.39ms
+step:818/1585 train_time:36323ms step_avg:44.40ms
+step:819/1585 train_time:36385ms step_avg:44.43ms
+step:820/1585 train_time:36444ms step_avg:44.44ms
+step:821/1585 train_time:36507ms step_avg:44.47ms
+step:822/1585 train_time:36567ms step_avg:44.49ms
+step:823/1585 train_time:36630ms step_avg:44.51ms
+step:824/1585 train_time:36689ms step_avg:44.53ms
+step:825/1585 train_time:36752ms step_avg:44.55ms
+step:826/1585 train_time:36811ms step_avg:44.57ms
+step:827/1585 train_time:36874ms step_avg:44.59ms
+step:828/1585 train_time:36933ms step_avg:44.60ms
+step:829/1585 train_time:36996ms step_avg:44.63ms
+step:830/1585 train_time:37055ms step_avg:44.64ms
+step:831/1585 train_time:37120ms step_avg:44.67ms
+step:832/1585 train_time:37179ms step_avg:44.69ms
+step:833/1585 train_time:37243ms step_avg:44.71ms
+step:834/1585 train_time:37302ms step_avg:44.73ms
+step:835/1585 train_time:37365ms step_avg:44.75ms
+step:836/1585 train_time:37424ms step_avg:44.77ms
+step:837/1585 train_time:37488ms step_avg:44.79ms
+step:838/1585 train_time:37547ms step_avg:44.81ms
+step:839/1585 train_time:37610ms step_avg:44.83ms
+step:840/1585 train_time:37670ms step_avg:44.84ms
+step:841/1585 train_time:37733ms step_avg:44.87ms
+step:842/1585 train_time:37791ms step_avg:44.88ms
+step:843/1585 train_time:37855ms step_avg:44.90ms
+step:844/1585 train_time:37914ms step_avg:44.92ms
+step:845/1585 train_time:37977ms step_avg:44.94ms
+step:846/1585 train_time:38037ms step_avg:44.96ms
+step:847/1585 train_time:38101ms step_avg:44.98ms
+step:848/1585 train_time:38160ms step_avg:45.00ms
+step:849/1585 train_time:38223ms step_avg:45.02ms
+step:850/1585 train_time:38282ms step_avg:45.04ms
+step:851/1585 train_time:38345ms step_avg:45.06ms
+step:852/1585 train_time:38404ms step_avg:45.08ms
+step:853/1585 train_time:38468ms step_avg:45.10ms
+step:854/1585 train_time:38528ms step_avg:45.11ms
+step:855/1585 train_time:38591ms step_avg:45.14ms
+step:856/1585 train_time:38650ms step_avg:45.15ms
+step:857/1585 train_time:38713ms step_avg:45.17ms
+step:858/1585 train_time:38772ms step_avg:45.19ms
+step:859/1585 train_time:38835ms step_avg:45.21ms
+step:860/1585 train_time:38894ms step_avg:45.23ms
+step:861/1585 train_time:38958ms step_avg:45.25ms
+step:862/1585 train_time:39017ms step_avg:45.26ms
+step:863/1585 train_time:39080ms step_avg:45.28ms
+step:864/1585 train_time:39139ms step_avg:45.30ms
+step:865/1585 train_time:39202ms step_avg:45.32ms
+step:866/1585 train_time:39261ms step_avg:45.34ms
+step:867/1585 train_time:39325ms step_avg:45.36ms
+step:868/1585 train_time:39384ms step_avg:45.37ms
+step:869/1585 train_time:39447ms step_avg:45.39ms
+step:870/1585 train_time:39506ms step_avg:45.41ms
+step:871/1585 train_time:39570ms step_avg:45.43ms
+step:872/1585 train_time:39629ms step_avg:45.45ms
+step:873/1585 train_time:39692ms step_avg:45.47ms
+step:874/1585 train_time:39751ms step_avg:45.48ms
+step:875/1585 train_time:39814ms step_avg:45.50ms
+step:876/1585 train_time:39874ms step_avg:45.52ms
+step:877/1585 train_time:39937ms step_avg:45.54ms
+step:878/1585 train_time:39996ms step_avg:45.55ms
+step:879/1585 train_time:40059ms step_avg:45.57ms
+step:880/1585 train_time:40119ms step_avg:45.59ms
+step:881/1585 train_time:40181ms step_avg:45.61ms
+step:882/1585 train_time:40242ms step_avg:45.63ms
+step:883/1585 train_time:40304ms step_avg:45.64ms
+step:884/1585 train_time:40364ms step_avg:45.66ms
+step:885/1585 train_time:40427ms step_avg:45.68ms
+step:886/1585 train_time:40486ms step_avg:45.70ms
+step:887/1585 train_time:40550ms step_avg:45.72ms
+step:888/1585 train_time:40610ms step_avg:45.73ms
+step:889/1585 train_time:40673ms step_avg:45.75ms
+step:890/1585 train_time:40732ms step_avg:45.77ms
+step:891/1585 train_time:40795ms step_avg:45.79ms
+step:892/1585 train_time:40854ms step_avg:45.80ms
+step:893/1585 train_time:40917ms step_avg:45.82ms
+step:894/1585 train_time:40977ms step_avg:45.84ms
+step:895/1585 train_time:41041ms step_avg:45.86ms
+step:896/1585 train_time:41099ms step_avg:45.87ms
+step:897/1585 train_time:41162ms step_avg:45.89ms
+step:898/1585 train_time:41221ms step_avg:45.90ms
+step:899/1585 train_time:41285ms step_avg:45.92ms
+step:900/1585 train_time:41344ms step_avg:45.94ms
+step:901/1585 train_time:41407ms step_avg:45.96ms
+step:902/1585 train_time:41467ms step_avg:45.97ms
+step:903/1585 train_time:41530ms step_avg:45.99ms
+step:904/1585 train_time:41589ms step_avg:46.01ms
+step:905/1585 train_time:41652ms step_avg:46.02ms
+step:906/1585 train_time:41711ms step_avg:46.04ms
+step:907/1585 train_time:41774ms step_avg:46.06ms
+step:908/1585 train_time:41834ms step_avg:46.07ms
+step:909/1585 train_time:41897ms step_avg:46.09ms
+step:910/1585 train_time:41956ms step_avg:46.11ms
+step:911/1585 train_time:42020ms step_avg:46.12ms
+step:912/1585 train_time:42079ms step_avg:46.14ms
+step:913/1585 train_time:42142ms step_avg:46.16ms
+step:914/1585 train_time:42201ms step_avg:46.17ms
+step:915/1585 train_time:42264ms step_avg:46.19ms
+step:916/1585 train_time:42323ms step_avg:46.20ms
+step:917/1585 train_time:42387ms step_avg:46.22ms
+step:918/1585 train_time:42446ms step_avg:46.24ms
+step:919/1585 train_time:42509ms step_avg:46.26ms
+step:920/1585 train_time:42568ms step_avg:46.27ms
+step:921/1585 train_time:42632ms step_avg:46.29ms
+step:922/1585 train_time:42690ms step_avg:46.30ms
+step:923/1585 train_time:42753ms step_avg:46.32ms
+step:924/1585 train_time:42812ms step_avg:46.33ms
+step:925/1585 train_time:42875ms step_avg:46.35ms
+step:926/1585 train_time:42935ms step_avg:46.37ms
+step:927/1585 train_time:42999ms step_avg:46.38ms
+step:928/1585 train_time:43057ms step_avg:46.40ms
+step:929/1585 train_time:43121ms step_avg:46.42ms
+step:930/1585 train_time:43180ms step_avg:46.43ms
+step:931/1585 train_time:43243ms step_avg:46.45ms
+step:932/1585 train_time:43302ms step_avg:46.46ms
+step:933/1585 train_time:43365ms step_avg:46.48ms
+step:934/1585 train_time:43424ms step_avg:46.49ms
+step:935/1585 train_time:43488ms step_avg:46.51ms
+step:936/1585 train_time:43547ms step_avg:46.53ms
+step:937/1585 train_time:43610ms step_avg:46.54ms
+step:938/1585 train_time:43669ms step_avg:46.56ms
+step:939/1585 train_time:43733ms step_avg:46.57ms
+step:940/1585 train_time:43791ms step_avg:46.59ms
+step:941/1585 train_time:43854ms step_avg:46.60ms
+step:942/1585 train_time:43915ms step_avg:46.62ms
+step:943/1585 train_time:43978ms step_avg:46.64ms
+step:944/1585 train_time:44037ms step_avg:46.65ms
+step:945/1585 train_time:44101ms step_avg:46.67ms
+step:946/1585 train_time:44160ms step_avg:46.68ms
+step:947/1585 train_time:44223ms step_avg:46.70ms
+step:948/1585 train_time:44282ms step_avg:46.71ms
+step:949/1585 train_time:44345ms step_avg:46.73ms
+step:950/1585 train_time:44404ms step_avg:46.74ms
+step:951/1585 train_time:44467ms step_avg:46.76ms
+step:952/1585 train_time:44527ms step_avg:46.77ms
+step:953/1585 train_time:44590ms step_avg:46.79ms
+step:954/1585 train_time:44649ms step_avg:46.80ms
+step:955/1585 train_time:44712ms step_avg:46.82ms
+step:956/1585 train_time:44772ms step_avg:46.83ms
+step:957/1585 train_time:44835ms step_avg:46.85ms
+step:958/1585 train_time:44894ms step_avg:46.86ms
+step:959/1585 train_time:44957ms step_avg:46.88ms
+step:960/1585 train_time:45016ms step_avg:46.89ms
+step:961/1585 train_time:45080ms step_avg:46.91ms
+step:962/1585 train_time:45140ms step_avg:46.92ms
+step:963/1585 train_time:45203ms step_avg:46.94ms
+step:964/1585 train_time:45262ms step_avg:46.95ms
+step:965/1585 train_time:45324ms step_avg:46.97ms
+step:966/1585 train_time:45384ms step_avg:46.98ms
+step:967/1585 train_time:45447ms step_avg:47.00ms
+step:968/1585 train_time:45507ms step_avg:47.01ms
+step:969/1585 train_time:45570ms step_avg:47.03ms
+step:970/1585 train_time:45629ms step_avg:47.04ms
+step:971/1585 train_time:45692ms step_avg:47.06ms
+step:972/1585 train_time:45751ms step_avg:47.07ms
+step:973/1585 train_time:45814ms step_avg:47.09ms
+step:974/1585 train_time:45874ms step_avg:47.10ms
+step:975/1585 train_time:45937ms step_avg:47.11ms
+step:976/1585 train_time:45996ms step_avg:47.13ms
+step:977/1585 train_time:46059ms step_avg:47.14ms
+step:978/1585 train_time:46120ms step_avg:47.16ms
+step:979/1585 train_time:46183ms step_avg:47.17ms
+step:980/1585 train_time:46242ms step_avg:47.19ms
+step:981/1585 train_time:46305ms step_avg:47.20ms
+step:982/1585 train_time:46364ms step_avg:47.21ms
+step:983/1585 train_time:46427ms step_avg:47.23ms
+step:984/1585 train_time:46486ms step_avg:47.24ms
+step:985/1585 train_time:46550ms step_avg:47.26ms
+step:986/1585 train_time:46610ms step_avg:47.27ms
+step:987/1585 train_time:46673ms step_avg:47.29ms
+step:988/1585 train_time:46732ms step_avg:47.30ms
+step:989/1585 train_time:46795ms step_avg:47.32ms
+step:990/1585 train_time:46854ms step_avg:47.33ms
+step:991/1585 train_time:46917ms step_avg:47.34ms
+step:992/1585 train_time:46976ms step_avg:47.36ms
+step:993/1585 train_time:47039ms step_avg:47.37ms
+step:994/1585 train_time:47098ms step_avg:47.38ms
+step:995/1585 train_time:47162ms step_avg:47.40ms
+step:996/1585 train_time:47221ms step_avg:47.41ms
+step:997/1585 train_time:47284ms step_avg:47.43ms
+step:998/1585 train_time:47343ms step_avg:47.44ms
+step:999/1585 train_time:47407ms step_avg:47.45ms
+step:1000/1585 train_time:47466ms step_avg:47.47ms
+step:1000/1585 val_loss:3.5863 train_time:47511ms step_avg:47.51ms
+step:1001/1585 train_time:47531ms step_avg:47.48ms
+step:1002/1585 train_time:47591ms step_avg:47.50ms
+step:1003/1585 train_time:47657ms step_avg:47.51ms
+step:1004/1585 train_time:47717ms step_avg:47.53ms
+step:1005/1585 train_time:47780ms step_avg:47.54ms
+step:1006/1585 train_time:47839ms step_avg:47.55ms
+step:1007/1585 train_time:47901ms step_avg:47.57ms
+step:1008/1585 train_time:47961ms step_avg:47.58ms
+step:1009/1585 train_time:48023ms step_avg:47.59ms
+step:1010/1585 train_time:48083ms step_avg:47.61ms
+step:1011/1585 train_time:48146ms step_avg:47.62ms
+step:1012/1585 train_time:48204ms step_avg:47.63ms
+step:1013/1585 train_time:48267ms step_avg:47.65ms
+step:1014/1585 train_time:48326ms step_avg:47.66ms
+step:1015/1585 train_time:48388ms step_avg:47.67ms
+step:1016/1585 train_time:48448ms step_avg:47.69ms
+step:1017/1585 train_time:48513ms step_avg:47.70ms
+step:1018/1585 train_time:48573ms step_avg:47.71ms
+step:1019/1585 train_time:48637ms step_avg:47.73ms
+step:1020/1585 train_time:48697ms step_avg:47.74ms
+step:1021/1585 train_time:48760ms step_avg:47.76ms
+step:1022/1585 train_time:48819ms step_avg:47.77ms
+step:1023/1585 train_time:48882ms step_avg:47.78ms
+step:1024/1585 train_time:48941ms step_avg:47.79ms
+step:1025/1585 train_time:49004ms step_avg:47.81ms
+step:1026/1585 train_time:49063ms step_avg:47.82ms
+step:1027/1585 train_time:49126ms step_avg:47.83ms
+step:1028/1585 train_time:49184ms step_avg:47.84ms
+step:1029/1585 train_time:49248ms step_avg:47.86ms
+step:1030/1585 train_time:49306ms step_avg:47.87ms
+step:1031/1585 train_time:49375ms step_avg:47.89ms
+step:1032/1585 train_time:49462ms step_avg:47.93ms
+step:1033/1585 train_time:49553ms step_avg:47.97ms
+step:1034/1585 train_time:49640ms step_avg:48.01ms
+step:1035/1585 train_time:49731ms step_avg:48.05ms
+step:1036/1585 train_time:49818ms step_avg:48.09ms
+step:1037/1585 train_time:49908ms step_avg:48.13ms
+step:1038/1585 train_time:49994ms step_avg:48.16ms
+step:1039/1585 train_time:50083ms step_avg:48.20ms
+step:1040/1585 train_time:50169ms step_avg:48.24ms
+step:1041/1585 train_time:50258ms step_avg:48.28ms
+step:1042/1585 train_time:50344ms step_avg:48.31ms
+step:1043/1585 train_time:50433ms step_avg:48.35ms
+step:1044/1585 train_time:50519ms step_avg:48.39ms
+step:1045/1585 train_time:50609ms step_avg:48.43ms
+step:1046/1585 train_time:50696ms step_avg:48.47ms
+step:1047/1585 train_time:50785ms step_avg:48.51ms
+step:1048/1585 train_time:50872ms step_avg:48.54ms
+step:1049/1585 train_time:50962ms step_avg:48.58ms
+step:1050/1585 train_time:51048ms step_avg:48.62ms
+step:1051/1585 train_time:51136ms step_avg:48.65ms
+step:1052/1585 train_time:51222ms step_avg:48.69ms
+step:1053/1585 train_time:51312ms step_avg:48.73ms
+step:1054/1585 train_time:51397ms step_avg:48.76ms
+step:1055/1585 train_time:51486ms step_avg:48.80ms
+step:1056/1585 train_time:51573ms step_avg:48.84ms
+step:1057/1585 train_time:51662ms step_avg:48.88ms
+step:1058/1585 train_time:51749ms step_avg:48.91ms
+step:1059/1585 train_time:51838ms step_avg:48.95ms
+step:1060/1585 train_time:51925ms step_avg:48.99ms
+step:1061/1585 train_time:52014ms step_avg:49.02ms
+step:1062/1585 train_time:52100ms step_avg:49.06ms
+step:1063/1585 train_time:52189ms step_avg:49.10ms
+step:1064/1585 train_time:52276ms step_avg:49.13ms
+step:1065/1585 train_time:52364ms step_avg:49.17ms
+step:1066/1585 train_time:52450ms step_avg:49.20ms
+step:1067/1585 train_time:52540ms step_avg:49.24ms
+step:1068/1585 train_time:52626ms step_avg:49.28ms
+step:1069/1585 train_time:52716ms step_avg:49.31ms
+step:1070/1585 train_time:52804ms step_avg:49.35ms
+step:1071/1585 train_time:52893ms step_avg:49.39ms
+step:1072/1585 train_time:52980ms step_avg:49.42ms
+step:1073/1585 train_time:53071ms step_avg:49.46ms
+step:1074/1585 train_time:53157ms step_avg:49.49ms
+step:1075/1585 train_time:53246ms step_avg:49.53ms
+step:1076/1585 train_time:53332ms step_avg:49.56ms
+step:1077/1585 train_time:53429ms step_avg:49.61ms
+step:1078/1585 train_time:53506ms step_avg:49.63ms
+step:1079/1585 train_time:53595ms step_avg:49.67ms
+step:1080/1585 train_time:53681ms step_avg:49.70ms
+step:1081/1585 train_time:53770ms step_avg:49.74ms
+step:1082/1585 train_time:53857ms step_avg:49.78ms
+step:1083/1585 train_time:53947ms step_avg:49.81ms
+step:1084/1585 train_time:54033ms step_avg:49.85ms
+step:1085/1585 train_time:54121ms step_avg:49.88ms
+step:1086/1585 train_time:54207ms step_avg:49.91ms
+step:1087/1585 train_time:54295ms step_avg:49.95ms
+step:1088/1585 train_time:54381ms step_avg:49.98ms
+step:1089/1585 train_time:54471ms step_avg:50.02ms
+step:1090/1585 train_time:54557ms step_avg:50.05ms
+step:1091/1585 train_time:54646ms step_avg:50.09ms
+step:1092/1585 train_time:54732ms step_avg:50.12ms
+step:1093/1585 train_time:54822ms step_avg:50.16ms
+step:1094/1585 train_time:54908ms step_avg:50.19ms
+step:1095/1585 train_time:54998ms step_avg:50.23ms
+step:1096/1585 train_time:55084ms step_avg:50.26ms
+step:1097/1585 train_time:55173ms step_avg:50.29ms
+step:1098/1585 train_time:55259ms step_avg:50.33ms
+step:1099/1585 train_time:55348ms step_avg:50.36ms
+step:1100/1585 train_time:55434ms step_avg:50.39ms
+step:1101/1585 train_time:55523ms step_avg:50.43ms
+step:1102/1585 train_time:55609ms step_avg:50.46ms
+step:1103/1585 train_time:55699ms step_avg:50.50ms
+step:1104/1585 train_time:55785ms step_avg:50.53ms
+step:1105/1585 train_time:55874ms step_avg:50.56ms
+step:1106/1585 train_time:55959ms step_avg:50.60ms
+step:1107/1585 train_time:56049ms step_avg:50.63ms
+step:1108/1585 train_time:56135ms step_avg:50.66ms
+step:1109/1585 train_time:56224ms step_avg:50.70ms
+step:1110/1585 train_time:56309ms step_avg:50.73ms
+step:1111/1585 train_time:56398ms step_avg:50.76ms
+step:1112/1585 train_time:56484ms step_avg:50.80ms
+step:1113/1585 train_time:56573ms step_avg:50.83ms
+step:1114/1585 train_time:56659ms step_avg:50.86ms
+step:1115/1585 train_time:56748ms step_avg:50.90ms
+step:1116/1585 train_time:56835ms step_avg:50.93ms
+step:1117/1585 train_time:56923ms step_avg:50.96ms
+step:1118/1585 train_time:57010ms step_avg:50.99ms
+step:1119/1585 train_time:57100ms step_avg:51.03ms
+step:1120/1585 train_time:57186ms step_avg:51.06ms
+step:1121/1585 train_time:57276ms step_avg:51.09ms
+step:1122/1585 train_time:57362ms step_avg:51.12ms
+step:1123/1585 train_time:57452ms step_avg:51.16ms
+step:1124/1585 train_time:57537ms step_avg:51.19ms
+step:1125/1585 train_time:57626ms step_avg:51.22ms
+step:1126/1585 train_time:57712ms step_avg:51.25ms
+step:1127/1585 train_time:57801ms step_avg:51.29ms
+step:1128/1585 train_time:57887ms step_avg:51.32ms
+step:1129/1585 train_time:57977ms step_avg:51.35ms
+step:1130/1585 train_time:58063ms step_avg:51.38ms
+step:1131/1585 train_time:58152ms step_avg:51.42ms
+step:1132/1585 train_time:58239ms step_avg:51.45ms
+step:1133/1585 train_time:58328ms step_avg:51.48ms
+step:1134/1585 train_time:58413ms step_avg:51.51ms
+step:1135/1585 train_time:58502ms step_avg:51.54ms
+step:1136/1585 train_time:58589ms step_avg:51.57ms
+step:1137/1585 train_time:58678ms step_avg:51.61ms
+step:1138/1585 train_time:58764ms step_avg:51.64ms
+step:1139/1585 train_time:58853ms step_avg:51.67ms
+step:1140/1585 train_time:58939ms step_avg:51.70ms
+step:1141/1585 train_time:59028ms step_avg:51.73ms
+step:1142/1585 train_time:59114ms step_avg:51.76ms
+step:1143/1585 train_time:59204ms step_avg:51.80ms
+step:1144/1585 train_time:59290ms step_avg:51.83ms
+step:1145/1585 train_time:59379ms step_avg:51.86ms
+step:1146/1585 train_time:59466ms step_avg:51.89ms
+step:1147/1585 train_time:59555ms step_avg:51.92ms
+step:1148/1585 train_time:59643ms step_avg:51.95ms
+step:1149/1585 train_time:59731ms step_avg:51.99ms
+step:1150/1585 train_time:59817ms step_avg:52.01ms
+step:1151/1585 train_time:59906ms step_avg:52.05ms
+step:1152/1585 train_time:59992ms step_avg:52.08ms
+step:1153/1585 train_time:60082ms step_avg:52.11ms
+step:1154/1585 train_time:60168ms step_avg:52.14ms
+step:1155/1585 train_time:60257ms step_avg:52.17ms
+step:1156/1585 train_time:60343ms step_avg:52.20ms
+step:1157/1585 train_time:60432ms step_avg:52.23ms
+step:1158/1585 train_time:60517ms step_avg:52.26ms
+step:1159/1585 train_time:60606ms step_avg:52.29ms
+step:1160/1585 train_time:60692ms step_avg:52.32ms
+step:1161/1585 train_time:60782ms step_avg:52.35ms
+step:1162/1585 train_time:60868ms step_avg:52.38ms
+step:1163/1585 train_time:60958ms step_avg:52.41ms
+step:1164/1585 train_time:61044ms step_avg:52.44ms
+step:1165/1585 train_time:61134ms step_avg:52.48ms
+step:1166/1585 train_time:61221ms step_avg:52.50ms
+step:1167/1585 train_time:61310ms step_avg:52.54ms
+step:1168/1585 train_time:61396ms step_avg:52.57ms
+step:1169/1585 train_time:61486ms step_avg:52.60ms
+step:1170/1585 train_time:61572ms step_avg:52.63ms
+step:1171/1585 train_time:61661ms step_avg:52.66ms
+step:1172/1585 train_time:61747ms step_avg:52.69ms
+step:1173/1585 train_time:61837ms step_avg:52.72ms
+step:1174/1585 train_time:61923ms step_avg:52.75ms
+step:1175/1585 train_time:62013ms step_avg:52.78ms
+step:1176/1585 train_time:62099ms step_avg:52.81ms
+step:1177/1585 train_time:62188ms step_avg:52.84ms
+step:1178/1585 train_time:62275ms step_avg:52.86ms
+step:1179/1585 train_time:62364ms step_avg:52.90ms
+step:1180/1585 train_time:62450ms step_avg:52.92ms
+step:1181/1585 train_time:62539ms step_avg:52.95ms
+step:1182/1585 train_time:62625ms step_avg:52.98ms
+step:1183/1585 train_time:62715ms step_avg:53.01ms
+step:1184/1585 train_time:62801ms step_avg:53.04ms
+step:1185/1585 train_time:62890ms step_avg:53.07ms
+step:1186/1585 train_time:62976ms step_avg:53.10ms
+step:1187/1585 train_time:63066ms step_avg:53.13ms
+step:1188/1585 train_time:63152ms step_avg:53.16ms
+step:1189/1585 train_time:63241ms step_avg:53.19ms
+step:1190/1585 train_time:63326ms step_avg:53.22ms
+step:1191/1585 train_time:63416ms step_avg:53.25ms
+step:1192/1585 train_time:63502ms step_avg:53.27ms
+step:1193/1585 train_time:63591ms step_avg:53.30ms
+step:1194/1585 train_time:63677ms step_avg:53.33ms
+step:1195/1585 train_time:63767ms step_avg:53.36ms
+step:1196/1585 train_time:63853ms step_avg:53.39ms
+step:1197/1585 train_time:63942ms step_avg:53.42ms
+step:1198/1585 train_time:64028ms step_avg:53.45ms
+step:1199/1585 train_time:64117ms step_avg:53.48ms
+step:1200/1585 train_time:64204ms step_avg:53.50ms
+step:1201/1585 train_time:64294ms step_avg:53.53ms
+step:1202/1585 train_time:64381ms step_avg:53.56ms
+step:1203/1585 train_time:64471ms step_avg:53.59ms
+step:1204/1585 train_time:64557ms step_avg:53.62ms
+step:1205/1585 train_time:64648ms step_avg:53.65ms
+step:1206/1585 train_time:64733ms step_avg:53.68ms
+step:1207/1585 train_time:64821ms step_avg:53.70ms
+step:1208/1585 train_time:64907ms step_avg:53.73ms
+step:1209/1585 train_time:64998ms step_avg:53.76ms
+step:1210/1585 train_time:65084ms step_avg:53.79ms
+step:1211/1585 train_time:65173ms step_avg:53.82ms
+step:1212/1585 train_time:65259ms step_avg:53.84ms
+step:1213/1585 train_time:65349ms step_avg:53.87ms
+step:1214/1585 train_time:65435ms step_avg:53.90ms
+step:1215/1585 train_time:65524ms step_avg:53.93ms
+step:1216/1585 train_time:65610ms step_avg:53.96ms
+step:1217/1585 train_time:65699ms step_avg:53.98ms
+step:1218/1585 train_time:65785ms step_avg:54.01ms
+step:1219/1585 train_time:65874ms step_avg:54.04ms
+step:1220/1585 train_time:65961ms step_avg:54.07ms
+step:1221/1585 train_time:66050ms step_avg:54.10ms
+step:1222/1585 train_time:66135ms step_avg:54.12ms
+step:1223/1585 train_time:66225ms step_avg:54.15ms
+step:1224/1585 train_time:66311ms step_avg:54.18ms
+step:1225/1585 train_time:66400ms step_avg:54.20ms
+step:1226/1585 train_time:66487ms step_avg:54.23ms
+step:1227/1585 train_time:66576ms step_avg:54.26ms
+step:1228/1585 train_time:66662ms step_avg:54.29ms
+step:1229/1585 train_time:66751ms step_avg:54.31ms
+step:1230/1585 train_time:66837ms step_avg:54.34ms
+step:1231/1585 train_time:66927ms step_avg:54.37ms
+step:1232/1585 train_time:67013ms step_avg:54.39ms
+step:1233/1585 train_time:67102ms step_avg:54.42ms
+step:1234/1585 train_time:67188ms step_avg:54.45ms
+step:1235/1585 train_time:67278ms step_avg:54.48ms
+step:1236/1585 train_time:67365ms step_avg:54.50ms
+step:1237/1585 train_time:67454ms step_avg:54.53ms
+step:1238/1585 train_time:67540ms step_avg:54.56ms
+step:1239/1585 train_time:67630ms step_avg:54.58ms
+step:1240/1585 train_time:67715ms step_avg:54.61ms
+step:1241/1585 train_time:67806ms step_avg:54.64ms
+step:1242/1585 train_time:67892ms step_avg:54.66ms
+step:1243/1585 train_time:67981ms step_avg:54.69ms
+step:1244/1585 train_time:68068ms step_avg:54.72ms
+step:1245/1585 train_time:68157ms step_avg:54.74ms
+step:1246/1585 train_time:68243ms step_avg:54.77ms
+step:1247/1585 train_time:68332ms step_avg:54.80ms
+step:1248/1585 train_time:68419ms step_avg:54.82ms
+step:1249/1585 train_time:68508ms step_avg:54.85ms
+step:1250/1585 train_time:68595ms step_avg:54.88ms
+step:1250/1585 val_loss:3.4081 train_time:68666ms step_avg:54.93ms
+step:1251/1585 train_time:68684ms step_avg:54.90ms
+step:1252/1585 train_time:68772ms step_avg:54.93ms
+step:1253/1585 train_time:68867ms step_avg:54.96ms
+step:1254/1585 train_time:68953ms step_avg:54.99ms
+step:1255/1585 train_time:69041ms step_avg:55.01ms
+step:1256/1585 train_time:69126ms step_avg:55.04ms
+step:1257/1585 train_time:69215ms step_avg:55.06ms
+step:1258/1585 train_time:69301ms step_avg:55.09ms
+step:1259/1585 train_time:69390ms step_avg:55.11ms
+step:1260/1585 train_time:69477ms step_avg:55.14ms
+step:1261/1585 train_time:69566ms step_avg:55.17ms
+step:1262/1585 train_time:69653ms step_avg:55.19ms
+step:1263/1585 train_time:69745ms step_avg:55.22ms
+step:1264/1585 train_time:69833ms step_avg:55.25ms
+step:1265/1585 train_time:69923ms step_avg:55.28ms
+step:1266/1585 train_time:70009ms step_avg:55.30ms
+step:1267/1585 train_time:70096ms step_avg:55.32ms
+step:1268/1585 train_time:70181ms step_avg:55.35ms
+step:1269/1585 train_time:70269ms step_avg:55.37ms
+step:1270/1585 train_time:70355ms step_avg:55.40ms
+step:1271/1585 train_time:70444ms step_avg:55.42ms
+step:1272/1585 train_time:70530ms step_avg:55.45ms
+step:1273/1585 train_time:70620ms step_avg:55.48ms
+step:1274/1585 train_time:70708ms step_avg:55.50ms
+step:1275/1585 train_time:70799ms step_avg:55.53ms
+step:1276/1585 train_time:70885ms step_avg:55.55ms
+step:1277/1585 train_time:70975ms step_avg:55.58ms
+step:1278/1585 train_time:71061ms step_avg:55.60ms
+step:1279/1585 train_time:71150ms step_avg:55.63ms
+step:1280/1585 train_time:71235ms step_avg:55.65ms
+step:1281/1585 train_time:71324ms step_avg:55.68ms
+step:1282/1585 train_time:71410ms step_avg:55.70ms
+step:1283/1585 train_time:71499ms step_avg:55.73ms
+step:1284/1585 train_time:71584ms step_avg:55.75ms
+step:1285/1585 train_time:71674ms step_avg:55.78ms
+step:1286/1585 train_time:71761ms step_avg:55.80ms
+step:1287/1585 train_time:71851ms step_avg:55.83ms
+step:1288/1585 train_time:71938ms step_avg:55.85ms
+step:1289/1585 train_time:72027ms step_avg:55.88ms
+step:1290/1585 train_time:72113ms step_avg:55.90ms
+step:1291/1585 train_time:72202ms step_avg:55.93ms
+step:1292/1585 train_time:72289ms step_avg:55.95ms
+step:1293/1585 train_time:72377ms step_avg:55.98ms
+step:1294/1585 train_time:72463ms step_avg:56.00ms
+step:1295/1585 train_time:72552ms step_avg:56.02ms
+step:1296/1585 train_time:72638ms step_avg:56.05ms
+step:1297/1585 train_time:72728ms step_avg:56.07ms
+step:1298/1585 train_time:72816ms step_avg:56.10ms
+step:1299/1585 train_time:72905ms step_avg:56.12ms
+step:1300/1585 train_time:72992ms step_avg:56.15ms
+step:1301/1585 train_time:73082ms step_avg:56.17ms
+step:1302/1585 train_time:73168ms step_avg:56.20ms
+step:1303/1585 train_time:73257ms step_avg:56.22ms
+step:1304/1585 train_time:73342ms step_avg:56.24ms
+step:1305/1585 train_time:73431ms step_avg:56.27ms
+step:1306/1585 train_time:73519ms step_avg:56.29ms
+step:1307/1585 train_time:73608ms step_avg:56.32ms
+step:1308/1585 train_time:73694ms step_avg:56.34ms
+step:1309/1585 train_time:73784ms step_avg:56.37ms
+step:1310/1585 train_time:73870ms step_avg:56.39ms
+step:1311/1585 train_time:73960ms step_avg:56.42ms
+step:1312/1585 train_time:74046ms step_avg:56.44ms
+step:1313/1585 train_time:74135ms step_avg:56.46ms
+step:1314/1585 train_time:74221ms step_avg:56.48ms
+step:1315/1585 train_time:74311ms step_avg:56.51ms
+step:1316/1585 train_time:74397ms step_avg:56.53ms
+step:1317/1585 train_time:74486ms step_avg:56.56ms
+step:1318/1585 train_time:74572ms step_avg:56.58ms
+step:1319/1585 train_time:74661ms step_avg:56.60ms
+step:1320/1585 train_time:74748ms step_avg:56.63ms
+step:1321/1585 train_time:74838ms step_avg:56.65ms
+step:1322/1585 train_time:74924ms step_avg:56.68ms
+step:1323/1585 train_time:75014ms step_avg:56.70ms
+step:1324/1585 train_time:75100ms step_avg:56.72ms
+step:1325/1585 train_time:75188ms step_avg:56.75ms
+step:1326/1585 train_time:75275ms step_avg:56.77ms
+step:1327/1585 train_time:75364ms step_avg:56.79ms
+step:1328/1585 train_time:75450ms step_avg:56.81ms
+step:1329/1585 train_time:75539ms step_avg:56.84ms
+step:1330/1585 train_time:75625ms step_avg:56.86ms
+step:1331/1585 train_time:75715ms step_avg:56.89ms
+step:1332/1585 train_time:75802ms step_avg:56.91ms
+step:1333/1585 train_time:75892ms step_avg:56.93ms
+step:1334/1585 train_time:75978ms step_avg:56.96ms
+step:1335/1585 train_time:76068ms step_avg:56.98ms
+step:1336/1585 train_time:76154ms step_avg:57.00ms
+step:1337/1585 train_time:76244ms step_avg:57.03ms
+step:1338/1585 train_time:76330ms step_avg:57.05ms
+step:1339/1585 train_time:76419ms step_avg:57.07ms
+step:1340/1585 train_time:76505ms step_avg:57.09ms
+step:1341/1585 train_time:76595ms step_avg:57.12ms
+step:1342/1585 train_time:76680ms step_avg:57.14ms
+step:1343/1585 train_time:76770ms step_avg:57.16ms
+step:1344/1585 train_time:76856ms step_avg:57.18ms
+step:1345/1585 train_time:76945ms step_avg:57.21ms
+step:1346/1585 train_time:77031ms step_avg:57.23ms
+step:1347/1585 train_time:77121ms step_avg:57.25ms
+step:1348/1585 train_time:77208ms step_avg:57.28ms
+step:1349/1585 train_time:77297ms step_avg:57.30ms
+step:1350/1585 train_time:77383ms step_avg:57.32ms
+step:1351/1585 train_time:77473ms step_avg:57.34ms
+step:1352/1585 train_time:77559ms step_avg:57.37ms
+step:1353/1585 train_time:77648ms step_avg:57.39ms
+step:1354/1585 train_time:77735ms step_avg:57.41ms
+step:1355/1585 train_time:77823ms step_avg:57.43ms
+step:1356/1585 train_time:77910ms step_avg:57.46ms
+step:1357/1585 train_time:78000ms step_avg:57.48ms
+step:1358/1585 train_time:78088ms step_avg:57.50ms
+step:1359/1585 train_time:78177ms step_avg:57.53ms
+step:1360/1585 train_time:78263ms step_avg:57.55ms
+step:1361/1585 train_time:78352ms step_avg:57.57ms
+step:1362/1585 train_time:78439ms step_avg:57.59ms
+step:1363/1585 train_time:78527ms step_avg:57.61ms
+step:1364/1585 train_time:78614ms step_avg:57.63ms
+step:1365/1585 train_time:78703ms step_avg:57.66ms
+step:1366/1585 train_time:78789ms step_avg:57.68ms
+step:1367/1585 train_time:78879ms step_avg:57.70ms
+step:1368/1585 train_time:78965ms step_avg:57.72ms
+step:1369/1585 train_time:79055ms step_avg:57.75ms
+step:1370/1585 train_time:79141ms step_avg:57.77ms
+step:1371/1585 train_time:79230ms step_avg:57.79ms
+step:1372/1585 train_time:79316ms step_avg:57.81ms
+step:1373/1585 train_time:79405ms step_avg:57.83ms
+step:1374/1585 train_time:79491ms step_avg:57.85ms
+step:1375/1585 train_time:79581ms step_avg:57.88ms
+step:1376/1585 train_time:79667ms step_avg:57.90ms
+step:1377/1585 train_time:79757ms step_avg:57.92ms
+step:1378/1585 train_time:79842ms step_avg:57.94ms
+step:1379/1585 train_time:79931ms step_avg:57.96ms
+step:1380/1585 train_time:80017ms step_avg:57.98ms
+step:1381/1585 train_time:80107ms step_avg:58.01ms
+step:1382/1585 train_time:80193ms step_avg:58.03ms
+step:1383/1585 train_time:80284ms step_avg:58.05ms
+step:1384/1585 train_time:80370ms step_avg:58.07ms
+step:1385/1585 train_time:80460ms step_avg:58.09ms
+step:1386/1585 train_time:80547ms step_avg:58.11ms
+step:1387/1585 train_time:80636ms step_avg:58.14ms
+step:1388/1585 train_time:80722ms step_avg:58.16ms
+step:1389/1585 train_time:80812ms step_avg:58.18ms
+step:1390/1585 train_time:80898ms step_avg:58.20ms
+step:1391/1585 train_time:80987ms step_avg:58.22ms
+step:1392/1585 train_time:81073ms step_avg:58.24ms
+step:1393/1585 train_time:81162ms step_avg:58.26ms
+step:1394/1585 train_time:81248ms step_avg:58.28ms
+step:1395/1585 train_time:81338ms step_avg:58.31ms
+step:1396/1585 train_time:81424ms step_avg:58.33ms
+step:1397/1585 train_time:81513ms step_avg:58.35ms
+step:1398/1585 train_time:81600ms step_avg:58.37ms
+step:1399/1585 train_time:81689ms step_avg:58.39ms
+step:1400/1585 train_time:81776ms step_avg:58.41ms
+step:1401/1585 train_time:81865ms step_avg:58.43ms
+step:1402/1585 train_time:81951ms step_avg:58.45ms
+step:1403/1585 train_time:82040ms step_avg:58.47ms
+step:1404/1585 train_time:82126ms step_avg:58.49ms
+step:1405/1585 train_time:82216ms step_avg:58.52ms
+step:1406/1585 train_time:82302ms step_avg:58.54ms
+step:1407/1585 train_time:82391ms step_avg:58.56ms
+step:1408/1585 train_time:82478ms step_avg:58.58ms
+step:1409/1585 train_time:82567ms step_avg:58.60ms
+step:1410/1585 train_time:82653ms step_avg:58.62ms
+step:1411/1585 train_time:82742ms step_avg:58.64ms
+step:1412/1585 train_time:82828ms step_avg:58.66ms
+step:1413/1585 train_time:82918ms step_avg:58.68ms
+step:1414/1585 train_time:83003ms step_avg:58.70ms
+step:1415/1585 train_time:83093ms step_avg:58.72ms
+step:1416/1585 train_time:83180ms step_avg:58.74ms
+step:1417/1585 train_time:83268ms step_avg:58.76ms
+step:1418/1585 train_time:83355ms step_avg:58.78ms
+step:1419/1585 train_time:83444ms step_avg:58.80ms
+step:1420/1585 train_time:83530ms step_avg:58.82ms
+step:1421/1585 train_time:83620ms step_avg:58.85ms
+step:1422/1585 train_time:83706ms step_avg:58.87ms
+step:1423/1585 train_time:83796ms step_avg:58.89ms
+step:1424/1585 train_time:83881ms step_avg:58.91ms
+step:1425/1585 train_time:83970ms step_avg:58.93ms
+step:1426/1585 train_time:84056ms step_avg:58.95ms
+step:1427/1585 train_time:84146ms step_avg:58.97ms
+step:1428/1585 train_time:84231ms step_avg:58.99ms
+step:1429/1585 train_time:84320ms step_avg:59.01ms
+step:1430/1585 train_time:84407ms step_avg:59.03ms
+step:1431/1585 train_time:84496ms step_avg:59.05ms
+step:1432/1585 train_time:84582ms step_avg:59.07ms
+step:1433/1585 train_time:84672ms step_avg:59.09ms
+step:1434/1585 train_time:84760ms step_avg:59.11ms
+step:1435/1585 train_time:84849ms step_avg:59.13ms
+step:1436/1585 train_time:84936ms step_avg:59.15ms
+step:1437/1585 train_time:85024ms step_avg:59.17ms
+step:1438/1585 train_time:85111ms step_avg:59.19ms
+step:1439/1585 train_time:85200ms step_avg:59.21ms
+step:1440/1585 train_time:85286ms step_avg:59.23ms
+step:1441/1585 train_time:85376ms step_avg:59.25ms
+step:1442/1585 train_time:85462ms step_avg:59.27ms
+step:1443/1585 train_time:85551ms step_avg:59.29ms
+step:1444/1585 train_time:85638ms step_avg:59.31ms
+step:1445/1585 train_time:85727ms step_avg:59.33ms
+step:1446/1585 train_time:85813ms step_avg:59.35ms
+step:1447/1585 train_time:85903ms step_avg:59.37ms
+step:1448/1585 train_time:85989ms step_avg:59.38ms
+step:1449/1585 train_time:86079ms step_avg:59.41ms
+step:1450/1585 train_time:86164ms step_avg:59.42ms
+step:1451/1585 train_time:86254ms step_avg:59.44ms
+step:1452/1585 train_time:86340ms step_avg:59.46ms
+step:1453/1585 train_time:86428ms step_avg:59.48ms
+step:1454/1585 train_time:86515ms step_avg:59.50ms
+step:1455/1585 train_time:86605ms step_avg:59.52ms
+step:1456/1585 train_time:86691ms step_avg:59.54ms
+step:1457/1585 train_time:86781ms step_avg:59.56ms
+step:1458/1585 train_time:86867ms step_avg:59.58ms
+step:1459/1585 train_time:86955ms step_avg:59.60ms
+step:1460/1585 train_time:87042ms step_avg:59.62ms
+step:1461/1585 train_time:87131ms step_avg:59.64ms
+step:1462/1585 train_time:87217ms step_avg:59.66ms
+step:1463/1585 train_time:87307ms step_avg:59.68ms
+step:1464/1585 train_time:87393ms step_avg:59.69ms
+step:1465/1585 train_time:87483ms step_avg:59.72ms
+step:1466/1585 train_time:87569ms step_avg:59.73ms
+step:1467/1585 train_time:87658ms step_avg:59.75ms
+step:1468/1585 train_time:87744ms step_avg:59.77ms
+step:1469/1585 train_time:87834ms step_avg:59.79ms
+step:1470/1585 train_time:87919ms step_avg:59.81ms
+step:1471/1585 train_time:88008ms step_avg:59.83ms
+step:1472/1585 train_time:88094ms step_avg:59.85ms
+step:1473/1585 train_time:88184ms step_avg:59.87ms
+step:1474/1585 train_time:88271ms step_avg:59.89ms
+step:1475/1585 train_time:88360ms step_avg:59.91ms
+step:1476/1585 train_time:88446ms step_avg:59.92ms
+step:1477/1585 train_time:88536ms step_avg:59.94ms
+step:1478/1585 train_time:88622ms step_avg:59.96ms
+step:1479/1585 train_time:88712ms step_avg:59.98ms
+step:1480/1585 train_time:88798ms step_avg:60.00ms
+step:1481/1585 train_time:88888ms step_avg:60.02ms
+step:1482/1585 train_time:88974ms step_avg:60.04ms
+step:1483/1585 train_time:89063ms step_avg:60.06ms
+step:1484/1585 train_time:89149ms step_avg:60.07ms
+step:1485/1585 train_time:89239ms step_avg:60.09ms
+step:1486/1585 train_time:89325ms step_avg:60.11ms
+step:1487/1585 train_time:89414ms step_avg:60.13ms
+step:1488/1585 train_time:89501ms step_avg:60.15ms
+step:1489/1585 train_time:89590ms step_avg:60.17ms
+step:1490/1585 train_time:89677ms step_avg:60.19ms
+step:1491/1585 train_time:89767ms step_avg:60.21ms
+step:1492/1585 train_time:89853ms step_avg:60.22ms
+step:1493/1585 train_time:89943ms step_avg:60.24ms
+step:1494/1585 train_time:90029ms step_avg:60.26ms
+step:1495/1585 train_time:90118ms step_avg:60.28ms
+step:1496/1585 train_time:90204ms step_avg:60.30ms
+step:1497/1585 train_time:90293ms step_avg:60.32ms
+step:1498/1585 train_time:90380ms step_avg:60.33ms
+step:1499/1585 train_time:90469ms step_avg:60.35ms
+step:1500/1585 train_time:90554ms step_avg:60.37ms
+step:1500/1585 val_loss:3.3015 train_time:90627ms step_avg:60.42ms
+step:1501/1585 train_time:90646ms step_avg:60.39ms
+step:1502/1585 train_time:90734ms step_avg:60.41ms
+step:1503/1585 train_time:90825ms step_avg:60.43ms
+step:1504/1585 train_time:90913ms step_avg:60.45ms
+step:1505/1585 train_time:91002ms step_avg:60.47ms
+step:1506/1585 train_time:91087ms step_avg:60.48ms
+step:1507/1585 train_time:91175ms step_avg:60.50ms
+step:1508/1585 train_time:91260ms step_avg:60.52ms
+step:1509/1585 train_time:91349ms step_avg:60.54ms
+step:1510/1585 train_time:91435ms step_avg:60.55ms
+step:1511/1585 train_time:91525ms step_avg:60.57ms
+step:1512/1585 train_time:91613ms step_avg:60.59ms
+step:1513/1585 train_time:91706ms step_avg:60.61ms
+step:1514/1585 train_time:91794ms step_avg:60.63ms
+step:1515/1585 train_time:91883ms step_avg:60.65ms
+step:1516/1585 train_time:91969ms step_avg:60.67ms
+step:1517/1585 train_time:92058ms step_avg:60.68ms
+step:1518/1585 train_time:92143ms step_avg:60.70ms
+step:1519/1585 train_time:92232ms step_avg:60.72ms
+step:1520/1585 train_time:92317ms step_avg:60.73ms
+step:1521/1585 train_time:92406ms step_avg:60.75ms
+step:1522/1585 train_time:92493ms step_avg:60.77ms
+step:1523/1585 train_time:92583ms step_avg:60.79ms
+step:1524/1585 train_time:92669ms step_avg:60.81ms
+step:1525/1585 train_time:92760ms step_avg:60.83ms
+step:1526/1585 train_time:92846ms step_avg:60.84ms
+step:1527/1585 train_time:92937ms step_avg:60.86ms
+step:1528/1585 train_time:93024ms step_avg:60.88ms
+step:1529/1585 train_time:93113ms step_avg:60.90ms
+step:1530/1585 train_time:93198ms step_avg:60.91ms
+step:1531/1585 train_time:93287ms step_avg:60.93ms
+step:1532/1585 train_time:93372ms step_avg:60.95ms
+step:1533/1585 train_time:93462ms step_avg:60.97ms
+step:1534/1585 train_time:93548ms step_avg:60.98ms
+step:1535/1585 train_time:93638ms step_avg:61.00ms
+step:1536/1585 train_time:93726ms step_avg:61.02ms
+step:1537/1585 train_time:93816ms step_avg:61.04ms
+step:1538/1585 train_time:93903ms step_avg:61.06ms
+step:1539/1585 train_time:93993ms step_avg:61.07ms
+step:1540/1585 train_time:94078ms step_avg:61.09ms
+step:1541/1585 train_time:94167ms step_avg:61.11ms
+step:1542/1585 train_time:94253ms step_avg:61.12ms
+step:1543/1585 train_time:94341ms step_avg:61.14ms
+step:1544/1585 train_time:94427ms step_avg:61.16ms
+step:1545/1585 train_time:94516ms step_avg:61.18ms
+step:1546/1585 train_time:94610ms step_avg:61.20ms
+step:1547/1585 train_time:94699ms step_avg:61.21ms
+step:1548/1585 train_time:94786ms step_avg:61.23ms
+step:1549/1585 train_time:94877ms step_avg:61.25ms
+step:1550/1585 train_time:94963ms step_avg:61.27ms
+step:1551/1585 train_time:95052ms step_avg:61.28ms
+step:1552/1585 train_time:95138ms step_avg:61.30ms
+step:1553/1585 train_time:95228ms step_avg:61.32ms
+step:1554/1585 train_time:95314ms step_avg:61.33ms
+step:1555/1585 train_time:95403ms step_avg:61.35ms
+step:1556/1585 train_time:95490ms step_avg:61.37ms
+step:1557/1585 train_time:95580ms step_avg:61.39ms
+step:1558/1585 train_time:95667ms step_avg:61.40ms
+step:1559/1585 train_time:95758ms step_avg:61.42ms
+step:1560/1585 train_time:95845ms step_avg:61.44ms
+step:1561/1585 train_time:95935ms step_avg:61.46ms
+step:1562/1585 train_time:96021ms step_avg:61.47ms
+step:1563/1585 train_time:96110ms step_avg:61.49ms
+step:1564/1585 train_time:96197ms step_avg:61.51ms
+step:1565/1585 train_time:96285ms step_avg:61.52ms
+step:1566/1585 train_time:96371ms step_avg:61.54ms
+step:1567/1585 train_time:96461ms step_avg:61.56ms
+step:1568/1585 train_time:96548ms step_avg:61.57ms
+step:1569/1585 train_time:96637ms step_avg:61.59ms
+step:1570/1585 train_time:96724ms step_avg:61.61ms
+step:1571/1585 train_time:96814ms step_avg:61.63ms
+step:1572/1585 train_time:96902ms step_avg:61.64ms
+step:1573/1585 train_time:96991ms step_avg:61.66ms
+step:1574/1585 train_time:97077ms step_avg:61.68ms
+step:1575/1585 train_time:97167ms step_avg:61.69ms
+step:1576/1585 train_time:97253ms step_avg:61.71ms
+step:1577/1585 train_time:97343ms step_avg:61.73ms
+step:1578/1585 train_time:97429ms step_avg:61.74ms
+step:1579/1585 train_time:97518ms step_avg:61.76ms
+step:1580/1585 train_time:97605ms step_avg:61.78ms
+step:1581/1585 train_time:97696ms step_avg:61.79ms
+step:1582/1585 train_time:97782ms step_avg:61.81ms
+step:1583/1585 train_time:97872ms step_avg:61.83ms
+step:1584/1585 train_time:97959ms step_avg:61.84ms
+step:1585/1585 train_time:98049ms step_avg:61.86ms
+step:1585/1585 val_loss:3.2768 train_time:98116ms step_avg:61.90ms
+peak memory allocated: 30640 MiB reserved: 46658 MiB

--- a/records/track_1_short/2026-01-28_TieFirstLastVEs/ve01_230-15stps/76d85851-8fa7-43c9-ae27-95ce8e94f901.txt
+++ b/records/track_1_short/2026-01-28_TieFirstLastVEs/ve01_230-15stps/76d85851-8fa7-43c9-ae27-95ce8e94f901.txt
@@ -1,0 +1,4301 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    is_tall = G.size(-2) > G.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall matrices: use X^T @ X (small K×K) and right multiplication
+        # This avoids the transpose overhead that slows down Nesterov momentum
+        K = X.size(-1)
+        A = torch.empty((*X.shape[:-2], K, K), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched matmul for X @ B
+        XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.mT @ X 
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            # Right multiplication: C = a * X + X @ B
+            XB_matmul(X, B, out=C)  # C = X @ B
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place)
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide matrices: use X @ X^T and left multiplication (original approach)
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+major, _ = torch.cuda.get_device_capability()
+if major >= 9:
+    flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+else:
+    flash_attn_interface = get_kernel('kernels-community/flash-attn2').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(4)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = (major >= 9) # FP8 requires Hopper (SM90+)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # new layout: 01 ... 230 (ve0 shared at start and end)
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[0]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1545  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+
+# Check compute capability for Hopper-specific features
+_major, _ = torch.cuda.get_device_capability()
+_USE_TMA = _major >= 9
+
+if _USE_TMA:
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+# Note: This kernel was AI-written. It's been tested for numerical equivalence, 
+#       but not otherwised reviewed.
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < M - m * BLOCK_SIZE_K, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < M - m * BLOCK_SIZE_K, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(K, meta["BLOCK_SIZE_M"]) * triton.cdiv(K, meta["BLOCK_SIZE_N"]),
+    )
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+# Uses TMA (Tensor Memory Accelerator) which requires Hopper (SM90+)
+
+if _USE_TMA:
+    @triton.jit
+    def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                     M, N, K,
+                                     BLOCK_SIZE_M: tl.constexpr,
+                                     BLOCK_SIZE_N: tl.constexpr,
+                                     BLOCK_SIZE_K: tl.constexpr,
+                                     GROUP_SIZE_M: tl.constexpr,
+                                     NUM_SMS: tl.constexpr,
+                                     FORWARD: tl.constexpr,
+                                     ):
+        dtype = tl.bfloat16
+        start_pid = tl.program_id(axis=0)
+        num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+        num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+        k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+        num_tiles = num_pid_m * num_pid_n
+
+        tile_id_c = start_pid - NUM_SMS
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+        for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+            pid_m = tile_id // num_pid_n
+            pid_n = tile_id % num_pid_n
+            offs_am = pid_m * BLOCK_SIZE_M
+            offs_bn = pid_n * BLOCK_SIZE_N
+
+            accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+            for ki in range(k_tiles):
+                offs_k = ki * BLOCK_SIZE_K
+                a = a_desc.load([offs_am, offs_k])
+                b = b_desc.load([offs_bn, offs_k])
+                accumulator = tl.dot(a, b.T, accumulator)
+
+            tile_id_c += NUM_SMS
+            pid_m = tile_id // num_pid_n
+            pid_n = tile_id % num_pid_n
+            offs_am_c = pid_m * BLOCK_SIZE_M
+            offs_bn_c = pid_n * BLOCK_SIZE_N
+
+            acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+            acc = tl.permute(acc, (0, 2, 1))
+            acc0, acc1 = tl.split(acc)
+
+            c0 = acc0.to(dtype)
+            if not FORWARD:
+                c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+                c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+            c_desc.store([offs_am_c, offs_bn_c], c0)
+
+            if FORWARD:
+                c0_post = tl.maximum(c0, 0)
+                c0_post = c0_post * c0_post
+                aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+            c1 = acc1.to(dtype)
+            if not FORWARD:
+                c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+                c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+            c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+            if FORWARD:
+                c1_post = tl.maximum(c1, 0)
+                c1_post = c1_post * c1_post
+                aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+    def linear_relu_square(a, b, aux=None):
+        M, K = a.shape
+        N, K = b.shape
+        dtype = a.dtype
+
+        c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+        FORWARD = False
+        if aux is None:
+            FORWARD = True
+            aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+        BLOCK_SIZE_M = 128
+        BLOCK_SIZE_N = 256
+        BLOCK_SIZE_K = 64
+        num_stages = 4 if FORWARD else 3
+        num_warps = 8
+
+        a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+        b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+        c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+        aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+        def grid(META):
+            return (min(
+                NUM_SMS,
+                triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+            ), )
+
+        linear_relu_square_kernel[grid](
+            a_desc, b_desc, c_desc, aux_desc,
+            M, N, K,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_K=BLOCK_SIZE_K,
+            GROUP_SIZE_M=1,
+            NUM_SMS=NUM_SMS,
+            FORWARD=FORWARD,
+            num_stages=num_stages,
+            num_warps=num_warps
+        )
+
+        if FORWARD:
+            return c, aux
+        else:
+            return c
+
+    class FusedLinearReLUSquareFunction(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x, W1, W2):
+            pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+            x3 = post @ W2
+            ctx.save_for_backward(x, W1, W2, pre, post)
+            return x3.view(x.shape)
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            x, W1, W2, pre, post = ctx.saved_tensors
+            dW2 = post.T @ grad_output
+            dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+            dW1 = dpre.T @ x
+            dx = dpre @ W1
+            return dx.view(x.shape), dW1, dW2
+
+else:
+    # Fallback for Ampere (A100) and earlier - uses standard PyTorch ops
+    class FusedLinearReLUSquareFunction(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x, W1, W2):
+            # relu(x @ W1.T)^2 @ W2
+            x_flat = x.view(-1, x.shape[-1])
+            pre = x_flat @ W1.T  # (M, N)
+            post = torch.relu(pre).square()  # relu(...)^2
+            out = post @ W2
+            ctx.save_for_backward(x, W1, W2, pre, post)
+            return out.view(x.shape)
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            x, W1, W2, pre, post = ctx.saved_tensors
+            x_flat = x.view(-1, x.shape[-1])
+            grad_flat = grad_output.view(-1, grad_output.shape[-1])
+            
+            # grad w.r.t. W2: post.T @ grad_output
+            dW2 = post.T @ grad_flat
+            
+            # grad w.r.t. post: grad_output @ W2.T
+            dpost = grad_flat @ W2.T
+            
+            # grad through relu(pre)^2: d/dpre[relu(pre)^2] = 2*relu(pre) * (pre > 0)
+            dpre = 2 * dpost * torch.where(pre > 0, pre, pre.new_zeros(()))
+            
+            # grad w.r.t. W1: dpre.T @ x
+            dW1 = dpre.T @ x_flat
+            
+            # grad w.r.t. x: dpre @ W1
+            dx = dpre @ W1
+            return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.12.12 | packaged by conda-forge | (main, Jan 26 2026, 23:51:32) [GCC 14.3.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Thu Jan 29 05:59:10 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                  Off |
+| N/A   37C    P0            152W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:06:00.0 Off |                  Off |
+| N/A   34C    P0            130W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:07:00.0 Off |                  Off |
+| N/A   37C    P0            129W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:08:00.0 Off |                  Off |
+| N/A   35C    P0            135W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:09:00.0 Off |                  Off |
+| N/A   36C    P0            137W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                  Off |
+| N/A   35C    P0            131W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                  Off |
+| N/A   37C    P0            136W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:0C:00.0 Off |                  Off |
+| N/A   36C    P0            148W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          789360      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    1   N/A  N/A          789361      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    2   N/A  N/A          789362      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    3   N/A  N/A          789363      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    4   N/A  N/A          789364      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    5   N/A  N/A          789365      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    6   N/A  N/A          789366      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    7   N/A  N/A          789367      C   .../envs/speedrun/bin/python3.12       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 514, 515, 516, 1029, 1030, 1031, 1544, 1545, 1546] for warmup
+Resetting Model
+step:0/1585 val_loss:10.8313 train_time:0ms step_avg:0.03ms
+step:1/1585 train_time:52ms step_avg:52.26ms
+step:2/1585 train_time:72ms step_avg:36.01ms
+step:3/1585 train_time:91ms step_avg:30.41ms
+step:4/1585 train_time:122ms step_avg:30.41ms
+step:5/1585 train_time:151ms step_avg:30.27ms
+step:6/1585 train_time:232ms step_avg:38.61ms
+step:7/1585 train_time:248ms step_avg:35.40ms
+step:8/1585 train_time:273ms step_avg:34.17ms
+step:9/1585 train_time:304ms step_avg:33.77ms
+step:10/1585 train_time:342ms step_avg:34.21ms
+step:11/1585 train_time:373ms step_avg:33.89ms
+step:12/1585 train_time:411ms step_avg:34.26ms
+step:13/1585 train_time:442ms step_avg:33.97ms
+step:14/1585 train_time:480ms step_avg:34.26ms
+step:15/1585 train_time:510ms step_avg:34.00ms
+step:16/1585 train_time:548ms step_avg:34.26ms
+step:17/1585 train_time:579ms step_avg:34.03ms
+step:18/1585 train_time:617ms step_avg:34.27ms
+step:19/1585 train_time:648ms step_avg:34.09ms
+step:20/1585 train_time:686ms step_avg:34.30ms
+step:21/1585 train_time:716ms step_avg:34.11ms
+step:22/1585 train_time:754ms step_avg:34.29ms
+step:23/1585 train_time:785ms step_avg:34.12ms
+step:24/1585 train_time:823ms step_avg:34.30ms
+step:25/1585 train_time:854ms step_avg:34.15ms
+step:26/1585 train_time:892ms step_avg:34.29ms
+step:27/1585 train_time:922ms step_avg:34.15ms
+step:28/1585 train_time:960ms step_avg:34.29ms
+step:29/1585 train_time:991ms step_avg:34.16ms
+step:30/1585 train_time:1029ms step_avg:34.30ms
+step:31/1585 train_time:1060ms step_avg:34.18ms
+step:32/1585 train_time:1098ms step_avg:34.31ms
+step:33/1585 train_time:1128ms step_avg:34.20ms
+step:34/1585 train_time:1167ms step_avg:34.33ms
+step:35/1585 train_time:1198ms step_avg:34.22ms
+step:36/1585 train_time:1236ms step_avg:34.34ms
+step:37/1585 train_time:1267ms step_avg:34.24ms
+step:38/1585 train_time:1305ms step_avg:34.35ms
+step:39/1585 train_time:1336ms step_avg:34.26ms
+step:40/1585 train_time:1374ms step_avg:34.36ms
+step:41/1585 train_time:1405ms step_avg:34.26ms
+step:42/1585 train_time:1443ms step_avg:34.36ms
+step:43/1585 train_time:1474ms step_avg:34.28ms
+step:44/1585 train_time:1512ms step_avg:34.37ms
+step:45/1585 train_time:1543ms step_avg:34.29ms
+step:46/1585 train_time:1581ms step_avg:34.38ms
+step:47/1585 train_time:1613ms step_avg:34.31ms
+step:48/1585 train_time:1651ms step_avg:34.40ms
+step:49/1585 train_time:1682ms step_avg:34.32ms
+step:50/1585 train_time:1720ms step_avg:34.40ms
+step:51/1585 train_time:1750ms step_avg:34.32ms
+step:52/1585 train_time:1788ms step_avg:34.39ms
+step:53/1585 train_time:1819ms step_avg:34.32ms
+step:54/1585 train_time:1857ms step_avg:34.39ms
+step:55/1585 train_time:1888ms step_avg:34.32ms
+step:56/1585 train_time:1926ms step_avg:34.38ms
+step:57/1585 train_time:1956ms step_avg:34.32ms
+step:58/1585 train_time:1995ms step_avg:34.39ms
+step:59/1585 train_time:2025ms step_avg:34.32ms
+step:60/1585 train_time:2064ms step_avg:34.39ms
+step:61/1585 train_time:2094ms step_avg:34.34ms
+step:62/1585 train_time:2132ms step_avg:34.39ms
+step:63/1585 train_time:2163ms step_avg:34.33ms
+step:64/1585 train_time:2201ms step_avg:34.39ms
+step:65/1585 train_time:2231ms step_avg:34.33ms
+step:66/1585 train_time:2269ms step_avg:34.38ms
+step:67/1585 train_time:2300ms step_avg:34.33ms
+step:68/1585 train_time:2338ms step_avg:34.39ms
+step:69/1585 train_time:2369ms step_avg:34.33ms
+step:70/1585 train_time:2407ms step_avg:34.39ms
+step:71/1585 train_time:2438ms step_avg:34.34ms
+step:72/1585 train_time:2476ms step_avg:34.39ms
+step:73/1585 train_time:2506ms step_avg:34.33ms
+step:74/1585 train_time:2545ms step_avg:34.39ms
+step:75/1585 train_time:2576ms step_avg:34.35ms
+step:76/1585 train_time:2614ms step_avg:34.40ms
+step:77/1585 train_time:2645ms step_avg:34.35ms
+step:78/1585 train_time:2684ms step_avg:34.41ms
+step:79/1585 train_time:2715ms step_avg:34.36ms
+step:80/1585 train_time:2753ms step_avg:34.41ms
+step:81/1585 train_time:2783ms step_avg:34.36ms
+step:82/1585 train_time:2821ms step_avg:34.40ms
+step:83/1585 train_time:2852ms step_avg:34.36ms
+step:84/1585 train_time:2890ms step_avg:34.40ms
+step:85/1585 train_time:2920ms step_avg:34.36ms
+step:86/1585 train_time:2959ms step_avg:34.40ms
+step:87/1585 train_time:2989ms step_avg:34.36ms
+step:88/1585 train_time:3028ms step_avg:34.41ms
+step:89/1585 train_time:3058ms step_avg:34.36ms
+step:90/1585 train_time:3096ms step_avg:34.40ms
+step:91/1585 train_time:3127ms step_avg:34.36ms
+step:92/1585 train_time:3165ms step_avg:34.40ms
+step:93/1585 train_time:3195ms step_avg:34.36ms
+step:94/1585 train_time:3233ms step_avg:34.39ms
+step:95/1585 train_time:3264ms step_avg:34.36ms
+step:96/1585 train_time:3302ms step_avg:34.40ms
+step:97/1585 train_time:3333ms step_avg:34.36ms
+step:98/1585 train_time:3372ms step_avg:34.41ms
+step:99/1585 train_time:3403ms step_avg:34.37ms
+step:100/1585 train_time:3441ms step_avg:34.41ms
+step:101/1585 train_time:3472ms step_avg:34.38ms
+step:102/1585 train_time:3510ms step_avg:34.41ms
+step:103/1585 train_time:3540ms step_avg:34.37ms
+step:104/1585 train_time:3579ms step_avg:34.41ms
+step:105/1585 train_time:3609ms step_avg:34.37ms
+step:106/1585 train_time:3647ms step_avg:34.41ms
+step:107/1585 train_time:3678ms step_avg:34.38ms
+step:108/1585 train_time:3716ms step_avg:34.41ms
+step:109/1585 train_time:3747ms step_avg:34.37ms
+step:110/1585 train_time:3785ms step_avg:34.41ms
+step:111/1585 train_time:3815ms step_avg:34.37ms
+step:112/1585 train_time:3853ms step_avg:34.40ms
+step:113/1585 train_time:3883ms step_avg:34.37ms
+step:114/1585 train_time:3922ms step_avg:34.40ms
+step:115/1585 train_time:3952ms step_avg:34.37ms
+step:116/1585 train_time:3990ms step_avg:34.40ms
+step:117/1585 train_time:4021ms step_avg:34.37ms
+step:118/1585 train_time:4059ms step_avg:34.40ms
+step:119/1585 train_time:4090ms step_avg:34.37ms
+step:120/1585 train_time:4128ms step_avg:34.40ms
+step:121/1585 train_time:4158ms step_avg:34.37ms
+step:122/1585 train_time:4197ms step_avg:34.40ms
+step:123/1585 train_time:4227ms step_avg:34.37ms
+step:124/1585 train_time:4266ms step_avg:34.40ms
+step:125/1585 train_time:4296ms step_avg:34.37ms
+step:126/1585 train_time:4334ms step_avg:34.40ms
+step:127/1585 train_time:4365ms step_avg:34.37ms
+step:128/1585 train_time:4403ms step_avg:34.40ms
+step:129/1585 train_time:4434ms step_avg:34.37ms
+step:130/1585 train_time:4472ms step_avg:34.40ms
+step:131/1585 train_time:4503ms step_avg:34.37ms
+step:132/1585 train_time:4540ms step_avg:34.40ms
+step:133/1585 train_time:4571ms step_avg:34.37ms
+step:134/1585 train_time:4609ms step_avg:34.39ms
+step:135/1585 train_time:4640ms step_avg:34.37ms
+step:136/1585 train_time:4678ms step_avg:34.40ms
+step:137/1585 train_time:4708ms step_avg:34.37ms
+step:138/1585 train_time:4747ms step_avg:34.40ms
+step:139/1585 train_time:4778ms step_avg:34.37ms
+step:140/1585 train_time:4816ms step_avg:34.40ms
+step:141/1585 train_time:4847ms step_avg:34.37ms
+step:142/1585 train_time:4885ms step_avg:34.40ms
+step:143/1585 train_time:4916ms step_avg:34.38ms
+step:144/1585 train_time:4953ms step_avg:34.40ms
+step:145/1585 train_time:4984ms step_avg:34.37ms
+step:146/1585 train_time:5022ms step_avg:34.40ms
+step:147/1585 train_time:5053ms step_avg:34.37ms
+step:148/1585 train_time:5091ms step_avg:34.40ms
+step:149/1585 train_time:5122ms step_avg:34.37ms
+step:150/1585 train_time:5160ms step_avg:34.40ms
+step:151/1585 train_time:5191ms step_avg:34.38ms
+step:152/1585 train_time:5228ms step_avg:34.40ms
+step:153/1585 train_time:5259ms step_avg:34.38ms
+step:154/1585 train_time:5297ms step_avg:34.40ms
+step:155/1585 train_time:5328ms step_avg:34.37ms
+step:156/1585 train_time:5366ms step_avg:34.40ms
+step:157/1585 train_time:5397ms step_avg:34.38ms
+step:158/1585 train_time:5434ms step_avg:34.40ms
+step:159/1585 train_time:5465ms step_avg:34.37ms
+step:160/1585 train_time:5503ms step_avg:34.39ms
+step:161/1585 train_time:5535ms step_avg:34.38ms
+step:162/1585 train_time:5573ms step_avg:34.40ms
+step:163/1585 train_time:5603ms step_avg:34.38ms
+step:164/1585 train_time:5642ms step_avg:34.40ms
+step:165/1585 train_time:5673ms step_avg:34.38ms
+step:166/1585 train_time:5711ms step_avg:34.40ms
+step:167/1585 train_time:5742ms step_avg:34.38ms
+step:168/1585 train_time:5780ms step_avg:34.40ms
+step:169/1585 train_time:5811ms step_avg:34.38ms
+step:170/1585 train_time:5848ms step_avg:34.40ms
+step:171/1585 train_time:5879ms step_avg:34.38ms
+step:172/1585 train_time:5917ms step_avg:34.40ms
+step:173/1585 train_time:5948ms step_avg:34.38ms
+step:174/1585 train_time:5986ms step_avg:34.40ms
+step:175/1585 train_time:6016ms step_avg:34.38ms
+step:176/1585 train_time:6054ms step_avg:34.40ms
+step:177/1585 train_time:6085ms step_avg:34.38ms
+step:178/1585 train_time:6123ms step_avg:34.40ms
+step:179/1585 train_time:6153ms step_avg:34.38ms
+step:180/1585 train_time:6191ms step_avg:34.40ms
+step:181/1585 train_time:6222ms step_avg:34.38ms
+step:182/1585 train_time:6260ms step_avg:34.40ms
+step:183/1585 train_time:6291ms step_avg:34.38ms
+step:184/1585 train_time:6329ms step_avg:34.40ms
+step:185/1585 train_time:6359ms step_avg:34.37ms
+step:186/1585 train_time:6397ms step_avg:34.39ms
+step:187/1585 train_time:6427ms step_avg:34.37ms
+step:188/1585 train_time:6465ms step_avg:34.39ms
+step:189/1585 train_time:6496ms step_avg:34.37ms
+step:190/1585 train_time:6534ms step_avg:34.39ms
+step:191/1585 train_time:6565ms step_avg:34.37ms
+step:192/1585 train_time:6603ms step_avg:34.39ms
+step:193/1585 train_time:6635ms step_avg:34.38ms
+step:194/1585 train_time:6673ms step_avg:34.40ms
+step:195/1585 train_time:6704ms step_avg:34.38ms
+step:196/1585 train_time:6742ms step_avg:34.40ms
+step:197/1585 train_time:6773ms step_avg:34.38ms
+step:198/1585 train_time:6811ms step_avg:34.40ms
+step:199/1585 train_time:6842ms step_avg:34.38ms
+step:200/1585 train_time:6880ms step_avg:34.40ms
+step:201/1585 train_time:6911ms step_avg:34.38ms
+step:202/1585 train_time:6948ms step_avg:34.40ms
+step:203/1585 train_time:6979ms step_avg:34.38ms
+step:204/1585 train_time:7017ms step_avg:34.39ms
+step:205/1585 train_time:7047ms step_avg:34.38ms
+step:206/1585 train_time:7085ms step_avg:34.39ms
+step:207/1585 train_time:7116ms step_avg:34.38ms
+step:208/1585 train_time:7154ms step_avg:34.39ms
+step:209/1585 train_time:7184ms step_avg:34.37ms
+step:210/1585 train_time:7222ms step_avg:34.39ms
+step:211/1585 train_time:7253ms step_avg:34.37ms
+step:212/1585 train_time:7291ms step_avg:34.39ms
+step:213/1585 train_time:7321ms step_avg:34.37ms
+step:214/1585 train_time:7359ms step_avg:34.39ms
+step:215/1585 train_time:7390ms step_avg:34.37ms
+step:216/1585 train_time:7428ms step_avg:34.39ms
+step:217/1585 train_time:7458ms step_avg:34.37ms
+step:218/1585 train_time:7496ms step_avg:34.39ms
+step:219/1585 train_time:7527ms step_avg:34.37ms
+step:220/1585 train_time:7565ms step_avg:34.39ms
+step:221/1585 train_time:7596ms step_avg:34.37ms
+step:222/1585 train_time:7634ms step_avg:34.39ms
+step:223/1585 train_time:7665ms step_avg:34.37ms
+step:224/1585 train_time:7703ms step_avg:34.39ms
+step:225/1585 train_time:7733ms step_avg:34.37ms
+step:226/1585 train_time:7771ms step_avg:34.39ms
+step:227/1585 train_time:7802ms step_avg:34.37ms
+step:228/1585 train_time:7840ms step_avg:34.38ms
+step:229/1585 train_time:7871ms step_avg:34.37ms
+step:230/1585 train_time:7908ms step_avg:34.38ms
+step:231/1585 train_time:7939ms step_avg:34.37ms
+step:232/1585 train_time:7977ms step_avg:34.39ms
+step:233/1585 train_time:8008ms step_avg:34.37ms
+step:234/1585 train_time:8045ms step_avg:34.38ms
+step:235/1585 train_time:8076ms step_avg:34.37ms
+step:236/1585 train_time:8114ms step_avg:34.38ms
+step:237/1585 train_time:8145ms step_avg:34.37ms
+step:238/1585 train_time:8183ms step_avg:34.38ms
+step:239/1585 train_time:8213ms step_avg:34.37ms
+step:240/1585 train_time:8251ms step_avg:34.38ms
+step:241/1585 train_time:8282ms step_avg:34.37ms
+step:242/1585 train_time:8320ms step_avg:34.38ms
+step:243/1585 train_time:8351ms step_avg:34.36ms
+step:244/1585 train_time:8389ms step_avg:34.38ms
+step:245/1585 train_time:8419ms step_avg:34.36ms
+step:246/1585 train_time:8457ms step_avg:34.38ms
+step:247/1585 train_time:8487ms step_avg:34.36ms
+step:248/1585 train_time:8525ms step_avg:34.37ms
+step:249/1585 train_time:8556ms step_avg:34.36ms
+step:250/1585 train_time:8594ms step_avg:34.38ms
+step:250/1585 val_loss:4.5751 train_time:8642ms step_avg:34.57ms
+step:251/1585 train_time:8659ms step_avg:34.50ms
+step:252/1585 train_time:8676ms step_avg:34.43ms
+step:253/1585 train_time:8696ms step_avg:34.37ms
+step:254/1585 train_time:8735ms step_avg:34.39ms
+step:255/1585 train_time:8767ms step_avg:34.38ms
+step:256/1585 train_time:8806ms step_avg:34.40ms
+step:257/1585 train_time:8837ms step_avg:34.38ms
+step:258/1585 train_time:8874ms step_avg:34.40ms
+step:259/1585 train_time:8905ms step_avg:34.38ms
+step:260/1585 train_time:8943ms step_avg:34.40ms
+step:261/1585 train_time:8973ms step_avg:34.38ms
+step:262/1585 train_time:9010ms step_avg:34.39ms
+step:263/1585 train_time:9041ms step_avg:34.38ms
+step:264/1585 train_time:9078ms step_avg:34.39ms
+step:265/1585 train_time:9109ms step_avg:34.37ms
+step:266/1585 train_time:9147ms step_avg:34.39ms
+step:267/1585 train_time:9177ms step_avg:34.37ms
+step:268/1585 train_time:9215ms step_avg:34.38ms
+step:269/1585 train_time:9245ms step_avg:34.37ms
+step:270/1585 train_time:9283ms step_avg:34.38ms
+step:271/1585 train_time:9313ms step_avg:34.37ms
+step:272/1585 train_time:9351ms step_avg:34.38ms
+step:273/1585 train_time:9382ms step_avg:34.37ms
+step:274/1585 train_time:9420ms step_avg:34.38ms
+step:275/1585 train_time:9450ms step_avg:34.36ms
+step:276/1585 train_time:9488ms step_avg:34.38ms
+step:277/1585 train_time:9519ms step_avg:34.36ms
+step:278/1585 train_time:9557ms step_avg:34.38ms
+step:279/1585 train_time:9587ms step_avg:34.36ms
+step:280/1585 train_time:9625ms step_avg:34.38ms
+step:281/1585 train_time:9656ms step_avg:34.36ms
+step:282/1585 train_time:9694ms step_avg:34.38ms
+step:283/1585 train_time:9724ms step_avg:34.36ms
+step:284/1585 train_time:9762ms step_avg:34.37ms
+step:285/1585 train_time:9793ms step_avg:34.36ms
+step:286/1585 train_time:9831ms step_avg:34.37ms
+step:287/1585 train_time:9861ms step_avg:34.36ms
+step:288/1585 train_time:9899ms step_avg:34.37ms
+step:289/1585 train_time:9929ms step_avg:34.36ms
+step:290/1585 train_time:9967ms step_avg:34.37ms
+step:291/1585 train_time:9997ms step_avg:34.35ms
+step:292/1585 train_time:10035ms step_avg:34.37ms
+step:293/1585 train_time:10066ms step_avg:34.35ms
+step:294/1585 train_time:10104ms step_avg:34.37ms
+step:295/1585 train_time:10135ms step_avg:34.36ms
+step:296/1585 train_time:10173ms step_avg:34.37ms
+step:297/1585 train_time:10204ms step_avg:34.36ms
+step:298/1585 train_time:10241ms step_avg:34.37ms
+step:299/1585 train_time:10272ms step_avg:34.35ms
+step:300/1585 train_time:10309ms step_avg:34.36ms
+step:301/1585 train_time:10340ms step_avg:34.35ms
+step:302/1585 train_time:10377ms step_avg:34.36ms
+step:303/1585 train_time:10408ms step_avg:34.35ms
+step:304/1585 train_time:10446ms step_avg:34.36ms
+step:305/1585 train_time:10476ms step_avg:34.35ms
+step:306/1585 train_time:10514ms step_avg:34.36ms
+step:307/1585 train_time:10544ms step_avg:34.35ms
+step:308/1585 train_time:10582ms step_avg:34.36ms
+step:309/1585 train_time:10612ms step_avg:34.34ms
+step:310/1585 train_time:10650ms step_avg:34.36ms
+step:311/1585 train_time:10680ms step_avg:34.34ms
+step:312/1585 train_time:10718ms step_avg:34.35ms
+step:313/1585 train_time:10748ms step_avg:34.34ms
+step:314/1585 train_time:10787ms step_avg:34.35ms
+step:315/1585 train_time:10817ms step_avg:34.34ms
+step:316/1585 train_time:10855ms step_avg:34.35ms
+step:317/1585 train_time:10886ms step_avg:34.34ms
+step:318/1585 train_time:10924ms step_avg:34.35ms
+step:319/1585 train_time:10954ms step_avg:34.34ms
+step:320/1585 train_time:10992ms step_avg:34.35ms
+step:321/1585 train_time:11022ms step_avg:34.34ms
+step:322/1585 train_time:11060ms step_avg:34.35ms
+step:323/1585 train_time:11090ms step_avg:34.34ms
+step:324/1585 train_time:11128ms step_avg:34.35ms
+step:325/1585 train_time:11159ms step_avg:34.33ms
+step:326/1585 train_time:11196ms step_avg:34.34ms
+step:327/1585 train_time:11227ms step_avg:34.33ms
+step:328/1585 train_time:11265ms step_avg:34.34ms
+step:329/1585 train_time:11296ms step_avg:34.33ms
+step:330/1585 train_time:11333ms step_avg:34.34ms
+step:331/1585 train_time:11364ms step_avg:34.33ms
+step:332/1585 train_time:11402ms step_avg:34.34ms
+step:333/1585 train_time:11432ms step_avg:34.33ms
+step:334/1585 train_time:11470ms step_avg:34.34ms
+step:335/1585 train_time:11500ms step_avg:34.33ms
+step:336/1585 train_time:11538ms step_avg:34.34ms
+step:337/1585 train_time:11568ms step_avg:34.33ms
+step:338/1585 train_time:11606ms step_avg:34.34ms
+step:339/1585 train_time:11637ms step_avg:34.33ms
+step:340/1585 train_time:11674ms step_avg:34.34ms
+step:341/1585 train_time:11705ms step_avg:34.33ms
+step:342/1585 train_time:11743ms step_avg:34.34ms
+step:343/1585 train_time:11774ms step_avg:34.33ms
+step:344/1585 train_time:11812ms step_avg:34.34ms
+step:345/1585 train_time:11843ms step_avg:34.33ms
+step:346/1585 train_time:11881ms step_avg:34.34ms
+step:347/1585 train_time:11911ms step_avg:34.33ms
+step:348/1585 train_time:11949ms step_avg:34.34ms
+step:349/1585 train_time:11980ms step_avg:34.33ms
+step:350/1585 train_time:12018ms step_avg:34.34ms
+step:351/1585 train_time:12048ms step_avg:34.32ms
+step:352/1585 train_time:12086ms step_avg:34.34ms
+step:353/1585 train_time:12116ms step_avg:34.32ms
+step:354/1585 train_time:12155ms step_avg:34.34ms
+step:355/1585 train_time:12185ms step_avg:34.32ms
+step:356/1585 train_time:12223ms step_avg:34.33ms
+step:357/1585 train_time:12254ms step_avg:34.32ms
+step:358/1585 train_time:12291ms step_avg:34.33ms
+step:359/1585 train_time:12322ms step_avg:34.32ms
+step:360/1585 train_time:12360ms step_avg:34.33ms
+step:361/1585 train_time:12390ms step_avg:34.32ms
+step:362/1585 train_time:12428ms step_avg:34.33ms
+step:363/1585 train_time:12458ms step_avg:34.32ms
+step:364/1585 train_time:12496ms step_avg:34.33ms
+step:365/1585 train_time:12526ms step_avg:34.32ms
+step:366/1585 train_time:12565ms step_avg:34.33ms
+step:367/1585 train_time:12595ms step_avg:34.32ms
+step:368/1585 train_time:12633ms step_avg:34.33ms
+step:369/1585 train_time:12663ms step_avg:34.32ms
+step:370/1585 train_time:12701ms step_avg:34.33ms
+step:371/1585 train_time:12731ms step_avg:34.32ms
+step:372/1585 train_time:12769ms step_avg:34.33ms
+step:373/1585 train_time:12799ms step_avg:34.31ms
+step:374/1585 train_time:12837ms step_avg:34.32ms
+step:375/1585 train_time:12868ms step_avg:34.31ms
+step:376/1585 train_time:12906ms step_avg:34.32ms
+step:377/1585 train_time:12936ms step_avg:34.31ms
+step:378/1585 train_time:12975ms step_avg:34.32ms
+step:379/1585 train_time:13005ms step_avg:34.31ms
+step:380/1585 train_time:13044ms step_avg:34.33ms
+step:381/1585 train_time:13074ms step_avg:34.32ms
+step:382/1585 train_time:13112ms step_avg:34.32ms
+step:383/1585 train_time:13143ms step_avg:34.32ms
+step:384/1585 train_time:13181ms step_avg:34.33ms
+step:385/1585 train_time:13211ms step_avg:34.31ms
+step:386/1585 train_time:13249ms step_avg:34.32ms
+step:387/1585 train_time:13279ms step_avg:34.31ms
+step:388/1585 train_time:13317ms step_avg:34.32ms
+step:389/1585 train_time:13348ms step_avg:34.31ms
+step:390/1585 train_time:13386ms step_avg:34.32ms
+step:391/1585 train_time:13416ms step_avg:34.31ms
+step:392/1585 train_time:13454ms step_avg:34.32ms
+step:393/1585 train_time:13484ms step_avg:34.31ms
+step:394/1585 train_time:13522ms step_avg:34.32ms
+step:395/1585 train_time:13552ms step_avg:34.31ms
+step:396/1585 train_time:13590ms step_avg:34.32ms
+step:397/1585 train_time:13621ms step_avg:34.31ms
+step:398/1585 train_time:13659ms step_avg:34.32ms
+step:399/1585 train_time:13689ms step_avg:34.31ms
+step:400/1585 train_time:13727ms step_avg:34.32ms
+step:401/1585 train_time:13758ms step_avg:34.31ms
+step:402/1585 train_time:13796ms step_avg:34.32ms
+step:403/1585 train_time:13826ms step_avg:34.31ms
+step:404/1585 train_time:13864ms step_avg:34.32ms
+step:405/1585 train_time:13895ms step_avg:34.31ms
+step:406/1585 train_time:13933ms step_avg:34.32ms
+step:407/1585 train_time:13964ms step_avg:34.31ms
+step:408/1585 train_time:14002ms step_avg:34.32ms
+step:409/1585 train_time:14033ms step_avg:34.31ms
+step:410/1585 train_time:14070ms step_avg:34.32ms
+step:411/1585 train_time:14101ms step_avg:34.31ms
+step:412/1585 train_time:14139ms step_avg:34.32ms
+step:413/1585 train_time:14169ms step_avg:34.31ms
+step:414/1585 train_time:14207ms step_avg:34.32ms
+step:415/1585 train_time:14238ms step_avg:34.31ms
+step:416/1585 train_time:14276ms step_avg:34.32ms
+step:417/1585 train_time:14306ms step_avg:34.31ms
+step:418/1585 train_time:14344ms step_avg:34.32ms
+step:419/1585 train_time:14375ms step_avg:34.31ms
+step:420/1585 train_time:14413ms step_avg:34.32ms
+step:421/1585 train_time:14444ms step_avg:34.31ms
+step:422/1585 train_time:14482ms step_avg:34.32ms
+step:423/1585 train_time:14513ms step_avg:34.31ms
+step:424/1585 train_time:14550ms step_avg:34.32ms
+step:425/1585 train_time:14581ms step_avg:34.31ms
+step:426/1585 train_time:14619ms step_avg:34.32ms
+step:427/1585 train_time:14649ms step_avg:34.31ms
+step:428/1585 train_time:14686ms step_avg:34.31ms
+step:429/1585 train_time:14717ms step_avg:34.31ms
+step:430/1585 train_time:14755ms step_avg:34.31ms
+step:431/1585 train_time:14786ms step_avg:34.31ms
+step:432/1585 train_time:14824ms step_avg:34.31ms
+step:433/1585 train_time:14855ms step_avg:34.31ms
+step:434/1585 train_time:14893ms step_avg:34.32ms
+step:435/1585 train_time:14923ms step_avg:34.31ms
+step:436/1585 train_time:14961ms step_avg:34.31ms
+step:437/1585 train_time:14992ms step_avg:34.31ms
+step:438/1585 train_time:15029ms step_avg:34.31ms
+step:439/1585 train_time:15060ms step_avg:34.31ms
+step:440/1585 train_time:15097ms step_avg:34.31ms
+step:441/1585 train_time:15128ms step_avg:34.30ms
+step:442/1585 train_time:15166ms step_avg:34.31ms
+step:443/1585 train_time:15197ms step_avg:34.30ms
+step:444/1585 train_time:15234ms step_avg:34.31ms
+step:445/1585 train_time:15265ms step_avg:34.30ms
+step:446/1585 train_time:15303ms step_avg:34.31ms
+step:447/1585 train_time:15334ms step_avg:34.30ms
+step:448/1585 train_time:15371ms step_avg:34.31ms
+step:449/1585 train_time:15402ms step_avg:34.30ms
+step:450/1585 train_time:15440ms step_avg:34.31ms
+step:451/1585 train_time:15470ms step_avg:34.30ms
+step:452/1585 train_time:15508ms step_avg:34.31ms
+step:453/1585 train_time:15538ms step_avg:34.30ms
+step:454/1585 train_time:15576ms step_avg:34.31ms
+step:455/1585 train_time:15607ms step_avg:34.30ms
+step:456/1585 train_time:15645ms step_avg:34.31ms
+step:457/1585 train_time:15675ms step_avg:34.30ms
+step:458/1585 train_time:15714ms step_avg:34.31ms
+step:459/1585 train_time:15744ms step_avg:34.30ms
+step:460/1585 train_time:15783ms step_avg:34.31ms
+step:461/1585 train_time:15814ms step_avg:34.30ms
+step:462/1585 train_time:15851ms step_avg:34.31ms
+step:463/1585 train_time:15882ms step_avg:34.30ms
+step:464/1585 train_time:15920ms step_avg:34.31ms
+step:465/1585 train_time:15950ms step_avg:34.30ms
+step:466/1585 train_time:15988ms step_avg:34.31ms
+step:467/1585 train_time:16018ms step_avg:34.30ms
+step:468/1585 train_time:16057ms step_avg:34.31ms
+step:469/1585 train_time:16088ms step_avg:34.30ms
+step:470/1585 train_time:16125ms step_avg:34.31ms
+step:471/1585 train_time:16156ms step_avg:34.30ms
+step:472/1585 train_time:16193ms step_avg:34.31ms
+step:473/1585 train_time:16224ms step_avg:34.30ms
+step:474/1585 train_time:16262ms step_avg:34.31ms
+step:475/1585 train_time:16292ms step_avg:34.30ms
+step:476/1585 train_time:16330ms step_avg:34.31ms
+step:477/1585 train_time:16360ms step_avg:34.30ms
+step:478/1585 train_time:16398ms step_avg:34.31ms
+step:479/1585 train_time:16429ms step_avg:34.30ms
+step:480/1585 train_time:16467ms step_avg:34.31ms
+step:481/1585 train_time:16497ms step_avg:34.30ms
+step:482/1585 train_time:16535ms step_avg:34.30ms
+step:483/1585 train_time:16565ms step_avg:34.30ms
+step:484/1585 train_time:16603ms step_avg:34.30ms
+step:485/1585 train_time:16634ms step_avg:34.30ms
+step:486/1585 train_time:16671ms step_avg:34.30ms
+step:487/1585 train_time:16702ms step_avg:34.29ms
+step:488/1585 train_time:16740ms step_avg:34.30ms
+step:489/1585 train_time:16770ms step_avg:34.29ms
+step:490/1585 train_time:16808ms step_avg:34.30ms
+step:491/1585 train_time:16838ms step_avg:34.29ms
+step:492/1585 train_time:16876ms step_avg:34.30ms
+step:493/1585 train_time:16907ms step_avg:34.29ms
+step:494/1585 train_time:16945ms step_avg:34.30ms
+step:495/1585 train_time:16975ms step_avg:34.29ms
+step:496/1585 train_time:17013ms step_avg:34.30ms
+step:497/1585 train_time:17044ms step_avg:34.29ms
+step:498/1585 train_time:17082ms step_avg:34.30ms
+step:499/1585 train_time:17112ms step_avg:34.29ms
+step:500/1585 train_time:17150ms step_avg:34.30ms
+step:500/1585 val_loss:4.2658 train_time:17198ms step_avg:34.40ms
+step:501/1585 train_time:17216ms step_avg:34.36ms
+step:502/1585 train_time:17233ms step_avg:34.33ms
+step:503/1585 train_time:17253ms step_avg:34.30ms
+step:504/1585 train_time:17292ms step_avg:34.31ms
+step:505/1585 train_time:17324ms step_avg:34.30ms
+step:506/1585 train_time:17361ms step_avg:34.31ms
+step:507/1585 train_time:17392ms step_avg:34.30ms
+step:508/1585 train_time:17430ms step_avg:34.31ms
+step:509/1585 train_time:17461ms step_avg:34.30ms
+step:510/1585 train_time:17498ms step_avg:34.31ms
+step:511/1585 train_time:17528ms step_avg:34.30ms
+step:512/1585 train_time:17566ms step_avg:34.31ms
+step:513/1585 train_time:17597ms step_avg:34.30ms
+step:514/1585 train_time:17634ms step_avg:34.31ms
+step:515/1585 train_time:17665ms step_avg:34.30ms
+step:516/1585 train_time:17737ms step_avg:34.37ms
+step:517/1585 train_time:17798ms step_avg:34.42ms
+step:518/1585 train_time:17856ms step_avg:34.47ms
+step:519/1585 train_time:17918ms step_avg:34.52ms
+step:520/1585 train_time:17976ms step_avg:34.57ms
+step:521/1585 train_time:18038ms step_avg:34.62ms
+step:522/1585 train_time:18097ms step_avg:34.67ms
+step:523/1585 train_time:18161ms step_avg:34.72ms
+step:524/1585 train_time:18222ms step_avg:34.77ms
+step:525/1585 train_time:18287ms step_avg:34.83ms
+step:526/1585 train_time:18347ms step_avg:34.88ms
+step:527/1585 train_time:18411ms step_avg:34.93ms
+step:528/1585 train_time:18469ms step_avg:34.98ms
+step:529/1585 train_time:18533ms step_avg:35.03ms
+step:530/1585 train_time:18593ms step_avg:35.08ms
+step:531/1585 train_time:18656ms step_avg:35.13ms
+step:532/1585 train_time:18714ms step_avg:35.18ms
+step:533/1585 train_time:18777ms step_avg:35.23ms
+step:534/1585 train_time:18835ms step_avg:35.27ms
+step:535/1585 train_time:18897ms step_avg:35.32ms
+step:536/1585 train_time:18956ms step_avg:35.37ms
+step:537/1585 train_time:19018ms step_avg:35.42ms
+step:538/1585 train_time:19077ms step_avg:35.46ms
+step:539/1585 train_time:19140ms step_avg:35.51ms
+step:540/1585 train_time:19200ms step_avg:35.56ms
+step:541/1585 train_time:19264ms step_avg:35.61ms
+step:542/1585 train_time:19324ms step_avg:35.65ms
+step:543/1585 train_time:19388ms step_avg:35.71ms
+step:544/1585 train_time:19448ms step_avg:35.75ms
+step:545/1585 train_time:19512ms step_avg:35.80ms
+step:546/1585 train_time:19571ms step_avg:35.84ms
+step:547/1585 train_time:19634ms step_avg:35.89ms
+step:548/1585 train_time:19693ms step_avg:35.94ms
+step:549/1585 train_time:19756ms step_avg:35.99ms
+step:550/1585 train_time:19815ms step_avg:36.03ms
+step:551/1585 train_time:19878ms step_avg:36.08ms
+step:552/1585 train_time:19936ms step_avg:36.12ms
+step:553/1585 train_time:19999ms step_avg:36.16ms
+step:554/1585 train_time:20058ms step_avg:36.21ms
+step:555/1585 train_time:20121ms step_avg:36.25ms
+step:556/1585 train_time:20180ms step_avg:36.30ms
+step:557/1585 train_time:20244ms step_avg:36.34ms
+step:558/1585 train_time:20304ms step_avg:36.39ms
+step:559/1585 train_time:20368ms step_avg:36.44ms
+step:560/1585 train_time:20428ms step_avg:36.48ms
+step:561/1585 train_time:20492ms step_avg:36.53ms
+step:562/1585 train_time:20551ms step_avg:36.57ms
+step:563/1585 train_time:20614ms step_avg:36.61ms
+step:564/1585 train_time:20673ms step_avg:36.65ms
+step:565/1585 train_time:20736ms step_avg:36.70ms
+step:566/1585 train_time:20795ms step_avg:36.74ms
+step:567/1585 train_time:20858ms step_avg:36.79ms
+step:568/1585 train_time:20916ms step_avg:36.82ms
+step:569/1585 train_time:20980ms step_avg:36.87ms
+step:570/1585 train_time:21041ms step_avg:36.91ms
+step:571/1585 train_time:21104ms step_avg:36.96ms
+step:572/1585 train_time:21162ms step_avg:37.00ms
+step:573/1585 train_time:21224ms step_avg:37.04ms
+step:574/1585 train_time:21283ms step_avg:37.08ms
+step:575/1585 train_time:21348ms step_avg:37.13ms
+step:576/1585 train_time:21407ms step_avg:37.16ms
+step:577/1585 train_time:21471ms step_avg:37.21ms
+step:578/1585 train_time:21530ms step_avg:37.25ms
+step:579/1585 train_time:21594ms step_avg:37.30ms
+step:580/1585 train_time:21653ms step_avg:37.33ms
+step:581/1585 train_time:21716ms step_avg:37.38ms
+step:582/1585 train_time:21774ms step_avg:37.41ms
+step:583/1585 train_time:21838ms step_avg:37.46ms
+step:584/1585 train_time:21896ms step_avg:37.49ms
+step:585/1585 train_time:21960ms step_avg:37.54ms
+step:586/1585 train_time:22018ms step_avg:37.57ms
+step:587/1585 train_time:22081ms step_avg:37.62ms
+step:588/1585 train_time:22140ms step_avg:37.65ms
+step:589/1585 train_time:22203ms step_avg:37.70ms
+step:590/1585 train_time:22263ms step_avg:37.73ms
+step:591/1585 train_time:22326ms step_avg:37.78ms
+step:592/1585 train_time:22386ms step_avg:37.81ms
+step:593/1585 train_time:22450ms step_avg:37.86ms
+step:594/1585 train_time:22510ms step_avg:37.90ms
+step:595/1585 train_time:22573ms step_avg:37.94ms
+step:596/1585 train_time:22632ms step_avg:37.97ms
+step:597/1585 train_time:22695ms step_avg:38.02ms
+step:598/1585 train_time:22755ms step_avg:38.05ms
+step:599/1585 train_time:22817ms step_avg:38.09ms
+step:600/1585 train_time:22876ms step_avg:38.13ms
+step:601/1585 train_time:22939ms step_avg:38.17ms
+step:602/1585 train_time:22998ms step_avg:38.20ms
+step:603/1585 train_time:23061ms step_avg:38.24ms
+step:604/1585 train_time:23120ms step_avg:38.28ms
+step:605/1585 train_time:23183ms step_avg:38.32ms
+step:606/1585 train_time:23243ms step_avg:38.35ms
+step:607/1585 train_time:23306ms step_avg:38.39ms
+step:608/1585 train_time:23365ms step_avg:38.43ms
+step:609/1585 train_time:23429ms step_avg:38.47ms
+step:610/1585 train_time:23488ms step_avg:38.51ms
+step:611/1585 train_time:23553ms step_avg:38.55ms
+step:612/1585 train_time:23611ms step_avg:38.58ms
+step:613/1585 train_time:23674ms step_avg:38.62ms
+step:614/1585 train_time:23733ms step_avg:38.65ms
+step:615/1585 train_time:23796ms step_avg:38.69ms
+step:616/1585 train_time:23855ms step_avg:38.73ms
+step:617/1585 train_time:23918ms step_avg:38.77ms
+step:618/1585 train_time:23977ms step_avg:38.80ms
+step:619/1585 train_time:24041ms step_avg:38.84ms
+step:620/1585 train_time:24099ms step_avg:38.87ms
+step:621/1585 train_time:24162ms step_avg:38.91ms
+step:622/1585 train_time:24221ms step_avg:38.94ms
+step:623/1585 train_time:24284ms step_avg:38.98ms
+step:624/1585 train_time:24344ms step_avg:39.01ms
+step:625/1585 train_time:24408ms step_avg:39.05ms
+step:626/1585 train_time:24467ms step_avg:39.08ms
+step:627/1585 train_time:24532ms step_avg:39.13ms
+step:628/1585 train_time:24590ms step_avg:39.16ms
+step:629/1585 train_time:24654ms step_avg:39.20ms
+step:630/1585 train_time:24712ms step_avg:39.23ms
+step:631/1585 train_time:24776ms step_avg:39.26ms
+step:632/1585 train_time:24835ms step_avg:39.30ms
+step:633/1585 train_time:24897ms step_avg:39.33ms
+step:634/1585 train_time:24957ms step_avg:39.36ms
+step:635/1585 train_time:25020ms step_avg:39.40ms
+step:636/1585 train_time:25079ms step_avg:39.43ms
+step:637/1585 train_time:25143ms step_avg:39.47ms
+step:638/1585 train_time:25202ms step_avg:39.50ms
+step:639/1585 train_time:25265ms step_avg:39.54ms
+step:640/1585 train_time:25324ms step_avg:39.57ms
+step:641/1585 train_time:25388ms step_avg:39.61ms
+step:642/1585 train_time:25447ms step_avg:39.64ms
+step:643/1585 train_time:25511ms step_avg:39.67ms
+step:644/1585 train_time:25570ms step_avg:39.70ms
+step:645/1585 train_time:25633ms step_avg:39.74ms
+step:646/1585 train_time:25692ms step_avg:39.77ms
+step:647/1585 train_time:25754ms step_avg:39.81ms
+step:648/1585 train_time:25813ms step_avg:39.84ms
+step:649/1585 train_time:25876ms step_avg:39.87ms
+step:650/1585 train_time:25936ms step_avg:39.90ms
+step:651/1585 train_time:25999ms step_avg:39.94ms
+step:652/1585 train_time:26059ms step_avg:39.97ms
+step:653/1585 train_time:26122ms step_avg:40.00ms
+step:654/1585 train_time:26181ms step_avg:40.03ms
+step:655/1585 train_time:26244ms step_avg:40.07ms
+step:656/1585 train_time:26303ms step_avg:40.10ms
+step:657/1585 train_time:26367ms step_avg:40.13ms
+step:658/1585 train_time:26426ms step_avg:40.16ms
+step:659/1585 train_time:26490ms step_avg:40.20ms
+step:660/1585 train_time:26549ms step_avg:40.23ms
+step:661/1585 train_time:26612ms step_avg:40.26ms
+step:662/1585 train_time:26672ms step_avg:40.29ms
+step:663/1585 train_time:26735ms step_avg:40.32ms
+step:664/1585 train_time:26794ms step_avg:40.35ms
+step:665/1585 train_time:26857ms step_avg:40.39ms
+step:666/1585 train_time:26916ms step_avg:40.41ms
+step:667/1585 train_time:26980ms step_avg:40.45ms
+step:668/1585 train_time:27039ms step_avg:40.48ms
+step:669/1585 train_time:27102ms step_avg:40.51ms
+step:670/1585 train_time:27162ms step_avg:40.54ms
+step:671/1585 train_time:27225ms step_avg:40.57ms
+step:672/1585 train_time:27284ms step_avg:40.60ms
+step:673/1585 train_time:27348ms step_avg:40.64ms
+step:674/1585 train_time:27407ms step_avg:40.66ms
+step:675/1585 train_time:27470ms step_avg:40.70ms
+step:676/1585 train_time:27529ms step_avg:40.72ms
+step:677/1585 train_time:27592ms step_avg:40.76ms
+step:678/1585 train_time:27652ms step_avg:40.78ms
+step:679/1585 train_time:27715ms step_avg:40.82ms
+step:680/1585 train_time:27774ms step_avg:40.84ms
+step:681/1585 train_time:27837ms step_avg:40.88ms
+step:682/1585 train_time:27897ms step_avg:40.90ms
+step:683/1585 train_time:27960ms step_avg:40.94ms
+step:684/1585 train_time:28018ms step_avg:40.96ms
+step:685/1585 train_time:28081ms step_avg:40.99ms
+step:686/1585 train_time:28141ms step_avg:41.02ms
+step:687/1585 train_time:28204ms step_avg:41.05ms
+step:688/1585 train_time:28263ms step_avg:41.08ms
+step:689/1585 train_time:28327ms step_avg:41.11ms
+step:690/1585 train_time:28386ms step_avg:41.14ms
+step:691/1585 train_time:28449ms step_avg:41.17ms
+step:692/1585 train_time:28508ms step_avg:41.20ms
+step:693/1585 train_time:28571ms step_avg:41.23ms
+step:694/1585 train_time:28631ms step_avg:41.26ms
+step:695/1585 train_time:28694ms step_avg:41.29ms
+step:696/1585 train_time:28753ms step_avg:41.31ms
+step:697/1585 train_time:28816ms step_avg:41.34ms
+step:698/1585 train_time:28875ms step_avg:41.37ms
+step:699/1585 train_time:28938ms step_avg:41.40ms
+step:700/1585 train_time:28997ms step_avg:41.42ms
+step:701/1585 train_time:29061ms step_avg:41.46ms
+step:702/1585 train_time:29120ms step_avg:41.48ms
+step:703/1585 train_time:29183ms step_avg:41.51ms
+step:704/1585 train_time:29242ms step_avg:41.54ms
+step:705/1585 train_time:29306ms step_avg:41.57ms
+step:706/1585 train_time:29365ms step_avg:41.59ms
+step:707/1585 train_time:29428ms step_avg:41.62ms
+step:708/1585 train_time:29486ms step_avg:41.65ms
+step:709/1585 train_time:29550ms step_avg:41.68ms
+step:710/1585 train_time:29610ms step_avg:41.70ms
+step:711/1585 train_time:29673ms step_avg:41.73ms
+step:712/1585 train_time:29733ms step_avg:41.76ms
+step:713/1585 train_time:29795ms step_avg:41.79ms
+step:714/1585 train_time:29855ms step_avg:41.81ms
+step:715/1585 train_time:29918ms step_avg:41.84ms
+step:716/1585 train_time:29978ms step_avg:41.87ms
+step:717/1585 train_time:30041ms step_avg:41.90ms
+step:718/1585 train_time:30100ms step_avg:41.92ms
+step:719/1585 train_time:30164ms step_avg:41.95ms
+step:720/1585 train_time:30222ms step_avg:41.97ms
+step:721/1585 train_time:30285ms step_avg:42.00ms
+step:722/1585 train_time:30345ms step_avg:42.03ms
+step:723/1585 train_time:30408ms step_avg:42.06ms
+step:724/1585 train_time:30468ms step_avg:42.08ms
+step:725/1585 train_time:30531ms step_avg:42.11ms
+step:726/1585 train_time:30590ms step_avg:42.13ms
+step:727/1585 train_time:30654ms step_avg:42.16ms
+step:728/1585 train_time:30712ms step_avg:42.19ms
+step:729/1585 train_time:30775ms step_avg:42.22ms
+step:730/1585 train_time:30835ms step_avg:42.24ms
+step:731/1585 train_time:30898ms step_avg:42.27ms
+step:732/1585 train_time:30957ms step_avg:42.29ms
+step:733/1585 train_time:31021ms step_avg:42.32ms
+step:734/1585 train_time:31079ms step_avg:42.34ms
+step:735/1585 train_time:31143ms step_avg:42.37ms
+step:736/1585 train_time:31202ms step_avg:42.39ms
+step:737/1585 train_time:31265ms step_avg:42.42ms
+step:738/1585 train_time:31324ms step_avg:42.44ms
+step:739/1585 train_time:31388ms step_avg:42.47ms
+step:740/1585 train_time:31447ms step_avg:42.50ms
+step:741/1585 train_time:31510ms step_avg:42.52ms
+step:742/1585 train_time:31569ms step_avg:42.55ms
+step:743/1585 train_time:31632ms step_avg:42.57ms
+step:744/1585 train_time:31691ms step_avg:42.60ms
+step:745/1585 train_time:31754ms step_avg:42.62ms
+step:746/1585 train_time:31814ms step_avg:42.65ms
+step:747/1585 train_time:31878ms step_avg:42.67ms
+step:748/1585 train_time:31937ms step_avg:42.70ms
+step:749/1585 train_time:32000ms step_avg:42.72ms
+step:750/1585 train_time:32060ms step_avg:42.75ms
+step:750/1585 val_loss:3.8826 train_time:32107ms step_avg:42.81ms
+step:751/1585 train_time:32124ms step_avg:42.77ms
+step:752/1585 train_time:32184ms step_avg:42.80ms
+step:753/1585 train_time:32251ms step_avg:42.83ms
+step:754/1585 train_time:32311ms step_avg:42.85ms
+step:755/1585 train_time:32374ms step_avg:42.88ms
+step:756/1585 train_time:32433ms step_avg:42.90ms
+step:757/1585 train_time:32495ms step_avg:42.93ms
+step:758/1585 train_time:32554ms step_avg:42.95ms
+step:759/1585 train_time:32617ms step_avg:42.97ms
+step:760/1585 train_time:32675ms step_avg:42.99ms
+step:761/1585 train_time:32738ms step_avg:43.02ms
+step:762/1585 train_time:32797ms step_avg:43.04ms
+step:763/1585 train_time:32859ms step_avg:43.07ms
+step:764/1585 train_time:32919ms step_avg:43.09ms
+step:765/1585 train_time:32982ms step_avg:43.11ms
+step:766/1585 train_time:33041ms step_avg:43.13ms
+step:767/1585 train_time:33105ms step_avg:43.16ms
+step:768/1585 train_time:33165ms step_avg:43.18ms
+step:769/1585 train_time:33230ms step_avg:43.21ms
+step:770/1585 train_time:33289ms step_avg:43.23ms
+step:771/1585 train_time:33352ms step_avg:43.26ms
+step:772/1585 train_time:33412ms step_avg:43.28ms
+step:773/1585 train_time:33475ms step_avg:43.30ms
+step:774/1585 train_time:33533ms step_avg:43.32ms
+step:775/1585 train_time:33596ms step_avg:43.35ms
+step:776/1585 train_time:33655ms step_avg:43.37ms
+step:777/1585 train_time:33718ms step_avg:43.40ms
+step:778/1585 train_time:33777ms step_avg:43.42ms
+step:779/1585 train_time:33840ms step_avg:43.44ms
+step:780/1585 train_time:33899ms step_avg:43.46ms
+step:781/1585 train_time:33962ms step_avg:43.49ms
+step:782/1585 train_time:34021ms step_avg:43.51ms
+step:783/1585 train_time:34085ms step_avg:43.53ms
+step:784/1585 train_time:34145ms step_avg:43.55ms
+step:785/1585 train_time:34209ms step_avg:43.58ms
+step:786/1585 train_time:34268ms step_avg:43.60ms
+step:787/1585 train_time:34332ms step_avg:43.62ms
+step:788/1585 train_time:34391ms step_avg:43.64ms
+step:789/1585 train_time:34454ms step_avg:43.67ms
+step:790/1585 train_time:34513ms step_avg:43.69ms
+step:791/1585 train_time:34576ms step_avg:43.71ms
+step:792/1585 train_time:34635ms step_avg:43.73ms
+step:793/1585 train_time:34698ms step_avg:43.75ms
+step:794/1585 train_time:34756ms step_avg:43.77ms
+step:795/1585 train_time:34820ms step_avg:43.80ms
+step:796/1585 train_time:34879ms step_avg:43.82ms
+step:797/1585 train_time:34942ms step_avg:43.84ms
+step:798/1585 train_time:35001ms step_avg:43.86ms
+step:799/1585 train_time:35064ms step_avg:43.89ms
+step:800/1585 train_time:35123ms step_avg:43.90ms
+step:801/1585 train_time:35187ms step_avg:43.93ms
+step:802/1585 train_time:35246ms step_avg:43.95ms
+step:803/1585 train_time:35310ms step_avg:43.97ms
+step:804/1585 train_time:35369ms step_avg:43.99ms
+step:805/1585 train_time:35433ms step_avg:44.02ms
+step:806/1585 train_time:35492ms step_avg:44.03ms
+step:807/1585 train_time:35554ms step_avg:44.06ms
+step:808/1585 train_time:35614ms step_avg:44.08ms
+step:809/1585 train_time:35676ms step_avg:44.10ms
+step:810/1585 train_time:35735ms step_avg:44.12ms
+step:811/1585 train_time:35798ms step_avg:44.14ms
+step:812/1585 train_time:35857ms step_avg:44.16ms
+step:813/1585 train_time:35921ms step_avg:44.18ms
+step:814/1585 train_time:35980ms step_avg:44.20ms
+step:815/1585 train_time:36043ms step_avg:44.22ms
+step:816/1585 train_time:36102ms step_avg:44.24ms
+step:817/1585 train_time:36166ms step_avg:44.27ms
+step:818/1585 train_time:36225ms step_avg:44.28ms
+step:819/1585 train_time:36288ms step_avg:44.31ms
+step:820/1585 train_time:36348ms step_avg:44.33ms
+step:821/1585 train_time:36412ms step_avg:44.35ms
+step:822/1585 train_time:36471ms step_avg:44.37ms
+step:823/1585 train_time:36534ms step_avg:44.39ms
+step:824/1585 train_time:36594ms step_avg:44.41ms
+step:825/1585 train_time:36656ms step_avg:44.43ms
+step:826/1585 train_time:36715ms step_avg:44.45ms
+step:827/1585 train_time:36778ms step_avg:44.47ms
+step:828/1585 train_time:36837ms step_avg:44.49ms
+step:829/1585 train_time:36901ms step_avg:44.51ms
+step:830/1585 train_time:36960ms step_avg:44.53ms
+step:831/1585 train_time:37024ms step_avg:44.55ms
+step:832/1585 train_time:37083ms step_avg:44.57ms
+step:833/1585 train_time:37146ms step_avg:44.59ms
+step:834/1585 train_time:37205ms step_avg:44.61ms
+step:835/1585 train_time:37269ms step_avg:44.63ms
+step:836/1585 train_time:37328ms step_avg:44.65ms
+step:837/1585 train_time:37392ms step_avg:44.67ms
+step:838/1585 train_time:37451ms step_avg:44.69ms
+step:839/1585 train_time:37514ms step_avg:44.71ms
+step:840/1585 train_time:37573ms step_avg:44.73ms
+step:841/1585 train_time:37636ms step_avg:44.75ms
+step:842/1585 train_time:37695ms step_avg:44.77ms
+step:843/1585 train_time:37758ms step_avg:44.79ms
+step:844/1585 train_time:37817ms step_avg:44.81ms
+step:845/1585 train_time:37881ms step_avg:44.83ms
+step:846/1585 train_time:37939ms step_avg:44.85ms
+step:847/1585 train_time:38003ms step_avg:44.87ms
+step:848/1585 train_time:38061ms step_avg:44.88ms
+step:849/1585 train_time:38125ms step_avg:44.91ms
+step:850/1585 train_time:38184ms step_avg:44.92ms
+step:851/1585 train_time:38247ms step_avg:44.94ms
+step:852/1585 train_time:38307ms step_avg:44.96ms
+step:853/1585 train_time:38370ms step_avg:44.98ms
+step:854/1585 train_time:38429ms step_avg:45.00ms
+step:855/1585 train_time:38493ms step_avg:45.02ms
+step:856/1585 train_time:38552ms step_avg:45.04ms
+step:857/1585 train_time:38615ms step_avg:45.06ms
+step:858/1585 train_time:38675ms step_avg:45.08ms
+step:859/1585 train_time:38737ms step_avg:45.10ms
+step:860/1585 train_time:38797ms step_avg:45.11ms
+step:861/1585 train_time:38860ms step_avg:45.13ms
+step:862/1585 train_time:38919ms step_avg:45.15ms
+step:863/1585 train_time:38982ms step_avg:45.17ms
+step:864/1585 train_time:39040ms step_avg:45.19ms
+step:865/1585 train_time:39104ms step_avg:45.21ms
+step:866/1585 train_time:39163ms step_avg:45.22ms
+step:867/1585 train_time:39227ms step_avg:45.24ms
+step:868/1585 train_time:39287ms step_avg:45.26ms
+step:869/1585 train_time:39350ms step_avg:45.28ms
+step:870/1585 train_time:39409ms step_avg:45.30ms
+step:871/1585 train_time:39472ms step_avg:45.32ms
+step:872/1585 train_time:39531ms step_avg:45.33ms
+step:873/1585 train_time:39595ms step_avg:45.35ms
+step:874/1585 train_time:39654ms step_avg:45.37ms
+step:875/1585 train_time:39717ms step_avg:45.39ms
+step:876/1585 train_time:39777ms step_avg:45.41ms
+step:877/1585 train_time:39840ms step_avg:45.43ms
+step:878/1585 train_time:39899ms step_avg:45.44ms
+step:879/1585 train_time:39962ms step_avg:45.46ms
+step:880/1585 train_time:40021ms step_avg:45.48ms
+step:881/1585 train_time:40084ms step_avg:45.50ms
+step:882/1585 train_time:40142ms step_avg:45.51ms
+step:883/1585 train_time:40206ms step_avg:45.53ms
+step:884/1585 train_time:40265ms step_avg:45.55ms
+step:885/1585 train_time:40328ms step_avg:45.57ms
+step:886/1585 train_time:40388ms step_avg:45.59ms
+step:887/1585 train_time:40454ms step_avg:45.61ms
+step:888/1585 train_time:40513ms step_avg:45.62ms
+step:889/1585 train_time:40574ms step_avg:45.64ms
+step:890/1585 train_time:40633ms step_avg:45.66ms
+step:891/1585 train_time:40696ms step_avg:45.68ms
+step:892/1585 train_time:40755ms step_avg:45.69ms
+step:893/1585 train_time:40819ms step_avg:45.71ms
+step:894/1585 train_time:40878ms step_avg:45.72ms
+step:895/1585 train_time:40942ms step_avg:45.75ms
+step:896/1585 train_time:41001ms step_avg:45.76ms
+step:897/1585 train_time:41064ms step_avg:45.78ms
+step:898/1585 train_time:41123ms step_avg:45.79ms
+step:899/1585 train_time:41186ms step_avg:45.81ms
+step:900/1585 train_time:41245ms step_avg:45.83ms
+step:901/1585 train_time:41308ms step_avg:45.85ms
+step:902/1585 train_time:41367ms step_avg:45.86ms
+step:903/1585 train_time:41431ms step_avg:45.88ms
+step:904/1585 train_time:41490ms step_avg:45.90ms
+step:905/1585 train_time:41553ms step_avg:45.91ms
+step:906/1585 train_time:41613ms step_avg:45.93ms
+step:907/1585 train_time:41675ms step_avg:45.95ms
+step:908/1585 train_time:41734ms step_avg:45.96ms
+step:909/1585 train_time:41797ms step_avg:45.98ms
+step:910/1585 train_time:41856ms step_avg:46.00ms
+step:911/1585 train_time:41920ms step_avg:46.02ms
+step:912/1585 train_time:41979ms step_avg:46.03ms
+step:913/1585 train_time:42043ms step_avg:46.05ms
+step:914/1585 train_time:42102ms step_avg:46.06ms
+step:915/1585 train_time:42165ms step_avg:46.08ms
+step:916/1585 train_time:42224ms step_avg:46.10ms
+step:917/1585 train_time:42287ms step_avg:46.11ms
+step:918/1585 train_time:42346ms step_avg:46.13ms
+step:919/1585 train_time:42409ms step_avg:46.15ms
+step:920/1585 train_time:42469ms step_avg:46.16ms
+step:921/1585 train_time:42533ms step_avg:46.18ms
+step:922/1585 train_time:42592ms step_avg:46.20ms
+step:923/1585 train_time:42655ms step_avg:46.21ms
+step:924/1585 train_time:42715ms step_avg:46.23ms
+step:925/1585 train_time:42778ms step_avg:46.25ms
+step:926/1585 train_time:42837ms step_avg:46.26ms
+step:927/1585 train_time:42900ms step_avg:46.28ms
+step:928/1585 train_time:42958ms step_avg:46.29ms
+step:929/1585 train_time:43022ms step_avg:46.31ms
+step:930/1585 train_time:43081ms step_avg:46.32ms
+step:931/1585 train_time:43143ms step_avg:46.34ms
+step:932/1585 train_time:43202ms step_avg:46.35ms
+step:933/1585 train_time:43266ms step_avg:46.37ms
+step:934/1585 train_time:43325ms step_avg:46.39ms
+step:935/1585 train_time:43388ms step_avg:46.40ms
+step:936/1585 train_time:43448ms step_avg:46.42ms
+step:937/1585 train_time:43511ms step_avg:46.44ms
+step:938/1585 train_time:43571ms step_avg:46.45ms
+step:939/1585 train_time:43634ms step_avg:46.47ms
+step:940/1585 train_time:43693ms step_avg:46.48ms
+step:941/1585 train_time:43756ms step_avg:46.50ms
+step:942/1585 train_time:43815ms step_avg:46.51ms
+step:943/1585 train_time:43879ms step_avg:46.53ms
+step:944/1585 train_time:43938ms step_avg:46.54ms
+step:945/1585 train_time:44001ms step_avg:46.56ms
+step:946/1585 train_time:44061ms step_avg:46.58ms
+step:947/1585 train_time:44124ms step_avg:46.59ms
+step:948/1585 train_time:44183ms step_avg:46.61ms
+step:949/1585 train_time:44246ms step_avg:46.62ms
+step:950/1585 train_time:44306ms step_avg:46.64ms
+step:951/1585 train_time:44369ms step_avg:46.65ms
+step:952/1585 train_time:44428ms step_avg:46.67ms
+step:953/1585 train_time:44492ms step_avg:46.69ms
+step:954/1585 train_time:44550ms step_avg:46.70ms
+step:955/1585 train_time:44614ms step_avg:46.72ms
+step:956/1585 train_time:44673ms step_avg:46.73ms
+step:957/1585 train_time:44736ms step_avg:46.75ms
+step:958/1585 train_time:44795ms step_avg:46.76ms
+step:959/1585 train_time:44859ms step_avg:46.78ms
+step:960/1585 train_time:44917ms step_avg:46.79ms
+step:961/1585 train_time:44981ms step_avg:46.81ms
+step:962/1585 train_time:45040ms step_avg:46.82ms
+step:963/1585 train_time:45103ms step_avg:46.84ms
+step:964/1585 train_time:45162ms step_avg:46.85ms
+step:965/1585 train_time:45224ms step_avg:46.86ms
+step:966/1585 train_time:45284ms step_avg:46.88ms
+step:967/1585 train_time:45347ms step_avg:46.89ms
+step:968/1585 train_time:45406ms step_avg:46.91ms
+step:969/1585 train_time:45470ms step_avg:46.92ms
+step:970/1585 train_time:45529ms step_avg:46.94ms
+step:971/1585 train_time:45593ms step_avg:46.95ms
+step:972/1585 train_time:45651ms step_avg:46.97ms
+step:973/1585 train_time:45714ms step_avg:46.98ms
+step:974/1585 train_time:45773ms step_avg:46.99ms
+step:975/1585 train_time:45836ms step_avg:47.01ms
+step:976/1585 train_time:45896ms step_avg:47.02ms
+step:977/1585 train_time:45959ms step_avg:47.04ms
+step:978/1585 train_time:46019ms step_avg:47.05ms
+step:979/1585 train_time:46082ms step_avg:47.07ms
+step:980/1585 train_time:46141ms step_avg:47.08ms
+step:981/1585 train_time:46204ms step_avg:47.10ms
+step:982/1585 train_time:46263ms step_avg:47.11ms
+step:983/1585 train_time:46326ms step_avg:47.13ms
+step:984/1585 train_time:46385ms step_avg:47.14ms
+step:985/1585 train_time:46449ms step_avg:47.16ms
+step:986/1585 train_time:46508ms step_avg:47.17ms
+step:987/1585 train_time:46572ms step_avg:47.19ms
+step:988/1585 train_time:46631ms step_avg:47.20ms
+step:989/1585 train_time:46694ms step_avg:47.21ms
+step:990/1585 train_time:46753ms step_avg:47.23ms
+step:991/1585 train_time:46816ms step_avg:47.24ms
+step:992/1585 train_time:46876ms step_avg:47.25ms
+step:993/1585 train_time:46940ms step_avg:47.27ms
+step:994/1585 train_time:46999ms step_avg:47.28ms
+step:995/1585 train_time:47062ms step_avg:47.30ms
+step:996/1585 train_time:47121ms step_avg:47.31ms
+step:997/1585 train_time:47184ms step_avg:47.33ms
+step:998/1585 train_time:47243ms step_avg:47.34ms
+step:999/1585 train_time:47306ms step_avg:47.35ms
+step:1000/1585 train_time:47365ms step_avg:47.36ms
+step:1000/1585 val_loss:3.5874 train_time:47412ms step_avg:47.41ms
+step:1001/1585 train_time:47429ms step_avg:47.38ms
+step:1002/1585 train_time:47489ms step_avg:47.39ms
+step:1003/1585 train_time:47555ms step_avg:47.41ms
+step:1004/1585 train_time:47614ms step_avg:47.42ms
+step:1005/1585 train_time:47678ms step_avg:47.44ms
+step:1006/1585 train_time:47737ms step_avg:47.45ms
+step:1007/1585 train_time:47799ms step_avg:47.47ms
+step:1008/1585 train_time:47858ms step_avg:47.48ms
+step:1009/1585 train_time:47920ms step_avg:47.49ms
+step:1010/1585 train_time:47979ms step_avg:47.50ms
+step:1011/1585 train_time:48043ms step_avg:47.52ms
+step:1012/1585 train_time:48103ms step_avg:47.53ms
+step:1013/1585 train_time:48167ms step_avg:47.55ms
+step:1014/1585 train_time:48227ms step_avg:47.56ms
+step:1015/1585 train_time:48290ms step_avg:47.58ms
+step:1016/1585 train_time:48349ms step_avg:47.59ms
+step:1017/1585 train_time:48412ms step_avg:47.60ms
+step:1018/1585 train_time:48472ms step_avg:47.61ms
+step:1019/1585 train_time:48535ms step_avg:47.63ms
+step:1020/1585 train_time:48595ms step_avg:47.64ms
+step:1021/1585 train_time:48658ms step_avg:47.66ms
+step:1022/1585 train_time:48717ms step_avg:47.67ms
+step:1023/1585 train_time:48780ms step_avg:47.68ms
+step:1024/1585 train_time:48840ms step_avg:47.69ms
+step:1025/1585 train_time:48901ms step_avg:47.71ms
+step:1026/1585 train_time:48960ms step_avg:47.72ms
+step:1027/1585 train_time:49023ms step_avg:47.73ms
+step:1028/1585 train_time:49082ms step_avg:47.75ms
+step:1029/1585 train_time:49146ms step_avg:47.76ms
+step:1030/1585 train_time:49205ms step_avg:47.77ms
+step:1031/1585 train_time:49275ms step_avg:47.79ms
+step:1032/1585 train_time:49360ms step_avg:47.83ms
+step:1033/1585 train_time:49452ms step_avg:47.87ms
+step:1034/1585 train_time:49538ms step_avg:47.91ms
+step:1035/1585 train_time:49627ms step_avg:47.95ms
+step:1036/1585 train_time:49713ms step_avg:47.99ms
+step:1037/1585 train_time:49803ms step_avg:48.03ms
+step:1038/1585 train_time:49889ms step_avg:48.06ms
+step:1039/1585 train_time:49978ms step_avg:48.10ms
+step:1040/1585 train_time:50064ms step_avg:48.14ms
+step:1041/1585 train_time:50153ms step_avg:48.18ms
+step:1042/1585 train_time:50239ms step_avg:48.21ms
+step:1043/1585 train_time:50329ms step_avg:48.25ms
+step:1044/1585 train_time:50415ms step_avg:48.29ms
+step:1045/1585 train_time:50505ms step_avg:48.33ms
+step:1046/1585 train_time:50591ms step_avg:48.37ms
+step:1047/1585 train_time:50680ms step_avg:48.41ms
+step:1048/1585 train_time:50767ms step_avg:48.44ms
+step:1049/1585 train_time:50856ms step_avg:48.48ms
+step:1050/1585 train_time:50943ms step_avg:48.52ms
+step:1051/1585 train_time:51032ms step_avg:48.56ms
+step:1052/1585 train_time:51117ms step_avg:48.59ms
+step:1053/1585 train_time:51207ms step_avg:48.63ms
+step:1054/1585 train_time:51293ms step_avg:48.66ms
+step:1055/1585 train_time:51383ms step_avg:48.70ms
+step:1056/1585 train_time:51469ms step_avg:48.74ms
+step:1057/1585 train_time:51559ms step_avg:48.78ms
+step:1058/1585 train_time:51645ms step_avg:48.81ms
+step:1059/1585 train_time:51733ms step_avg:48.85ms
+step:1060/1585 train_time:51819ms step_avg:48.89ms
+step:1061/1585 train_time:51908ms step_avg:48.92ms
+step:1062/1585 train_time:51994ms step_avg:48.96ms
+step:1063/1585 train_time:52083ms step_avg:49.00ms
+step:1064/1585 train_time:52170ms step_avg:49.03ms
+step:1065/1585 train_time:52259ms step_avg:49.07ms
+step:1066/1585 train_time:52346ms step_avg:49.11ms
+step:1067/1585 train_time:52435ms step_avg:49.14ms
+step:1068/1585 train_time:52521ms step_avg:49.18ms
+step:1069/1585 train_time:52610ms step_avg:49.21ms
+step:1070/1585 train_time:52696ms step_avg:49.25ms
+step:1071/1585 train_time:52786ms step_avg:49.29ms
+step:1072/1585 train_time:52872ms step_avg:49.32ms
+step:1073/1585 train_time:52961ms step_avg:49.36ms
+step:1074/1585 train_time:53046ms step_avg:49.39ms
+step:1075/1585 train_time:53136ms step_avg:49.43ms
+step:1076/1585 train_time:53221ms step_avg:49.46ms
+step:1077/1585 train_time:53312ms step_avg:49.50ms
+step:1078/1585 train_time:53398ms step_avg:49.53ms
+step:1079/1585 train_time:53487ms step_avg:49.57ms
+step:1080/1585 train_time:53573ms step_avg:49.60ms
+step:1081/1585 train_time:53662ms step_avg:49.64ms
+step:1082/1585 train_time:53749ms step_avg:49.68ms
+step:1083/1585 train_time:53838ms step_avg:49.71ms
+step:1084/1585 train_time:53924ms step_avg:49.75ms
+step:1085/1585 train_time:54014ms step_avg:49.78ms
+step:1086/1585 train_time:54099ms step_avg:49.81ms
+step:1087/1585 train_time:54188ms step_avg:49.85ms
+step:1088/1585 train_time:54275ms step_avg:49.88ms
+step:1089/1585 train_time:54364ms step_avg:49.92ms
+step:1090/1585 train_time:54449ms step_avg:49.95ms
+step:1091/1585 train_time:54540ms step_avg:49.99ms
+step:1092/1585 train_time:54625ms step_avg:50.02ms
+step:1093/1585 train_time:54715ms step_avg:50.06ms
+step:1094/1585 train_time:54801ms step_avg:50.09ms
+step:1095/1585 train_time:54890ms step_avg:50.13ms
+step:1096/1585 train_time:54977ms step_avg:50.16ms
+step:1097/1585 train_time:55066ms step_avg:50.20ms
+step:1098/1585 train_time:55153ms step_avg:50.23ms
+step:1099/1585 train_time:55241ms step_avg:50.26ms
+step:1100/1585 train_time:55327ms step_avg:50.30ms
+step:1101/1585 train_time:55416ms step_avg:50.33ms
+step:1102/1585 train_time:55502ms step_avg:50.36ms
+step:1103/1585 train_time:55592ms step_avg:50.40ms
+step:1104/1585 train_time:55679ms step_avg:50.43ms
+step:1105/1585 train_time:55768ms step_avg:50.47ms
+step:1106/1585 train_time:55854ms step_avg:50.50ms
+step:1107/1585 train_time:55944ms step_avg:50.54ms
+step:1108/1585 train_time:56029ms step_avg:50.57ms
+step:1109/1585 train_time:56118ms step_avg:50.60ms
+step:1110/1585 train_time:56203ms step_avg:50.63ms
+step:1111/1585 train_time:56292ms step_avg:50.67ms
+step:1112/1585 train_time:56377ms step_avg:50.70ms
+step:1113/1585 train_time:56467ms step_avg:50.73ms
+step:1114/1585 train_time:56554ms step_avg:50.77ms
+step:1115/1585 train_time:56643ms step_avg:50.80ms
+step:1116/1585 train_time:56728ms step_avg:50.83ms
+step:1117/1585 train_time:56817ms step_avg:50.87ms
+step:1118/1585 train_time:56904ms step_avg:50.90ms
+step:1119/1585 train_time:56993ms step_avg:50.93ms
+step:1120/1585 train_time:57079ms step_avg:50.96ms
+step:1121/1585 train_time:57169ms step_avg:51.00ms
+step:1122/1585 train_time:57254ms step_avg:51.03ms
+step:1123/1585 train_time:57343ms step_avg:51.06ms
+step:1124/1585 train_time:57429ms step_avg:51.09ms
+step:1125/1585 train_time:57519ms step_avg:51.13ms
+step:1126/1585 train_time:57605ms step_avg:51.16ms
+step:1127/1585 train_time:57695ms step_avg:51.19ms
+step:1128/1585 train_time:57781ms step_avg:51.22ms
+step:1129/1585 train_time:57870ms step_avg:51.26ms
+step:1130/1585 train_time:57957ms step_avg:51.29ms
+step:1131/1585 train_time:58046ms step_avg:51.32ms
+step:1132/1585 train_time:58132ms step_avg:51.35ms
+step:1133/1585 train_time:58221ms step_avg:51.39ms
+step:1134/1585 train_time:58307ms step_avg:51.42ms
+step:1135/1585 train_time:58396ms step_avg:51.45ms
+step:1136/1585 train_time:58482ms step_avg:51.48ms
+step:1137/1585 train_time:58571ms step_avg:51.51ms
+step:1138/1585 train_time:58657ms step_avg:51.54ms
+step:1139/1585 train_time:58746ms step_avg:51.58ms
+step:1140/1585 train_time:58831ms step_avg:51.61ms
+step:1141/1585 train_time:58924ms step_avg:51.64ms
+step:1142/1585 train_time:59009ms step_avg:51.67ms
+step:1143/1585 train_time:59101ms step_avg:51.71ms
+step:1144/1585 train_time:59185ms step_avg:51.73ms
+step:1145/1585 train_time:59274ms step_avg:51.77ms
+step:1146/1585 train_time:59361ms step_avg:51.80ms
+step:1147/1585 train_time:59450ms step_avg:51.83ms
+step:1148/1585 train_time:59537ms step_avg:51.86ms
+step:1149/1585 train_time:59626ms step_avg:51.89ms
+step:1150/1585 train_time:59711ms step_avg:51.92ms
+step:1151/1585 train_time:59801ms step_avg:51.96ms
+step:1152/1585 train_time:59887ms step_avg:51.99ms
+step:1153/1585 train_time:59977ms step_avg:52.02ms
+step:1154/1585 train_time:60063ms step_avg:52.05ms
+step:1155/1585 train_time:60153ms step_avg:52.08ms
+step:1156/1585 train_time:60239ms step_avg:52.11ms
+step:1157/1585 train_time:60328ms step_avg:52.14ms
+step:1158/1585 train_time:60414ms step_avg:52.17ms
+step:1159/1585 train_time:60519ms step_avg:52.22ms
+step:1160/1585 train_time:60588ms step_avg:52.23ms
+step:1161/1585 train_time:60678ms step_avg:52.26ms
+step:1162/1585 train_time:60764ms step_avg:52.29ms
+step:1163/1585 train_time:60853ms step_avg:52.32ms
+step:1164/1585 train_time:60940ms step_avg:52.35ms
+step:1165/1585 train_time:61029ms step_avg:52.39ms
+step:1166/1585 train_time:61115ms step_avg:52.41ms
+step:1167/1585 train_time:61205ms step_avg:52.45ms
+step:1168/1585 train_time:61290ms step_avg:52.47ms
+step:1169/1585 train_time:61379ms step_avg:52.51ms
+step:1170/1585 train_time:61466ms step_avg:52.54ms
+step:1171/1585 train_time:61555ms step_avg:52.57ms
+step:1172/1585 train_time:61640ms step_avg:52.59ms
+step:1173/1585 train_time:61729ms step_avg:52.63ms
+step:1174/1585 train_time:61815ms step_avg:52.65ms
+step:1175/1585 train_time:61905ms step_avg:52.68ms
+step:1176/1585 train_time:61991ms step_avg:52.71ms
+step:1177/1585 train_time:62081ms step_avg:52.74ms
+step:1178/1585 train_time:62167ms step_avg:52.77ms
+step:1179/1585 train_time:62257ms step_avg:52.80ms
+step:1180/1585 train_time:62342ms step_avg:52.83ms
+step:1181/1585 train_time:62431ms step_avg:52.86ms
+step:1182/1585 train_time:62517ms step_avg:52.89ms
+step:1183/1585 train_time:62606ms step_avg:52.92ms
+step:1184/1585 train_time:62693ms step_avg:52.95ms
+step:1185/1585 train_time:62783ms step_avg:52.98ms
+step:1186/1585 train_time:62869ms step_avg:53.01ms
+step:1187/1585 train_time:62958ms step_avg:53.04ms
+step:1188/1585 train_time:63043ms step_avg:53.07ms
+step:1189/1585 train_time:63132ms step_avg:53.10ms
+step:1190/1585 train_time:63219ms step_avg:53.12ms
+step:1191/1585 train_time:63308ms step_avg:53.16ms
+step:1192/1585 train_time:63393ms step_avg:53.18ms
+step:1193/1585 train_time:63482ms step_avg:53.21ms
+step:1194/1585 train_time:63569ms step_avg:53.24ms
+step:1195/1585 train_time:63658ms step_avg:53.27ms
+step:1196/1585 train_time:63744ms step_avg:53.30ms
+step:1197/1585 train_time:63833ms step_avg:53.33ms
+step:1198/1585 train_time:63919ms step_avg:53.35ms
+step:1199/1585 train_time:64008ms step_avg:53.38ms
+step:1200/1585 train_time:64094ms step_avg:53.41ms
+step:1201/1585 train_time:64184ms step_avg:53.44ms
+step:1202/1585 train_time:64270ms step_avg:53.47ms
+step:1203/1585 train_time:64360ms step_avg:53.50ms
+step:1204/1585 train_time:64447ms step_avg:53.53ms
+step:1205/1585 train_time:64535ms step_avg:53.56ms
+step:1206/1585 train_time:64621ms step_avg:53.58ms
+step:1207/1585 train_time:64711ms step_avg:53.61ms
+step:1208/1585 train_time:64796ms step_avg:53.64ms
+step:1209/1585 train_time:64886ms step_avg:53.67ms
+step:1210/1585 train_time:64971ms step_avg:53.70ms
+step:1211/1585 train_time:65061ms step_avg:53.72ms
+step:1212/1585 train_time:65148ms step_avg:53.75ms
+step:1213/1585 train_time:65237ms step_avg:53.78ms
+step:1214/1585 train_time:65323ms step_avg:53.81ms
+step:1215/1585 train_time:65411ms step_avg:53.84ms
+step:1216/1585 train_time:65497ms step_avg:53.86ms
+step:1217/1585 train_time:65587ms step_avg:53.89ms
+step:1218/1585 train_time:65673ms step_avg:53.92ms
+step:1219/1585 train_time:65763ms step_avg:53.95ms
+step:1220/1585 train_time:65849ms step_avg:53.97ms
+step:1221/1585 train_time:65938ms step_avg:54.00ms
+step:1222/1585 train_time:66024ms step_avg:54.03ms
+step:1223/1585 train_time:66114ms step_avg:54.06ms
+step:1224/1585 train_time:66200ms step_avg:54.08ms
+step:1225/1585 train_time:66289ms step_avg:54.11ms
+step:1226/1585 train_time:66375ms step_avg:54.14ms
+step:1227/1585 train_time:66464ms step_avg:54.17ms
+step:1228/1585 train_time:66550ms step_avg:54.19ms
+step:1229/1585 train_time:66639ms step_avg:54.22ms
+step:1230/1585 train_time:66726ms step_avg:54.25ms
+step:1231/1585 train_time:66815ms step_avg:54.28ms
+step:1232/1585 train_time:66901ms step_avg:54.30ms
+step:1233/1585 train_time:66990ms step_avg:54.33ms
+step:1234/1585 train_time:67076ms step_avg:54.36ms
+step:1235/1585 train_time:67165ms step_avg:54.38ms
+step:1236/1585 train_time:67252ms step_avg:54.41ms
+step:1237/1585 train_time:67342ms step_avg:54.44ms
+step:1238/1585 train_time:67428ms step_avg:54.46ms
+step:1239/1585 train_time:67517ms step_avg:54.49ms
+step:1240/1585 train_time:67603ms step_avg:54.52ms
+step:1241/1585 train_time:67692ms step_avg:54.55ms
+step:1242/1585 train_time:67778ms step_avg:54.57ms
+step:1243/1585 train_time:67867ms step_avg:54.60ms
+step:1244/1585 train_time:67954ms step_avg:54.63ms
+step:1245/1585 train_time:68043ms step_avg:54.65ms
+step:1246/1585 train_time:68129ms step_avg:54.68ms
+step:1247/1585 train_time:68219ms step_avg:54.71ms
+step:1248/1585 train_time:68305ms step_avg:54.73ms
+step:1249/1585 train_time:68395ms step_avg:54.76ms
+step:1250/1585 train_time:68481ms step_avg:54.78ms
+step:1250/1585 val_loss:3.4081 train_time:68551ms step_avg:54.84ms
+step:1251/1585 train_time:68571ms step_avg:54.81ms
+step:1252/1585 train_time:68659ms step_avg:54.84ms
+step:1253/1585 train_time:68749ms step_avg:54.87ms
+step:1254/1585 train_time:68835ms step_avg:54.89ms
+step:1255/1585 train_time:68924ms step_avg:54.92ms
+step:1256/1585 train_time:69009ms step_avg:54.94ms
+step:1257/1585 train_time:69097ms step_avg:54.97ms
+step:1258/1585 train_time:69183ms step_avg:54.99ms
+step:1259/1585 train_time:69271ms step_avg:55.02ms
+step:1260/1585 train_time:69358ms step_avg:55.05ms
+step:1261/1585 train_time:69446ms step_avg:55.07ms
+step:1262/1585 train_time:69533ms step_avg:55.10ms
+step:1263/1585 train_time:69625ms step_avg:55.13ms
+step:1264/1585 train_time:69714ms step_avg:55.15ms
+step:1265/1585 train_time:69803ms step_avg:55.18ms
+step:1266/1585 train_time:69889ms step_avg:55.20ms
+step:1267/1585 train_time:69979ms step_avg:55.23ms
+step:1268/1585 train_time:70065ms step_avg:55.26ms
+step:1269/1585 train_time:70153ms step_avg:55.28ms
+step:1270/1585 train_time:70238ms step_avg:55.31ms
+step:1271/1585 train_time:70327ms step_avg:55.33ms
+step:1272/1585 train_time:70413ms step_avg:55.36ms
+step:1273/1585 train_time:70502ms step_avg:55.38ms
+step:1274/1585 train_time:70588ms step_avg:55.41ms
+step:1275/1585 train_time:70679ms step_avg:55.43ms
+step:1276/1585 train_time:70765ms step_avg:55.46ms
+step:1277/1585 train_time:70856ms step_avg:55.49ms
+step:1278/1585 train_time:70942ms step_avg:55.51ms
+step:1279/1585 train_time:71031ms step_avg:55.54ms
+step:1280/1585 train_time:71116ms step_avg:55.56ms
+step:1281/1585 train_time:71204ms step_avg:55.58ms
+step:1282/1585 train_time:71290ms step_avg:55.61ms
+step:1283/1585 train_time:71379ms step_avg:55.63ms
+step:1284/1585 train_time:71465ms step_avg:55.66ms
+step:1285/1585 train_time:71554ms step_avg:55.68ms
+step:1286/1585 train_time:71642ms step_avg:55.71ms
+step:1287/1585 train_time:71731ms step_avg:55.73ms
+step:1288/1585 train_time:71817ms step_avg:55.76ms
+step:1289/1585 train_time:71907ms step_avg:55.79ms
+step:1290/1585 train_time:71993ms step_avg:55.81ms
+step:1291/1585 train_time:72082ms step_avg:55.83ms
+step:1292/1585 train_time:72168ms step_avg:55.86ms
+step:1293/1585 train_time:72257ms step_avg:55.88ms
+step:1294/1585 train_time:72342ms step_avg:55.91ms
+step:1295/1585 train_time:72431ms step_avg:55.93ms
+step:1296/1585 train_time:72517ms step_avg:55.95ms
+step:1297/1585 train_time:72607ms step_avg:55.98ms
+step:1298/1585 train_time:72693ms step_avg:56.00ms
+step:1299/1585 train_time:72782ms step_avg:56.03ms
+step:1300/1585 train_time:72870ms step_avg:56.05ms
+step:1301/1585 train_time:72959ms step_avg:56.08ms
+step:1302/1585 train_time:73045ms step_avg:56.10ms
+step:1303/1585 train_time:73134ms step_avg:56.13ms
+step:1304/1585 train_time:73220ms step_avg:56.15ms
+step:1305/1585 train_time:73309ms step_avg:56.18ms
+step:1306/1585 train_time:73396ms step_avg:56.20ms
+step:1307/1585 train_time:73485ms step_avg:56.22ms
+step:1308/1585 train_time:73571ms step_avg:56.25ms
+step:1309/1585 train_time:73660ms step_avg:56.27ms
+step:1310/1585 train_time:73746ms step_avg:56.29ms
+step:1311/1585 train_time:73836ms step_avg:56.32ms
+step:1312/1585 train_time:73922ms step_avg:56.34ms
+step:1313/1585 train_time:74011ms step_avg:56.37ms
+step:1314/1585 train_time:74096ms step_avg:56.39ms
+step:1315/1585 train_time:74186ms step_avg:56.41ms
+step:1316/1585 train_time:74272ms step_avg:56.44ms
+step:1317/1585 train_time:74360ms step_avg:56.46ms
+step:1318/1585 train_time:74446ms step_avg:56.48ms
+step:1319/1585 train_time:74535ms step_avg:56.51ms
+step:1320/1585 train_time:74621ms step_avg:56.53ms
+step:1321/1585 train_time:74712ms step_avg:56.56ms
+step:1322/1585 train_time:74798ms step_avg:56.58ms
+step:1323/1585 train_time:74888ms step_avg:56.60ms
+step:1324/1585 train_time:74974ms step_avg:56.63ms
+step:1325/1585 train_time:75064ms step_avg:56.65ms
+step:1326/1585 train_time:75150ms step_avg:56.67ms
+step:1327/1585 train_time:75239ms step_avg:56.70ms
+step:1328/1585 train_time:75325ms step_avg:56.72ms
+step:1329/1585 train_time:75414ms step_avg:56.74ms
+step:1330/1585 train_time:75500ms step_avg:56.77ms
+step:1331/1585 train_time:75589ms step_avg:56.79ms
+step:1332/1585 train_time:75675ms step_avg:56.81ms
+step:1333/1585 train_time:75765ms step_avg:56.84ms
+step:1334/1585 train_time:75852ms step_avg:56.86ms
+step:1335/1585 train_time:75941ms step_avg:56.88ms
+step:1336/1585 train_time:76027ms step_avg:56.91ms
+step:1337/1585 train_time:76115ms step_avg:56.93ms
+step:1338/1585 train_time:76201ms step_avg:56.95ms
+step:1339/1585 train_time:76291ms step_avg:56.98ms
+step:1340/1585 train_time:76377ms step_avg:57.00ms
+step:1341/1585 train_time:76467ms step_avg:57.02ms
+step:1342/1585 train_time:76553ms step_avg:57.04ms
+step:1343/1585 train_time:76642ms step_avg:57.07ms
+step:1344/1585 train_time:76727ms step_avg:57.09ms
+step:1345/1585 train_time:76818ms step_avg:57.11ms
+step:1346/1585 train_time:76904ms step_avg:57.14ms
+step:1347/1585 train_time:76994ms step_avg:57.16ms
+step:1348/1585 train_time:77080ms step_avg:57.18ms
+step:1349/1585 train_time:77169ms step_avg:57.20ms
+step:1350/1585 train_time:77256ms step_avg:57.23ms
+step:1351/1585 train_time:77344ms step_avg:57.25ms
+step:1352/1585 train_time:77430ms step_avg:57.27ms
+step:1353/1585 train_time:77519ms step_avg:57.29ms
+step:1354/1585 train_time:77605ms step_avg:57.32ms
+step:1355/1585 train_time:77695ms step_avg:57.34ms
+step:1356/1585 train_time:77782ms step_avg:57.36ms
+step:1357/1585 train_time:77872ms step_avg:57.39ms
+step:1358/1585 train_time:77957ms step_avg:57.41ms
+step:1359/1585 train_time:78047ms step_avg:57.43ms
+step:1360/1585 train_time:78133ms step_avg:57.45ms
+step:1361/1585 train_time:78222ms step_avg:57.47ms
+step:1362/1585 train_time:78307ms step_avg:57.49ms
+step:1363/1585 train_time:78397ms step_avg:57.52ms
+step:1364/1585 train_time:78483ms step_avg:57.54ms
+step:1365/1585 train_time:78573ms step_avg:57.56ms
+step:1366/1585 train_time:78659ms step_avg:57.58ms
+step:1367/1585 train_time:78749ms step_avg:57.61ms
+step:1368/1585 train_time:78836ms step_avg:57.63ms
+step:1369/1585 train_time:78926ms step_avg:57.65ms
+step:1370/1585 train_time:79012ms step_avg:57.67ms
+step:1371/1585 train_time:79101ms step_avg:57.70ms
+step:1372/1585 train_time:79187ms step_avg:57.72ms
+step:1373/1585 train_time:79276ms step_avg:57.74ms
+step:1374/1585 train_time:79362ms step_avg:57.76ms
+step:1375/1585 train_time:79451ms step_avg:57.78ms
+step:1376/1585 train_time:79537ms step_avg:57.80ms
+step:1377/1585 train_time:79626ms step_avg:57.83ms
+step:1378/1585 train_time:79712ms step_avg:57.85ms
+step:1379/1585 train_time:79801ms step_avg:57.87ms
+step:1380/1585 train_time:79888ms step_avg:57.89ms
+step:1381/1585 train_time:79977ms step_avg:57.91ms
+step:1382/1585 train_time:80063ms step_avg:57.93ms
+step:1383/1585 train_time:80152ms step_avg:57.96ms
+step:1384/1585 train_time:80237ms step_avg:57.97ms
+step:1385/1585 train_time:80327ms step_avg:58.00ms
+step:1386/1585 train_time:80414ms step_avg:58.02ms
+step:1387/1585 train_time:80503ms step_avg:58.04ms
+step:1388/1585 train_time:80589ms step_avg:58.06ms
+step:1389/1585 train_time:80678ms step_avg:58.08ms
+step:1390/1585 train_time:80765ms step_avg:58.10ms
+step:1391/1585 train_time:80855ms step_avg:58.13ms
+step:1392/1585 train_time:80940ms step_avg:58.15ms
+step:1393/1585 train_time:81030ms step_avg:58.17ms
+step:1394/1585 train_time:81115ms step_avg:58.19ms
+step:1395/1585 train_time:81204ms step_avg:58.21ms
+step:1396/1585 train_time:81291ms step_avg:58.23ms
+step:1397/1585 train_time:81379ms step_avg:58.25ms
+step:1398/1585 train_time:81466ms step_avg:58.27ms
+step:1399/1585 train_time:81555ms step_avg:58.30ms
+step:1400/1585 train_time:81641ms step_avg:58.32ms
+step:1401/1585 train_time:81730ms step_avg:58.34ms
+step:1402/1585 train_time:81817ms step_avg:58.36ms
+step:1403/1585 train_time:81907ms step_avg:58.38ms
+step:1404/1585 train_time:81994ms step_avg:58.40ms
+step:1405/1585 train_time:82082ms step_avg:58.42ms
+step:1406/1585 train_time:82169ms step_avg:58.44ms
+step:1407/1585 train_time:82258ms step_avg:58.46ms
+step:1408/1585 train_time:82344ms step_avg:58.48ms
+step:1409/1585 train_time:82432ms step_avg:58.50ms
+step:1410/1585 train_time:82519ms step_avg:58.52ms
+step:1411/1585 train_time:82608ms step_avg:58.55ms
+step:1412/1585 train_time:82694ms step_avg:58.56ms
+step:1413/1585 train_time:82783ms step_avg:58.59ms
+step:1414/1585 train_time:82870ms step_avg:58.61ms
+step:1415/1585 train_time:82959ms step_avg:58.63ms
+step:1416/1585 train_time:83045ms step_avg:58.65ms
+step:1417/1585 train_time:83134ms step_avg:58.67ms
+step:1418/1585 train_time:83220ms step_avg:58.69ms
+step:1419/1585 train_time:83309ms step_avg:58.71ms
+step:1420/1585 train_time:83395ms step_avg:58.73ms
+step:1421/1585 train_time:83484ms step_avg:58.75ms
+step:1422/1585 train_time:83571ms step_avg:58.77ms
+step:1423/1585 train_time:83660ms step_avg:58.79ms
+step:1424/1585 train_time:83745ms step_avg:58.81ms
+step:1425/1585 train_time:83836ms step_avg:58.83ms
+step:1426/1585 train_time:83921ms step_avg:58.85ms
+step:1427/1585 train_time:84011ms step_avg:58.87ms
+step:1428/1585 train_time:84096ms step_avg:58.89ms
+step:1429/1585 train_time:84185ms step_avg:58.91ms
+step:1430/1585 train_time:84272ms step_avg:58.93ms
+step:1431/1585 train_time:84361ms step_avg:58.95ms
+step:1432/1585 train_time:84447ms step_avg:58.97ms
+step:1433/1585 train_time:84536ms step_avg:58.99ms
+step:1434/1585 train_time:84623ms step_avg:59.01ms
+step:1435/1585 train_time:84712ms step_avg:59.03ms
+step:1436/1585 train_time:84798ms step_avg:59.05ms
+step:1437/1585 train_time:84888ms step_avg:59.07ms
+step:1438/1585 train_time:84974ms step_avg:59.09ms
+step:1439/1585 train_time:85063ms step_avg:59.11ms
+step:1440/1585 train_time:85148ms step_avg:59.13ms
+step:1441/1585 train_time:85238ms step_avg:59.15ms
+step:1442/1585 train_time:85323ms step_avg:59.17ms
+step:1443/1585 train_time:85412ms step_avg:59.19ms
+step:1444/1585 train_time:85499ms step_avg:59.21ms
+step:1445/1585 train_time:85588ms step_avg:59.23ms
+step:1446/1585 train_time:85675ms step_avg:59.25ms
+step:1447/1585 train_time:85764ms step_avg:59.27ms
+step:1448/1585 train_time:85850ms step_avg:59.29ms
+step:1449/1585 train_time:85939ms step_avg:59.31ms
+step:1450/1585 train_time:86025ms step_avg:59.33ms
+step:1451/1585 train_time:86115ms step_avg:59.35ms
+step:1452/1585 train_time:86201ms step_avg:59.37ms
+step:1453/1585 train_time:86290ms step_avg:59.39ms
+step:1454/1585 train_time:86376ms step_avg:59.41ms
+step:1455/1585 train_time:86466ms step_avg:59.43ms
+step:1456/1585 train_time:86553ms step_avg:59.45ms
+step:1457/1585 train_time:86642ms step_avg:59.47ms
+step:1458/1585 train_time:86727ms step_avg:59.48ms
+step:1459/1585 train_time:86817ms step_avg:59.50ms
+step:1460/1585 train_time:86903ms step_avg:59.52ms
+step:1461/1585 train_time:86992ms step_avg:59.54ms
+step:1462/1585 train_time:87078ms step_avg:59.56ms
+step:1463/1585 train_time:87167ms step_avg:59.58ms
+step:1464/1585 train_time:87253ms step_avg:59.60ms
+step:1465/1585 train_time:87342ms step_avg:59.62ms
+step:1466/1585 train_time:87428ms step_avg:59.64ms
+step:1467/1585 train_time:87519ms step_avg:59.66ms
+step:1468/1585 train_time:87605ms step_avg:59.68ms
+step:1469/1585 train_time:87694ms step_avg:59.70ms
+step:1470/1585 train_time:87780ms step_avg:59.71ms
+step:1471/1585 train_time:87870ms step_avg:59.73ms
+step:1472/1585 train_time:87955ms step_avg:59.75ms
+step:1473/1585 train_time:88045ms step_avg:59.77ms
+step:1474/1585 train_time:88132ms step_avg:59.79ms
+step:1475/1585 train_time:88221ms step_avg:59.81ms
+step:1476/1585 train_time:88306ms step_avg:59.83ms
+step:1477/1585 train_time:88395ms step_avg:59.85ms
+step:1478/1585 train_time:88482ms step_avg:59.87ms
+step:1479/1585 train_time:88571ms step_avg:59.89ms
+step:1480/1585 train_time:88657ms step_avg:59.90ms
+step:1481/1585 train_time:88747ms step_avg:59.92ms
+step:1482/1585 train_time:88832ms step_avg:59.94ms
+step:1483/1585 train_time:88920ms step_avg:59.96ms
+step:1484/1585 train_time:89007ms step_avg:59.98ms
+step:1485/1585 train_time:89097ms step_avg:60.00ms
+step:1486/1585 train_time:89183ms step_avg:60.02ms
+step:1487/1585 train_time:89271ms step_avg:60.03ms
+step:1488/1585 train_time:89358ms step_avg:60.05ms
+step:1489/1585 train_time:89447ms step_avg:60.07ms
+step:1490/1585 train_time:89533ms step_avg:60.09ms
+step:1491/1585 train_time:89622ms step_avg:60.11ms
+step:1492/1585 train_time:89709ms step_avg:60.13ms
+step:1493/1585 train_time:89798ms step_avg:60.15ms
+step:1494/1585 train_time:89885ms step_avg:60.16ms
+step:1495/1585 train_time:89974ms step_avg:60.18ms
+step:1496/1585 train_time:90059ms step_avg:60.20ms
+step:1497/1585 train_time:90148ms step_avg:60.22ms
+step:1498/1585 train_time:90235ms step_avg:60.24ms
+step:1499/1585 train_time:90324ms step_avg:60.26ms
+step:1500/1585 train_time:90410ms step_avg:60.27ms
+step:1500/1585 val_loss:3.3012 train_time:90480ms step_avg:60.32ms
+step:1501/1585 train_time:90501ms step_avg:60.29ms
+step:1502/1585 train_time:90589ms step_avg:60.31ms
+step:1503/1585 train_time:90679ms step_avg:60.33ms
+step:1504/1585 train_time:90764ms step_avg:60.35ms
+step:1505/1585 train_time:90852ms step_avg:60.37ms
+step:1506/1585 train_time:90937ms step_avg:60.38ms
+step:1507/1585 train_time:91026ms step_avg:60.40ms
+step:1508/1585 train_time:91114ms step_avg:60.42ms
+step:1509/1585 train_time:91202ms step_avg:60.44ms
+step:1510/1585 train_time:91288ms step_avg:60.46ms
+step:1511/1585 train_time:91378ms step_avg:60.47ms
+step:1512/1585 train_time:91464ms step_avg:60.49ms
+step:1513/1585 train_time:91555ms step_avg:60.51ms
+step:1514/1585 train_time:91642ms step_avg:60.53ms
+step:1515/1585 train_time:91731ms step_avg:60.55ms
+step:1516/1585 train_time:91817ms step_avg:60.56ms
+step:1517/1585 train_time:91905ms step_avg:60.58ms
+step:1518/1585 train_time:91992ms step_avg:60.60ms
+step:1519/1585 train_time:92080ms step_avg:60.62ms
+step:1520/1585 train_time:92166ms step_avg:60.64ms
+step:1521/1585 train_time:92255ms step_avg:60.65ms
+step:1522/1585 train_time:92341ms step_avg:60.67ms
+step:1523/1585 train_time:92431ms step_avg:60.69ms
+step:1524/1585 train_time:92519ms step_avg:60.71ms
+step:1525/1585 train_time:92608ms step_avg:60.73ms
+step:1526/1585 train_time:92695ms step_avg:60.74ms
+step:1527/1585 train_time:92784ms step_avg:60.76ms
+step:1528/1585 train_time:92870ms step_avg:60.78ms
+step:1529/1585 train_time:92959ms step_avg:60.80ms
+step:1530/1585 train_time:93045ms step_avg:60.81ms
+step:1531/1585 train_time:93133ms step_avg:60.83ms
+step:1532/1585 train_time:93219ms step_avg:60.85ms
+step:1533/1585 train_time:93308ms step_avg:60.87ms
+step:1534/1585 train_time:93395ms step_avg:60.88ms
+step:1535/1585 train_time:93484ms step_avg:60.90ms
+step:1536/1585 train_time:93570ms step_avg:60.92ms
+step:1537/1585 train_time:93660ms step_avg:60.94ms
+step:1538/1585 train_time:93746ms step_avg:60.95ms
+step:1539/1585 train_time:93836ms step_avg:60.97ms
+step:1540/1585 train_time:93922ms step_avg:60.99ms
+step:1541/1585 train_time:94011ms step_avg:61.01ms
+step:1542/1585 train_time:94096ms step_avg:61.02ms
+step:1543/1585 train_time:94185ms step_avg:61.04ms
+step:1544/1585 train_time:94271ms step_avg:61.06ms
+step:1545/1585 train_time:94361ms step_avg:61.08ms
+step:1546/1585 train_time:94453ms step_avg:61.10ms
+step:1547/1585 train_time:94542ms step_avg:61.11ms
+step:1548/1585 train_time:94628ms step_avg:61.13ms
+step:1549/1585 train_time:94718ms step_avg:61.15ms
+step:1550/1585 train_time:94804ms step_avg:61.16ms
+step:1551/1585 train_time:94894ms step_avg:61.18ms
+step:1552/1585 train_time:94980ms step_avg:61.20ms
+step:1553/1585 train_time:95069ms step_avg:61.22ms
+step:1554/1585 train_time:95155ms step_avg:61.23ms
+step:1555/1585 train_time:95244ms step_avg:61.25ms
+step:1556/1585 train_time:95331ms step_avg:61.27ms
+step:1557/1585 train_time:95420ms step_avg:61.28ms
+step:1558/1585 train_time:95508ms step_avg:61.30ms
+step:1559/1585 train_time:95597ms step_avg:61.32ms
+step:1560/1585 train_time:95683ms step_avg:61.34ms
+step:1561/1585 train_time:95773ms step_avg:61.35ms
+step:1562/1585 train_time:95860ms step_avg:61.37ms
+step:1563/1585 train_time:95950ms step_avg:61.39ms
+step:1564/1585 train_time:96036ms step_avg:61.40ms
+step:1565/1585 train_time:96125ms step_avg:61.42ms
+step:1566/1585 train_time:96211ms step_avg:61.44ms
+step:1567/1585 train_time:96302ms step_avg:61.46ms
+step:1568/1585 train_time:96388ms step_avg:61.47ms
+step:1569/1585 train_time:96478ms step_avg:61.49ms
+step:1570/1585 train_time:96564ms step_avg:61.51ms
+step:1571/1585 train_time:96655ms step_avg:61.52ms
+step:1572/1585 train_time:96741ms step_avg:61.54ms
+step:1573/1585 train_time:96830ms step_avg:61.56ms
+step:1574/1585 train_time:96917ms step_avg:61.57ms
+step:1575/1585 train_time:97007ms step_avg:61.59ms
+step:1576/1585 train_time:97093ms step_avg:61.61ms
+step:1577/1585 train_time:97182ms step_avg:61.62ms
+step:1578/1585 train_time:97268ms step_avg:61.64ms
+step:1579/1585 train_time:97358ms step_avg:61.66ms
+step:1580/1585 train_time:97444ms step_avg:61.67ms
+step:1581/1585 train_time:97534ms step_avg:61.69ms
+step:1582/1585 train_time:97621ms step_avg:61.71ms
+step:1583/1585 train_time:97711ms step_avg:61.73ms
+step:1584/1585 train_time:97797ms step_avg:61.74ms
+step:1585/1585 train_time:97886ms step_avg:61.76ms
+step:1585/1585 val_loss:3.2761 train_time:97952ms step_avg:61.80ms
+peak memory allocated: 30557 MiB reserved: 46658 MiB

--- a/records/track_1_short/2026-01-28_TieFirstLastVEs/ve01_230-15stps/c7f2cd4f-16ce-481f-92a0-93a27042cefb.txt
+++ b/records/track_1_short/2026-01-28_TieFirstLastVEs/ve01_230-15stps/c7f2cd4f-16ce-481f-92a0-93a27042cefb.txt
@@ -1,0 +1,4301 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    is_tall = G.size(-2) > G.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall matrices: use X^T @ X (small K×K) and right multiplication
+        # This avoids the transpose overhead that slows down Nesterov momentum
+        K = X.size(-1)
+        A = torch.empty((*X.shape[:-2], K, K), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched matmul for X @ B
+        XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.mT @ X 
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            # Right multiplication: C = a * X + X @ B
+            XB_matmul(X, B, out=C)  # C = X @ B
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place)
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide matrices: use X @ X^T and left multiplication (original approach)
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+major, _ = torch.cuda.get_device_capability()
+if major >= 9:
+    flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+else:
+    flash_attn_interface = get_kernel('kernels-community/flash-attn2').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(4)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = (major >= 9) # FP8 requires Hopper (SM90+)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # new layout: 01 ... 230 (ve0 shared at start and end)
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[0]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1545  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+
+# Check compute capability for Hopper-specific features
+_major, _ = torch.cuda.get_device_capability()
+_USE_TMA = _major >= 9
+
+if _USE_TMA:
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+# Note: This kernel was AI-written. It's been tested for numerical equivalence, 
+#       but not otherwised reviewed.
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < M - m * BLOCK_SIZE_K, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < M - m * BLOCK_SIZE_K, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(K, meta["BLOCK_SIZE_M"]) * triton.cdiv(K, meta["BLOCK_SIZE_N"]),
+    )
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+# Uses TMA (Tensor Memory Accelerator) which requires Hopper (SM90+)
+
+if _USE_TMA:
+    @triton.jit
+    def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                     M, N, K,
+                                     BLOCK_SIZE_M: tl.constexpr,
+                                     BLOCK_SIZE_N: tl.constexpr,
+                                     BLOCK_SIZE_K: tl.constexpr,
+                                     GROUP_SIZE_M: tl.constexpr,
+                                     NUM_SMS: tl.constexpr,
+                                     FORWARD: tl.constexpr,
+                                     ):
+        dtype = tl.bfloat16
+        start_pid = tl.program_id(axis=0)
+        num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+        num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+        k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+        num_tiles = num_pid_m * num_pid_n
+
+        tile_id_c = start_pid - NUM_SMS
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+        for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+            pid_m = tile_id // num_pid_n
+            pid_n = tile_id % num_pid_n
+            offs_am = pid_m * BLOCK_SIZE_M
+            offs_bn = pid_n * BLOCK_SIZE_N
+
+            accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+            for ki in range(k_tiles):
+                offs_k = ki * BLOCK_SIZE_K
+                a = a_desc.load([offs_am, offs_k])
+                b = b_desc.load([offs_bn, offs_k])
+                accumulator = tl.dot(a, b.T, accumulator)
+
+            tile_id_c += NUM_SMS
+            pid_m = tile_id // num_pid_n
+            pid_n = tile_id % num_pid_n
+            offs_am_c = pid_m * BLOCK_SIZE_M
+            offs_bn_c = pid_n * BLOCK_SIZE_N
+
+            acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+            acc = tl.permute(acc, (0, 2, 1))
+            acc0, acc1 = tl.split(acc)
+
+            c0 = acc0.to(dtype)
+            if not FORWARD:
+                c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+                c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+            c_desc.store([offs_am_c, offs_bn_c], c0)
+
+            if FORWARD:
+                c0_post = tl.maximum(c0, 0)
+                c0_post = c0_post * c0_post
+                aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+            c1 = acc1.to(dtype)
+            if not FORWARD:
+                c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+                c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+            c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+            if FORWARD:
+                c1_post = tl.maximum(c1, 0)
+                c1_post = c1_post * c1_post
+                aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+    def linear_relu_square(a, b, aux=None):
+        M, K = a.shape
+        N, K = b.shape
+        dtype = a.dtype
+
+        c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+        FORWARD = False
+        if aux is None:
+            FORWARD = True
+            aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+        BLOCK_SIZE_M = 128
+        BLOCK_SIZE_N = 256
+        BLOCK_SIZE_K = 64
+        num_stages = 4 if FORWARD else 3
+        num_warps = 8
+
+        a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+        b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+        c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+        aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+        def grid(META):
+            return (min(
+                NUM_SMS,
+                triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+            ), )
+
+        linear_relu_square_kernel[grid](
+            a_desc, b_desc, c_desc, aux_desc,
+            M, N, K,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_K=BLOCK_SIZE_K,
+            GROUP_SIZE_M=1,
+            NUM_SMS=NUM_SMS,
+            FORWARD=FORWARD,
+            num_stages=num_stages,
+            num_warps=num_warps
+        )
+
+        if FORWARD:
+            return c, aux
+        else:
+            return c
+
+    class FusedLinearReLUSquareFunction(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x, W1, W2):
+            pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+            x3 = post @ W2
+            ctx.save_for_backward(x, W1, W2, pre, post)
+            return x3.view(x.shape)
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            x, W1, W2, pre, post = ctx.saved_tensors
+            dW2 = post.T @ grad_output
+            dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+            dW1 = dpre.T @ x
+            dx = dpre @ W1
+            return dx.view(x.shape), dW1, dW2
+
+else:
+    # Fallback for Ampere (A100) and earlier - uses standard PyTorch ops
+    class FusedLinearReLUSquareFunction(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x, W1, W2):
+            # relu(x @ W1.T)^2 @ W2
+            x_flat = x.view(-1, x.shape[-1])
+            pre = x_flat @ W1.T  # (M, N)
+            post = torch.relu(pre).square()  # relu(...)^2
+            out = post @ W2
+            ctx.save_for_backward(x, W1, W2, pre, post)
+            return out.view(x.shape)
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            x, W1, W2, pre, post = ctx.saved_tensors
+            x_flat = x.view(-1, x.shape[-1])
+            grad_flat = grad_output.view(-1, grad_output.shape[-1])
+            
+            # grad w.r.t. W2: post.T @ grad_output
+            dW2 = post.T @ grad_flat
+            
+            # grad w.r.t. post: grad_output @ W2.T
+            dpost = grad_flat @ W2.T
+            
+            # grad through relu(pre)^2: d/dpre[relu(pre)^2] = 2*relu(pre) * (pre > 0)
+            dpre = 2 * dpost * torch.where(pre > 0, pre, pre.new_zeros(()))
+            
+            # grad w.r.t. W1: dpre.T @ x
+            dW1 = dpre.T @ x_flat
+            
+            # grad w.r.t. x: dpre @ W1
+            dx = dpre @ W1
+            return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.12.12 | packaged by conda-forge | (main, Jan 26 2026, 23:51:32) [GCC 14.3.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Thu Jan 29 06:06:24 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                  Off |
+| N/A   46C    P0            159W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:06:00.0 Off |                  Off |
+| N/A   39C    P0            134W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:07:00.0 Off |                  Off |
+| N/A   46C    P0            138W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:08:00.0 Off |                  Off |
+| N/A   39C    P0            138W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:09:00.0 Off |                  Off |
+| N/A   45C    P0            145W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                  Off |
+| N/A   39C    P0            135W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                  Off |
+| N/A   45C    P0            143W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:0C:00.0 Off |                  Off |
+| N/A   40C    P0            151W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          820450      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    1   N/A  N/A          820451      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    2   N/A  N/A          820452      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    3   N/A  N/A          820453      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    4   N/A  N/A          820454      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    5   N/A  N/A          820455      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    6   N/A  N/A          820456      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    7   N/A  N/A          820457      C   .../envs/speedrun/bin/python3.12       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 514, 515, 516, 1029, 1030, 1031, 1544, 1545, 1546] for warmup
+Resetting Model
+step:0/1585 val_loss:10.8272 train_time:0ms step_avg:0.03ms
+step:1/1585 train_time:59ms step_avg:58.87ms
+step:2/1585 train_time:78ms step_avg:38.83ms
+step:3/1585 train_time:98ms step_avg:32.68ms
+step:4/1585 train_time:136ms step_avg:34.03ms
+step:5/1585 train_time:166ms step_avg:33.22ms
+step:6/1585 train_time:240ms step_avg:40.08ms
+step:7/1585 train_time:257ms step_avg:36.77ms
+step:8/1585 train_time:301ms step_avg:37.62ms
+step:9/1585 train_time:331ms step_avg:36.77ms
+step:10/1585 train_time:369ms step_avg:36.92ms
+step:11/1585 train_time:400ms step_avg:36.34ms
+step:12/1585 train_time:438ms step_avg:36.53ms
+step:13/1585 train_time:469ms step_avg:36.06ms
+step:14/1585 train_time:507ms step_avg:36.23ms
+step:15/1585 train_time:537ms step_avg:35.81ms
+step:16/1585 train_time:575ms step_avg:35.96ms
+step:17/1585 train_time:606ms step_avg:35.64ms
+step:18/1585 train_time:644ms step_avg:35.80ms
+step:19/1585 train_time:675ms step_avg:35.53ms
+step:20/1585 train_time:714ms step_avg:35.68ms
+step:21/1585 train_time:744ms step_avg:35.43ms
+step:22/1585 train_time:782ms step_avg:35.57ms
+step:23/1585 train_time:813ms step_avg:35.34ms
+step:24/1585 train_time:851ms step_avg:35.46ms
+step:25/1585 train_time:882ms step_avg:35.26ms
+step:26/1585 train_time:921ms step_avg:35.40ms
+step:27/1585 train_time:951ms step_avg:35.22ms
+step:28/1585 train_time:989ms step_avg:35.32ms
+step:29/1585 train_time:1019ms step_avg:35.15ms
+step:30/1585 train_time:1058ms step_avg:35.27ms
+step:31/1585 train_time:1088ms step_avg:35.11ms
+step:32/1585 train_time:1127ms step_avg:35.21ms
+step:33/1585 train_time:1157ms step_avg:35.06ms
+step:34/1585 train_time:1195ms step_avg:35.16ms
+step:35/1585 train_time:1226ms step_avg:35.02ms
+step:36/1585 train_time:1264ms step_avg:35.12ms
+step:37/1585 train_time:1295ms step_avg:35.00ms
+step:38/1585 train_time:1333ms step_avg:35.08ms
+step:39/1585 train_time:1364ms step_avg:34.96ms
+step:40/1585 train_time:1403ms step_avg:35.07ms
+step:41/1585 train_time:1433ms step_avg:34.95ms
+step:42/1585 train_time:1471ms step_avg:35.03ms
+step:43/1585 train_time:1502ms step_avg:34.93ms
+step:44/1585 train_time:1541ms step_avg:35.02ms
+step:45/1585 train_time:1571ms step_avg:34.91ms
+step:46/1585 train_time:1609ms step_avg:34.99ms
+step:47/1585 train_time:1640ms step_avg:34.89ms
+step:48/1585 train_time:1679ms step_avg:34.99ms
+step:49/1585 train_time:1710ms step_avg:34.90ms
+step:50/1585 train_time:1749ms step_avg:34.98ms
+step:51/1585 train_time:1780ms step_avg:34.89ms
+step:52/1585 train_time:1818ms step_avg:34.97ms
+step:53/1585 train_time:1849ms step_avg:34.89ms
+step:54/1585 train_time:1888ms step_avg:34.96ms
+step:55/1585 train_time:1918ms step_avg:34.87ms
+step:56/1585 train_time:1956ms step_avg:34.94ms
+step:57/1585 train_time:1987ms step_avg:34.86ms
+step:58/1585 train_time:2025ms step_avg:34.92ms
+step:59/1585 train_time:2056ms step_avg:34.84ms
+step:60/1585 train_time:2094ms step_avg:34.90ms
+step:61/1585 train_time:2124ms step_avg:34.82ms
+step:62/1585 train_time:2163ms step_avg:34.88ms
+step:63/1585 train_time:2193ms step_avg:34.82ms
+step:64/1585 train_time:2232ms step_avg:34.87ms
+step:65/1585 train_time:2262ms step_avg:34.80ms
+step:66/1585 train_time:2301ms step_avg:34.86ms
+step:67/1585 train_time:2331ms step_avg:34.80ms
+step:68/1585 train_time:2370ms step_avg:34.85ms
+step:69/1585 train_time:2400ms step_avg:34.78ms
+step:70/1585 train_time:2439ms step_avg:34.84ms
+step:71/1585 train_time:2470ms step_avg:34.78ms
+step:72/1585 train_time:2509ms step_avg:34.85ms
+step:73/1585 train_time:2539ms step_avg:34.78ms
+step:74/1585 train_time:2577ms step_avg:34.83ms
+step:75/1585 train_time:2608ms step_avg:34.77ms
+step:76/1585 train_time:2646ms step_avg:34.82ms
+step:77/1585 train_time:2677ms step_avg:34.76ms
+step:78/1585 train_time:2715ms step_avg:34.81ms
+step:79/1585 train_time:2745ms step_avg:34.75ms
+step:80/1585 train_time:2784ms step_avg:34.80ms
+step:81/1585 train_time:2814ms step_avg:34.74ms
+step:82/1585 train_time:2853ms step_avg:34.79ms
+step:83/1585 train_time:2883ms step_avg:34.74ms
+step:84/1585 train_time:2922ms step_avg:34.79ms
+step:85/1585 train_time:2953ms step_avg:34.74ms
+step:86/1585 train_time:2991ms step_avg:34.78ms
+step:87/1585 train_time:3021ms step_avg:34.73ms
+step:88/1585 train_time:3059ms step_avg:34.77ms
+step:89/1585 train_time:3090ms step_avg:34.72ms
+step:90/1585 train_time:3129ms step_avg:34.76ms
+step:91/1585 train_time:3159ms step_avg:34.71ms
+step:92/1585 train_time:3197ms step_avg:34.75ms
+step:93/1585 train_time:3227ms step_avg:34.70ms
+step:94/1585 train_time:3266ms step_avg:34.74ms
+step:95/1585 train_time:3296ms step_avg:34.70ms
+step:96/1585 train_time:3335ms step_avg:34.74ms
+step:97/1585 train_time:3365ms step_avg:34.69ms
+step:98/1585 train_time:3404ms step_avg:34.73ms
+step:99/1585 train_time:3434ms step_avg:34.69ms
+step:100/1585 train_time:3472ms step_avg:34.72ms
+step:101/1585 train_time:3502ms step_avg:34.68ms
+step:102/1585 train_time:3541ms step_avg:34.72ms
+step:103/1585 train_time:3571ms step_avg:34.67ms
+step:104/1585 train_time:3610ms step_avg:34.71ms
+step:105/1585 train_time:3640ms step_avg:34.67ms
+step:106/1585 train_time:3678ms step_avg:34.70ms
+step:107/1585 train_time:3708ms step_avg:34.66ms
+step:108/1585 train_time:3747ms step_avg:34.69ms
+step:109/1585 train_time:3777ms step_avg:34.65ms
+step:110/1585 train_time:3816ms step_avg:34.69ms
+step:111/1585 train_time:3846ms step_avg:34.65ms
+step:112/1585 train_time:3884ms step_avg:34.68ms
+step:113/1585 train_time:3914ms step_avg:34.64ms
+step:114/1585 train_time:3953ms step_avg:34.67ms
+step:115/1585 train_time:3983ms step_avg:34.63ms
+step:116/1585 train_time:4021ms step_avg:34.67ms
+step:117/1585 train_time:4052ms step_avg:34.63ms
+step:118/1585 train_time:4090ms step_avg:34.66ms
+step:119/1585 train_time:4121ms step_avg:34.63ms
+step:120/1585 train_time:4159ms step_avg:34.66ms
+step:121/1585 train_time:4190ms step_avg:34.63ms
+step:122/1585 train_time:4229ms step_avg:34.66ms
+step:123/1585 train_time:4259ms step_avg:34.63ms
+step:124/1585 train_time:4298ms step_avg:34.66ms
+step:125/1585 train_time:4329ms step_avg:34.63ms
+step:126/1585 train_time:4367ms step_avg:34.66ms
+step:127/1585 train_time:4398ms step_avg:34.63ms
+step:128/1585 train_time:4436ms step_avg:34.66ms
+step:129/1585 train_time:4467ms step_avg:34.62ms
+step:130/1585 train_time:4505ms step_avg:34.65ms
+step:131/1585 train_time:4536ms step_avg:34.62ms
+step:132/1585 train_time:4574ms step_avg:34.65ms
+step:133/1585 train_time:4605ms step_avg:34.62ms
+step:134/1585 train_time:4643ms step_avg:34.65ms
+step:135/1585 train_time:4674ms step_avg:34.62ms
+step:136/1585 train_time:4712ms step_avg:34.65ms
+step:137/1585 train_time:4742ms step_avg:34.62ms
+step:138/1585 train_time:4782ms step_avg:34.65ms
+step:139/1585 train_time:4812ms step_avg:34.62ms
+step:140/1585 train_time:4850ms step_avg:34.65ms
+step:141/1585 train_time:4881ms step_avg:34.62ms
+step:142/1585 train_time:4920ms step_avg:34.65ms
+step:143/1585 train_time:4950ms step_avg:34.62ms
+step:144/1585 train_time:4988ms step_avg:34.64ms
+step:145/1585 train_time:5018ms step_avg:34.61ms
+step:146/1585 train_time:5057ms step_avg:34.64ms
+step:147/1585 train_time:5087ms step_avg:34.61ms
+step:148/1585 train_time:5126ms step_avg:34.63ms
+step:149/1585 train_time:5156ms step_avg:34.60ms
+step:150/1585 train_time:5194ms step_avg:34.63ms
+step:151/1585 train_time:5224ms step_avg:34.60ms
+step:152/1585 train_time:5263ms step_avg:34.62ms
+step:153/1585 train_time:5293ms step_avg:34.60ms
+step:154/1585 train_time:5332ms step_avg:34.62ms
+step:155/1585 train_time:5362ms step_avg:34.60ms
+step:156/1585 train_time:5401ms step_avg:34.62ms
+step:157/1585 train_time:5431ms step_avg:34.59ms
+step:158/1585 train_time:5470ms step_avg:34.62ms
+step:159/1585 train_time:5500ms step_avg:34.59ms
+step:160/1585 train_time:5540ms step_avg:34.62ms
+step:161/1585 train_time:5570ms step_avg:34.60ms
+step:162/1585 train_time:5608ms step_avg:34.62ms
+step:163/1585 train_time:5639ms step_avg:34.59ms
+step:164/1585 train_time:5677ms step_avg:34.62ms
+step:165/1585 train_time:5708ms step_avg:34.59ms
+step:166/1585 train_time:5746ms step_avg:34.62ms
+step:167/1585 train_time:5777ms step_avg:34.59ms
+step:168/1585 train_time:5815ms step_avg:34.62ms
+step:169/1585 train_time:5846ms step_avg:34.59ms
+step:170/1585 train_time:5884ms step_avg:34.61ms
+step:171/1585 train_time:5915ms step_avg:34.59ms
+step:172/1585 train_time:5953ms step_avg:34.61ms
+step:173/1585 train_time:5983ms step_avg:34.59ms
+step:174/1585 train_time:6022ms step_avg:34.61ms
+step:175/1585 train_time:6053ms step_avg:34.59ms
+step:176/1585 train_time:6091ms step_avg:34.61ms
+step:177/1585 train_time:6121ms step_avg:34.58ms
+step:178/1585 train_time:6159ms step_avg:34.60ms
+step:179/1585 train_time:6190ms step_avg:34.58ms
+step:180/1585 train_time:6228ms step_avg:34.60ms
+step:181/1585 train_time:6259ms step_avg:34.58ms
+step:182/1585 train_time:6297ms step_avg:34.60ms
+step:183/1585 train_time:6327ms step_avg:34.57ms
+step:184/1585 train_time:6365ms step_avg:34.59ms
+step:185/1585 train_time:6396ms step_avg:34.57ms
+step:186/1585 train_time:6434ms step_avg:34.59ms
+step:187/1585 train_time:6464ms step_avg:34.57ms
+step:188/1585 train_time:6503ms step_avg:34.59ms
+step:189/1585 train_time:6533ms step_avg:34.57ms
+step:190/1585 train_time:6572ms step_avg:34.59ms
+step:191/1585 train_time:6602ms step_avg:34.57ms
+step:192/1585 train_time:6641ms step_avg:34.59ms
+step:193/1585 train_time:6671ms step_avg:34.56ms
+step:194/1585 train_time:6710ms step_avg:34.59ms
+step:195/1585 train_time:6741ms step_avg:34.57ms
+step:196/1585 train_time:6779ms step_avg:34.59ms
+step:197/1585 train_time:6809ms step_avg:34.57ms
+step:198/1585 train_time:6848ms step_avg:34.59ms
+step:199/1585 train_time:6878ms step_avg:34.56ms
+step:200/1585 train_time:6917ms step_avg:34.59ms
+step:201/1585 train_time:6947ms step_avg:34.56ms
+step:202/1585 train_time:6985ms step_avg:34.58ms
+step:203/1585 train_time:7016ms step_avg:34.56ms
+step:204/1585 train_time:7054ms step_avg:34.58ms
+step:205/1585 train_time:7085ms step_avg:34.56ms
+step:206/1585 train_time:7123ms step_avg:34.58ms
+step:207/1585 train_time:7153ms step_avg:34.56ms
+step:208/1585 train_time:7191ms step_avg:34.57ms
+step:209/1585 train_time:7221ms step_avg:34.55ms
+step:210/1585 train_time:7259ms step_avg:34.57ms
+step:211/1585 train_time:7289ms step_avg:34.55ms
+step:212/1585 train_time:7329ms step_avg:34.57ms
+step:213/1585 train_time:7358ms step_avg:34.55ms
+step:214/1585 train_time:7397ms step_avg:34.56ms
+step:215/1585 train_time:7427ms step_avg:34.54ms
+step:216/1585 train_time:7465ms step_avg:34.56ms
+step:217/1585 train_time:7495ms step_avg:34.54ms
+step:218/1585 train_time:7533ms step_avg:34.56ms
+step:219/1585 train_time:7564ms step_avg:34.54ms
+step:220/1585 train_time:7602ms step_avg:34.56ms
+step:221/1585 train_time:7633ms step_avg:34.54ms
+step:222/1585 train_time:7671ms step_avg:34.55ms
+step:223/1585 train_time:7701ms step_avg:34.54ms
+step:224/1585 train_time:7740ms step_avg:34.55ms
+step:225/1585 train_time:7770ms step_avg:34.53ms
+step:226/1585 train_time:7808ms step_avg:34.55ms
+step:227/1585 train_time:7838ms step_avg:34.53ms
+step:228/1585 train_time:7877ms step_avg:34.55ms
+step:229/1585 train_time:7906ms step_avg:34.53ms
+step:230/1585 train_time:7945ms step_avg:34.54ms
+step:231/1585 train_time:7975ms step_avg:34.53ms
+step:232/1585 train_time:8014ms step_avg:34.54ms
+step:233/1585 train_time:8044ms step_avg:34.52ms
+step:234/1585 train_time:8082ms step_avg:34.54ms
+step:235/1585 train_time:8113ms step_avg:34.52ms
+step:236/1585 train_time:8152ms step_avg:34.54ms
+step:237/1585 train_time:8182ms step_avg:34.52ms
+step:238/1585 train_time:8221ms step_avg:34.54ms
+step:239/1585 train_time:8252ms step_avg:34.53ms
+step:240/1585 train_time:8290ms step_avg:34.54ms
+step:241/1585 train_time:8320ms step_avg:34.52ms
+step:242/1585 train_time:8359ms step_avg:34.54ms
+step:243/1585 train_time:8390ms step_avg:34.52ms
+step:244/1585 train_time:8427ms step_avg:34.54ms
+step:245/1585 train_time:8457ms step_avg:34.52ms
+step:246/1585 train_time:8495ms step_avg:34.53ms
+step:247/1585 train_time:8526ms step_avg:34.52ms
+step:248/1585 train_time:8564ms step_avg:34.53ms
+step:249/1585 train_time:8594ms step_avg:34.51ms
+step:250/1585 train_time:8632ms step_avg:34.53ms
+step:250/1585 val_loss:4.6009 train_time:8680ms step_avg:34.72ms
+step:251/1585 train_time:8699ms step_avg:34.66ms
+step:252/1585 train_time:8718ms step_avg:34.59ms
+step:253/1585 train_time:8734ms step_avg:34.52ms
+step:254/1585 train_time:8773ms step_avg:34.54ms
+step:255/1585 train_time:8805ms step_avg:34.53ms
+step:256/1585 train_time:8843ms step_avg:34.54ms
+step:257/1585 train_time:8873ms step_avg:34.53ms
+step:258/1585 train_time:8912ms step_avg:34.54ms
+step:259/1585 train_time:8943ms step_avg:34.53ms
+step:260/1585 train_time:8981ms step_avg:34.54ms
+step:261/1585 train_time:9011ms step_avg:34.53ms
+step:262/1585 train_time:9049ms step_avg:34.54ms
+step:263/1585 train_time:9079ms step_avg:34.52ms
+step:264/1585 train_time:9117ms step_avg:34.54ms
+step:265/1585 train_time:9148ms step_avg:34.52ms
+step:266/1585 train_time:9187ms step_avg:34.54ms
+step:267/1585 train_time:9216ms step_avg:34.52ms
+step:268/1585 train_time:9255ms step_avg:34.53ms
+step:269/1585 train_time:9285ms step_avg:34.52ms
+step:270/1585 train_time:9323ms step_avg:34.53ms
+step:271/1585 train_time:9353ms step_avg:34.51ms
+step:272/1585 train_time:9391ms step_avg:34.53ms
+step:273/1585 train_time:9421ms step_avg:34.51ms
+step:274/1585 train_time:9459ms step_avg:34.52ms
+step:275/1585 train_time:9489ms step_avg:34.51ms
+step:276/1585 train_time:9527ms step_avg:34.52ms
+step:277/1585 train_time:9558ms step_avg:34.50ms
+step:278/1585 train_time:9596ms step_avg:34.52ms
+step:279/1585 train_time:9626ms step_avg:34.50ms
+step:280/1585 train_time:9664ms step_avg:34.52ms
+step:281/1585 train_time:9695ms step_avg:34.50ms
+step:282/1585 train_time:9733ms step_avg:34.51ms
+step:283/1585 train_time:9763ms step_avg:34.50ms
+step:284/1585 train_time:9802ms step_avg:34.51ms
+step:285/1585 train_time:9833ms step_avg:34.50ms
+step:286/1585 train_time:9872ms step_avg:34.52ms
+step:287/1585 train_time:9902ms step_avg:34.50ms
+step:288/1585 train_time:9941ms step_avg:34.52ms
+step:289/1585 train_time:9971ms step_avg:34.50ms
+step:290/1585 train_time:10009ms step_avg:34.51ms
+step:291/1585 train_time:10039ms step_avg:34.50ms
+step:292/1585 train_time:10078ms step_avg:34.51ms
+step:293/1585 train_time:10108ms step_avg:34.50ms
+step:294/1585 train_time:10146ms step_avg:34.51ms
+step:295/1585 train_time:10176ms step_avg:34.50ms
+step:296/1585 train_time:10214ms step_avg:34.51ms
+step:297/1585 train_time:10245ms step_avg:34.49ms
+step:298/1585 train_time:10283ms step_avg:34.51ms
+step:299/1585 train_time:10313ms step_avg:34.49ms
+step:300/1585 train_time:10351ms step_avg:34.50ms
+step:301/1585 train_time:10381ms step_avg:34.49ms
+step:302/1585 train_time:10419ms step_avg:34.50ms
+step:303/1585 train_time:10450ms step_avg:34.49ms
+step:304/1585 train_time:10488ms step_avg:34.50ms
+step:305/1585 train_time:10518ms step_avg:34.48ms
+step:306/1585 train_time:10556ms step_avg:34.50ms
+step:307/1585 train_time:10587ms step_avg:34.49ms
+step:308/1585 train_time:10625ms step_avg:34.50ms
+step:309/1585 train_time:10655ms step_avg:34.48ms
+step:310/1585 train_time:10693ms step_avg:34.49ms
+step:311/1585 train_time:10723ms step_avg:34.48ms
+step:312/1585 train_time:10762ms step_avg:34.49ms
+step:313/1585 train_time:10792ms step_avg:34.48ms
+step:314/1585 train_time:10830ms step_avg:34.49ms
+step:315/1585 train_time:10860ms step_avg:34.48ms
+step:316/1585 train_time:10899ms step_avg:34.49ms
+step:317/1585 train_time:10929ms step_avg:34.48ms
+step:318/1585 train_time:10967ms step_avg:34.49ms
+step:319/1585 train_time:10997ms step_avg:34.47ms
+step:320/1585 train_time:11036ms step_avg:34.49ms
+step:321/1585 train_time:11066ms step_avg:34.47ms
+step:322/1585 train_time:11105ms step_avg:34.49ms
+step:323/1585 train_time:11135ms step_avg:34.47ms
+step:324/1585 train_time:11173ms step_avg:34.48ms
+step:325/1585 train_time:11203ms step_avg:34.47ms
+step:326/1585 train_time:11241ms step_avg:34.48ms
+step:327/1585 train_time:11271ms step_avg:34.47ms
+step:328/1585 train_time:11310ms step_avg:34.48ms
+step:329/1585 train_time:11340ms step_avg:34.47ms
+step:330/1585 train_time:11378ms step_avg:34.48ms
+step:331/1585 train_time:11408ms step_avg:34.46ms
+step:332/1585 train_time:11446ms step_avg:34.48ms
+step:333/1585 train_time:11476ms step_avg:34.46ms
+step:334/1585 train_time:11515ms step_avg:34.48ms
+step:335/1585 train_time:11545ms step_avg:34.46ms
+step:336/1585 train_time:11584ms step_avg:34.48ms
+step:337/1585 train_time:11614ms step_avg:34.46ms
+step:338/1585 train_time:11652ms step_avg:34.47ms
+step:339/1585 train_time:11682ms step_avg:34.46ms
+step:340/1585 train_time:11720ms step_avg:34.47ms
+step:341/1585 train_time:11751ms step_avg:34.46ms
+step:342/1585 train_time:11789ms step_avg:34.47ms
+step:343/1585 train_time:11820ms step_avg:34.46ms
+step:344/1585 train_time:11857ms step_avg:34.47ms
+step:345/1585 train_time:11888ms step_avg:34.46ms
+step:346/1585 train_time:11926ms step_avg:34.47ms
+step:347/1585 train_time:11956ms step_avg:34.46ms
+step:348/1585 train_time:11995ms step_avg:34.47ms
+step:349/1585 train_time:12026ms step_avg:34.46ms
+step:350/1585 train_time:12064ms step_avg:34.47ms
+step:351/1585 train_time:12094ms step_avg:34.46ms
+step:352/1585 train_time:12133ms step_avg:34.47ms
+step:353/1585 train_time:12164ms step_avg:34.46ms
+step:354/1585 train_time:12202ms step_avg:34.47ms
+step:355/1585 train_time:12233ms step_avg:34.46ms
+step:356/1585 train_time:12271ms step_avg:34.47ms
+step:357/1585 train_time:12301ms step_avg:34.46ms
+step:358/1585 train_time:12339ms step_avg:34.47ms
+step:359/1585 train_time:12369ms step_avg:34.45ms
+step:360/1585 train_time:12408ms step_avg:34.47ms
+step:361/1585 train_time:12438ms step_avg:34.45ms
+step:362/1585 train_time:12476ms step_avg:34.46ms
+step:363/1585 train_time:12507ms step_avg:34.45ms
+step:364/1585 train_time:12545ms step_avg:34.46ms
+step:365/1585 train_time:12575ms step_avg:34.45ms
+step:366/1585 train_time:12613ms step_avg:34.46ms
+step:367/1585 train_time:12644ms step_avg:34.45ms
+step:368/1585 train_time:12682ms step_avg:34.46ms
+step:369/1585 train_time:12712ms step_avg:34.45ms
+step:370/1585 train_time:12750ms step_avg:34.46ms
+step:371/1585 train_time:12780ms step_avg:34.45ms
+step:372/1585 train_time:12819ms step_avg:34.46ms
+step:373/1585 train_time:12849ms step_avg:34.45ms
+step:374/1585 train_time:12888ms step_avg:34.46ms
+step:375/1585 train_time:12918ms step_avg:34.45ms
+step:376/1585 train_time:12956ms step_avg:34.46ms
+step:377/1585 train_time:12986ms step_avg:34.45ms
+step:378/1585 train_time:13024ms step_avg:34.46ms
+step:379/1585 train_time:13054ms step_avg:34.44ms
+step:380/1585 train_time:13093ms step_avg:34.45ms
+step:381/1585 train_time:13122ms step_avg:34.44ms
+step:382/1585 train_time:13161ms step_avg:34.45ms
+step:383/1585 train_time:13191ms step_avg:34.44ms
+step:384/1585 train_time:13229ms step_avg:34.45ms
+step:385/1585 train_time:13259ms step_avg:34.44ms
+step:386/1585 train_time:13298ms step_avg:34.45ms
+step:387/1585 train_time:13328ms step_avg:34.44ms
+step:388/1585 train_time:13365ms step_avg:34.45ms
+step:389/1585 train_time:13396ms step_avg:34.44ms
+step:390/1585 train_time:13434ms step_avg:34.45ms
+step:391/1585 train_time:13465ms step_avg:34.44ms
+step:392/1585 train_time:13503ms step_avg:34.45ms
+step:393/1585 train_time:13534ms step_avg:34.44ms
+step:394/1585 train_time:13572ms step_avg:34.45ms
+step:395/1585 train_time:13602ms step_avg:34.44ms
+step:396/1585 train_time:13640ms step_avg:34.44ms
+step:397/1585 train_time:13670ms step_avg:34.43ms
+step:398/1585 train_time:13708ms step_avg:34.44ms
+step:399/1585 train_time:13738ms step_avg:34.43ms
+step:400/1585 train_time:13777ms step_avg:34.44ms
+step:401/1585 train_time:13807ms step_avg:34.43ms
+step:402/1585 train_time:13845ms step_avg:34.44ms
+step:403/1585 train_time:13875ms step_avg:34.43ms
+step:404/1585 train_time:13913ms step_avg:34.44ms
+step:405/1585 train_time:13943ms step_avg:34.43ms
+step:406/1585 train_time:13981ms step_avg:34.44ms
+step:407/1585 train_time:14012ms step_avg:34.43ms
+step:408/1585 train_time:14050ms step_avg:34.44ms
+step:409/1585 train_time:14080ms step_avg:34.43ms
+step:410/1585 train_time:14118ms step_avg:34.43ms
+step:411/1585 train_time:14148ms step_avg:34.42ms
+step:412/1585 train_time:14186ms step_avg:34.43ms
+step:413/1585 train_time:14217ms step_avg:34.42ms
+step:414/1585 train_time:14255ms step_avg:34.43ms
+step:415/1585 train_time:14286ms step_avg:34.42ms
+step:416/1585 train_time:14324ms step_avg:34.43ms
+step:417/1585 train_time:14354ms step_avg:34.42ms
+step:418/1585 train_time:14393ms step_avg:34.43ms
+step:419/1585 train_time:14423ms step_avg:34.42ms
+step:420/1585 train_time:14461ms step_avg:34.43ms
+step:421/1585 train_time:14492ms step_avg:34.42ms
+step:422/1585 train_time:14530ms step_avg:34.43ms
+step:423/1585 train_time:14560ms step_avg:34.42ms
+step:424/1585 train_time:14599ms step_avg:34.43ms
+step:425/1585 train_time:14629ms step_avg:34.42ms
+step:426/1585 train_time:14667ms step_avg:34.43ms
+step:427/1585 train_time:14697ms step_avg:34.42ms
+step:428/1585 train_time:14736ms step_avg:34.43ms
+step:429/1585 train_time:14766ms step_avg:34.42ms
+step:430/1585 train_time:14805ms step_avg:34.43ms
+step:431/1585 train_time:14835ms step_avg:34.42ms
+step:432/1585 train_time:14872ms step_avg:34.43ms
+step:433/1585 train_time:14903ms step_avg:34.42ms
+step:434/1585 train_time:14941ms step_avg:34.43ms
+step:435/1585 train_time:14971ms step_avg:34.42ms
+step:436/1585 train_time:15010ms step_avg:34.43ms
+step:437/1585 train_time:15040ms step_avg:34.42ms
+step:438/1585 train_time:15078ms step_avg:34.42ms
+step:439/1585 train_time:15108ms step_avg:34.42ms
+step:440/1585 train_time:15147ms step_avg:34.42ms
+step:441/1585 train_time:15177ms step_avg:34.42ms
+step:442/1585 train_time:15216ms step_avg:34.42ms
+step:443/1585 train_time:15246ms step_avg:34.41ms
+step:444/1585 train_time:15284ms step_avg:34.42ms
+step:445/1585 train_time:15315ms step_avg:34.41ms
+step:446/1585 train_time:15353ms step_avg:34.42ms
+step:447/1585 train_time:15383ms step_avg:34.41ms
+step:448/1585 train_time:15422ms step_avg:34.42ms
+step:449/1585 train_time:15452ms step_avg:34.41ms
+step:450/1585 train_time:15490ms step_avg:34.42ms
+step:451/1585 train_time:15520ms step_avg:34.41ms
+step:452/1585 train_time:15559ms step_avg:34.42ms
+step:453/1585 train_time:15589ms step_avg:34.41ms
+step:454/1585 train_time:15627ms step_avg:34.42ms
+step:455/1585 train_time:15657ms step_avg:34.41ms
+step:456/1585 train_time:15696ms step_avg:34.42ms
+step:457/1585 train_time:15726ms step_avg:34.41ms
+step:458/1585 train_time:15764ms step_avg:34.42ms
+step:459/1585 train_time:15795ms step_avg:34.41ms
+step:460/1585 train_time:15834ms step_avg:34.42ms
+step:461/1585 train_time:15863ms step_avg:34.41ms
+step:462/1585 train_time:15902ms step_avg:34.42ms
+step:463/1585 train_time:15932ms step_avg:34.41ms
+step:464/1585 train_time:15970ms step_avg:34.42ms
+step:465/1585 train_time:16000ms step_avg:34.41ms
+step:466/1585 train_time:16038ms step_avg:34.42ms
+step:467/1585 train_time:16069ms step_avg:34.41ms
+step:468/1585 train_time:16107ms step_avg:34.42ms
+step:469/1585 train_time:16138ms step_avg:34.41ms
+step:470/1585 train_time:16176ms step_avg:34.42ms
+step:471/1585 train_time:16206ms step_avg:34.41ms
+step:472/1585 train_time:16244ms step_avg:34.42ms
+step:473/1585 train_time:16275ms step_avg:34.41ms
+step:474/1585 train_time:16313ms step_avg:34.42ms
+step:475/1585 train_time:16343ms step_avg:34.41ms
+step:476/1585 train_time:16381ms step_avg:34.41ms
+step:477/1585 train_time:16412ms step_avg:34.41ms
+step:478/1585 train_time:16450ms step_avg:34.41ms
+step:479/1585 train_time:16480ms step_avg:34.40ms
+step:480/1585 train_time:16518ms step_avg:34.41ms
+step:481/1585 train_time:16549ms step_avg:34.40ms
+step:482/1585 train_time:16586ms step_avg:34.41ms
+step:483/1585 train_time:16617ms step_avg:34.40ms
+step:484/1585 train_time:16655ms step_avg:34.41ms
+step:485/1585 train_time:16685ms step_avg:34.40ms
+step:486/1585 train_time:16724ms step_avg:34.41ms
+step:487/1585 train_time:16754ms step_avg:34.40ms
+step:488/1585 train_time:16793ms step_avg:34.41ms
+step:489/1585 train_time:16823ms step_avg:34.40ms
+step:490/1585 train_time:16861ms step_avg:34.41ms
+step:491/1585 train_time:16891ms step_avg:34.40ms
+step:492/1585 train_time:16929ms step_avg:34.41ms
+step:493/1585 train_time:16959ms step_avg:34.40ms
+step:494/1585 train_time:16997ms step_avg:34.41ms
+step:495/1585 train_time:17028ms step_avg:34.40ms
+step:496/1585 train_time:17066ms step_avg:34.41ms
+step:497/1585 train_time:17096ms step_avg:34.40ms
+step:498/1585 train_time:17134ms step_avg:34.41ms
+step:499/1585 train_time:17165ms step_avg:34.40ms
+step:500/1585 train_time:17203ms step_avg:34.41ms
+step:500/1585 val_loss:4.2396 train_time:17251ms step_avg:34.50ms
+step:501/1585 train_time:17270ms step_avg:34.47ms
+step:502/1585 train_time:17289ms step_avg:34.44ms
+step:503/1585 train_time:17307ms step_avg:34.41ms
+step:504/1585 train_time:17346ms step_avg:34.42ms
+step:505/1585 train_time:17376ms step_avg:34.41ms
+step:506/1585 train_time:17415ms step_avg:34.42ms
+step:507/1585 train_time:17445ms step_avg:34.41ms
+step:508/1585 train_time:17483ms step_avg:34.42ms
+step:509/1585 train_time:17514ms step_avg:34.41ms
+step:510/1585 train_time:17553ms step_avg:34.42ms
+step:511/1585 train_time:17582ms step_avg:34.41ms
+step:512/1585 train_time:17620ms step_avg:34.41ms
+step:513/1585 train_time:17650ms step_avg:34.41ms
+step:514/1585 train_time:17689ms step_avg:34.41ms
+step:515/1585 train_time:17719ms step_avg:34.41ms
+step:516/1585 train_time:17794ms step_avg:34.48ms
+step:517/1585 train_time:17854ms step_avg:34.53ms
+step:518/1585 train_time:17913ms step_avg:34.58ms
+step:519/1585 train_time:17975ms step_avg:34.63ms
+step:520/1585 train_time:18034ms step_avg:34.68ms
+step:521/1585 train_time:18098ms step_avg:34.74ms
+step:522/1585 train_time:18157ms step_avg:34.78ms
+step:523/1585 train_time:18221ms step_avg:34.84ms
+step:524/1585 train_time:18282ms step_avg:34.89ms
+step:525/1585 train_time:18345ms step_avg:34.94ms
+step:526/1585 train_time:18405ms step_avg:34.99ms
+step:527/1585 train_time:18470ms step_avg:35.05ms
+step:528/1585 train_time:18530ms step_avg:35.09ms
+step:529/1585 train_time:18594ms step_avg:35.15ms
+step:530/1585 train_time:18653ms step_avg:35.19ms
+step:531/1585 train_time:18717ms step_avg:35.25ms
+step:532/1585 train_time:18776ms step_avg:35.29ms
+step:533/1585 train_time:18837ms step_avg:35.34ms
+step:534/1585 train_time:18896ms step_avg:35.39ms
+step:535/1585 train_time:18959ms step_avg:35.44ms
+step:536/1585 train_time:19018ms step_avg:35.48ms
+step:537/1585 train_time:19081ms step_avg:35.53ms
+step:538/1585 train_time:19140ms step_avg:35.58ms
+step:539/1585 train_time:19204ms step_avg:35.63ms
+step:540/1585 train_time:19263ms step_avg:35.67ms
+step:541/1585 train_time:19327ms step_avg:35.72ms
+step:542/1585 train_time:19387ms step_avg:35.77ms
+step:543/1585 train_time:19450ms step_avg:35.82ms
+step:544/1585 train_time:19510ms step_avg:35.86ms
+step:545/1585 train_time:19574ms step_avg:35.92ms
+step:546/1585 train_time:19633ms step_avg:35.96ms
+step:547/1585 train_time:19697ms step_avg:36.01ms
+step:548/1585 train_time:19756ms step_avg:36.05ms
+step:549/1585 train_time:19819ms step_avg:36.10ms
+step:550/1585 train_time:19878ms step_avg:36.14ms
+step:551/1585 train_time:19940ms step_avg:36.19ms
+step:552/1585 train_time:19999ms step_avg:36.23ms
+step:553/1585 train_time:20062ms step_avg:36.28ms
+step:554/1585 train_time:20121ms step_avg:36.32ms
+step:555/1585 train_time:20184ms step_avg:36.37ms
+step:556/1585 train_time:20243ms step_avg:36.41ms
+step:557/1585 train_time:20308ms step_avg:36.46ms
+step:558/1585 train_time:20367ms step_avg:36.50ms
+step:559/1585 train_time:20430ms step_avg:36.55ms
+step:560/1585 train_time:20491ms step_avg:36.59ms
+step:561/1585 train_time:20554ms step_avg:36.64ms
+step:562/1585 train_time:20613ms step_avg:36.68ms
+step:563/1585 train_time:20677ms step_avg:36.73ms
+step:564/1585 train_time:20736ms step_avg:36.77ms
+step:565/1585 train_time:20799ms step_avg:36.81ms
+step:566/1585 train_time:20858ms step_avg:36.85ms
+step:567/1585 train_time:20921ms step_avg:36.90ms
+step:568/1585 train_time:20980ms step_avg:36.94ms
+step:569/1585 train_time:21043ms step_avg:36.98ms
+step:570/1585 train_time:21103ms step_avg:37.02ms
+step:571/1585 train_time:21167ms step_avg:37.07ms
+step:572/1585 train_time:21226ms step_avg:37.11ms
+step:573/1585 train_time:21289ms step_avg:37.15ms
+step:574/1585 train_time:21348ms step_avg:37.19ms
+step:575/1585 train_time:21412ms step_avg:37.24ms
+step:576/1585 train_time:21471ms step_avg:37.28ms
+step:577/1585 train_time:21534ms step_avg:37.32ms
+step:578/1585 train_time:21594ms step_avg:37.36ms
+step:579/1585 train_time:21657ms step_avg:37.40ms
+step:580/1585 train_time:21717ms step_avg:37.44ms
+step:581/1585 train_time:21780ms step_avg:37.49ms
+step:582/1585 train_time:21839ms step_avg:37.52ms
+step:583/1585 train_time:21902ms step_avg:37.57ms
+step:584/1585 train_time:21961ms step_avg:37.60ms
+step:585/1585 train_time:22025ms step_avg:37.65ms
+step:586/1585 train_time:22084ms step_avg:37.69ms
+step:587/1585 train_time:22146ms step_avg:37.73ms
+step:588/1585 train_time:22206ms step_avg:37.77ms
+step:589/1585 train_time:22269ms step_avg:37.81ms
+step:590/1585 train_time:22329ms step_avg:37.85ms
+step:591/1585 train_time:22392ms step_avg:37.89ms
+step:592/1585 train_time:22452ms step_avg:37.93ms
+step:593/1585 train_time:22515ms step_avg:37.97ms
+step:594/1585 train_time:22576ms step_avg:38.01ms
+step:595/1585 train_time:22639ms step_avg:38.05ms
+step:596/1585 train_time:22698ms step_avg:38.08ms
+step:597/1585 train_time:22761ms step_avg:38.13ms
+step:598/1585 train_time:22821ms step_avg:38.16ms
+step:599/1585 train_time:22884ms step_avg:38.20ms
+step:600/1585 train_time:22942ms step_avg:38.24ms
+step:601/1585 train_time:23006ms step_avg:38.28ms
+step:602/1585 train_time:23065ms step_avg:38.31ms
+step:603/1585 train_time:23127ms step_avg:38.35ms
+step:604/1585 train_time:23187ms step_avg:38.39ms
+step:605/1585 train_time:23249ms step_avg:38.43ms
+step:606/1585 train_time:23309ms step_avg:38.46ms
+step:607/1585 train_time:23373ms step_avg:38.51ms
+step:608/1585 train_time:23431ms step_avg:38.54ms
+step:609/1585 train_time:23495ms step_avg:38.58ms
+step:610/1585 train_time:23554ms step_avg:38.61ms
+step:611/1585 train_time:23618ms step_avg:38.66ms
+step:612/1585 train_time:23678ms step_avg:38.69ms
+step:613/1585 train_time:23741ms step_avg:38.73ms
+step:614/1585 train_time:23800ms step_avg:38.76ms
+step:615/1585 train_time:23863ms step_avg:38.80ms
+step:616/1585 train_time:23923ms step_avg:38.84ms
+step:617/1585 train_time:23985ms step_avg:38.87ms
+step:618/1585 train_time:24044ms step_avg:38.91ms
+step:619/1585 train_time:24108ms step_avg:38.95ms
+step:620/1585 train_time:24167ms step_avg:38.98ms
+step:621/1585 train_time:24230ms step_avg:39.02ms
+step:622/1585 train_time:24289ms step_avg:39.05ms
+step:623/1585 train_time:24352ms step_avg:39.09ms
+step:624/1585 train_time:24412ms step_avg:39.12ms
+step:625/1585 train_time:24475ms step_avg:39.16ms
+step:626/1585 train_time:24534ms step_avg:39.19ms
+step:627/1585 train_time:24598ms step_avg:39.23ms
+step:628/1585 train_time:24657ms step_avg:39.26ms
+step:629/1585 train_time:24721ms step_avg:39.30ms
+step:630/1585 train_time:24780ms step_avg:39.33ms
+step:631/1585 train_time:24843ms step_avg:39.37ms
+step:632/1585 train_time:24903ms step_avg:39.40ms
+step:633/1585 train_time:24966ms step_avg:39.44ms
+step:634/1585 train_time:25025ms step_avg:39.47ms
+step:635/1585 train_time:25088ms step_avg:39.51ms
+step:636/1585 train_time:25147ms step_avg:39.54ms
+step:637/1585 train_time:25210ms step_avg:39.58ms
+step:638/1585 train_time:25271ms step_avg:39.61ms
+step:639/1585 train_time:25333ms step_avg:39.64ms
+step:640/1585 train_time:25392ms step_avg:39.68ms
+step:641/1585 train_time:25456ms step_avg:39.71ms
+step:642/1585 train_time:25516ms step_avg:39.74ms
+step:643/1585 train_time:25580ms step_avg:39.78ms
+step:644/1585 train_time:25639ms step_avg:39.81ms
+step:645/1585 train_time:25702ms step_avg:39.85ms
+step:646/1585 train_time:25761ms step_avg:39.88ms
+step:647/1585 train_time:25824ms step_avg:39.91ms
+step:648/1585 train_time:25884ms step_avg:39.94ms
+step:649/1585 train_time:25947ms step_avg:39.98ms
+step:650/1585 train_time:26007ms step_avg:40.01ms
+step:651/1585 train_time:26070ms step_avg:40.05ms
+step:652/1585 train_time:26130ms step_avg:40.08ms
+step:653/1585 train_time:26193ms step_avg:40.11ms
+step:654/1585 train_time:26252ms step_avg:40.14ms
+step:655/1585 train_time:26315ms step_avg:40.17ms
+step:656/1585 train_time:26375ms step_avg:40.21ms
+step:657/1585 train_time:26438ms step_avg:40.24ms
+step:658/1585 train_time:26497ms step_avg:40.27ms
+step:659/1585 train_time:26561ms step_avg:40.30ms
+step:660/1585 train_time:26620ms step_avg:40.33ms
+step:661/1585 train_time:26683ms step_avg:40.37ms
+step:662/1585 train_time:26742ms step_avg:40.40ms
+step:663/1585 train_time:26805ms step_avg:40.43ms
+step:664/1585 train_time:26864ms step_avg:40.46ms
+step:665/1585 train_time:26927ms step_avg:40.49ms
+step:666/1585 train_time:26987ms step_avg:40.52ms
+step:667/1585 train_time:27050ms step_avg:40.55ms
+step:668/1585 train_time:27110ms step_avg:40.58ms
+step:669/1585 train_time:27173ms step_avg:40.62ms
+step:670/1585 train_time:27233ms step_avg:40.65ms
+step:671/1585 train_time:27296ms step_avg:40.68ms
+step:672/1585 train_time:27355ms step_avg:40.71ms
+step:673/1585 train_time:27418ms step_avg:40.74ms
+step:674/1585 train_time:27478ms step_avg:40.77ms
+step:675/1585 train_time:27542ms step_avg:40.80ms
+step:676/1585 train_time:27601ms step_avg:40.83ms
+step:677/1585 train_time:27664ms step_avg:40.86ms
+step:678/1585 train_time:27723ms step_avg:40.89ms
+step:679/1585 train_time:27787ms step_avg:40.92ms
+step:680/1585 train_time:27845ms step_avg:40.95ms
+step:681/1585 train_time:27909ms step_avg:40.98ms
+step:682/1585 train_time:27968ms step_avg:41.01ms
+step:683/1585 train_time:28031ms step_avg:41.04ms
+step:684/1585 train_time:28090ms step_avg:41.07ms
+step:685/1585 train_time:28153ms step_avg:41.10ms
+step:686/1585 train_time:28213ms step_avg:41.13ms
+step:687/1585 train_time:28275ms step_avg:41.16ms
+step:688/1585 train_time:28336ms step_avg:41.19ms
+step:689/1585 train_time:28399ms step_avg:41.22ms
+step:690/1585 train_time:28458ms step_avg:41.24ms
+step:691/1585 train_time:28522ms step_avg:41.28ms
+step:692/1585 train_time:28581ms step_avg:41.30ms
+step:693/1585 train_time:28644ms step_avg:41.33ms
+step:694/1585 train_time:28704ms step_avg:41.36ms
+step:695/1585 train_time:28766ms step_avg:41.39ms
+step:696/1585 train_time:28826ms step_avg:41.42ms
+step:697/1585 train_time:28889ms step_avg:41.45ms
+step:698/1585 train_time:28948ms step_avg:41.47ms
+step:699/1585 train_time:29011ms step_avg:41.50ms
+step:700/1585 train_time:29071ms step_avg:41.53ms
+step:701/1585 train_time:29134ms step_avg:41.56ms
+step:702/1585 train_time:29194ms step_avg:41.59ms
+step:703/1585 train_time:29256ms step_avg:41.62ms
+step:704/1585 train_time:29316ms step_avg:41.64ms
+step:705/1585 train_time:29380ms step_avg:41.67ms
+step:706/1585 train_time:29439ms step_avg:41.70ms
+step:707/1585 train_time:29502ms step_avg:41.73ms
+step:708/1585 train_time:29561ms step_avg:41.75ms
+step:709/1585 train_time:29625ms step_avg:41.78ms
+step:710/1585 train_time:29684ms step_avg:41.81ms
+step:711/1585 train_time:29747ms step_avg:41.84ms
+step:712/1585 train_time:29806ms step_avg:41.86ms
+step:713/1585 train_time:29869ms step_avg:41.89ms
+step:714/1585 train_time:29928ms step_avg:41.92ms
+step:715/1585 train_time:29992ms step_avg:41.95ms
+step:716/1585 train_time:30051ms step_avg:41.97ms
+step:717/1585 train_time:30114ms step_avg:42.00ms
+step:718/1585 train_time:30174ms step_avg:42.03ms
+step:719/1585 train_time:30238ms step_avg:42.06ms
+step:720/1585 train_time:30297ms step_avg:42.08ms
+step:721/1585 train_time:30360ms step_avg:42.11ms
+step:722/1585 train_time:30420ms step_avg:42.13ms
+step:723/1585 train_time:30484ms step_avg:42.16ms
+step:724/1585 train_time:30543ms step_avg:42.19ms
+step:725/1585 train_time:30606ms step_avg:42.21ms
+step:726/1585 train_time:30665ms step_avg:42.24ms
+step:727/1585 train_time:30728ms step_avg:42.27ms
+step:728/1585 train_time:30788ms step_avg:42.29ms
+step:729/1585 train_time:30851ms step_avg:42.32ms
+step:730/1585 train_time:30910ms step_avg:42.34ms
+step:731/1585 train_time:30973ms step_avg:42.37ms
+step:732/1585 train_time:31033ms step_avg:42.39ms
+step:733/1585 train_time:31096ms step_avg:42.42ms
+step:734/1585 train_time:31155ms step_avg:42.45ms
+step:735/1585 train_time:31219ms step_avg:42.47ms
+step:736/1585 train_time:31278ms step_avg:42.50ms
+step:737/1585 train_time:31341ms step_avg:42.53ms
+step:738/1585 train_time:31401ms step_avg:42.55ms
+step:739/1585 train_time:31464ms step_avg:42.58ms
+step:740/1585 train_time:31523ms step_avg:42.60ms
+step:741/1585 train_time:31586ms step_avg:42.63ms
+step:742/1585 train_time:31645ms step_avg:42.65ms
+step:743/1585 train_time:31708ms step_avg:42.68ms
+step:744/1585 train_time:31767ms step_avg:42.70ms
+step:745/1585 train_time:31830ms step_avg:42.72ms
+step:746/1585 train_time:31890ms step_avg:42.75ms
+step:747/1585 train_time:31954ms step_avg:42.78ms
+step:748/1585 train_time:32014ms step_avg:42.80ms
+step:749/1585 train_time:32077ms step_avg:42.83ms
+step:750/1585 train_time:32136ms step_avg:42.85ms
+step:750/1585 val_loss:3.8825 train_time:32180ms step_avg:42.91ms
+step:751/1585 train_time:32200ms step_avg:42.88ms
+step:752/1585 train_time:32260ms step_avg:42.90ms
+step:753/1585 train_time:32326ms step_avg:42.93ms
+step:754/1585 train_time:32386ms step_avg:42.95ms
+step:755/1585 train_time:32449ms step_avg:42.98ms
+step:756/1585 train_time:32508ms step_avg:43.00ms
+step:757/1585 train_time:32571ms step_avg:43.03ms
+step:758/1585 train_time:32630ms step_avg:43.05ms
+step:759/1585 train_time:32695ms step_avg:43.08ms
+step:760/1585 train_time:32754ms step_avg:43.10ms
+step:761/1585 train_time:32817ms step_avg:43.12ms
+step:762/1585 train_time:32876ms step_avg:43.14ms
+step:763/1585 train_time:32938ms step_avg:43.17ms
+step:764/1585 train_time:32998ms step_avg:43.19ms
+step:765/1585 train_time:33060ms step_avg:43.22ms
+step:766/1585 train_time:33120ms step_avg:43.24ms
+step:767/1585 train_time:33185ms step_avg:43.27ms
+step:768/1585 train_time:33245ms step_avg:43.29ms
+step:769/1585 train_time:33309ms step_avg:43.31ms
+step:770/1585 train_time:33369ms step_avg:43.34ms
+step:771/1585 train_time:33432ms step_avg:43.36ms
+step:772/1585 train_time:33492ms step_avg:43.38ms
+step:773/1585 train_time:33555ms step_avg:43.41ms
+step:774/1585 train_time:33615ms step_avg:43.43ms
+step:775/1585 train_time:33678ms step_avg:43.46ms
+step:776/1585 train_time:33737ms step_avg:43.48ms
+step:777/1585 train_time:33800ms step_avg:43.50ms
+step:778/1585 train_time:33859ms step_avg:43.52ms
+step:779/1585 train_time:33921ms step_avg:43.54ms
+step:780/1585 train_time:33981ms step_avg:43.56ms
+step:781/1585 train_time:34044ms step_avg:43.59ms
+step:782/1585 train_time:34103ms step_avg:43.61ms
+step:783/1585 train_time:34167ms step_avg:43.64ms
+step:784/1585 train_time:34227ms step_avg:43.66ms
+step:785/1585 train_time:34291ms step_avg:43.68ms
+step:786/1585 train_time:34350ms step_avg:43.70ms
+step:787/1585 train_time:34413ms step_avg:43.73ms
+step:788/1585 train_time:34472ms step_avg:43.75ms
+step:789/1585 train_time:34535ms step_avg:43.77ms
+step:790/1585 train_time:34595ms step_avg:43.79ms
+step:791/1585 train_time:34658ms step_avg:43.82ms
+step:792/1585 train_time:34717ms step_avg:43.83ms
+step:793/1585 train_time:34780ms step_avg:43.86ms
+step:794/1585 train_time:34838ms step_avg:43.88ms
+step:795/1585 train_time:34901ms step_avg:43.90ms
+step:796/1585 train_time:34960ms step_avg:43.92ms
+step:797/1585 train_time:35023ms step_avg:43.94ms
+step:798/1585 train_time:35082ms step_avg:43.96ms
+step:799/1585 train_time:35146ms step_avg:43.99ms
+step:800/1585 train_time:35206ms step_avg:44.01ms
+step:801/1585 train_time:35270ms step_avg:44.03ms
+step:802/1585 train_time:35329ms step_avg:44.05ms
+step:803/1585 train_time:35394ms step_avg:44.08ms
+step:804/1585 train_time:35453ms step_avg:44.10ms
+step:805/1585 train_time:35517ms step_avg:44.12ms
+step:806/1585 train_time:35576ms step_avg:44.14ms
+step:807/1585 train_time:35640ms step_avg:44.16ms
+step:808/1585 train_time:35699ms step_avg:44.18ms
+step:809/1585 train_time:35761ms step_avg:44.20ms
+step:810/1585 train_time:35820ms step_avg:44.22ms
+step:811/1585 train_time:35883ms step_avg:44.25ms
+step:812/1585 train_time:35942ms step_avg:44.26ms
+step:813/1585 train_time:36004ms step_avg:44.29ms
+step:814/1585 train_time:36064ms step_avg:44.30ms
+step:815/1585 train_time:36128ms step_avg:44.33ms
+step:816/1585 train_time:36187ms step_avg:44.35ms
+step:817/1585 train_time:36251ms step_avg:44.37ms
+step:818/1585 train_time:36311ms step_avg:44.39ms
+step:819/1585 train_time:36374ms step_avg:44.41ms
+step:820/1585 train_time:36434ms step_avg:44.43ms
+step:821/1585 train_time:36497ms step_avg:44.45ms
+step:822/1585 train_time:36556ms step_avg:44.47ms
+step:823/1585 train_time:36619ms step_avg:44.49ms
+step:824/1585 train_time:36679ms step_avg:44.51ms
+step:825/1585 train_time:36742ms step_avg:44.54ms
+step:826/1585 train_time:36802ms step_avg:44.55ms
+step:827/1585 train_time:36864ms step_avg:44.58ms
+step:828/1585 train_time:36923ms step_avg:44.59ms
+step:829/1585 train_time:36986ms step_avg:44.62ms
+step:830/1585 train_time:37046ms step_avg:44.63ms
+step:831/1585 train_time:37109ms step_avg:44.66ms
+step:832/1585 train_time:37168ms step_avg:44.67ms
+step:833/1585 train_time:37231ms step_avg:44.70ms
+step:834/1585 train_time:37291ms step_avg:44.71ms
+step:835/1585 train_time:37354ms step_avg:44.74ms
+step:836/1585 train_time:37413ms step_avg:44.75ms
+step:837/1585 train_time:37478ms step_avg:44.78ms
+step:838/1585 train_time:37537ms step_avg:44.79ms
+step:839/1585 train_time:37601ms step_avg:44.82ms
+step:840/1585 train_time:37660ms step_avg:44.83ms
+step:841/1585 train_time:37723ms step_avg:44.85ms
+step:842/1585 train_time:37782ms step_avg:44.87ms
+step:843/1585 train_time:37845ms step_avg:44.89ms
+step:844/1585 train_time:37905ms step_avg:44.91ms
+step:845/1585 train_time:37967ms step_avg:44.93ms
+step:846/1585 train_time:38026ms step_avg:44.95ms
+step:847/1585 train_time:38089ms step_avg:44.97ms
+step:848/1585 train_time:38149ms step_avg:44.99ms
+step:849/1585 train_time:38212ms step_avg:45.01ms
+step:850/1585 train_time:38272ms step_avg:45.03ms
+step:851/1585 train_time:38334ms step_avg:45.05ms
+step:852/1585 train_time:38394ms step_avg:45.06ms
+step:853/1585 train_time:38458ms step_avg:45.09ms
+step:854/1585 train_time:38517ms step_avg:45.10ms
+step:855/1585 train_time:38580ms step_avg:45.12ms
+step:856/1585 train_time:38640ms step_avg:45.14ms
+step:857/1585 train_time:38703ms step_avg:45.16ms
+step:858/1585 train_time:38761ms step_avg:45.18ms
+step:859/1585 train_time:38825ms step_avg:45.20ms
+step:860/1585 train_time:38885ms step_avg:45.21ms
+step:861/1585 train_time:38947ms step_avg:45.24ms
+step:862/1585 train_time:39007ms step_avg:45.25ms
+step:863/1585 train_time:39070ms step_avg:45.27ms
+step:864/1585 train_time:39129ms step_avg:45.29ms
+step:865/1585 train_time:39193ms step_avg:45.31ms
+step:866/1585 train_time:39252ms step_avg:45.33ms
+step:867/1585 train_time:39315ms step_avg:45.35ms
+step:868/1585 train_time:39374ms step_avg:45.36ms
+step:869/1585 train_time:39438ms step_avg:45.38ms
+step:870/1585 train_time:39497ms step_avg:45.40ms
+step:871/1585 train_time:39561ms step_avg:45.42ms
+step:872/1585 train_time:39620ms step_avg:45.44ms
+step:873/1585 train_time:39684ms step_avg:45.46ms
+step:874/1585 train_time:39743ms step_avg:45.47ms
+step:875/1585 train_time:39806ms step_avg:45.49ms
+step:876/1585 train_time:39865ms step_avg:45.51ms
+step:877/1585 train_time:39928ms step_avg:45.53ms
+step:878/1585 train_time:39987ms step_avg:45.54ms
+step:879/1585 train_time:40050ms step_avg:45.56ms
+step:880/1585 train_time:40110ms step_avg:45.58ms
+step:881/1585 train_time:40173ms step_avg:45.60ms
+step:882/1585 train_time:40232ms step_avg:45.62ms
+step:883/1585 train_time:40296ms step_avg:45.63ms
+step:884/1585 train_time:40355ms step_avg:45.65ms
+step:885/1585 train_time:40419ms step_avg:45.67ms
+step:886/1585 train_time:40478ms step_avg:45.69ms
+step:887/1585 train_time:40541ms step_avg:45.71ms
+step:888/1585 train_time:40602ms step_avg:45.72ms
+step:889/1585 train_time:40665ms step_avg:45.74ms
+step:890/1585 train_time:40724ms step_avg:45.76ms
+step:891/1585 train_time:40787ms step_avg:45.78ms
+step:892/1585 train_time:40846ms step_avg:45.79ms
+step:893/1585 train_time:40910ms step_avg:45.81ms
+step:894/1585 train_time:40968ms step_avg:45.83ms
+step:895/1585 train_time:41032ms step_avg:45.85ms
+step:896/1585 train_time:41091ms step_avg:45.86ms
+step:897/1585 train_time:41155ms step_avg:45.88ms
+step:898/1585 train_time:41214ms step_avg:45.90ms
+step:899/1585 train_time:41277ms step_avg:45.91ms
+step:900/1585 train_time:41336ms step_avg:45.93ms
+step:901/1585 train_time:41400ms step_avg:45.95ms
+step:902/1585 train_time:41459ms step_avg:45.96ms
+step:903/1585 train_time:41523ms step_avg:45.98ms
+step:904/1585 train_time:41582ms step_avg:46.00ms
+step:905/1585 train_time:41644ms step_avg:46.02ms
+step:906/1585 train_time:41704ms step_avg:46.03ms
+step:907/1585 train_time:41767ms step_avg:46.05ms
+step:908/1585 train_time:41826ms step_avg:46.06ms
+step:909/1585 train_time:41889ms step_avg:46.08ms
+step:910/1585 train_time:41949ms step_avg:46.10ms
+step:911/1585 train_time:42012ms step_avg:46.12ms
+step:912/1585 train_time:42071ms step_avg:46.13ms
+step:913/1585 train_time:42134ms step_avg:46.15ms
+step:914/1585 train_time:42195ms step_avg:46.17ms
+step:915/1585 train_time:42257ms step_avg:46.18ms
+step:916/1585 train_time:42317ms step_avg:46.20ms
+step:917/1585 train_time:42380ms step_avg:46.22ms
+step:918/1585 train_time:42439ms step_avg:46.23ms
+step:919/1585 train_time:42502ms step_avg:46.25ms
+step:920/1585 train_time:42561ms step_avg:46.26ms
+step:921/1585 train_time:42625ms step_avg:46.28ms
+step:922/1585 train_time:42684ms step_avg:46.30ms
+step:923/1585 train_time:42747ms step_avg:46.31ms
+step:924/1585 train_time:42807ms step_avg:46.33ms
+step:925/1585 train_time:42870ms step_avg:46.35ms
+step:926/1585 train_time:42929ms step_avg:46.36ms
+step:927/1585 train_time:42992ms step_avg:46.38ms
+step:928/1585 train_time:43052ms step_avg:46.39ms
+step:929/1585 train_time:43115ms step_avg:46.41ms
+step:930/1585 train_time:43174ms step_avg:46.42ms
+step:931/1585 train_time:43237ms step_avg:46.44ms
+step:932/1585 train_time:43296ms step_avg:46.46ms
+step:933/1585 train_time:43360ms step_avg:46.47ms
+step:934/1585 train_time:43419ms step_avg:46.49ms
+step:935/1585 train_time:43482ms step_avg:46.50ms
+step:936/1585 train_time:43541ms step_avg:46.52ms
+step:937/1585 train_time:43604ms step_avg:46.54ms
+step:938/1585 train_time:43664ms step_avg:46.55ms
+step:939/1585 train_time:43726ms step_avg:46.57ms
+step:940/1585 train_time:43785ms step_avg:46.58ms
+step:941/1585 train_time:43849ms step_avg:46.60ms
+step:942/1585 train_time:43909ms step_avg:46.61ms
+step:943/1585 train_time:43972ms step_avg:46.63ms
+step:944/1585 train_time:44031ms step_avg:46.64ms
+step:945/1585 train_time:44094ms step_avg:46.66ms
+step:946/1585 train_time:44153ms step_avg:46.67ms
+step:947/1585 train_time:44216ms step_avg:46.69ms
+step:948/1585 train_time:44275ms step_avg:46.70ms
+step:949/1585 train_time:44339ms step_avg:46.72ms
+step:950/1585 train_time:44399ms step_avg:46.74ms
+step:951/1585 train_time:44463ms step_avg:46.75ms
+step:952/1585 train_time:44522ms step_avg:46.77ms
+step:953/1585 train_time:44585ms step_avg:46.78ms
+step:954/1585 train_time:44645ms step_avg:46.80ms
+step:955/1585 train_time:44708ms step_avg:46.81ms
+step:956/1585 train_time:44767ms step_avg:46.83ms
+step:957/1585 train_time:44830ms step_avg:46.84ms
+step:958/1585 train_time:44890ms step_avg:46.86ms
+step:959/1585 train_time:44953ms step_avg:46.87ms
+step:960/1585 train_time:45013ms step_avg:46.89ms
+step:961/1585 train_time:45075ms step_avg:46.90ms
+step:962/1585 train_time:45134ms step_avg:46.92ms
+step:963/1585 train_time:45198ms step_avg:46.93ms
+step:964/1585 train_time:45257ms step_avg:46.95ms
+step:965/1585 train_time:45320ms step_avg:46.96ms
+step:966/1585 train_time:45379ms step_avg:46.98ms
+step:967/1585 train_time:45442ms step_avg:46.99ms
+step:968/1585 train_time:45502ms step_avg:47.01ms
+step:969/1585 train_time:45566ms step_avg:47.02ms
+step:970/1585 train_time:45625ms step_avg:47.04ms
+step:971/1585 train_time:45688ms step_avg:47.05ms
+step:972/1585 train_time:45747ms step_avg:47.06ms
+step:973/1585 train_time:45811ms step_avg:47.08ms
+step:974/1585 train_time:45869ms step_avg:47.09ms
+step:975/1585 train_time:45932ms step_avg:47.11ms
+step:976/1585 train_time:45992ms step_avg:47.12ms
+step:977/1585 train_time:46055ms step_avg:47.14ms
+step:978/1585 train_time:46115ms step_avg:47.15ms
+step:979/1585 train_time:46178ms step_avg:47.17ms
+step:980/1585 train_time:46237ms step_avg:47.18ms
+step:981/1585 train_time:46299ms step_avg:47.20ms
+step:982/1585 train_time:46358ms step_avg:47.21ms
+step:983/1585 train_time:46422ms step_avg:47.22ms
+step:984/1585 train_time:46481ms step_avg:47.24ms
+step:985/1585 train_time:46544ms step_avg:47.25ms
+step:986/1585 train_time:46604ms step_avg:47.27ms
+step:987/1585 train_time:46666ms step_avg:47.28ms
+step:988/1585 train_time:46726ms step_avg:47.29ms
+step:989/1585 train_time:46789ms step_avg:47.31ms
+step:990/1585 train_time:46849ms step_avg:47.32ms
+step:991/1585 train_time:46912ms step_avg:47.34ms
+step:992/1585 train_time:46971ms step_avg:47.35ms
+step:993/1585 train_time:47035ms step_avg:47.37ms
+step:994/1585 train_time:47094ms step_avg:47.38ms
+step:995/1585 train_time:47157ms step_avg:47.39ms
+step:996/1585 train_time:47216ms step_avg:47.41ms
+step:997/1585 train_time:47279ms step_avg:47.42ms
+step:998/1585 train_time:47338ms step_avg:47.43ms
+step:999/1585 train_time:47402ms step_avg:47.45ms
+step:1000/1585 train_time:47461ms step_avg:47.46ms
+step:1000/1585 val_loss:3.5868 train_time:47506ms step_avg:47.51ms
+step:1001/1585 train_time:47526ms step_avg:47.48ms
+step:1002/1585 train_time:47585ms step_avg:47.49ms
+step:1003/1585 train_time:47650ms step_avg:47.51ms
+step:1004/1585 train_time:47709ms step_avg:47.52ms
+step:1005/1585 train_time:47773ms step_avg:47.54ms
+step:1006/1585 train_time:47833ms step_avg:47.55ms
+step:1007/1585 train_time:47895ms step_avg:47.56ms
+step:1008/1585 train_time:47954ms step_avg:47.57ms
+step:1009/1585 train_time:48016ms step_avg:47.59ms
+step:1010/1585 train_time:48075ms step_avg:47.60ms
+step:1011/1585 train_time:48138ms step_avg:47.61ms
+step:1012/1585 train_time:48197ms step_avg:47.63ms
+step:1013/1585 train_time:48259ms step_avg:47.64ms
+step:1014/1585 train_time:48319ms step_avg:47.65ms
+step:1015/1585 train_time:48382ms step_avg:47.67ms
+step:1016/1585 train_time:48443ms step_avg:47.68ms
+step:1017/1585 train_time:48507ms step_avg:47.70ms
+step:1018/1585 train_time:48567ms step_avg:47.71ms
+step:1019/1585 train_time:48630ms step_avg:47.72ms
+step:1020/1585 train_time:48689ms step_avg:47.73ms
+step:1021/1585 train_time:48753ms step_avg:47.75ms
+step:1022/1585 train_time:48814ms step_avg:47.76ms
+step:1023/1585 train_time:48877ms step_avg:47.78ms
+step:1024/1585 train_time:48936ms step_avg:47.79ms
+step:1025/1585 train_time:48999ms step_avg:47.80ms
+step:1026/1585 train_time:49058ms step_avg:47.81ms
+step:1027/1585 train_time:49120ms step_avg:47.83ms
+step:1028/1585 train_time:49180ms step_avg:47.84ms
+step:1029/1585 train_time:49243ms step_avg:47.85ms
+step:1030/1585 train_time:49302ms step_avg:47.87ms
+step:1031/1585 train_time:49371ms step_avg:47.89ms
+step:1032/1585 train_time:49458ms step_avg:47.92ms
+step:1033/1585 train_time:49549ms step_avg:47.97ms
+step:1034/1585 train_time:49636ms step_avg:48.00ms
+step:1035/1585 train_time:49726ms step_avg:48.04ms
+step:1036/1585 train_time:49813ms step_avg:48.08ms
+step:1037/1585 train_time:49903ms step_avg:48.12ms
+step:1038/1585 train_time:49989ms step_avg:48.16ms
+step:1039/1585 train_time:50078ms step_avg:48.20ms
+step:1040/1585 train_time:50164ms step_avg:48.23ms
+step:1041/1585 train_time:50254ms step_avg:48.27ms
+step:1042/1585 train_time:50340ms step_avg:48.31ms
+step:1043/1585 train_time:50429ms step_avg:48.35ms
+step:1044/1585 train_time:50516ms step_avg:48.39ms
+step:1045/1585 train_time:50605ms step_avg:48.43ms
+step:1046/1585 train_time:50692ms step_avg:48.46ms
+step:1047/1585 train_time:50782ms step_avg:48.50ms
+step:1048/1585 train_time:50868ms step_avg:48.54ms
+step:1049/1585 train_time:50957ms step_avg:48.58ms
+step:1050/1585 train_time:51044ms step_avg:48.61ms
+step:1051/1585 train_time:51133ms step_avg:48.65ms
+step:1052/1585 train_time:51220ms step_avg:48.69ms
+step:1053/1585 train_time:51309ms step_avg:48.73ms
+step:1054/1585 train_time:51395ms step_avg:48.76ms
+step:1055/1585 train_time:51484ms step_avg:48.80ms
+step:1056/1585 train_time:51571ms step_avg:48.84ms
+step:1057/1585 train_time:51661ms step_avg:48.87ms
+step:1058/1585 train_time:51747ms step_avg:48.91ms
+step:1059/1585 train_time:51836ms step_avg:48.95ms
+step:1060/1585 train_time:51923ms step_avg:48.98ms
+step:1061/1585 train_time:52013ms step_avg:49.02ms
+step:1062/1585 train_time:52099ms step_avg:49.06ms
+step:1063/1585 train_time:52188ms step_avg:49.10ms
+step:1064/1585 train_time:52274ms step_avg:49.13ms
+step:1065/1585 train_time:52363ms step_avg:49.17ms
+step:1066/1585 train_time:52449ms step_avg:49.20ms
+step:1067/1585 train_time:52538ms step_avg:49.24ms
+step:1068/1585 train_time:52624ms step_avg:49.27ms
+step:1069/1585 train_time:52714ms step_avg:49.31ms
+step:1070/1585 train_time:52800ms step_avg:49.35ms
+step:1071/1585 train_time:52890ms step_avg:49.38ms
+step:1072/1585 train_time:52977ms step_avg:49.42ms
+step:1073/1585 train_time:53066ms step_avg:49.46ms
+step:1074/1585 train_time:53152ms step_avg:49.49ms
+step:1075/1585 train_time:53242ms step_avg:49.53ms
+step:1076/1585 train_time:53329ms step_avg:49.56ms
+step:1077/1585 train_time:53418ms step_avg:49.60ms
+step:1078/1585 train_time:53504ms step_avg:49.63ms
+step:1079/1585 train_time:53594ms step_avg:49.67ms
+step:1080/1585 train_time:53680ms step_avg:49.70ms
+step:1081/1585 train_time:53770ms step_avg:49.74ms
+step:1082/1585 train_time:53857ms step_avg:49.78ms
+step:1083/1585 train_time:53946ms step_avg:49.81ms
+step:1084/1585 train_time:54032ms step_avg:49.85ms
+step:1085/1585 train_time:54122ms step_avg:49.88ms
+step:1086/1585 train_time:54208ms step_avg:49.92ms
+step:1087/1585 train_time:54297ms step_avg:49.95ms
+step:1088/1585 train_time:54383ms step_avg:49.98ms
+step:1089/1585 train_time:54473ms step_avg:50.02ms
+step:1090/1585 train_time:54559ms step_avg:50.05ms
+step:1091/1585 train_time:54649ms step_avg:50.09ms
+step:1092/1585 train_time:54735ms step_avg:50.12ms
+step:1093/1585 train_time:54825ms step_avg:50.16ms
+step:1094/1585 train_time:54910ms step_avg:50.19ms
+step:1095/1585 train_time:55000ms step_avg:50.23ms
+step:1096/1585 train_time:55087ms step_avg:50.26ms
+step:1097/1585 train_time:55176ms step_avg:50.30ms
+step:1098/1585 train_time:55263ms step_avg:50.33ms
+step:1099/1585 train_time:55352ms step_avg:50.37ms
+step:1100/1585 train_time:55438ms step_avg:50.40ms
+step:1101/1585 train_time:55527ms step_avg:50.43ms
+step:1102/1585 train_time:55613ms step_avg:50.47ms
+step:1103/1585 train_time:55702ms step_avg:50.50ms
+step:1104/1585 train_time:55789ms step_avg:50.53ms
+step:1105/1585 train_time:55878ms step_avg:50.57ms
+step:1106/1585 train_time:55964ms step_avg:50.60ms
+step:1107/1585 train_time:56054ms step_avg:50.64ms
+step:1108/1585 train_time:56140ms step_avg:50.67ms
+step:1109/1585 train_time:56230ms step_avg:50.70ms
+step:1110/1585 train_time:56316ms step_avg:50.73ms
+step:1111/1585 train_time:56405ms step_avg:50.77ms
+step:1112/1585 train_time:56491ms step_avg:50.80ms
+step:1113/1585 train_time:56580ms step_avg:50.84ms
+step:1114/1585 train_time:56668ms step_avg:50.87ms
+step:1115/1585 train_time:56757ms step_avg:50.90ms
+step:1116/1585 train_time:56843ms step_avg:50.93ms
+step:1117/1585 train_time:56933ms step_avg:50.97ms
+step:1118/1585 train_time:57018ms step_avg:51.00ms
+step:1119/1585 train_time:57108ms step_avg:51.03ms
+step:1120/1585 train_time:57195ms step_avg:51.07ms
+step:1121/1585 train_time:57285ms step_avg:51.10ms
+step:1122/1585 train_time:57371ms step_avg:51.13ms
+step:1123/1585 train_time:57461ms step_avg:51.17ms
+step:1124/1585 train_time:57547ms step_avg:51.20ms
+step:1125/1585 train_time:57636ms step_avg:51.23ms
+step:1126/1585 train_time:57721ms step_avg:51.26ms
+step:1127/1585 train_time:57811ms step_avg:51.30ms
+step:1128/1585 train_time:57897ms step_avg:51.33ms
+step:1129/1585 train_time:57986ms step_avg:51.36ms
+step:1130/1585 train_time:58073ms step_avg:51.39ms
+step:1131/1585 train_time:58162ms step_avg:51.43ms
+step:1132/1585 train_time:58249ms step_avg:51.46ms
+step:1133/1585 train_time:58338ms step_avg:51.49ms
+step:1134/1585 train_time:58424ms step_avg:51.52ms
+step:1135/1585 train_time:58514ms step_avg:51.55ms
+step:1136/1585 train_time:58600ms step_avg:51.58ms
+step:1137/1585 train_time:58688ms step_avg:51.62ms
+step:1138/1585 train_time:58775ms step_avg:51.65ms
+step:1139/1585 train_time:58864ms step_avg:51.68ms
+step:1140/1585 train_time:58949ms step_avg:51.71ms
+step:1141/1585 train_time:59039ms step_avg:51.74ms
+step:1142/1585 train_time:59124ms step_avg:51.77ms
+step:1143/1585 train_time:59214ms step_avg:51.81ms
+step:1144/1585 train_time:59300ms step_avg:51.84ms
+step:1145/1585 train_time:59390ms step_avg:51.87ms
+step:1146/1585 train_time:59477ms step_avg:51.90ms
+step:1147/1585 train_time:59566ms step_avg:51.93ms
+step:1148/1585 train_time:59652ms step_avg:51.96ms
+step:1149/1585 train_time:59742ms step_avg:51.99ms
+step:1150/1585 train_time:59827ms step_avg:52.02ms
+step:1151/1585 train_time:59917ms step_avg:52.06ms
+step:1152/1585 train_time:60003ms step_avg:52.09ms
+step:1153/1585 train_time:60092ms step_avg:52.12ms
+step:1154/1585 train_time:60178ms step_avg:52.15ms
+step:1155/1585 train_time:60267ms step_avg:52.18ms
+step:1156/1585 train_time:60353ms step_avg:52.21ms
+step:1157/1585 train_time:60443ms step_avg:52.24ms
+step:1158/1585 train_time:60528ms step_avg:52.27ms
+step:1159/1585 train_time:60619ms step_avg:52.30ms
+step:1160/1585 train_time:60706ms step_avg:52.33ms
+step:1161/1585 train_time:60796ms step_avg:52.36ms
+step:1162/1585 train_time:60882ms step_avg:52.39ms
+step:1163/1585 train_time:60971ms step_avg:52.43ms
+step:1164/1585 train_time:61058ms step_avg:52.46ms
+step:1165/1585 train_time:61147ms step_avg:52.49ms
+step:1166/1585 train_time:61232ms step_avg:52.51ms
+step:1167/1585 train_time:61322ms step_avg:52.55ms
+step:1168/1585 train_time:61408ms step_avg:52.58ms
+step:1169/1585 train_time:61498ms step_avg:52.61ms
+step:1170/1585 train_time:61584ms step_avg:52.64ms
+step:1171/1585 train_time:61675ms step_avg:52.67ms
+step:1172/1585 train_time:61761ms step_avg:52.70ms
+step:1173/1585 train_time:61851ms step_avg:52.73ms
+step:1174/1585 train_time:61937ms step_avg:52.76ms
+step:1175/1585 train_time:62026ms step_avg:52.79ms
+step:1176/1585 train_time:62113ms step_avg:52.82ms
+step:1177/1585 train_time:62202ms step_avg:52.85ms
+step:1178/1585 train_time:62289ms step_avg:52.88ms
+step:1179/1585 train_time:62379ms step_avg:52.91ms
+step:1180/1585 train_time:62465ms step_avg:52.94ms
+step:1181/1585 train_time:62555ms step_avg:52.97ms
+step:1182/1585 train_time:62640ms step_avg:53.00ms
+step:1183/1585 train_time:62729ms step_avg:53.03ms
+step:1184/1585 train_time:62816ms step_avg:53.05ms
+step:1185/1585 train_time:62905ms step_avg:53.08ms
+step:1186/1585 train_time:62992ms step_avg:53.11ms
+step:1187/1585 train_time:63081ms step_avg:53.14ms
+step:1188/1585 train_time:63168ms step_avg:53.17ms
+step:1189/1585 train_time:63257ms step_avg:53.20ms
+step:1190/1585 train_time:63343ms step_avg:53.23ms
+step:1191/1585 train_time:63432ms step_avg:53.26ms
+step:1192/1585 train_time:63518ms step_avg:53.29ms
+step:1193/1585 train_time:63608ms step_avg:53.32ms
+step:1194/1585 train_time:63694ms step_avg:53.34ms
+step:1195/1585 train_time:63783ms step_avg:53.37ms
+step:1196/1585 train_time:63869ms step_avg:53.40ms
+step:1197/1585 train_time:63958ms step_avg:53.43ms
+step:1198/1585 train_time:64044ms step_avg:53.46ms
+step:1199/1585 train_time:64133ms step_avg:53.49ms
+step:1200/1585 train_time:64219ms step_avg:53.52ms
+step:1201/1585 train_time:64308ms step_avg:53.55ms
+step:1202/1585 train_time:64394ms step_avg:53.57ms
+step:1203/1585 train_time:64484ms step_avg:53.60ms
+step:1204/1585 train_time:64570ms step_avg:53.63ms
+step:1205/1585 train_time:64660ms step_avg:53.66ms
+step:1206/1585 train_time:64746ms step_avg:53.69ms
+step:1207/1585 train_time:64835ms step_avg:53.72ms
+step:1208/1585 train_time:64922ms step_avg:53.74ms
+step:1209/1585 train_time:65012ms step_avg:53.77ms
+step:1210/1585 train_time:65098ms step_avg:53.80ms
+step:1211/1585 train_time:65189ms step_avg:53.83ms
+step:1212/1585 train_time:65274ms step_avg:53.86ms
+step:1213/1585 train_time:65364ms step_avg:53.89ms
+step:1214/1585 train_time:65450ms step_avg:53.91ms
+step:1215/1585 train_time:65539ms step_avg:53.94ms
+step:1216/1585 train_time:65626ms step_avg:53.97ms
+step:1217/1585 train_time:65715ms step_avg:54.00ms
+step:1218/1585 train_time:65801ms step_avg:54.02ms
+step:1219/1585 train_time:65890ms step_avg:54.05ms
+step:1220/1585 train_time:65976ms step_avg:54.08ms
+step:1221/1585 train_time:66066ms step_avg:54.11ms
+step:1222/1585 train_time:66152ms step_avg:54.13ms
+step:1223/1585 train_time:66242ms step_avg:54.16ms
+step:1224/1585 train_time:66328ms step_avg:54.19ms
+step:1225/1585 train_time:66419ms step_avg:54.22ms
+step:1226/1585 train_time:66505ms step_avg:54.25ms
+step:1227/1585 train_time:66594ms step_avg:54.27ms
+step:1228/1585 train_time:66680ms step_avg:54.30ms
+step:1229/1585 train_time:66771ms step_avg:54.33ms
+step:1230/1585 train_time:66858ms step_avg:54.36ms
+step:1231/1585 train_time:66946ms step_avg:54.38ms
+step:1232/1585 train_time:67032ms step_avg:54.41ms
+step:1233/1585 train_time:67121ms step_avg:54.44ms
+step:1234/1585 train_time:67207ms step_avg:54.46ms
+step:1235/1585 train_time:67296ms step_avg:54.49ms
+step:1236/1585 train_time:67383ms step_avg:54.52ms
+step:1237/1585 train_time:67472ms step_avg:54.55ms
+step:1238/1585 train_time:67559ms step_avg:54.57ms
+step:1239/1585 train_time:67648ms step_avg:54.60ms
+step:1240/1585 train_time:67735ms step_avg:54.63ms
+step:1241/1585 train_time:67824ms step_avg:54.65ms
+step:1242/1585 train_time:67910ms step_avg:54.68ms
+step:1243/1585 train_time:68000ms step_avg:54.71ms
+step:1244/1585 train_time:68086ms step_avg:54.73ms
+step:1245/1585 train_time:68176ms step_avg:54.76ms
+step:1246/1585 train_time:68262ms step_avg:54.78ms
+step:1247/1585 train_time:68352ms step_avg:54.81ms
+step:1248/1585 train_time:68438ms step_avg:54.84ms
+step:1249/1585 train_time:68527ms step_avg:54.87ms
+step:1250/1585 train_time:68614ms step_avg:54.89ms
+step:1250/1585 val_loss:3.4079 train_time:68685ms step_avg:54.95ms
+step:1251/1585 train_time:68705ms step_avg:54.92ms
+step:1252/1585 train_time:68796ms step_avg:54.95ms
+step:1253/1585 train_time:68887ms step_avg:54.98ms
+step:1254/1585 train_time:68973ms step_avg:55.00ms
+step:1255/1585 train_time:69062ms step_avg:55.03ms
+step:1256/1585 train_time:69148ms step_avg:55.05ms
+step:1257/1585 train_time:69236ms step_avg:55.08ms
+step:1258/1585 train_time:69321ms step_avg:55.10ms
+step:1259/1585 train_time:69410ms step_avg:55.13ms
+step:1260/1585 train_time:69496ms step_avg:55.16ms
+step:1261/1585 train_time:69585ms step_avg:55.18ms
+step:1262/1585 train_time:69674ms step_avg:55.21ms
+step:1263/1585 train_time:69765ms step_avg:55.24ms
+step:1264/1585 train_time:69853ms step_avg:55.26ms
+step:1265/1585 train_time:69943ms step_avg:55.29ms
+step:1266/1585 train_time:70030ms step_avg:55.32ms
+step:1267/1585 train_time:70118ms step_avg:55.34ms
+step:1268/1585 train_time:70203ms step_avg:55.37ms
+step:1269/1585 train_time:70292ms step_avg:55.39ms
+step:1270/1585 train_time:70378ms step_avg:55.42ms
+step:1271/1585 train_time:70467ms step_avg:55.44ms
+step:1272/1585 train_time:70552ms step_avg:55.47ms
+step:1273/1585 train_time:70642ms step_avg:55.49ms
+step:1274/1585 train_time:70730ms step_avg:55.52ms
+step:1275/1585 train_time:70820ms step_avg:55.54ms
+step:1276/1585 train_time:70907ms step_avg:55.57ms
+step:1277/1585 train_time:70997ms step_avg:55.60ms
+step:1278/1585 train_time:71083ms step_avg:55.62ms
+step:1279/1585 train_time:71172ms step_avg:55.65ms
+step:1280/1585 train_time:71259ms step_avg:55.67ms
+step:1281/1585 train_time:71347ms step_avg:55.70ms
+step:1282/1585 train_time:71433ms step_avg:55.72ms
+step:1283/1585 train_time:71522ms step_avg:55.75ms
+step:1284/1585 train_time:71608ms step_avg:55.77ms
+step:1285/1585 train_time:71698ms step_avg:55.80ms
+step:1286/1585 train_time:71784ms step_avg:55.82ms
+step:1287/1585 train_time:71874ms step_avg:55.85ms
+step:1288/1585 train_time:71962ms step_avg:55.87ms
+step:1289/1585 train_time:72051ms step_avg:55.90ms
+step:1290/1585 train_time:72137ms step_avg:55.92ms
+step:1291/1585 train_time:72226ms step_avg:55.95ms
+step:1292/1585 train_time:72313ms step_avg:55.97ms
+step:1293/1585 train_time:72402ms step_avg:56.00ms
+step:1294/1585 train_time:72486ms step_avg:56.02ms
+step:1295/1585 train_time:72576ms step_avg:56.04ms
+step:1296/1585 train_time:72663ms step_avg:56.07ms
+step:1297/1585 train_time:72753ms step_avg:56.09ms
+step:1298/1585 train_time:72840ms step_avg:56.12ms
+step:1299/1585 train_time:72929ms step_avg:56.14ms
+step:1300/1585 train_time:73016ms step_avg:56.17ms
+step:1301/1585 train_time:73105ms step_avg:56.19ms
+step:1302/1585 train_time:73191ms step_avg:56.21ms
+step:1303/1585 train_time:73280ms step_avg:56.24ms
+step:1304/1585 train_time:73366ms step_avg:56.26ms
+step:1305/1585 train_time:73454ms step_avg:56.29ms
+step:1306/1585 train_time:73542ms step_avg:56.31ms
+step:1307/1585 train_time:73631ms step_avg:56.34ms
+step:1308/1585 train_time:73717ms step_avg:56.36ms
+step:1309/1585 train_time:73808ms step_avg:56.39ms
+step:1310/1585 train_time:73894ms step_avg:56.41ms
+step:1311/1585 train_time:73984ms step_avg:56.43ms
+step:1312/1585 train_time:74071ms step_avg:56.46ms
+step:1313/1585 train_time:74160ms step_avg:56.48ms
+step:1314/1585 train_time:74246ms step_avg:56.50ms
+step:1315/1585 train_time:74335ms step_avg:56.53ms
+step:1316/1585 train_time:74420ms step_avg:56.55ms
+step:1317/1585 train_time:74509ms step_avg:56.57ms
+step:1318/1585 train_time:74595ms step_avg:56.60ms
+step:1319/1585 train_time:74685ms step_avg:56.62ms
+step:1320/1585 train_time:74772ms step_avg:56.65ms
+step:1321/1585 train_time:74862ms step_avg:56.67ms
+step:1322/1585 train_time:74948ms step_avg:56.69ms
+step:1323/1585 train_time:75037ms step_avg:56.72ms
+step:1324/1585 train_time:75123ms step_avg:56.74ms
+step:1325/1585 train_time:75213ms step_avg:56.76ms
+step:1326/1585 train_time:75299ms step_avg:56.79ms
+step:1327/1585 train_time:75389ms step_avg:56.81ms
+step:1328/1585 train_time:75474ms step_avg:56.83ms
+step:1329/1585 train_time:75564ms step_avg:56.86ms
+step:1330/1585 train_time:75650ms step_avg:56.88ms
+step:1331/1585 train_time:75740ms step_avg:56.90ms
+step:1332/1585 train_time:75826ms step_avg:56.93ms
+step:1333/1585 train_time:75915ms step_avg:56.95ms
+step:1334/1585 train_time:76002ms step_avg:56.97ms
+step:1335/1585 train_time:76091ms step_avg:57.00ms
+step:1336/1585 train_time:76177ms step_avg:57.02ms
+step:1337/1585 train_time:76267ms step_avg:57.04ms
+step:1338/1585 train_time:76354ms step_avg:57.07ms
+step:1339/1585 train_time:76442ms step_avg:57.09ms
+step:1340/1585 train_time:76528ms step_avg:57.11ms
+step:1341/1585 train_time:76618ms step_avg:57.13ms
+step:1342/1585 train_time:76704ms step_avg:57.16ms
+step:1343/1585 train_time:76793ms step_avg:57.18ms
+step:1344/1585 train_time:76880ms step_avg:57.20ms
+step:1345/1585 train_time:76970ms step_avg:57.23ms
+step:1346/1585 train_time:77056ms step_avg:57.25ms
+step:1347/1585 train_time:77145ms step_avg:57.27ms
+step:1348/1585 train_time:77232ms step_avg:57.29ms
+step:1349/1585 train_time:77321ms step_avg:57.32ms
+step:1350/1585 train_time:77407ms step_avg:57.34ms
+step:1351/1585 train_time:77496ms step_avg:57.36ms
+step:1352/1585 train_time:77583ms step_avg:57.38ms
+step:1353/1585 train_time:77672ms step_avg:57.41ms
+step:1354/1585 train_time:77759ms step_avg:57.43ms
+step:1355/1585 train_time:77848ms step_avg:57.45ms
+step:1356/1585 train_time:77934ms step_avg:57.47ms
+step:1357/1585 train_time:78025ms step_avg:57.50ms
+step:1358/1585 train_time:78111ms step_avg:57.52ms
+step:1359/1585 train_time:78200ms step_avg:57.54ms
+step:1360/1585 train_time:78286ms step_avg:57.56ms
+step:1361/1585 train_time:78376ms step_avg:57.59ms
+step:1362/1585 train_time:78463ms step_avg:57.61ms
+step:1363/1585 train_time:78552ms step_avg:57.63ms
+step:1364/1585 train_time:78639ms step_avg:57.65ms
+step:1365/1585 train_time:78728ms step_avg:57.68ms
+step:1366/1585 train_time:78814ms step_avg:57.70ms
+step:1367/1585 train_time:78904ms step_avg:57.72ms
+step:1368/1585 train_time:78991ms step_avg:57.74ms
+step:1369/1585 train_time:79081ms step_avg:57.77ms
+step:1370/1585 train_time:79168ms step_avg:57.79ms
+step:1371/1585 train_time:79258ms step_avg:57.81ms
+step:1372/1585 train_time:79343ms step_avg:57.83ms
+step:1373/1585 train_time:79433ms step_avg:57.85ms
+step:1374/1585 train_time:79519ms step_avg:57.87ms
+step:1375/1585 train_time:79608ms step_avg:57.90ms
+step:1376/1585 train_time:79695ms step_avg:57.92ms
+step:1377/1585 train_time:79784ms step_avg:57.94ms
+step:1378/1585 train_time:79871ms step_avg:57.96ms
+step:1379/1585 train_time:79960ms step_avg:57.98ms
+step:1380/1585 train_time:80046ms step_avg:58.00ms
+step:1381/1585 train_time:80136ms step_avg:58.03ms
+step:1382/1585 train_time:80222ms step_avg:58.05ms
+step:1383/1585 train_time:80311ms step_avg:58.07ms
+step:1384/1585 train_time:80397ms step_avg:58.09ms
+step:1385/1585 train_time:80486ms step_avg:58.11ms
+step:1386/1585 train_time:80573ms step_avg:58.13ms
+step:1387/1585 train_time:80662ms step_avg:58.16ms
+step:1388/1585 train_time:80748ms step_avg:58.18ms
+step:1389/1585 train_time:80837ms step_avg:58.20ms
+step:1390/1585 train_time:80924ms step_avg:58.22ms
+step:1391/1585 train_time:81013ms step_avg:58.24ms
+step:1392/1585 train_time:81099ms step_avg:58.26ms
+step:1393/1585 train_time:81189ms step_avg:58.28ms
+step:1394/1585 train_time:81275ms step_avg:58.30ms
+step:1395/1585 train_time:81364ms step_avg:58.33ms
+step:1396/1585 train_time:81451ms step_avg:58.35ms
+step:1397/1585 train_time:81541ms step_avg:58.37ms
+step:1398/1585 train_time:81626ms step_avg:58.39ms
+step:1399/1585 train_time:81715ms step_avg:58.41ms
+step:1400/1585 train_time:81802ms step_avg:58.43ms
+step:1401/1585 train_time:81891ms step_avg:58.45ms
+step:1402/1585 train_time:81978ms step_avg:58.47ms
+step:1403/1585 train_time:82068ms step_avg:58.49ms
+step:1404/1585 train_time:82154ms step_avg:58.51ms
+step:1405/1585 train_time:82243ms step_avg:58.54ms
+step:1406/1585 train_time:82329ms step_avg:58.56ms
+step:1407/1585 train_time:82419ms step_avg:58.58ms
+step:1408/1585 train_time:82505ms step_avg:58.60ms
+step:1409/1585 train_time:82594ms step_avg:58.62ms
+step:1410/1585 train_time:82682ms step_avg:58.64ms
+step:1411/1585 train_time:82770ms step_avg:58.66ms
+step:1412/1585 train_time:82856ms step_avg:58.68ms
+step:1413/1585 train_time:82945ms step_avg:58.70ms
+step:1414/1585 train_time:83032ms step_avg:58.72ms
+step:1415/1585 train_time:83121ms step_avg:58.74ms
+step:1416/1585 train_time:83207ms step_avg:58.76ms
+step:1417/1585 train_time:83296ms step_avg:58.78ms
+step:1418/1585 train_time:83382ms step_avg:58.80ms
+step:1419/1585 train_time:83471ms step_avg:58.82ms
+step:1420/1585 train_time:83558ms step_avg:58.84ms
+step:1421/1585 train_time:83648ms step_avg:58.87ms
+step:1422/1585 train_time:83734ms step_avg:58.88ms
+step:1423/1585 train_time:83823ms step_avg:58.91ms
+step:1424/1585 train_time:83909ms step_avg:58.92ms
+step:1425/1585 train_time:83999ms step_avg:58.95ms
+step:1426/1585 train_time:84085ms step_avg:58.97ms
+step:1427/1585 train_time:84175ms step_avg:58.99ms
+step:1428/1585 train_time:84261ms step_avg:59.01ms
+step:1429/1585 train_time:84350ms step_avg:59.03ms
+step:1430/1585 train_time:84435ms step_avg:59.05ms
+step:1431/1585 train_time:84525ms step_avg:59.07ms
+step:1432/1585 train_time:84611ms step_avg:59.09ms
+step:1433/1585 train_time:84700ms step_avg:59.11ms
+step:1434/1585 train_time:84787ms step_avg:59.13ms
+step:1435/1585 train_time:84877ms step_avg:59.15ms
+step:1436/1585 train_time:84963ms step_avg:59.17ms
+step:1437/1585 train_time:85052ms step_avg:59.19ms
+step:1438/1585 train_time:85138ms step_avg:59.21ms
+step:1439/1585 train_time:85228ms step_avg:59.23ms
+step:1440/1585 train_time:85314ms step_avg:59.25ms
+step:1441/1585 train_time:85403ms step_avg:59.27ms
+step:1442/1585 train_time:85490ms step_avg:59.29ms
+step:1443/1585 train_time:85578ms step_avg:59.31ms
+step:1444/1585 train_time:85664ms step_avg:59.32ms
+step:1445/1585 train_time:85754ms step_avg:59.35ms
+step:1446/1585 train_time:85840ms step_avg:59.36ms
+step:1447/1585 train_time:85929ms step_avg:59.38ms
+step:1448/1585 train_time:86015ms step_avg:59.40ms
+step:1449/1585 train_time:86105ms step_avg:59.42ms
+step:1450/1585 train_time:86191ms step_avg:59.44ms
+step:1451/1585 train_time:86281ms step_avg:59.46ms
+step:1452/1585 train_time:86366ms step_avg:59.48ms
+step:1453/1585 train_time:86456ms step_avg:59.50ms
+step:1454/1585 train_time:86542ms step_avg:59.52ms
+step:1455/1585 train_time:86632ms step_avg:59.54ms
+step:1456/1585 train_time:86719ms step_avg:59.56ms
+step:1457/1585 train_time:86809ms step_avg:59.58ms
+step:1458/1585 train_time:86895ms step_avg:59.60ms
+step:1459/1585 train_time:86984ms step_avg:59.62ms
+step:1460/1585 train_time:87071ms step_avg:59.64ms
+step:1461/1585 train_time:87161ms step_avg:59.66ms
+step:1462/1585 train_time:87247ms step_avg:59.68ms
+step:1463/1585 train_time:87337ms step_avg:59.70ms
+step:1464/1585 train_time:87422ms step_avg:59.71ms
+step:1465/1585 train_time:87511ms step_avg:59.73ms
+step:1466/1585 train_time:87597ms step_avg:59.75ms
+step:1467/1585 train_time:87686ms step_avg:59.77ms
+step:1468/1585 train_time:87774ms step_avg:59.79ms
+step:1469/1585 train_time:87863ms step_avg:59.81ms
+step:1470/1585 train_time:87949ms step_avg:59.83ms
+step:1471/1585 train_time:88038ms step_avg:59.85ms
+step:1472/1585 train_time:88123ms step_avg:59.87ms
+step:1473/1585 train_time:88213ms step_avg:59.89ms
+step:1474/1585 train_time:88299ms step_avg:59.90ms
+step:1475/1585 train_time:88389ms step_avg:59.92ms
+step:1476/1585 train_time:88476ms step_avg:59.94ms
+step:1477/1585 train_time:88566ms step_avg:59.96ms
+step:1478/1585 train_time:88651ms step_avg:59.98ms
+step:1479/1585 train_time:88741ms step_avg:60.00ms
+step:1480/1585 train_time:88827ms step_avg:60.02ms
+step:1481/1585 train_time:88917ms step_avg:60.04ms
+step:1482/1585 train_time:89003ms step_avg:60.06ms
+step:1483/1585 train_time:89092ms step_avg:60.08ms
+step:1484/1585 train_time:89178ms step_avg:60.09ms
+step:1485/1585 train_time:89267ms step_avg:60.11ms
+step:1486/1585 train_time:89354ms step_avg:60.13ms
+step:1487/1585 train_time:89443ms step_avg:60.15ms
+step:1488/1585 train_time:89530ms step_avg:60.17ms
+step:1489/1585 train_time:89619ms step_avg:60.19ms
+step:1490/1585 train_time:89705ms step_avg:60.20ms
+step:1491/1585 train_time:89794ms step_avg:60.22ms
+step:1492/1585 train_time:89881ms step_avg:60.24ms
+step:1493/1585 train_time:89971ms step_avg:60.26ms
+step:1494/1585 train_time:90058ms step_avg:60.28ms
+step:1495/1585 train_time:90147ms step_avg:60.30ms
+step:1496/1585 train_time:90233ms step_avg:60.32ms
+step:1497/1585 train_time:90321ms step_avg:60.33ms
+step:1498/1585 train_time:90408ms step_avg:60.35ms
+step:1499/1585 train_time:90497ms step_avg:60.37ms
+step:1500/1585 train_time:90583ms step_avg:60.39ms
+step:1500/1585 val_loss:3.3010 train_time:90653ms step_avg:60.44ms
+step:1501/1585 train_time:90673ms step_avg:60.41ms
+step:1502/1585 train_time:90764ms step_avg:60.43ms
+step:1503/1585 train_time:90857ms step_avg:60.45ms
+step:1504/1585 train_time:90943ms step_avg:60.47ms
+step:1505/1585 train_time:91033ms step_avg:60.49ms
+step:1506/1585 train_time:91118ms step_avg:60.50ms
+step:1507/1585 train_time:91206ms step_avg:60.52ms
+step:1508/1585 train_time:91292ms step_avg:60.54ms
+step:1509/1585 train_time:91381ms step_avg:60.56ms
+step:1510/1585 train_time:91468ms step_avg:60.57ms
+step:1511/1585 train_time:91556ms step_avg:60.59ms
+step:1512/1585 train_time:91645ms step_avg:60.61ms
+step:1513/1585 train_time:91735ms step_avg:60.63ms
+step:1514/1585 train_time:91825ms step_avg:60.65ms
+step:1515/1585 train_time:91915ms step_avg:60.67ms
+step:1516/1585 train_time:92001ms step_avg:60.69ms
+step:1517/1585 train_time:92090ms step_avg:60.71ms
+step:1518/1585 train_time:92175ms step_avg:60.72ms
+step:1519/1585 train_time:92264ms step_avg:60.74ms
+step:1520/1585 train_time:92351ms step_avg:60.76ms
+step:1521/1585 train_time:92439ms step_avg:60.78ms
+step:1522/1585 train_time:92525ms step_avg:60.79ms
+step:1523/1585 train_time:92615ms step_avg:60.81ms
+step:1524/1585 train_time:92702ms step_avg:60.83ms
+step:1525/1585 train_time:92793ms step_avg:60.85ms
+step:1526/1585 train_time:92880ms step_avg:60.87ms
+step:1527/1585 train_time:92969ms step_avg:60.88ms
+step:1528/1585 train_time:93055ms step_avg:60.90ms
+step:1529/1585 train_time:93144ms step_avg:60.92ms
+step:1530/1585 train_time:93230ms step_avg:60.93ms
+step:1531/1585 train_time:93318ms step_avg:60.95ms
+step:1532/1585 train_time:93404ms step_avg:60.97ms
+step:1533/1585 train_time:93494ms step_avg:60.99ms
+step:1534/1585 train_time:93580ms step_avg:61.00ms
+step:1535/1585 train_time:93669ms step_avg:61.02ms
+step:1536/1585 train_time:93756ms step_avg:61.04ms
+step:1537/1585 train_time:93848ms step_avg:61.06ms
+step:1538/1585 train_time:93934ms step_avg:61.08ms
+step:1539/1585 train_time:94023ms step_avg:61.09ms
+step:1540/1585 train_time:94110ms step_avg:61.11ms
+step:1541/1585 train_time:94199ms step_avg:61.13ms
+step:1542/1585 train_time:94285ms step_avg:61.14ms
+step:1543/1585 train_time:94374ms step_avg:61.16ms
+step:1544/1585 train_time:94460ms step_avg:61.18ms
+step:1545/1585 train_time:94549ms step_avg:61.20ms
+step:1546/1585 train_time:94641ms step_avg:61.22ms
+step:1547/1585 train_time:94730ms step_avg:61.23ms
+step:1548/1585 train_time:94817ms step_avg:61.25ms
+step:1549/1585 train_time:94907ms step_avg:61.27ms
+step:1550/1585 train_time:94994ms step_avg:61.29ms
+step:1551/1585 train_time:95084ms step_avg:61.31ms
+step:1552/1585 train_time:95171ms step_avg:61.32ms
+step:1553/1585 train_time:95259ms step_avg:61.34ms
+step:1554/1585 train_time:95346ms step_avg:61.36ms
+step:1555/1585 train_time:95436ms step_avg:61.37ms
+step:1556/1585 train_time:95522ms step_avg:61.39ms
+step:1557/1585 train_time:95613ms step_avg:61.41ms
+step:1558/1585 train_time:95700ms step_avg:61.42ms
+step:1559/1585 train_time:95790ms step_avg:61.44ms
+step:1560/1585 train_time:95877ms step_avg:61.46ms
+step:1561/1585 train_time:95967ms step_avg:61.48ms
+step:1562/1585 train_time:96055ms step_avg:61.49ms
+step:1563/1585 train_time:96146ms step_avg:61.51ms
+step:1564/1585 train_time:96232ms step_avg:61.53ms
+step:1565/1585 train_time:96322ms step_avg:61.55ms
+step:1566/1585 train_time:96408ms step_avg:61.56ms
+step:1567/1585 train_time:96498ms step_avg:61.58ms
+step:1568/1585 train_time:96584ms step_avg:61.60ms
+step:1569/1585 train_time:96675ms step_avg:61.62ms
+step:1570/1585 train_time:96761ms step_avg:61.63ms
+step:1571/1585 train_time:96852ms step_avg:61.65ms
+step:1572/1585 train_time:96939ms step_avg:61.67ms
+step:1573/1585 train_time:97028ms step_avg:61.68ms
+step:1574/1585 train_time:97116ms step_avg:61.70ms
+step:1575/1585 train_time:97206ms step_avg:61.72ms
+step:1576/1585 train_time:97292ms step_avg:61.73ms
+step:1577/1585 train_time:97382ms step_avg:61.75ms
+step:1578/1585 train_time:97469ms step_avg:61.77ms
+step:1579/1585 train_time:97559ms step_avg:61.79ms
+step:1580/1585 train_time:97645ms step_avg:61.80ms
+step:1581/1585 train_time:97736ms step_avg:61.82ms
+step:1582/1585 train_time:97823ms step_avg:61.84ms
+step:1583/1585 train_time:97914ms step_avg:61.85ms
+step:1584/1585 train_time:98001ms step_avg:61.87ms
+step:1585/1585 train_time:98091ms step_avg:61.89ms
+step:1585/1585 val_loss:3.2764 train_time:98156ms step_avg:61.93ms
+peak memory allocated: 31148 MiB reserved: 46658 MiB

--- a/records/track_1_short/2026-01-28_TieFirstLastVEs/ve01_230-15stps/f1b25b7b-4f7a-4a8c-805a-7e79a9f77ca0.txt
+++ b/records/track_1_short/2026-01-28_TieFirstLastVEs/ve01_230-15stps/f1b25b7b-4f7a-4a8c-805a-7e79a9f77ca0.txt
@@ -1,0 +1,4301 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    is_tall = G.size(-2) > G.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall matrices: use X^T @ X (small K×K) and right multiplication
+        # This avoids the transpose overhead that slows down Nesterov momentum
+        K = X.size(-1)
+        A = torch.empty((*X.shape[:-2], K, K), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched matmul for X @ B
+        XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.mT @ X 
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            # Right multiplication: C = a * X + X @ B
+            XB_matmul(X, B, out=C)  # C = X @ B
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place)
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide matrices: use X @ X^T and left multiplication (original approach)
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+major, _ = torch.cuda.get_device_capability()
+if major >= 9:
+    flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+else:
+    flash_attn_interface = get_kernel('kernels-community/flash-attn2').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(4)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = (major >= 9) # FP8 requires Hopper (SM90+)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # new layout: 01 ... 230 (ve0 shared at start and end)
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[0]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1545  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+
+# Check compute capability for Hopper-specific features
+_major, _ = torch.cuda.get_device_capability()
+_USE_TMA = _major >= 9
+
+if _USE_TMA:
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+# Note: This kernel was AI-written. It's been tested for numerical equivalence, 
+#       but not otherwised reviewed.
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < M - m * BLOCK_SIZE_K, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < M - m * BLOCK_SIZE_K, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(K, meta["BLOCK_SIZE_M"]) * triton.cdiv(K, meta["BLOCK_SIZE_N"]),
+    )
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+# Uses TMA (Tensor Memory Accelerator) which requires Hopper (SM90+)
+
+if _USE_TMA:
+    @triton.jit
+    def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                     M, N, K,
+                                     BLOCK_SIZE_M: tl.constexpr,
+                                     BLOCK_SIZE_N: tl.constexpr,
+                                     BLOCK_SIZE_K: tl.constexpr,
+                                     GROUP_SIZE_M: tl.constexpr,
+                                     NUM_SMS: tl.constexpr,
+                                     FORWARD: tl.constexpr,
+                                     ):
+        dtype = tl.bfloat16
+        start_pid = tl.program_id(axis=0)
+        num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+        num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+        k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+        num_tiles = num_pid_m * num_pid_n
+
+        tile_id_c = start_pid - NUM_SMS
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+        for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+            pid_m = tile_id // num_pid_n
+            pid_n = tile_id % num_pid_n
+            offs_am = pid_m * BLOCK_SIZE_M
+            offs_bn = pid_n * BLOCK_SIZE_N
+
+            accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+            for ki in range(k_tiles):
+                offs_k = ki * BLOCK_SIZE_K
+                a = a_desc.load([offs_am, offs_k])
+                b = b_desc.load([offs_bn, offs_k])
+                accumulator = tl.dot(a, b.T, accumulator)
+
+            tile_id_c += NUM_SMS
+            pid_m = tile_id // num_pid_n
+            pid_n = tile_id % num_pid_n
+            offs_am_c = pid_m * BLOCK_SIZE_M
+            offs_bn_c = pid_n * BLOCK_SIZE_N
+
+            acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+            acc = tl.permute(acc, (0, 2, 1))
+            acc0, acc1 = tl.split(acc)
+
+            c0 = acc0.to(dtype)
+            if not FORWARD:
+                c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+                c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+            c_desc.store([offs_am_c, offs_bn_c], c0)
+
+            if FORWARD:
+                c0_post = tl.maximum(c0, 0)
+                c0_post = c0_post * c0_post
+                aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+            c1 = acc1.to(dtype)
+            if not FORWARD:
+                c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+                c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+            c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+            if FORWARD:
+                c1_post = tl.maximum(c1, 0)
+                c1_post = c1_post * c1_post
+                aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+    def linear_relu_square(a, b, aux=None):
+        M, K = a.shape
+        N, K = b.shape
+        dtype = a.dtype
+
+        c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+        FORWARD = False
+        if aux is None:
+            FORWARD = True
+            aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+        BLOCK_SIZE_M = 128
+        BLOCK_SIZE_N = 256
+        BLOCK_SIZE_K = 64
+        num_stages = 4 if FORWARD else 3
+        num_warps = 8
+
+        a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+        b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+        c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+        aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+        def grid(META):
+            return (min(
+                NUM_SMS,
+                triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+            ), )
+
+        linear_relu_square_kernel[grid](
+            a_desc, b_desc, c_desc, aux_desc,
+            M, N, K,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_K=BLOCK_SIZE_K,
+            GROUP_SIZE_M=1,
+            NUM_SMS=NUM_SMS,
+            FORWARD=FORWARD,
+            num_stages=num_stages,
+            num_warps=num_warps
+        )
+
+        if FORWARD:
+            return c, aux
+        else:
+            return c
+
+    class FusedLinearReLUSquareFunction(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x, W1, W2):
+            pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+            x3 = post @ W2
+            ctx.save_for_backward(x, W1, W2, pre, post)
+            return x3.view(x.shape)
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            x, W1, W2, pre, post = ctx.saved_tensors
+            dW2 = post.T @ grad_output
+            dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+            dW1 = dpre.T @ x
+            dx = dpre @ W1
+            return dx.view(x.shape), dW1, dW2
+
+else:
+    # Fallback for Ampere (A100) and earlier - uses standard PyTorch ops
+    class FusedLinearReLUSquareFunction(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x, W1, W2):
+            # relu(x @ W1.T)^2 @ W2
+            x_flat = x.view(-1, x.shape[-1])
+            pre = x_flat @ W1.T  # (M, N)
+            post = torch.relu(pre).square()  # relu(...)^2
+            out = post @ W2
+            ctx.save_for_backward(x, W1, W2, pre, post)
+            return out.view(x.shape)
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            x, W1, W2, pre, post = ctx.saved_tensors
+            x_flat = x.view(-1, x.shape[-1])
+            grad_flat = grad_output.view(-1, grad_output.shape[-1])
+            
+            # grad w.r.t. W2: post.T @ grad_output
+            dW2 = post.T @ grad_flat
+            
+            # grad w.r.t. post: grad_output @ W2.T
+            dpost = grad_flat @ W2.T
+            
+            # grad through relu(pre)^2: d/dpre[relu(pre)^2] = 2*relu(pre) * (pre > 0)
+            dpre = 2 * dpost * torch.where(pre > 0, pre, pre.new_zeros(()))
+            
+            # grad w.r.t. W1: dpre.T @ x
+            dW1 = dpre.T @ x_flat
+            
+            # grad w.r.t. x: dpre @ W1
+            dx = dpre @ W1
+            return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.12.12 | packaged by conda-forge | (main, Jan 26 2026, 23:51:32) [GCC 14.3.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Thu Jan 29 06:09:48 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                  Off |
+| N/A   46C    P0            160W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:06:00.0 Off |                  Off |
+| N/A   39C    P0            135W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:07:00.0 Off |                  Off |
+| N/A   46C    P0            138W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:08:00.0 Off |                  Off |
+| N/A   39C    P0            138W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:09:00.0 Off |                  Off |
+| N/A   46C    P0            147W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                  Off |
+| N/A   39C    P0            136W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                  Off |
+| N/A   46C    P0            143W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:0C:00.0 Off |                  Off |
+| N/A   40C    P0            153W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          836257      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    1   N/A  N/A          836258      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    2   N/A  N/A          836259      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    3   N/A  N/A          836260      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    4   N/A  N/A          836261      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    5   N/A  N/A          836262      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    6   N/A  N/A          836263      C   .../envs/speedrun/bin/python3.12       1512MiB |
+|    7   N/A  N/A          836264      C   .../envs/speedrun/bin/python3.12       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 514, 515, 516, 1029, 1030, 1031, 1544, 1545, 1546] for warmup
+Resetting Model
+step:0/1585 val_loss:10.8277 train_time:0ms step_avg:0.04ms
+step:1/1585 train_time:45ms step_avg:45.44ms
+step:2/1585 train_time:64ms step_avg:32.08ms
+step:3/1585 train_time:84ms step_avg:28.05ms
+step:4/1585 train_time:123ms step_avg:30.65ms
+step:5/1585 train_time:152ms step_avg:30.47ms
+step:6/1585 train_time:225ms step_avg:37.54ms
+step:7/1585 train_time:242ms step_avg:34.55ms
+step:8/1585 train_time:283ms step_avg:35.35ms
+step:9/1585 train_time:313ms step_avg:34.77ms
+step:10/1585 train_time:351ms step_avg:35.10ms
+step:11/1585 train_time:382ms step_avg:34.70ms
+step:12/1585 train_time:420ms step_avg:35.00ms
+step:13/1585 train_time:451ms step_avg:34.67ms
+step:14/1585 train_time:490ms step_avg:34.97ms
+step:15/1585 train_time:520ms step_avg:34.67ms
+step:16/1585 train_time:558ms step_avg:34.88ms
+step:17/1585 train_time:588ms step_avg:34.62ms
+step:18/1585 train_time:627ms step_avg:34.81ms
+step:19/1585 train_time:657ms step_avg:34.59ms
+step:20/1585 train_time:695ms step_avg:34.77ms
+step:21/1585 train_time:727ms step_avg:34.60ms
+step:22/1585 train_time:765ms step_avg:34.76ms
+step:23/1585 train_time:795ms step_avg:34.56ms
+step:24/1585 train_time:833ms step_avg:34.73ms
+step:25/1585 train_time:864ms step_avg:34.57ms
+step:26/1585 train_time:902ms step_avg:34.70ms
+step:27/1585 train_time:933ms step_avg:34.55ms
+step:28/1585 train_time:971ms step_avg:34.70ms
+step:29/1585 train_time:1002ms step_avg:34.56ms
+step:30/1585 train_time:1041ms step_avg:34.69ms
+step:31/1585 train_time:1071ms step_avg:34.55ms
+step:32/1585 train_time:1110ms step_avg:34.68ms
+step:33/1585 train_time:1140ms step_avg:34.55ms
+step:34/1585 train_time:1179ms step_avg:34.67ms
+step:35/1585 train_time:1211ms step_avg:34.59ms
+step:36/1585 train_time:1249ms step_avg:34.71ms
+step:37/1585 train_time:1280ms step_avg:34.59ms
+step:38/1585 train_time:1318ms step_avg:34.69ms
+step:39/1585 train_time:1349ms step_avg:34.59ms
+step:40/1585 train_time:1387ms step_avg:34.69ms
+step:41/1585 train_time:1418ms step_avg:34.58ms
+step:42/1585 train_time:1456ms step_avg:34.67ms
+step:43/1585 train_time:1487ms step_avg:34.58ms
+step:44/1585 train_time:1525ms step_avg:34.65ms
+step:45/1585 train_time:1555ms step_avg:34.56ms
+step:46/1585 train_time:1594ms step_avg:34.64ms
+step:47/1585 train_time:1624ms step_avg:34.55ms
+step:48/1585 train_time:1662ms step_avg:34.63ms
+step:49/1585 train_time:1693ms step_avg:34.56ms
+step:50/1585 train_time:1732ms step_avg:34.65ms
+step:51/1585 train_time:1763ms step_avg:34.57ms
+step:52/1585 train_time:1802ms step_avg:34.65ms
+step:53/1585 train_time:1832ms step_avg:34.57ms
+step:54/1585 train_time:1871ms step_avg:34.64ms
+step:55/1585 train_time:1901ms step_avg:34.57ms
+step:56/1585 train_time:1940ms step_avg:34.64ms
+step:57/1585 train_time:1970ms step_avg:34.57ms
+step:58/1585 train_time:2009ms step_avg:34.63ms
+step:59/1585 train_time:2039ms step_avg:34.55ms
+step:60/1585 train_time:2077ms step_avg:34.62ms
+step:61/1585 train_time:2108ms step_avg:34.56ms
+step:62/1585 train_time:2147ms step_avg:34.62ms
+step:63/1585 train_time:2177ms step_avg:34.56ms
+step:64/1585 train_time:2215ms step_avg:34.61ms
+step:65/1585 train_time:2246ms step_avg:34.55ms
+step:66/1585 train_time:2284ms step_avg:34.61ms
+step:67/1585 train_time:2315ms step_avg:34.55ms
+step:68/1585 train_time:2353ms step_avg:34.61ms
+step:69/1585 train_time:2384ms step_avg:34.55ms
+step:70/1585 train_time:2422ms step_avg:34.60ms
+step:71/1585 train_time:2453ms step_avg:34.54ms
+step:72/1585 train_time:2492ms step_avg:34.61ms
+step:73/1585 train_time:2522ms step_avg:34.55ms
+step:74/1585 train_time:2561ms step_avg:34.61ms
+step:75/1585 train_time:2592ms step_avg:34.56ms
+step:76/1585 train_time:2631ms step_avg:34.62ms
+step:77/1585 train_time:2661ms step_avg:34.56ms
+step:78/1585 train_time:2700ms step_avg:34.62ms
+step:79/1585 train_time:2731ms step_avg:34.56ms
+step:80/1585 train_time:2769ms step_avg:34.62ms
+step:81/1585 train_time:2800ms step_avg:34.57ms
+step:82/1585 train_time:2838ms step_avg:34.61ms
+step:83/1585 train_time:2869ms step_avg:34.56ms
+step:84/1585 train_time:2907ms step_avg:34.61ms
+step:85/1585 train_time:2937ms step_avg:34.56ms
+step:86/1585 train_time:2976ms step_avg:34.60ms
+step:87/1585 train_time:3006ms step_avg:34.55ms
+step:88/1585 train_time:3044ms step_avg:34.59ms
+step:89/1585 train_time:3074ms step_avg:34.54ms
+step:90/1585 train_time:3113ms step_avg:34.59ms
+step:91/1585 train_time:3144ms step_avg:34.55ms
+step:92/1585 train_time:3182ms step_avg:34.59ms
+step:93/1585 train_time:3212ms step_avg:34.54ms
+step:94/1585 train_time:3250ms step_avg:34.58ms
+step:95/1585 train_time:3281ms step_avg:34.53ms
+step:96/1585 train_time:3319ms step_avg:34.57ms
+step:97/1585 train_time:3349ms step_avg:34.53ms
+step:98/1585 train_time:3388ms step_avg:34.57ms
+step:99/1585 train_time:3418ms step_avg:34.52ms
+step:100/1585 train_time:3456ms step_avg:34.56ms
+step:101/1585 train_time:3486ms step_avg:34.52ms
+step:102/1585 train_time:3524ms step_avg:34.55ms
+step:103/1585 train_time:3555ms step_avg:34.51ms
+step:104/1585 train_time:3593ms step_avg:34.55ms
+step:105/1585 train_time:3624ms step_avg:34.52ms
+step:106/1585 train_time:3663ms step_avg:34.55ms
+step:107/1585 train_time:3693ms step_avg:34.52ms
+step:108/1585 train_time:3732ms step_avg:34.55ms
+step:109/1585 train_time:3763ms step_avg:34.52ms
+step:110/1585 train_time:3801ms step_avg:34.56ms
+step:111/1585 train_time:3832ms step_avg:34.52ms
+step:112/1585 train_time:3870ms step_avg:34.55ms
+step:113/1585 train_time:3900ms step_avg:34.52ms
+step:114/1585 train_time:3939ms step_avg:34.55ms
+step:115/1585 train_time:3969ms step_avg:34.51ms
+step:116/1585 train_time:4008ms step_avg:34.55ms
+step:117/1585 train_time:4038ms step_avg:34.51ms
+step:118/1585 train_time:4076ms step_avg:34.55ms
+step:119/1585 train_time:4106ms step_avg:34.51ms
+step:120/1585 train_time:4144ms step_avg:34.54ms
+step:121/1585 train_time:4175ms step_avg:34.50ms
+step:122/1585 train_time:4213ms step_avg:34.54ms
+step:123/1585 train_time:4244ms step_avg:34.50ms
+step:124/1585 train_time:4282ms step_avg:34.53ms
+step:125/1585 train_time:4312ms step_avg:34.50ms
+step:126/1585 train_time:4351ms step_avg:34.53ms
+step:127/1585 train_time:4382ms step_avg:34.51ms
+step:128/1585 train_time:4421ms step_avg:34.54ms
+step:129/1585 train_time:4452ms step_avg:34.51ms
+step:130/1585 train_time:4490ms step_avg:34.54ms
+step:131/1585 train_time:4520ms step_avg:34.51ms
+step:132/1585 train_time:4559ms step_avg:34.54ms
+step:133/1585 train_time:4590ms step_avg:34.51ms
+step:134/1585 train_time:4628ms step_avg:34.54ms
+step:135/1585 train_time:4659ms step_avg:34.51ms
+step:136/1585 train_time:4697ms step_avg:34.54ms
+step:137/1585 train_time:4728ms step_avg:34.51ms
+step:138/1585 train_time:4766ms step_avg:34.53ms
+step:139/1585 train_time:4796ms step_avg:34.50ms
+step:140/1585 train_time:4834ms step_avg:34.53ms
+step:141/1585 train_time:4865ms step_avg:34.50ms
+step:142/1585 train_time:4903ms step_avg:34.53ms
+step:143/1585 train_time:4933ms step_avg:34.50ms
+step:144/1585 train_time:4972ms step_avg:34.53ms
+step:145/1585 train_time:5003ms step_avg:34.50ms
+step:146/1585 train_time:5041ms step_avg:34.53ms
+step:147/1585 train_time:5071ms step_avg:34.50ms
+step:148/1585 train_time:5109ms step_avg:34.52ms
+step:149/1585 train_time:5140ms step_avg:34.49ms
+step:150/1585 train_time:5178ms step_avg:34.52ms
+step:151/1585 train_time:5208ms step_avg:34.49ms
+step:152/1585 train_time:5246ms step_avg:34.52ms
+step:153/1585 train_time:5277ms step_avg:34.49ms
+step:154/1585 train_time:5315ms step_avg:34.51ms
+step:155/1585 train_time:5345ms step_avg:34.49ms
+step:156/1585 train_time:5384ms step_avg:34.51ms
+step:157/1585 train_time:5414ms step_avg:34.48ms
+step:158/1585 train_time:5453ms step_avg:34.51ms
+step:159/1585 train_time:5483ms step_avg:34.48ms
+step:160/1585 train_time:5521ms step_avg:34.51ms
+step:161/1585 train_time:5551ms step_avg:34.48ms
+step:162/1585 train_time:5590ms step_avg:34.50ms
+step:163/1585 train_time:5620ms step_avg:34.48ms
+step:164/1585 train_time:5658ms step_avg:34.50ms
+step:165/1585 train_time:5689ms step_avg:34.48ms
+step:166/1585 train_time:5727ms step_avg:34.50ms
+step:167/1585 train_time:5757ms step_avg:34.48ms
+step:168/1585 train_time:5796ms step_avg:34.50ms
+step:169/1585 train_time:5826ms step_avg:34.47ms
+step:170/1585 train_time:5864ms step_avg:34.50ms
+step:171/1585 train_time:5895ms step_avg:34.47ms
+step:172/1585 train_time:5933ms step_avg:34.49ms
+step:173/1585 train_time:5963ms step_avg:34.47ms
+step:174/1585 train_time:6002ms step_avg:34.49ms
+step:175/1585 train_time:6032ms step_avg:34.47ms
+step:176/1585 train_time:6071ms step_avg:34.49ms
+step:177/1585 train_time:6101ms step_avg:34.47ms
+step:178/1585 train_time:6139ms step_avg:34.49ms
+step:179/1585 train_time:6170ms step_avg:34.47ms
+step:180/1585 train_time:6209ms step_avg:34.49ms
+step:181/1585 train_time:6239ms step_avg:34.47ms
+step:182/1585 train_time:6278ms step_avg:34.49ms
+step:183/1585 train_time:6309ms step_avg:34.47ms
+step:184/1585 train_time:6347ms step_avg:34.49ms
+step:185/1585 train_time:6377ms step_avg:34.47ms
+step:186/1585 train_time:6416ms step_avg:34.49ms
+step:187/1585 train_time:6446ms step_avg:34.47ms
+step:188/1585 train_time:6485ms step_avg:34.49ms
+step:189/1585 train_time:6515ms step_avg:34.47ms
+step:190/1585 train_time:6553ms step_avg:34.49ms
+step:191/1585 train_time:6584ms step_avg:34.47ms
+step:192/1585 train_time:6622ms step_avg:34.49ms
+step:193/1585 train_time:6652ms step_avg:34.47ms
+step:194/1585 train_time:6691ms step_avg:34.49ms
+step:195/1585 train_time:6721ms step_avg:34.47ms
+step:196/1585 train_time:6759ms step_avg:34.49ms
+step:197/1585 train_time:6790ms step_avg:34.47ms
+step:198/1585 train_time:6828ms step_avg:34.48ms
+step:199/1585 train_time:6858ms step_avg:34.46ms
+step:200/1585 train_time:6897ms step_avg:34.48ms
+step:201/1585 train_time:6927ms step_avg:34.46ms
+step:202/1585 train_time:6965ms step_avg:34.48ms
+step:203/1585 train_time:6995ms step_avg:34.46ms
+step:204/1585 train_time:7034ms step_avg:34.48ms
+step:205/1585 train_time:7064ms step_avg:34.46ms
+step:206/1585 train_time:7102ms step_avg:34.48ms
+step:207/1585 train_time:7133ms step_avg:34.46ms
+step:208/1585 train_time:7171ms step_avg:34.48ms
+step:209/1585 train_time:7201ms step_avg:34.46ms
+step:210/1585 train_time:7240ms step_avg:34.47ms
+step:211/1585 train_time:7270ms step_avg:34.45ms
+step:212/1585 train_time:7309ms step_avg:34.47ms
+step:213/1585 train_time:7339ms step_avg:34.46ms
+step:214/1585 train_time:7377ms step_avg:34.47ms
+step:215/1585 train_time:7407ms step_avg:34.45ms
+step:216/1585 train_time:7445ms step_avg:34.47ms
+step:217/1585 train_time:7476ms step_avg:34.45ms
+step:218/1585 train_time:7515ms step_avg:34.47ms
+step:219/1585 train_time:7545ms step_avg:34.45ms
+step:220/1585 train_time:7583ms step_avg:34.47ms
+step:221/1585 train_time:7613ms step_avg:34.45ms
+step:222/1585 train_time:7651ms step_avg:34.47ms
+step:223/1585 train_time:7682ms step_avg:34.45ms
+step:224/1585 train_time:7720ms step_avg:34.46ms
+step:225/1585 train_time:7750ms step_avg:34.45ms
+step:226/1585 train_time:7789ms step_avg:34.46ms
+step:227/1585 train_time:7819ms step_avg:34.45ms
+step:228/1585 train_time:7858ms step_avg:34.46ms
+step:229/1585 train_time:7888ms step_avg:34.45ms
+step:230/1585 train_time:7926ms step_avg:34.46ms
+step:231/1585 train_time:7956ms step_avg:34.44ms
+step:232/1585 train_time:7995ms step_avg:34.46ms
+step:233/1585 train_time:8025ms step_avg:34.44ms
+step:234/1585 train_time:8063ms step_avg:34.46ms
+step:235/1585 train_time:8094ms step_avg:34.44ms
+step:236/1585 train_time:8132ms step_avg:34.46ms
+step:237/1585 train_time:8162ms step_avg:34.44ms
+step:238/1585 train_time:8200ms step_avg:34.45ms
+step:239/1585 train_time:8230ms step_avg:34.44ms
+step:240/1585 train_time:8269ms step_avg:34.45ms
+step:241/1585 train_time:8300ms step_avg:34.44ms
+step:242/1585 train_time:8338ms step_avg:34.45ms
+step:243/1585 train_time:8369ms step_avg:34.44ms
+step:244/1585 train_time:8407ms step_avg:34.45ms
+step:245/1585 train_time:8437ms step_avg:34.44ms
+step:246/1585 train_time:8475ms step_avg:34.45ms
+step:247/1585 train_time:8506ms step_avg:34.44ms
+step:248/1585 train_time:8544ms step_avg:34.45ms
+step:249/1585 train_time:8575ms step_avg:34.44ms
+step:250/1585 train_time:8613ms step_avg:34.45ms
+step:250/1585 val_loss:4.5761 train_time:8661ms step_avg:34.64ms
+step:251/1585 train_time:8680ms step_avg:34.58ms
+step:252/1585 train_time:8698ms step_avg:34.52ms
+step:253/1585 train_time:8715ms step_avg:34.45ms
+step:254/1585 train_time:8753ms step_avg:34.46ms
+step:255/1585 train_time:8784ms step_avg:34.45ms
+step:256/1585 train_time:8823ms step_avg:34.46ms
+step:257/1585 train_time:8854ms step_avg:34.45ms
+step:258/1585 train_time:8892ms step_avg:34.46ms
+step:259/1585 train_time:8923ms step_avg:34.45ms
+step:260/1585 train_time:8961ms step_avg:34.46ms
+step:261/1585 train_time:8991ms step_avg:34.45ms
+step:262/1585 train_time:9029ms step_avg:34.46ms
+step:263/1585 train_time:9059ms step_avg:34.45ms
+step:264/1585 train_time:9097ms step_avg:34.46ms
+step:265/1585 train_time:9127ms step_avg:34.44ms
+step:266/1585 train_time:9165ms step_avg:34.46ms
+step:267/1585 train_time:9196ms step_avg:34.44ms
+step:268/1585 train_time:9234ms step_avg:34.45ms
+step:269/1585 train_time:9264ms step_avg:34.44ms
+step:270/1585 train_time:9302ms step_avg:34.45ms
+step:271/1585 train_time:9332ms step_avg:34.44ms
+step:272/1585 train_time:9370ms step_avg:34.45ms
+step:273/1585 train_time:9400ms step_avg:34.43ms
+step:274/1585 train_time:9439ms step_avg:34.45ms
+step:275/1585 train_time:9469ms step_avg:34.43ms
+step:276/1585 train_time:9507ms step_avg:34.45ms
+step:277/1585 train_time:9537ms step_avg:34.43ms
+step:278/1585 train_time:9576ms step_avg:34.44ms
+step:279/1585 train_time:9606ms step_avg:34.43ms
+step:280/1585 train_time:9644ms step_avg:34.44ms
+step:281/1585 train_time:9674ms step_avg:34.43ms
+step:282/1585 train_time:9713ms step_avg:34.44ms
+step:283/1585 train_time:9743ms step_avg:34.43ms
+step:284/1585 train_time:9781ms step_avg:34.44ms
+step:285/1585 train_time:9812ms step_avg:34.43ms
+step:286/1585 train_time:9850ms step_avg:34.44ms
+step:287/1585 train_time:9880ms step_avg:34.43ms
+step:288/1585 train_time:9919ms step_avg:34.44ms
+step:289/1585 train_time:9949ms step_avg:34.43ms
+step:290/1585 train_time:9987ms step_avg:34.44ms
+step:291/1585 train_time:10018ms step_avg:34.42ms
+step:292/1585 train_time:10056ms step_avg:34.44ms
+step:293/1585 train_time:10086ms step_avg:34.42ms
+step:294/1585 train_time:10124ms step_avg:34.44ms
+step:295/1585 train_time:10155ms step_avg:34.42ms
+step:296/1585 train_time:10193ms step_avg:34.43ms
+step:297/1585 train_time:10223ms step_avg:34.42ms
+step:298/1585 train_time:10261ms step_avg:34.43ms
+step:299/1585 train_time:10291ms step_avg:34.42ms
+step:300/1585 train_time:10329ms step_avg:34.43ms
+step:301/1585 train_time:10360ms step_avg:34.42ms
+step:302/1585 train_time:10398ms step_avg:34.43ms
+step:303/1585 train_time:10428ms step_avg:34.42ms
+step:304/1585 train_time:10467ms step_avg:34.43ms
+step:305/1585 train_time:10497ms step_avg:34.42ms
+step:306/1585 train_time:10535ms step_avg:34.43ms
+step:307/1585 train_time:10565ms step_avg:34.41ms
+step:308/1585 train_time:10603ms step_avg:34.43ms
+step:309/1585 train_time:10633ms step_avg:34.41ms
+step:310/1585 train_time:10672ms step_avg:34.42ms
+step:311/1585 train_time:10702ms step_avg:34.41ms
+step:312/1585 train_time:10740ms step_avg:34.42ms
+step:313/1585 train_time:10770ms step_avg:34.41ms
+step:314/1585 train_time:10808ms step_avg:34.42ms
+step:315/1585 train_time:10839ms step_avg:34.41ms
+step:316/1585 train_time:10877ms step_avg:34.42ms
+step:317/1585 train_time:10908ms step_avg:34.41ms
+step:318/1585 train_time:10946ms step_avg:34.42ms
+step:319/1585 train_time:10976ms step_avg:34.41ms
+step:320/1585 train_time:11015ms step_avg:34.42ms
+step:321/1585 train_time:11045ms step_avg:34.41ms
+step:322/1585 train_time:11084ms step_avg:34.42ms
+step:323/1585 train_time:11114ms step_avg:34.41ms
+step:324/1585 train_time:11152ms step_avg:34.42ms
+step:325/1585 train_time:11182ms step_avg:34.41ms
+step:326/1585 train_time:11220ms step_avg:34.42ms
+step:327/1585 train_time:11250ms step_avg:34.41ms
+step:328/1585 train_time:11289ms step_avg:34.42ms
+step:329/1585 train_time:11319ms step_avg:34.40ms
+step:330/1585 train_time:11357ms step_avg:34.42ms
+step:331/1585 train_time:11388ms step_avg:34.40ms
+step:332/1585 train_time:11426ms step_avg:34.41ms
+step:333/1585 train_time:11456ms step_avg:34.40ms
+step:334/1585 train_time:11494ms step_avg:34.41ms
+step:335/1585 train_time:11524ms step_avg:34.40ms
+step:336/1585 train_time:11562ms step_avg:34.41ms
+step:337/1585 train_time:11592ms step_avg:34.40ms
+step:338/1585 train_time:11630ms step_avg:34.41ms
+step:339/1585 train_time:11660ms step_avg:34.40ms
+step:340/1585 train_time:11699ms step_avg:34.41ms
+step:341/1585 train_time:11729ms step_avg:34.40ms
+step:342/1585 train_time:11767ms step_avg:34.41ms
+step:343/1585 train_time:11797ms step_avg:34.39ms
+step:344/1585 train_time:11836ms step_avg:34.41ms
+step:345/1585 train_time:11867ms step_avg:34.40ms
+step:346/1585 train_time:11905ms step_avg:34.41ms
+step:347/1585 train_time:11936ms step_avg:34.40ms
+step:348/1585 train_time:11974ms step_avg:34.41ms
+step:349/1585 train_time:12004ms step_avg:34.40ms
+step:350/1585 train_time:12042ms step_avg:34.41ms
+step:351/1585 train_time:12073ms step_avg:34.40ms
+step:352/1585 train_time:12111ms step_avg:34.41ms
+step:353/1585 train_time:12141ms step_avg:34.39ms
+step:354/1585 train_time:12179ms step_avg:34.40ms
+step:355/1585 train_time:12209ms step_avg:34.39ms
+step:356/1585 train_time:12248ms step_avg:34.40ms
+step:357/1585 train_time:12278ms step_avg:34.39ms
+step:358/1585 train_time:12316ms step_avg:34.40ms
+step:359/1585 train_time:12346ms step_avg:34.39ms
+step:360/1585 train_time:12384ms step_avg:34.40ms
+step:361/1585 train_time:12414ms step_avg:34.39ms
+step:362/1585 train_time:12453ms step_avg:34.40ms
+step:363/1585 train_time:12483ms step_avg:34.39ms
+step:364/1585 train_time:12522ms step_avg:34.40ms
+step:365/1585 train_time:12553ms step_avg:34.39ms
+step:366/1585 train_time:12591ms step_avg:34.40ms
+step:367/1585 train_time:12621ms step_avg:34.39ms
+step:368/1585 train_time:12660ms step_avg:34.40ms
+step:369/1585 train_time:12690ms step_avg:34.39ms
+step:370/1585 train_time:12728ms step_avg:34.40ms
+step:371/1585 train_time:12758ms step_avg:34.39ms
+step:372/1585 train_time:12796ms step_avg:34.40ms
+step:373/1585 train_time:12827ms step_avg:34.39ms
+step:374/1585 train_time:12865ms step_avg:34.40ms
+step:375/1585 train_time:12895ms step_avg:34.39ms
+step:376/1585 train_time:12933ms step_avg:34.40ms
+step:377/1585 train_time:12963ms step_avg:34.39ms
+step:378/1585 train_time:13002ms step_avg:34.40ms
+step:379/1585 train_time:13032ms step_avg:34.39ms
+step:380/1585 train_time:13071ms step_avg:34.40ms
+step:381/1585 train_time:13101ms step_avg:34.39ms
+step:382/1585 train_time:13139ms step_avg:34.40ms
+step:383/1585 train_time:13169ms step_avg:34.38ms
+step:384/1585 train_time:13207ms step_avg:34.39ms
+step:385/1585 train_time:13238ms step_avg:34.38ms
+step:386/1585 train_time:13276ms step_avg:34.39ms
+step:387/1585 train_time:13306ms step_avg:34.38ms
+step:388/1585 train_time:13345ms step_avg:34.39ms
+step:389/1585 train_time:13375ms step_avg:34.38ms
+step:390/1585 train_time:13413ms step_avg:34.39ms
+step:391/1585 train_time:13444ms step_avg:34.38ms
+step:392/1585 train_time:13482ms step_avg:34.39ms
+step:393/1585 train_time:13512ms step_avg:34.38ms
+step:394/1585 train_time:13550ms step_avg:34.39ms
+step:395/1585 train_time:13580ms step_avg:34.38ms
+step:396/1585 train_time:13618ms step_avg:34.39ms
+step:397/1585 train_time:13649ms step_avg:34.38ms
+step:398/1585 train_time:13687ms step_avg:34.39ms
+step:399/1585 train_time:13717ms step_avg:34.38ms
+step:400/1585 train_time:13756ms step_avg:34.39ms
+step:401/1585 train_time:13787ms step_avg:34.38ms
+step:402/1585 train_time:13825ms step_avg:34.39ms
+step:403/1585 train_time:13855ms step_avg:34.38ms
+step:404/1585 train_time:13893ms step_avg:34.39ms
+step:405/1585 train_time:13924ms step_avg:34.38ms
+step:406/1585 train_time:13963ms step_avg:34.39ms
+step:407/1585 train_time:13993ms step_avg:34.38ms
+step:408/1585 train_time:14031ms step_avg:34.39ms
+step:409/1585 train_time:14061ms step_avg:34.38ms
+step:410/1585 train_time:14099ms step_avg:34.39ms
+step:411/1585 train_time:14129ms step_avg:34.38ms
+step:412/1585 train_time:14168ms step_avg:34.39ms
+step:413/1585 train_time:14198ms step_avg:34.38ms
+step:414/1585 train_time:14237ms step_avg:34.39ms
+step:415/1585 train_time:14267ms step_avg:34.38ms
+step:416/1585 train_time:14305ms step_avg:34.39ms
+step:417/1585 train_time:14335ms step_avg:34.38ms
+step:418/1585 train_time:14374ms step_avg:34.39ms
+step:419/1585 train_time:14405ms step_avg:34.38ms
+step:420/1585 train_time:14443ms step_avg:34.39ms
+step:421/1585 train_time:14473ms step_avg:34.38ms
+step:422/1585 train_time:14511ms step_avg:34.39ms
+step:423/1585 train_time:14541ms step_avg:34.38ms
+step:424/1585 train_time:14580ms step_avg:34.39ms
+step:425/1585 train_time:14610ms step_avg:34.38ms
+step:426/1585 train_time:14648ms step_avg:34.39ms
+step:427/1585 train_time:14678ms step_avg:34.38ms
+step:428/1585 train_time:14717ms step_avg:34.38ms
+step:429/1585 train_time:14747ms step_avg:34.38ms
+step:430/1585 train_time:14786ms step_avg:34.38ms
+step:431/1585 train_time:14816ms step_avg:34.38ms
+step:432/1585 train_time:14855ms step_avg:34.39ms
+step:433/1585 train_time:14886ms step_avg:34.38ms
+step:434/1585 train_time:14924ms step_avg:34.39ms
+step:435/1585 train_time:14954ms step_avg:34.38ms
+step:436/1585 train_time:14992ms step_avg:34.38ms
+step:437/1585 train_time:15022ms step_avg:34.38ms
+step:438/1585 train_time:15061ms step_avg:34.39ms
+step:439/1585 train_time:15091ms step_avg:34.38ms
+step:440/1585 train_time:15129ms step_avg:34.38ms
+step:441/1585 train_time:15159ms step_avg:34.38ms
+step:442/1585 train_time:15197ms step_avg:34.38ms
+step:443/1585 train_time:15228ms step_avg:34.38ms
+step:444/1585 train_time:15266ms step_avg:34.38ms
+step:445/1585 train_time:15296ms step_avg:34.37ms
+step:446/1585 train_time:15335ms step_avg:34.38ms
+step:447/1585 train_time:15365ms step_avg:34.37ms
+step:448/1585 train_time:15403ms step_avg:34.38ms
+step:449/1585 train_time:15434ms step_avg:34.37ms
+step:450/1585 train_time:15471ms step_avg:34.38ms
+step:451/1585 train_time:15502ms step_avg:34.37ms
+step:452/1585 train_time:15540ms step_avg:34.38ms
+step:453/1585 train_time:15570ms step_avg:34.37ms
+step:454/1585 train_time:15608ms step_avg:34.38ms
+step:455/1585 train_time:15638ms step_avg:34.37ms
+step:456/1585 train_time:15677ms step_avg:34.38ms
+step:457/1585 train_time:15707ms step_avg:34.37ms
+step:458/1585 train_time:15745ms step_avg:34.38ms
+step:459/1585 train_time:15776ms step_avg:34.37ms
+step:460/1585 train_time:15814ms step_avg:34.38ms
+step:461/1585 train_time:15845ms step_avg:34.37ms
+step:462/1585 train_time:15882ms step_avg:34.38ms
+step:463/1585 train_time:15913ms step_avg:34.37ms
+step:464/1585 train_time:15951ms step_avg:34.38ms
+step:465/1585 train_time:15981ms step_avg:34.37ms
+step:466/1585 train_time:16019ms step_avg:34.38ms
+step:467/1585 train_time:16050ms step_avg:34.37ms
+step:468/1585 train_time:16088ms step_avg:34.38ms
+step:469/1585 train_time:16118ms step_avg:34.37ms
+step:470/1585 train_time:16157ms step_avg:34.38ms
+step:471/1585 train_time:16186ms step_avg:34.37ms
+step:472/1585 train_time:16225ms step_avg:34.38ms
+step:473/1585 train_time:16255ms step_avg:34.37ms
+step:474/1585 train_time:16294ms step_avg:34.37ms
+step:475/1585 train_time:16324ms step_avg:34.37ms
+step:476/1585 train_time:16362ms step_avg:34.37ms
+step:477/1585 train_time:16392ms step_avg:34.36ms
+step:478/1585 train_time:16430ms step_avg:34.37ms
+step:479/1585 train_time:16460ms step_avg:34.36ms
+step:480/1585 train_time:16499ms step_avg:34.37ms
+step:481/1585 train_time:16529ms step_avg:34.36ms
+step:482/1585 train_time:16567ms step_avg:34.37ms
+step:483/1585 train_time:16597ms step_avg:34.36ms
+step:484/1585 train_time:16635ms step_avg:34.37ms
+step:485/1585 train_time:16666ms step_avg:34.36ms
+step:486/1585 train_time:16704ms step_avg:34.37ms
+step:487/1585 train_time:16735ms step_avg:34.36ms
+step:488/1585 train_time:16773ms step_avg:34.37ms
+step:489/1585 train_time:16803ms step_avg:34.36ms
+step:490/1585 train_time:16842ms step_avg:34.37ms
+step:491/1585 train_time:16872ms step_avg:34.36ms
+step:492/1585 train_time:16910ms step_avg:34.37ms
+step:493/1585 train_time:16941ms step_avg:34.36ms
+step:494/1585 train_time:16979ms step_avg:34.37ms
+step:495/1585 train_time:17009ms step_avg:34.36ms
+step:496/1585 train_time:17047ms step_avg:34.37ms
+step:497/1585 train_time:17077ms step_avg:34.36ms
+step:498/1585 train_time:17116ms step_avg:34.37ms
+step:499/1585 train_time:17146ms step_avg:34.36ms
+step:500/1585 train_time:17184ms step_avg:34.37ms
+step:500/1585 val_loss:4.2412 train_time:17232ms step_avg:34.46ms
+step:501/1585 train_time:17251ms step_avg:34.43ms
+step:502/1585 train_time:17269ms step_avg:34.40ms
+step:503/1585 train_time:17286ms step_avg:34.37ms
+step:504/1585 train_time:17324ms step_avg:34.37ms
+step:505/1585 train_time:17355ms step_avg:34.37ms
+step:506/1585 train_time:17393ms step_avg:34.37ms
+step:507/1585 train_time:17424ms step_avg:34.37ms
+step:508/1585 train_time:17462ms step_avg:34.37ms
+step:509/1585 train_time:17492ms step_avg:34.37ms
+step:510/1585 train_time:17530ms step_avg:34.37ms
+step:511/1585 train_time:17560ms step_avg:34.36ms
+step:512/1585 train_time:17598ms step_avg:34.37ms
+step:513/1585 train_time:17629ms step_avg:34.36ms
+step:514/1585 train_time:17667ms step_avg:34.37ms
+step:515/1585 train_time:17697ms step_avg:34.36ms
+step:516/1585 train_time:17772ms step_avg:34.44ms
+step:517/1585 train_time:17832ms step_avg:34.49ms
+step:518/1585 train_time:17891ms step_avg:34.54ms
+step:519/1585 train_time:17953ms step_avg:34.59ms
+step:520/1585 train_time:18012ms step_avg:34.64ms
+step:521/1585 train_time:18074ms step_avg:34.69ms
+step:522/1585 train_time:18133ms step_avg:34.74ms
+step:523/1585 train_time:18197ms step_avg:34.79ms
+step:524/1585 train_time:18259ms step_avg:34.85ms
+step:525/1585 train_time:18323ms step_avg:34.90ms
+step:526/1585 train_time:18382ms step_avg:34.95ms
+step:527/1585 train_time:18445ms step_avg:35.00ms
+step:528/1585 train_time:18505ms step_avg:35.05ms
+step:529/1585 train_time:18568ms step_avg:35.10ms
+step:530/1585 train_time:18627ms step_avg:35.15ms
+step:531/1585 train_time:18690ms step_avg:35.20ms
+step:532/1585 train_time:18749ms step_avg:35.24ms
+step:533/1585 train_time:18812ms step_avg:35.29ms
+step:534/1585 train_time:18870ms step_avg:35.34ms
+step:535/1585 train_time:18934ms step_avg:35.39ms
+step:536/1585 train_time:18993ms step_avg:35.43ms
+step:537/1585 train_time:19056ms step_avg:35.49ms
+step:538/1585 train_time:19115ms step_avg:35.53ms
+step:539/1585 train_time:19178ms step_avg:35.58ms
+step:540/1585 train_time:19238ms step_avg:35.63ms
+step:541/1585 train_time:19302ms step_avg:35.68ms
+step:542/1585 train_time:19362ms step_avg:35.72ms
+step:543/1585 train_time:19425ms step_avg:35.77ms
+step:544/1585 train_time:19484ms step_avg:35.82ms
+step:545/1585 train_time:19548ms step_avg:35.87ms
+step:546/1585 train_time:19608ms step_avg:35.91ms
+step:547/1585 train_time:19670ms step_avg:35.96ms
+step:548/1585 train_time:19730ms step_avg:36.00ms
+step:549/1585 train_time:19792ms step_avg:36.05ms
+step:550/1585 train_time:19852ms step_avg:36.09ms
+step:551/1585 train_time:19914ms step_avg:36.14ms
+step:552/1585 train_time:19973ms step_avg:36.18ms
+step:553/1585 train_time:20036ms step_avg:36.23ms
+step:554/1585 train_time:20095ms step_avg:36.27ms
+step:555/1585 train_time:20159ms step_avg:36.32ms
+step:556/1585 train_time:20218ms step_avg:36.36ms
+step:557/1585 train_time:20281ms step_avg:36.41ms
+step:558/1585 train_time:20340ms step_avg:36.45ms
+step:559/1585 train_time:20403ms step_avg:36.50ms
+step:560/1585 train_time:20462ms step_avg:36.54ms
+step:561/1585 train_time:20525ms step_avg:36.59ms
+step:562/1585 train_time:20585ms step_avg:36.63ms
+step:563/1585 train_time:20648ms step_avg:36.67ms
+step:564/1585 train_time:20708ms step_avg:36.72ms
+step:565/1585 train_time:20770ms step_avg:36.76ms
+step:566/1585 train_time:20829ms step_avg:36.80ms
+step:567/1585 train_time:20892ms step_avg:36.85ms
+step:568/1585 train_time:20951ms step_avg:36.89ms
+step:569/1585 train_time:21015ms step_avg:36.93ms
+step:570/1585 train_time:21076ms step_avg:36.97ms
+step:571/1585 train_time:21139ms step_avg:37.02ms
+step:572/1585 train_time:21199ms step_avg:37.06ms
+step:573/1585 train_time:21261ms step_avg:37.11ms
+step:574/1585 train_time:21320ms step_avg:37.14ms
+step:575/1585 train_time:21383ms step_avg:37.19ms
+step:576/1585 train_time:21442ms step_avg:37.23ms
+step:577/1585 train_time:21505ms step_avg:37.27ms
+step:578/1585 train_time:21564ms step_avg:37.31ms
+step:579/1585 train_time:21628ms step_avg:37.35ms
+step:580/1585 train_time:21687ms step_avg:37.39ms
+step:581/1585 train_time:21750ms step_avg:37.44ms
+step:582/1585 train_time:21809ms step_avg:37.47ms
+step:583/1585 train_time:21872ms step_avg:37.52ms
+step:584/1585 train_time:21931ms step_avg:37.55ms
+step:585/1585 train_time:21994ms step_avg:37.60ms
+step:586/1585 train_time:22053ms step_avg:37.63ms
+step:587/1585 train_time:22117ms step_avg:37.68ms
+step:588/1585 train_time:22177ms step_avg:37.72ms
+step:589/1585 train_time:22240ms step_avg:37.76ms
+step:590/1585 train_time:22300ms step_avg:37.80ms
+step:591/1585 train_time:22363ms step_avg:37.84ms
+step:592/1585 train_time:22423ms step_avg:37.88ms
+step:593/1585 train_time:22485ms step_avg:37.92ms
+step:594/1585 train_time:22544ms step_avg:37.95ms
+step:595/1585 train_time:22607ms step_avg:38.00ms
+step:596/1585 train_time:22666ms step_avg:38.03ms
+step:597/1585 train_time:22730ms step_avg:38.07ms
+step:598/1585 train_time:22790ms step_avg:38.11ms
+step:599/1585 train_time:22853ms step_avg:38.15ms
+step:600/1585 train_time:22913ms step_avg:38.19ms
+step:601/1585 train_time:22975ms step_avg:38.23ms
+step:602/1585 train_time:23034ms step_avg:38.26ms
+step:603/1585 train_time:23098ms step_avg:38.31ms
+step:604/1585 train_time:23157ms step_avg:38.34ms
+step:605/1585 train_time:23221ms step_avg:38.38ms
+step:606/1585 train_time:23280ms step_avg:38.42ms
+step:607/1585 train_time:23343ms step_avg:38.46ms
+step:608/1585 train_time:23403ms step_avg:38.49ms
+step:609/1585 train_time:23466ms step_avg:38.53ms
+step:610/1585 train_time:23526ms step_avg:38.57ms
+step:611/1585 train_time:23589ms step_avg:38.61ms
+step:612/1585 train_time:23648ms step_avg:38.64ms
+step:613/1585 train_time:23712ms step_avg:38.68ms
+step:614/1585 train_time:23771ms step_avg:38.71ms
+step:615/1585 train_time:23834ms step_avg:38.75ms
+step:616/1585 train_time:23893ms step_avg:38.79ms
+step:617/1585 train_time:23956ms step_avg:38.83ms
+step:618/1585 train_time:24015ms step_avg:38.86ms
+step:619/1585 train_time:24079ms step_avg:38.90ms
+step:620/1585 train_time:24139ms step_avg:38.93ms
+step:621/1585 train_time:24203ms step_avg:38.97ms
+step:622/1585 train_time:24262ms step_avg:39.01ms
+step:623/1585 train_time:24325ms step_avg:39.04ms
+step:624/1585 train_time:24384ms step_avg:39.08ms
+step:625/1585 train_time:24447ms step_avg:39.11ms
+step:626/1585 train_time:24506ms step_avg:39.15ms
+step:627/1585 train_time:24569ms step_avg:39.18ms
+step:628/1585 train_time:24628ms step_avg:39.22ms
+step:629/1585 train_time:24691ms step_avg:39.25ms
+step:630/1585 train_time:24751ms step_avg:39.29ms
+step:631/1585 train_time:24814ms step_avg:39.32ms
+step:632/1585 train_time:24873ms step_avg:39.36ms
+step:633/1585 train_time:24936ms step_avg:39.39ms
+step:634/1585 train_time:24995ms step_avg:39.42ms
+step:635/1585 train_time:25058ms step_avg:39.46ms
+step:636/1585 train_time:25118ms step_avg:39.49ms
+step:637/1585 train_time:25181ms step_avg:39.53ms
+step:638/1585 train_time:25241ms step_avg:39.56ms
+step:639/1585 train_time:25304ms step_avg:39.60ms
+step:640/1585 train_time:25363ms step_avg:39.63ms
+step:641/1585 train_time:25426ms step_avg:39.67ms
+step:642/1585 train_time:25485ms step_avg:39.70ms
+step:643/1585 train_time:25549ms step_avg:39.73ms
+step:644/1585 train_time:25608ms step_avg:39.76ms
+step:645/1585 train_time:25671ms step_avg:39.80ms
+step:646/1585 train_time:25731ms step_avg:39.83ms
+step:647/1585 train_time:25794ms step_avg:39.87ms
+step:648/1585 train_time:25853ms step_avg:39.90ms
+step:649/1585 train_time:25917ms step_avg:39.93ms
+step:650/1585 train_time:25975ms step_avg:39.96ms
+step:651/1585 train_time:26038ms step_avg:40.00ms
+step:652/1585 train_time:26098ms step_avg:40.03ms
+step:653/1585 train_time:26161ms step_avg:40.06ms
+step:654/1585 train_time:26220ms step_avg:40.09ms
+step:655/1585 train_time:26283ms step_avg:40.13ms
+step:656/1585 train_time:26342ms step_avg:40.16ms
+step:657/1585 train_time:26405ms step_avg:40.19ms
+step:658/1585 train_time:26465ms step_avg:40.22ms
+step:659/1585 train_time:26528ms step_avg:40.26ms
+step:660/1585 train_time:26587ms step_avg:40.28ms
+step:661/1585 train_time:26651ms step_avg:40.32ms
+step:662/1585 train_time:26711ms step_avg:40.35ms
+step:663/1585 train_time:26773ms step_avg:40.38ms
+step:664/1585 train_time:26832ms step_avg:40.41ms
+step:665/1585 train_time:26895ms step_avg:40.44ms
+step:666/1585 train_time:26954ms step_avg:40.47ms
+step:667/1585 train_time:27018ms step_avg:40.51ms
+step:668/1585 train_time:27077ms step_avg:40.53ms
+step:669/1585 train_time:27140ms step_avg:40.57ms
+step:670/1585 train_time:27200ms step_avg:40.60ms
+step:671/1585 train_time:27263ms step_avg:40.63ms
+step:672/1585 train_time:27323ms step_avg:40.66ms
+step:673/1585 train_time:27385ms step_avg:40.69ms
+step:674/1585 train_time:27445ms step_avg:40.72ms
+step:675/1585 train_time:27508ms step_avg:40.75ms
+step:676/1585 train_time:27567ms step_avg:40.78ms
+step:677/1585 train_time:27631ms step_avg:40.81ms
+step:678/1585 train_time:27691ms step_avg:40.84ms
+step:679/1585 train_time:27754ms step_avg:40.87ms
+step:680/1585 train_time:27814ms step_avg:40.90ms
+step:681/1585 train_time:27877ms step_avg:40.93ms
+step:682/1585 train_time:27936ms step_avg:40.96ms
+step:683/1585 train_time:27999ms step_avg:40.99ms
+step:684/1585 train_time:28058ms step_avg:41.02ms
+step:685/1585 train_time:28122ms step_avg:41.05ms
+step:686/1585 train_time:28181ms step_avg:41.08ms
+step:687/1585 train_time:28244ms step_avg:41.11ms
+step:688/1585 train_time:28304ms step_avg:41.14ms
+step:689/1585 train_time:28367ms step_avg:41.17ms
+step:690/1585 train_time:28426ms step_avg:41.20ms
+step:691/1585 train_time:28489ms step_avg:41.23ms
+step:692/1585 train_time:28548ms step_avg:41.25ms
+step:693/1585 train_time:28611ms step_avg:41.29ms
+step:694/1585 train_time:28670ms step_avg:41.31ms
+step:695/1585 train_time:28734ms step_avg:41.34ms
+step:696/1585 train_time:28793ms step_avg:41.37ms
+step:697/1585 train_time:28856ms step_avg:41.40ms
+step:698/1585 train_time:28915ms step_avg:41.43ms
+step:699/1585 train_time:28979ms step_avg:41.46ms
+step:700/1585 train_time:29038ms step_avg:41.48ms
+step:701/1585 train_time:29102ms step_avg:41.51ms
+step:702/1585 train_time:29161ms step_avg:41.54ms
+step:703/1585 train_time:29224ms step_avg:41.57ms
+step:704/1585 train_time:29282ms step_avg:41.59ms
+step:705/1585 train_time:29345ms step_avg:41.62ms
+step:706/1585 train_time:29405ms step_avg:41.65ms
+step:707/1585 train_time:29468ms step_avg:41.68ms
+step:708/1585 train_time:29527ms step_avg:41.70ms
+step:709/1585 train_time:29590ms step_avg:41.73ms
+step:710/1585 train_time:29649ms step_avg:41.76ms
+step:711/1585 train_time:29712ms step_avg:41.79ms
+step:712/1585 train_time:29772ms step_avg:41.82ms
+step:713/1585 train_time:29836ms step_avg:41.85ms
+step:714/1585 train_time:29895ms step_avg:41.87ms
+step:715/1585 train_time:29958ms step_avg:41.90ms
+step:716/1585 train_time:30017ms step_avg:41.92ms
+step:717/1585 train_time:30081ms step_avg:41.95ms
+step:718/1585 train_time:30140ms step_avg:41.98ms
+step:719/1585 train_time:30203ms step_avg:42.01ms
+step:720/1585 train_time:30262ms step_avg:42.03ms
+step:721/1585 train_time:30325ms step_avg:42.06ms
+step:722/1585 train_time:30384ms step_avg:42.08ms
+step:723/1585 train_time:30447ms step_avg:42.11ms
+step:724/1585 train_time:30507ms step_avg:42.14ms
+step:725/1585 train_time:30570ms step_avg:42.17ms
+step:726/1585 train_time:30630ms step_avg:42.19ms
+step:727/1585 train_time:30693ms step_avg:42.22ms
+step:728/1585 train_time:30752ms step_avg:42.24ms
+step:729/1585 train_time:30816ms step_avg:42.27ms
+step:730/1585 train_time:30875ms step_avg:42.29ms
+step:731/1585 train_time:30938ms step_avg:42.32ms
+step:732/1585 train_time:30997ms step_avg:42.35ms
+step:733/1585 train_time:31060ms step_avg:42.37ms
+step:734/1585 train_time:31120ms step_avg:42.40ms
+step:735/1585 train_time:31183ms step_avg:42.43ms
+step:736/1585 train_time:31242ms step_avg:42.45ms
+step:737/1585 train_time:31306ms step_avg:42.48ms
+step:738/1585 train_time:31365ms step_avg:42.50ms
+step:739/1585 train_time:31428ms step_avg:42.53ms
+step:740/1585 train_time:31487ms step_avg:42.55ms
+step:741/1585 train_time:31550ms step_avg:42.58ms
+step:742/1585 train_time:31609ms step_avg:42.60ms
+step:743/1585 train_time:31672ms step_avg:42.63ms
+step:744/1585 train_time:31731ms step_avg:42.65ms
+step:745/1585 train_time:31794ms step_avg:42.68ms
+step:746/1585 train_time:31854ms step_avg:42.70ms
+step:747/1585 train_time:31918ms step_avg:42.73ms
+step:748/1585 train_time:31977ms step_avg:42.75ms
+step:749/1585 train_time:32041ms step_avg:42.78ms
+step:750/1585 train_time:32099ms step_avg:42.80ms
+step:750/1585 val_loss:3.8898 train_time:32144ms step_avg:42.86ms
+step:751/1585 train_time:32164ms step_avg:42.83ms
+step:752/1585 train_time:32224ms step_avg:42.85ms
+step:753/1585 train_time:32288ms step_avg:42.88ms
+step:754/1585 train_time:32346ms step_avg:42.90ms
+step:755/1585 train_time:32409ms step_avg:42.93ms
+step:756/1585 train_time:32468ms step_avg:42.95ms
+step:757/1585 train_time:32530ms step_avg:42.97ms
+step:758/1585 train_time:32589ms step_avg:42.99ms
+step:759/1585 train_time:32652ms step_avg:43.02ms
+step:760/1585 train_time:32710ms step_avg:43.04ms
+step:761/1585 train_time:32773ms step_avg:43.07ms
+step:762/1585 train_time:32831ms step_avg:43.09ms
+step:763/1585 train_time:32895ms step_avg:43.11ms
+step:764/1585 train_time:32955ms step_avg:43.13ms
+step:765/1585 train_time:33018ms step_avg:43.16ms
+step:766/1585 train_time:33078ms step_avg:43.18ms
+step:767/1585 train_time:33143ms step_avg:43.21ms
+step:768/1585 train_time:33204ms step_avg:43.23ms
+step:769/1585 train_time:33268ms step_avg:43.26ms
+step:770/1585 train_time:33328ms step_avg:43.28ms
+step:771/1585 train_time:33393ms step_avg:43.31ms
+step:772/1585 train_time:33452ms step_avg:43.33ms
+step:773/1585 train_time:33515ms step_avg:43.36ms
+step:774/1585 train_time:33574ms step_avg:43.38ms
+step:775/1585 train_time:33636ms step_avg:43.40ms
+step:776/1585 train_time:33695ms step_avg:43.42ms
+step:777/1585 train_time:33757ms step_avg:43.45ms
+step:778/1585 train_time:33816ms step_avg:43.47ms
+step:779/1585 train_time:33879ms step_avg:43.49ms
+step:780/1585 train_time:33938ms step_avg:43.51ms
+step:781/1585 train_time:34001ms step_avg:43.54ms
+step:782/1585 train_time:34060ms step_avg:43.56ms
+step:783/1585 train_time:34124ms step_avg:43.58ms
+step:784/1585 train_time:34184ms step_avg:43.60ms
+step:785/1585 train_time:34247ms step_avg:43.63ms
+step:786/1585 train_time:34306ms step_avg:43.65ms
+step:787/1585 train_time:34370ms step_avg:43.67ms
+step:788/1585 train_time:34429ms step_avg:43.69ms
+step:789/1585 train_time:34493ms step_avg:43.72ms
+step:790/1585 train_time:34551ms step_avg:43.74ms
+step:791/1585 train_time:34614ms step_avg:43.76ms
+step:792/1585 train_time:34673ms step_avg:43.78ms
+step:793/1585 train_time:34736ms step_avg:43.80ms
+step:794/1585 train_time:34795ms step_avg:43.82ms
+step:795/1585 train_time:34858ms step_avg:43.85ms
+step:796/1585 train_time:34917ms step_avg:43.87ms
+step:797/1585 train_time:34980ms step_avg:43.89ms
+step:798/1585 train_time:35040ms step_avg:43.91ms
+step:799/1585 train_time:35104ms step_avg:43.94ms
+step:800/1585 train_time:35163ms step_avg:43.95ms
+step:801/1585 train_time:35226ms step_avg:43.98ms
+step:802/1585 train_time:35286ms step_avg:44.00ms
+step:803/1585 train_time:35349ms step_avg:44.02ms
+step:804/1585 train_time:35409ms step_avg:44.04ms
+step:805/1585 train_time:35472ms step_avg:44.06ms
+step:806/1585 train_time:35531ms step_avg:44.08ms
+step:807/1585 train_time:35594ms step_avg:44.11ms
+step:808/1585 train_time:35654ms step_avg:44.13ms
+step:809/1585 train_time:35717ms step_avg:44.15ms
+step:810/1585 train_time:35775ms step_avg:44.17ms
+step:811/1585 train_time:35839ms step_avg:44.19ms
+step:812/1585 train_time:35898ms step_avg:44.21ms
+step:813/1585 train_time:35961ms step_avg:44.23ms
+step:814/1585 train_time:36021ms step_avg:44.25ms
+step:815/1585 train_time:36084ms step_avg:44.27ms
+step:816/1585 train_time:36144ms step_avg:44.29ms
+step:817/1585 train_time:36207ms step_avg:44.32ms
+step:818/1585 train_time:36266ms step_avg:44.34ms
+step:819/1585 train_time:36330ms step_avg:44.36ms
+step:820/1585 train_time:36389ms step_avg:44.38ms
+step:821/1585 train_time:36452ms step_avg:44.40ms
+step:822/1585 train_time:36511ms step_avg:44.42ms
+step:823/1585 train_time:36574ms step_avg:44.44ms
+step:824/1585 train_time:36633ms step_avg:44.46ms
+step:825/1585 train_time:36696ms step_avg:44.48ms
+step:826/1585 train_time:36755ms step_avg:44.50ms
+step:827/1585 train_time:36819ms step_avg:44.52ms
+step:828/1585 train_time:36878ms step_avg:44.54ms
+step:829/1585 train_time:36941ms step_avg:44.56ms
+step:830/1585 train_time:37000ms step_avg:44.58ms
+step:831/1585 train_time:37064ms step_avg:44.60ms
+step:832/1585 train_time:37123ms step_avg:44.62ms
+step:833/1585 train_time:37187ms step_avg:44.64ms
+step:834/1585 train_time:37247ms step_avg:44.66ms
+step:835/1585 train_time:37310ms step_avg:44.68ms
+step:836/1585 train_time:37369ms step_avg:44.70ms
+step:837/1585 train_time:37432ms step_avg:44.72ms
+step:838/1585 train_time:37491ms step_avg:44.74ms
+step:839/1585 train_time:37554ms step_avg:44.76ms
+step:840/1585 train_time:37613ms step_avg:44.78ms
+step:841/1585 train_time:37676ms step_avg:44.80ms
+step:842/1585 train_time:37735ms step_avg:44.82ms
+step:843/1585 train_time:37798ms step_avg:44.84ms
+step:844/1585 train_time:37857ms step_avg:44.85ms
+step:845/1585 train_time:37921ms step_avg:44.88ms
+step:846/1585 train_time:37980ms step_avg:44.89ms
+step:847/1585 train_time:38043ms step_avg:44.92ms
+step:848/1585 train_time:38103ms step_avg:44.93ms
+step:849/1585 train_time:38166ms step_avg:44.95ms
+step:850/1585 train_time:38226ms step_avg:44.97ms
+step:851/1585 train_time:38289ms step_avg:44.99ms
+step:852/1585 train_time:38348ms step_avg:45.01ms
+step:853/1585 train_time:38411ms step_avg:45.03ms
+step:854/1585 train_time:38470ms step_avg:45.05ms
+step:855/1585 train_time:38533ms step_avg:45.07ms
+step:856/1585 train_time:38592ms step_avg:45.08ms
+step:857/1585 train_time:38655ms step_avg:45.11ms
+step:858/1585 train_time:38715ms step_avg:45.12ms
+step:859/1585 train_time:38778ms step_avg:45.14ms
+step:860/1585 train_time:38837ms step_avg:45.16ms
+step:861/1585 train_time:38900ms step_avg:45.18ms
+step:862/1585 train_time:38959ms step_avg:45.20ms
+step:863/1585 train_time:39023ms step_avg:45.22ms
+step:864/1585 train_time:39082ms step_avg:45.23ms
+step:865/1585 train_time:39146ms step_avg:45.26ms
+step:866/1585 train_time:39205ms step_avg:45.27ms
+step:867/1585 train_time:39268ms step_avg:45.29ms
+step:868/1585 train_time:39328ms step_avg:45.31ms
+step:869/1585 train_time:39391ms step_avg:45.33ms
+step:870/1585 train_time:39450ms step_avg:45.34ms
+step:871/1585 train_time:39514ms step_avg:45.37ms
+step:872/1585 train_time:39573ms step_avg:45.38ms
+step:873/1585 train_time:39636ms step_avg:45.40ms
+step:874/1585 train_time:39695ms step_avg:45.42ms
+step:875/1585 train_time:39758ms step_avg:45.44ms
+step:876/1585 train_time:39817ms step_avg:45.45ms
+step:877/1585 train_time:39881ms step_avg:45.47ms
+step:878/1585 train_time:39940ms step_avg:45.49ms
+step:879/1585 train_time:40004ms step_avg:45.51ms
+step:880/1585 train_time:40063ms step_avg:45.53ms
+step:881/1585 train_time:40126ms step_avg:45.55ms
+step:882/1585 train_time:40185ms step_avg:45.56ms
+step:883/1585 train_time:40249ms step_avg:45.58ms
+step:884/1585 train_time:40308ms step_avg:45.60ms
+step:885/1585 train_time:40371ms step_avg:45.62ms
+step:886/1585 train_time:40431ms step_avg:45.63ms
+step:887/1585 train_time:40494ms step_avg:45.65ms
+step:888/1585 train_time:40553ms step_avg:45.67ms
+step:889/1585 train_time:40617ms step_avg:45.69ms
+step:890/1585 train_time:40675ms step_avg:45.70ms
+step:891/1585 train_time:40739ms step_avg:45.72ms
+step:892/1585 train_time:40798ms step_avg:45.74ms
+step:893/1585 train_time:40861ms step_avg:45.76ms
+step:894/1585 train_time:40921ms step_avg:45.77ms
+step:895/1585 train_time:40983ms step_avg:45.79ms
+step:896/1585 train_time:41042ms step_avg:45.81ms
+step:897/1585 train_time:41105ms step_avg:45.83ms
+step:898/1585 train_time:41165ms step_avg:45.84ms
+step:899/1585 train_time:41228ms step_avg:45.86ms
+step:900/1585 train_time:41287ms step_avg:45.87ms
+step:901/1585 train_time:41351ms step_avg:45.89ms
+step:902/1585 train_time:41410ms step_avg:45.91ms
+step:903/1585 train_time:41474ms step_avg:45.93ms
+step:904/1585 train_time:41533ms step_avg:45.94ms
+step:905/1585 train_time:41596ms step_avg:45.96ms
+step:906/1585 train_time:41655ms step_avg:45.98ms
+step:907/1585 train_time:41719ms step_avg:46.00ms
+step:908/1585 train_time:41777ms step_avg:46.01ms
+step:909/1585 train_time:41840ms step_avg:46.03ms
+step:910/1585 train_time:41900ms step_avg:46.04ms
+step:911/1585 train_time:41963ms step_avg:46.06ms
+step:912/1585 train_time:42023ms step_avg:46.08ms
+step:913/1585 train_time:42086ms step_avg:46.10ms
+step:914/1585 train_time:42145ms step_avg:46.11ms
+step:915/1585 train_time:42208ms step_avg:46.13ms
+step:916/1585 train_time:42267ms step_avg:46.14ms
+step:917/1585 train_time:42332ms step_avg:46.16ms
+step:918/1585 train_time:42391ms step_avg:46.18ms
+step:919/1585 train_time:42453ms step_avg:46.20ms
+step:920/1585 train_time:42513ms step_avg:46.21ms
+step:921/1585 train_time:42576ms step_avg:46.23ms
+step:922/1585 train_time:42635ms step_avg:46.24ms
+step:923/1585 train_time:42698ms step_avg:46.26ms
+step:924/1585 train_time:42757ms step_avg:46.27ms
+step:925/1585 train_time:42821ms step_avg:46.29ms
+step:926/1585 train_time:42880ms step_avg:46.31ms
+step:927/1585 train_time:42943ms step_avg:46.32ms
+step:928/1585 train_time:43003ms step_avg:46.34ms
+step:929/1585 train_time:43066ms step_avg:46.36ms
+step:930/1585 train_time:43126ms step_avg:46.37ms
+step:931/1585 train_time:43189ms step_avg:46.39ms
+step:932/1585 train_time:43248ms step_avg:46.40ms
+step:933/1585 train_time:43311ms step_avg:46.42ms
+step:934/1585 train_time:43370ms step_avg:46.43ms
+step:935/1585 train_time:43433ms step_avg:46.45ms
+step:936/1585 train_time:43492ms step_avg:46.47ms
+step:937/1585 train_time:43556ms step_avg:46.48ms
+step:938/1585 train_time:43615ms step_avg:46.50ms
+step:939/1585 train_time:43678ms step_avg:46.52ms
+step:940/1585 train_time:43737ms step_avg:46.53ms
+step:941/1585 train_time:43800ms step_avg:46.55ms
+step:942/1585 train_time:43859ms step_avg:46.56ms
+step:943/1585 train_time:43923ms step_avg:46.58ms
+step:944/1585 train_time:43982ms step_avg:46.59ms
+step:945/1585 train_time:44046ms step_avg:46.61ms
+step:946/1585 train_time:44104ms step_avg:46.62ms
+step:947/1585 train_time:44167ms step_avg:46.64ms
+step:948/1585 train_time:44227ms step_avg:46.65ms
+step:949/1585 train_time:44290ms step_avg:46.67ms
+step:950/1585 train_time:44349ms step_avg:46.68ms
+step:951/1585 train_time:44412ms step_avg:46.70ms
+step:952/1585 train_time:44471ms step_avg:46.71ms
+step:953/1585 train_time:44534ms step_avg:46.73ms
+step:954/1585 train_time:44593ms step_avg:46.74ms
+step:955/1585 train_time:44656ms step_avg:46.76ms
+step:956/1585 train_time:44715ms step_avg:46.77ms
+step:957/1585 train_time:44779ms step_avg:46.79ms
+step:958/1585 train_time:44839ms step_avg:46.80ms
+step:959/1585 train_time:44902ms step_avg:46.82ms
+step:960/1585 train_time:44961ms step_avg:46.83ms
+step:961/1585 train_time:45024ms step_avg:46.85ms
+step:962/1585 train_time:45083ms step_avg:46.86ms
+step:963/1585 train_time:45147ms step_avg:46.88ms
+step:964/1585 train_time:45206ms step_avg:46.89ms
+step:965/1585 train_time:45270ms step_avg:46.91ms
+step:966/1585 train_time:45329ms step_avg:46.92ms
+step:967/1585 train_time:45392ms step_avg:46.94ms
+step:968/1585 train_time:45451ms step_avg:46.95ms
+step:969/1585 train_time:45514ms step_avg:46.97ms
+step:970/1585 train_time:45573ms step_avg:46.98ms
+step:971/1585 train_time:45636ms step_avg:47.00ms
+step:972/1585 train_time:45695ms step_avg:47.01ms
+step:973/1585 train_time:45759ms step_avg:47.03ms
+step:974/1585 train_time:45819ms step_avg:47.04ms
+step:975/1585 train_time:45882ms step_avg:47.06ms
+step:976/1585 train_time:45941ms step_avg:47.07ms
+step:977/1585 train_time:46004ms step_avg:47.09ms
+step:978/1585 train_time:46063ms step_avg:47.10ms
+step:979/1585 train_time:46126ms step_avg:47.12ms
+step:980/1585 train_time:46185ms step_avg:47.13ms
+step:981/1585 train_time:46249ms step_avg:47.14ms
+step:982/1585 train_time:46307ms step_avg:47.16ms
+step:983/1585 train_time:46372ms step_avg:47.17ms
+step:984/1585 train_time:46431ms step_avg:47.19ms
+step:985/1585 train_time:46494ms step_avg:47.20ms
+step:986/1585 train_time:46554ms step_avg:47.21ms
+step:987/1585 train_time:46617ms step_avg:47.23ms
+step:988/1585 train_time:46676ms step_avg:47.24ms
+step:989/1585 train_time:46740ms step_avg:47.26ms
+step:990/1585 train_time:46800ms step_avg:47.27ms
+step:991/1585 train_time:46864ms step_avg:47.29ms
+step:992/1585 train_time:46923ms step_avg:47.30ms
+step:993/1585 train_time:46986ms step_avg:47.32ms
+step:994/1585 train_time:47045ms step_avg:47.33ms
+step:995/1585 train_time:47108ms step_avg:47.34ms
+step:996/1585 train_time:47168ms step_avg:47.36ms
+step:997/1585 train_time:47231ms step_avg:47.37ms
+step:998/1585 train_time:47290ms step_avg:47.38ms
+step:999/1585 train_time:47353ms step_avg:47.40ms
+step:1000/1585 train_time:47412ms step_avg:47.41ms
+step:1000/1585 val_loss:3.5880 train_time:47456ms step_avg:47.46ms
+step:1001/1585 train_time:47476ms step_avg:47.43ms
+step:1002/1585 train_time:47535ms step_avg:47.44ms
+step:1003/1585 train_time:47600ms step_avg:47.46ms
+step:1004/1585 train_time:47659ms step_avg:47.47ms
+step:1005/1585 train_time:47723ms step_avg:47.49ms
+step:1006/1585 train_time:47782ms step_avg:47.50ms
+step:1007/1585 train_time:47844ms step_avg:47.51ms
+step:1008/1585 train_time:47905ms step_avg:47.52ms
+step:1009/1585 train_time:47968ms step_avg:47.54ms
+step:1010/1585 train_time:48027ms step_avg:47.55ms
+step:1011/1585 train_time:48091ms step_avg:47.57ms
+step:1012/1585 train_time:48150ms step_avg:47.58ms
+step:1013/1585 train_time:48213ms step_avg:47.59ms
+step:1014/1585 train_time:48273ms step_avg:47.61ms
+step:1015/1585 train_time:48334ms step_avg:47.62ms
+step:1016/1585 train_time:48394ms step_avg:47.63ms
+step:1017/1585 train_time:48459ms step_avg:47.65ms
+step:1018/1585 train_time:48518ms step_avg:47.66ms
+step:1019/1585 train_time:48582ms step_avg:47.68ms
+step:1020/1585 train_time:48642ms step_avg:47.69ms
+step:1021/1585 train_time:48705ms step_avg:47.70ms
+step:1022/1585 train_time:48764ms step_avg:47.71ms
+step:1023/1585 train_time:48826ms step_avg:47.73ms
+step:1024/1585 train_time:48885ms step_avg:47.74ms
+step:1025/1585 train_time:48948ms step_avg:47.75ms
+step:1026/1585 train_time:49007ms step_avg:47.76ms
+step:1027/1585 train_time:49070ms step_avg:47.78ms
+step:1028/1585 train_time:49130ms step_avg:47.79ms
+step:1029/1585 train_time:49192ms step_avg:47.81ms
+step:1030/1585 train_time:49251ms step_avg:47.82ms
+step:1031/1585 train_time:49321ms step_avg:47.84ms
+step:1032/1585 train_time:49407ms step_avg:47.88ms
+step:1033/1585 train_time:49499ms step_avg:47.92ms
+step:1034/1585 train_time:49588ms step_avg:47.96ms
+step:1035/1585 train_time:49678ms step_avg:48.00ms
+step:1036/1585 train_time:49766ms step_avg:48.04ms
+step:1037/1585 train_time:49854ms step_avg:48.08ms
+step:1038/1585 train_time:49940ms step_avg:48.11ms
+step:1039/1585 train_time:50030ms step_avg:48.15ms
+step:1040/1585 train_time:50118ms step_avg:48.19ms
+step:1041/1585 train_time:50207ms step_avg:48.23ms
+step:1042/1585 train_time:50294ms step_avg:48.27ms
+step:1043/1585 train_time:50383ms step_avg:48.31ms
+step:1044/1585 train_time:50469ms step_avg:48.34ms
+step:1045/1585 train_time:50559ms step_avg:48.38ms
+step:1046/1585 train_time:50647ms step_avg:48.42ms
+step:1047/1585 train_time:50736ms step_avg:48.46ms
+step:1048/1585 train_time:50822ms step_avg:48.49ms
+step:1049/1585 train_time:50912ms step_avg:48.53ms
+step:1050/1585 train_time:50998ms step_avg:48.57ms
+step:1051/1585 train_time:51087ms step_avg:48.61ms
+step:1052/1585 train_time:51174ms step_avg:48.64ms
+step:1053/1585 train_time:51263ms step_avg:48.68ms
+step:1054/1585 train_time:51349ms step_avg:48.72ms
+step:1055/1585 train_time:51439ms step_avg:48.76ms
+step:1056/1585 train_time:51525ms step_avg:48.79ms
+step:1057/1585 train_time:51615ms step_avg:48.83ms
+step:1058/1585 train_time:51701ms step_avg:48.87ms
+step:1059/1585 train_time:51791ms step_avg:48.91ms
+step:1060/1585 train_time:51878ms step_avg:48.94ms
+step:1061/1585 train_time:51967ms step_avg:48.98ms
+step:1062/1585 train_time:52053ms step_avg:49.01ms
+step:1063/1585 train_time:52142ms step_avg:49.05ms
+step:1064/1585 train_time:52229ms step_avg:49.09ms
+step:1065/1585 train_time:52319ms step_avg:49.13ms
+step:1066/1585 train_time:52405ms step_avg:49.16ms
+step:1067/1585 train_time:52494ms step_avg:49.20ms
+step:1068/1585 train_time:52580ms step_avg:49.23ms
+step:1069/1585 train_time:52669ms step_avg:49.27ms
+step:1070/1585 train_time:52756ms step_avg:49.30ms
+step:1071/1585 train_time:52846ms step_avg:49.34ms
+step:1072/1585 train_time:52931ms step_avg:49.38ms
+step:1073/1585 train_time:53021ms step_avg:49.41ms
+step:1074/1585 train_time:53107ms step_avg:49.45ms
+step:1075/1585 train_time:53196ms step_avg:49.48ms
+step:1076/1585 train_time:53283ms step_avg:49.52ms
+step:1077/1585 train_time:53372ms step_avg:49.56ms
+step:1078/1585 train_time:53458ms step_avg:49.59ms
+step:1079/1585 train_time:53547ms step_avg:49.63ms
+step:1080/1585 train_time:53633ms step_avg:49.66ms
+step:1081/1585 train_time:53723ms step_avg:49.70ms
+step:1082/1585 train_time:53809ms step_avg:49.73ms
+step:1083/1585 train_time:53898ms step_avg:49.77ms
+step:1084/1585 train_time:53986ms step_avg:49.80ms
+step:1085/1585 train_time:54074ms step_avg:49.84ms
+step:1086/1585 train_time:54160ms step_avg:49.87ms
+step:1087/1585 train_time:54250ms step_avg:49.91ms
+step:1088/1585 train_time:54335ms step_avg:49.94ms
+step:1089/1585 train_time:54424ms step_avg:49.98ms
+step:1090/1585 train_time:54538ms step_avg:50.03ms
+step:1091/1585 train_time:54615ms step_avg:50.06ms
+step:1092/1585 train_time:54692ms step_avg:50.08ms
+step:1093/1585 train_time:54782ms step_avg:50.12ms
+step:1094/1585 train_time:54868ms step_avg:50.15ms
+step:1095/1585 train_time:54957ms step_avg:50.19ms
+step:1096/1585 train_time:55042ms step_avg:50.22ms
+step:1097/1585 train_time:55132ms step_avg:50.26ms
+step:1098/1585 train_time:55219ms step_avg:50.29ms
+step:1099/1585 train_time:55309ms step_avg:50.33ms
+step:1100/1585 train_time:55395ms step_avg:50.36ms
+step:1101/1585 train_time:55484ms step_avg:50.39ms
+step:1102/1585 train_time:55571ms step_avg:50.43ms
+step:1103/1585 train_time:55660ms step_avg:50.46ms
+step:1104/1585 train_time:55746ms step_avg:50.49ms
+step:1105/1585 train_time:55835ms step_avg:50.53ms
+step:1106/1585 train_time:55922ms step_avg:50.56ms
+step:1107/1585 train_time:56010ms step_avg:50.60ms
+step:1108/1585 train_time:56096ms step_avg:50.63ms
+step:1109/1585 train_time:56185ms step_avg:50.66ms
+step:1110/1585 train_time:56272ms step_avg:50.70ms
+step:1111/1585 train_time:56361ms step_avg:50.73ms
+step:1112/1585 train_time:56448ms step_avg:50.76ms
+step:1113/1585 train_time:56537ms step_avg:50.80ms
+step:1114/1585 train_time:56623ms step_avg:50.83ms
+step:1115/1585 train_time:56713ms step_avg:50.86ms
+step:1116/1585 train_time:56800ms step_avg:50.90ms
+step:1117/1585 train_time:56889ms step_avg:50.93ms
+step:1118/1585 train_time:56976ms step_avg:50.96ms
+step:1119/1585 train_time:57065ms step_avg:51.00ms
+step:1120/1585 train_time:57151ms step_avg:51.03ms
+step:1121/1585 train_time:57241ms step_avg:51.06ms
+step:1122/1585 train_time:57327ms step_avg:51.09ms
+step:1123/1585 train_time:57417ms step_avg:51.13ms
+step:1124/1585 train_time:57502ms step_avg:51.16ms
+step:1125/1585 train_time:57592ms step_avg:51.19ms
+step:1126/1585 train_time:57679ms step_avg:51.22ms
+step:1127/1585 train_time:57768ms step_avg:51.26ms
+step:1128/1585 train_time:57854ms step_avg:51.29ms
+step:1129/1585 train_time:57943ms step_avg:51.32ms
+step:1130/1585 train_time:58030ms step_avg:51.35ms
+step:1131/1585 train_time:58119ms step_avg:51.39ms
+step:1132/1585 train_time:58206ms step_avg:51.42ms
+step:1133/1585 train_time:58295ms step_avg:51.45ms
+step:1134/1585 train_time:58381ms step_avg:51.48ms
+step:1135/1585 train_time:58470ms step_avg:51.52ms
+step:1136/1585 train_time:58556ms step_avg:51.55ms
+step:1137/1585 train_time:58645ms step_avg:51.58ms
+step:1138/1585 train_time:58731ms step_avg:51.61ms
+step:1139/1585 train_time:58821ms step_avg:51.64ms
+step:1140/1585 train_time:58907ms step_avg:51.67ms
+step:1141/1585 train_time:58997ms step_avg:51.71ms
+step:1142/1585 train_time:59083ms step_avg:51.74ms
+step:1143/1585 train_time:59172ms step_avg:51.77ms
+step:1144/1585 train_time:59258ms step_avg:51.80ms
+step:1145/1585 train_time:59347ms step_avg:51.83ms
+step:1146/1585 train_time:59434ms step_avg:51.86ms
+step:1147/1585 train_time:59523ms step_avg:51.89ms
+step:1148/1585 train_time:59611ms step_avg:51.93ms
+step:1149/1585 train_time:59699ms step_avg:51.96ms
+step:1150/1585 train_time:59785ms step_avg:51.99ms
+step:1151/1585 train_time:59874ms step_avg:52.02ms
+step:1152/1585 train_time:59960ms step_avg:52.05ms
+step:1153/1585 train_time:60050ms step_avg:52.08ms
+step:1154/1585 train_time:60137ms step_avg:52.11ms
+step:1155/1585 train_time:60226ms step_avg:52.14ms
+step:1156/1585 train_time:60313ms step_avg:52.17ms
+step:1157/1585 train_time:60403ms step_avg:52.21ms
+step:1158/1585 train_time:60490ms step_avg:52.24ms
+step:1159/1585 train_time:60579ms step_avg:52.27ms
+step:1160/1585 train_time:60665ms step_avg:52.30ms
+step:1161/1585 train_time:60754ms step_avg:52.33ms
+step:1162/1585 train_time:60840ms step_avg:52.36ms
+step:1163/1585 train_time:60930ms step_avg:52.39ms
+step:1164/1585 train_time:61016ms step_avg:52.42ms
+step:1165/1585 train_time:61105ms step_avg:52.45ms
+step:1166/1585 train_time:61191ms step_avg:52.48ms
+step:1167/1585 train_time:61280ms step_avg:52.51ms
+step:1168/1585 train_time:61366ms step_avg:52.54ms
+step:1169/1585 train_time:61455ms step_avg:52.57ms
+step:1170/1585 train_time:61541ms step_avg:52.60ms
+step:1171/1585 train_time:61631ms step_avg:52.63ms
+step:1172/1585 train_time:61717ms step_avg:52.66ms
+step:1173/1585 train_time:61807ms step_avg:52.69ms
+step:1174/1585 train_time:61893ms step_avg:52.72ms
+step:1175/1585 train_time:61983ms step_avg:52.75ms
+step:1176/1585 train_time:62069ms step_avg:52.78ms
+step:1177/1585 train_time:62158ms step_avg:52.81ms
+step:1178/1585 train_time:62244ms step_avg:52.84ms
+step:1179/1585 train_time:62334ms step_avg:52.87ms
+step:1180/1585 train_time:62421ms step_avg:52.90ms
+step:1181/1585 train_time:62510ms step_avg:52.93ms
+step:1182/1585 train_time:62596ms step_avg:52.96ms
+step:1183/1585 train_time:62685ms step_avg:52.99ms
+step:1184/1585 train_time:62773ms step_avg:53.02ms
+step:1185/1585 train_time:62862ms step_avg:53.05ms
+step:1186/1585 train_time:62948ms step_avg:53.08ms
+step:1187/1585 train_time:63038ms step_avg:53.11ms
+step:1188/1585 train_time:63123ms step_avg:53.13ms
+step:1189/1585 train_time:63212ms step_avg:53.16ms
+step:1190/1585 train_time:63299ms step_avg:53.19ms
+step:1191/1585 train_time:63387ms step_avg:53.22ms
+step:1192/1585 train_time:63474ms step_avg:53.25ms
+step:1193/1585 train_time:63563ms step_avg:53.28ms
+step:1194/1585 train_time:63649ms step_avg:53.31ms
+step:1195/1585 train_time:63739ms step_avg:53.34ms
+step:1196/1585 train_time:63825ms step_avg:53.37ms
+step:1197/1585 train_time:63915ms step_avg:53.40ms
+step:1198/1585 train_time:64001ms step_avg:53.42ms
+step:1199/1585 train_time:64090ms step_avg:53.45ms
+step:1200/1585 train_time:64178ms step_avg:53.48ms
+step:1201/1585 train_time:64267ms step_avg:53.51ms
+step:1202/1585 train_time:64353ms step_avg:53.54ms
+step:1203/1585 train_time:64443ms step_avg:53.57ms
+step:1204/1585 train_time:64530ms step_avg:53.60ms
+step:1205/1585 train_time:64619ms step_avg:53.63ms
+step:1206/1585 train_time:64705ms step_avg:53.65ms
+step:1207/1585 train_time:64794ms step_avg:53.68ms
+step:1208/1585 train_time:64881ms step_avg:53.71ms
+step:1209/1585 train_time:64971ms step_avg:53.74ms
+step:1210/1585 train_time:65056ms step_avg:53.77ms
+step:1211/1585 train_time:65145ms step_avg:53.79ms
+step:1212/1585 train_time:65231ms step_avg:53.82ms
+step:1213/1585 train_time:65321ms step_avg:53.85ms
+step:1214/1585 train_time:65407ms step_avg:53.88ms
+step:1215/1585 train_time:65496ms step_avg:53.91ms
+step:1216/1585 train_time:65582ms step_avg:53.93ms
+step:1217/1585 train_time:65671ms step_avg:53.96ms
+step:1218/1585 train_time:65758ms step_avg:53.99ms
+step:1219/1585 train_time:65848ms step_avg:54.02ms
+step:1220/1585 train_time:65935ms step_avg:54.04ms
+step:1221/1585 train_time:66024ms step_avg:54.07ms
+step:1222/1585 train_time:66111ms step_avg:54.10ms
+step:1223/1585 train_time:66200ms step_avg:54.13ms
+step:1224/1585 train_time:66286ms step_avg:54.16ms
+step:1225/1585 train_time:66375ms step_avg:54.18ms
+step:1226/1585 train_time:66461ms step_avg:54.21ms
+step:1227/1585 train_time:66550ms step_avg:54.24ms
+step:1228/1585 train_time:66636ms step_avg:54.26ms
+step:1229/1585 train_time:66726ms step_avg:54.29ms
+step:1230/1585 train_time:66812ms step_avg:54.32ms
+step:1231/1585 train_time:66903ms step_avg:54.35ms
+step:1232/1585 train_time:66990ms step_avg:54.38ms
+step:1233/1585 train_time:67079ms step_avg:54.40ms
+step:1234/1585 train_time:67166ms step_avg:54.43ms
+step:1235/1585 train_time:67255ms step_avg:54.46ms
+step:1236/1585 train_time:67341ms step_avg:54.48ms
+step:1237/1585 train_time:67431ms step_avg:54.51ms
+step:1238/1585 train_time:67517ms step_avg:54.54ms
+step:1239/1585 train_time:67606ms step_avg:54.56ms
+step:1240/1585 train_time:67692ms step_avg:54.59ms
+step:1241/1585 train_time:67782ms step_avg:54.62ms
+step:1242/1585 train_time:67868ms step_avg:54.64ms
+step:1243/1585 train_time:67957ms step_avg:54.67ms
+step:1244/1585 train_time:68044ms step_avg:54.70ms
+step:1245/1585 train_time:68134ms step_avg:54.73ms
+step:1246/1585 train_time:68219ms step_avg:54.75ms
+step:1247/1585 train_time:68308ms step_avg:54.78ms
+step:1248/1585 train_time:68395ms step_avg:54.80ms
+step:1249/1585 train_time:68484ms step_avg:54.83ms
+step:1250/1585 train_time:68570ms step_avg:54.86ms
+step:1250/1585 val_loss:3.4107 train_time:68640ms step_avg:54.91ms
+step:1251/1585 train_time:68660ms step_avg:54.88ms
+step:1252/1585 train_time:68754ms step_avg:54.92ms
+step:1253/1585 train_time:68847ms step_avg:54.95ms
+step:1254/1585 train_time:68933ms step_avg:54.97ms
+step:1255/1585 train_time:69021ms step_avg:55.00ms
+step:1256/1585 train_time:69106ms step_avg:55.02ms
+step:1257/1585 train_time:69194ms step_avg:55.05ms
+step:1258/1585 train_time:69280ms step_avg:55.07ms
+step:1259/1585 train_time:69370ms step_avg:55.10ms
+step:1260/1585 train_time:69456ms step_avg:55.12ms
+step:1261/1585 train_time:69545ms step_avg:55.15ms
+step:1262/1585 train_time:69632ms step_avg:55.18ms
+step:1263/1585 train_time:69724ms step_avg:55.21ms
+step:1264/1585 train_time:69812ms step_avg:55.23ms
+step:1265/1585 train_time:69902ms step_avg:55.26ms
+step:1266/1585 train_time:69988ms step_avg:55.28ms
+step:1267/1585 train_time:70076ms step_avg:55.31ms
+step:1268/1585 train_time:70162ms step_avg:55.33ms
+step:1269/1585 train_time:70250ms step_avg:55.36ms
+step:1270/1585 train_time:70336ms step_avg:55.38ms
+step:1271/1585 train_time:70424ms step_avg:55.41ms
+step:1272/1585 train_time:70509ms step_avg:55.43ms
+step:1273/1585 train_time:70600ms step_avg:55.46ms
+step:1274/1585 train_time:70688ms step_avg:55.48ms
+step:1275/1585 train_time:70779ms step_avg:55.51ms
+step:1276/1585 train_time:70865ms step_avg:55.54ms
+step:1277/1585 train_time:70954ms step_avg:55.56ms
+step:1278/1585 train_time:71040ms step_avg:55.59ms
+step:1279/1585 train_time:71128ms step_avg:55.61ms
+step:1280/1585 train_time:71215ms step_avg:55.64ms
+step:1281/1585 train_time:71303ms step_avg:55.66ms
+step:1282/1585 train_time:71389ms step_avg:55.69ms
+step:1283/1585 train_time:71477ms step_avg:55.71ms
+step:1284/1585 train_time:71563ms step_avg:55.73ms
+step:1285/1585 train_time:71654ms step_avg:55.76ms
+step:1286/1585 train_time:71741ms step_avg:55.79ms
+step:1287/1585 train_time:71832ms step_avg:55.81ms
+step:1288/1585 train_time:71919ms step_avg:55.84ms
+step:1289/1585 train_time:72007ms step_avg:55.86ms
+step:1290/1585 train_time:72094ms step_avg:55.89ms
+step:1291/1585 train_time:72183ms step_avg:55.91ms
+step:1292/1585 train_time:72268ms step_avg:55.94ms
+step:1293/1585 train_time:72357ms step_avg:55.96ms
+step:1294/1585 train_time:72444ms step_avg:55.98ms
+step:1295/1585 train_time:72534ms step_avg:56.01ms
+step:1296/1585 train_time:72620ms step_avg:56.03ms
+step:1297/1585 train_time:72711ms step_avg:56.06ms
+step:1298/1585 train_time:72798ms step_avg:56.08ms
+step:1299/1585 train_time:72888ms step_avg:56.11ms
+step:1300/1585 train_time:72974ms step_avg:56.13ms
+step:1301/1585 train_time:73063ms step_avg:56.16ms
+step:1302/1585 train_time:73150ms step_avg:56.18ms
+step:1303/1585 train_time:73238ms step_avg:56.21ms
+step:1304/1585 train_time:73324ms step_avg:56.23ms
+step:1305/1585 train_time:73413ms step_avg:56.25ms
+step:1306/1585 train_time:73499ms step_avg:56.28ms
+step:1307/1585 train_time:73588ms step_avg:56.30ms
+step:1308/1585 train_time:73674ms step_avg:56.33ms
+step:1309/1585 train_time:73764ms step_avg:56.35ms
+step:1310/1585 train_time:73851ms step_avg:56.37ms
+step:1311/1585 train_time:73940ms step_avg:56.40ms
+step:1312/1585 train_time:74026ms step_avg:56.42ms
+step:1313/1585 train_time:74115ms step_avg:56.45ms
+step:1314/1585 train_time:74201ms step_avg:56.47ms
+step:1315/1585 train_time:74290ms step_avg:56.49ms
+step:1316/1585 train_time:74375ms step_avg:56.52ms
+step:1317/1585 train_time:74465ms step_avg:56.54ms
+step:1318/1585 train_time:74551ms step_avg:56.56ms
+step:1319/1585 train_time:74641ms step_avg:56.59ms
+step:1320/1585 train_time:74728ms step_avg:56.61ms
+step:1321/1585 train_time:74818ms step_avg:56.64ms
+step:1322/1585 train_time:74905ms step_avg:56.66ms
+step:1323/1585 train_time:74993ms step_avg:56.68ms
+step:1324/1585 train_time:75079ms step_avg:56.71ms
+step:1325/1585 train_time:75169ms step_avg:56.73ms
+step:1326/1585 train_time:75255ms step_avg:56.75ms
+step:1327/1585 train_time:75345ms step_avg:56.78ms
+step:1328/1585 train_time:75430ms step_avg:56.80ms
+step:1329/1585 train_time:75520ms step_avg:56.82ms
+step:1330/1585 train_time:75606ms step_avg:56.85ms
+step:1331/1585 train_time:75696ms step_avg:56.87ms
+step:1332/1585 train_time:75781ms step_avg:56.89ms
+step:1333/1585 train_time:75872ms step_avg:56.92ms
+step:1334/1585 train_time:75958ms step_avg:56.94ms
+step:1335/1585 train_time:76047ms step_avg:56.96ms
+step:1336/1585 train_time:76133ms step_avg:56.99ms
+step:1337/1585 train_time:76222ms step_avg:57.01ms
+step:1338/1585 train_time:76309ms step_avg:57.03ms
+step:1339/1585 train_time:76397ms step_avg:57.06ms
+step:1340/1585 train_time:76483ms step_avg:57.08ms
+step:1341/1585 train_time:76572ms step_avg:57.10ms
+step:1342/1585 train_time:76659ms step_avg:57.12ms
+step:1343/1585 train_time:76749ms step_avg:57.15ms
+step:1344/1585 train_time:76835ms step_avg:57.17ms
+step:1345/1585 train_time:76925ms step_avg:57.19ms
+step:1346/1585 train_time:77011ms step_avg:57.21ms
+step:1347/1585 train_time:77101ms step_avg:57.24ms
+step:1348/1585 train_time:77187ms step_avg:57.26ms
+step:1349/1585 train_time:77276ms step_avg:57.28ms
+step:1350/1585 train_time:77361ms step_avg:57.30ms
+step:1351/1585 train_time:77451ms step_avg:57.33ms
+step:1352/1585 train_time:77537ms step_avg:57.35ms
+step:1353/1585 train_time:77627ms step_avg:57.37ms
+step:1354/1585 train_time:77714ms step_avg:57.40ms
+step:1355/1585 train_time:77804ms step_avg:57.42ms
+step:1356/1585 train_time:77890ms step_avg:57.44ms
+step:1357/1585 train_time:77980ms step_avg:57.47ms
+step:1358/1585 train_time:78067ms step_avg:57.49ms
+step:1359/1585 train_time:78155ms step_avg:57.51ms
+step:1360/1585 train_time:78243ms step_avg:57.53ms
+step:1361/1585 train_time:78331ms step_avg:57.55ms
+step:1362/1585 train_time:78417ms step_avg:57.57ms
+step:1363/1585 train_time:78506ms step_avg:57.60ms
+step:1364/1585 train_time:78592ms step_avg:57.62ms
+step:1365/1585 train_time:78681ms step_avg:57.64ms
+step:1366/1585 train_time:78768ms step_avg:57.66ms
+step:1367/1585 train_time:78857ms step_avg:57.69ms
+step:1368/1585 train_time:78944ms step_avg:57.71ms
+step:1369/1585 train_time:79033ms step_avg:57.73ms
+step:1370/1585 train_time:79120ms step_avg:57.75ms
+step:1371/1585 train_time:79210ms step_avg:57.78ms
+step:1372/1585 train_time:79296ms step_avg:57.80ms
+step:1373/1585 train_time:79385ms step_avg:57.82ms
+step:1374/1585 train_time:79471ms step_avg:57.84ms
+step:1375/1585 train_time:79561ms step_avg:57.86ms
+step:1376/1585 train_time:79647ms step_avg:57.88ms
+step:1377/1585 train_time:79736ms step_avg:57.91ms
+step:1378/1585 train_time:79822ms step_avg:57.93ms
+step:1379/1585 train_time:79912ms step_avg:57.95ms
+step:1380/1585 train_time:79998ms step_avg:57.97ms
+step:1381/1585 train_time:80088ms step_avg:57.99ms
+step:1382/1585 train_time:80175ms step_avg:58.01ms
+step:1383/1585 train_time:80264ms step_avg:58.04ms
+step:1384/1585 train_time:80350ms step_avg:58.06ms
+step:1385/1585 train_time:80439ms step_avg:58.08ms
+step:1386/1585 train_time:80526ms step_avg:58.10ms
+step:1387/1585 train_time:80616ms step_avg:58.12ms
+step:1388/1585 train_time:80702ms step_avg:58.14ms
+step:1389/1585 train_time:80791ms step_avg:58.17ms
+step:1390/1585 train_time:80877ms step_avg:58.19ms
+step:1391/1585 train_time:80966ms step_avg:58.21ms
+step:1392/1585 train_time:81054ms step_avg:58.23ms
+step:1393/1585 train_time:81143ms step_avg:58.25ms
+step:1394/1585 train_time:81229ms step_avg:58.27ms
+step:1395/1585 train_time:81319ms step_avg:58.29ms
+step:1396/1585 train_time:81406ms step_avg:58.31ms
+step:1397/1585 train_time:81496ms step_avg:58.34ms
+step:1398/1585 train_time:81582ms step_avg:58.36ms
+step:1399/1585 train_time:81671ms step_avg:58.38ms
+step:1400/1585 train_time:81758ms step_avg:58.40ms
+step:1401/1585 train_time:81847ms step_avg:58.42ms
+step:1402/1585 train_time:81933ms step_avg:58.44ms
+step:1403/1585 train_time:82023ms step_avg:58.46ms
+step:1404/1585 train_time:82110ms step_avg:58.48ms
+step:1405/1585 train_time:82199ms step_avg:58.50ms
+step:1406/1585 train_time:82286ms step_avg:58.52ms
+step:1407/1585 train_time:82375ms step_avg:58.55ms
+step:1408/1585 train_time:82461ms step_avg:58.57ms
+step:1409/1585 train_time:82551ms step_avg:58.59ms
+step:1410/1585 train_time:82637ms step_avg:58.61ms
+step:1411/1585 train_time:82727ms step_avg:58.63ms
+step:1412/1585 train_time:82814ms step_avg:58.65ms
+step:1413/1585 train_time:82903ms step_avg:58.67ms
+step:1414/1585 train_time:82990ms step_avg:58.69ms
+step:1415/1585 train_time:83079ms step_avg:58.71ms
+step:1416/1585 train_time:83166ms step_avg:58.73ms
+step:1417/1585 train_time:83254ms step_avg:58.75ms
+step:1418/1585 train_time:83340ms step_avg:58.77ms
+step:1419/1585 train_time:83429ms step_avg:58.79ms
+step:1420/1585 train_time:83516ms step_avg:58.81ms
+step:1421/1585 train_time:83605ms step_avg:58.84ms
+step:1422/1585 train_time:83691ms step_avg:58.85ms
+step:1423/1585 train_time:83781ms step_avg:58.88ms
+step:1424/1585 train_time:83867ms step_avg:58.90ms
+step:1425/1585 train_time:83956ms step_avg:58.92ms
+step:1426/1585 train_time:84043ms step_avg:58.94ms
+step:1427/1585 train_time:84133ms step_avg:58.96ms
+step:1428/1585 train_time:84219ms step_avg:58.98ms
+step:1429/1585 train_time:84308ms step_avg:59.00ms
+step:1430/1585 train_time:84394ms step_avg:59.02ms
+step:1431/1585 train_time:84483ms step_avg:59.04ms
+step:1432/1585 train_time:84569ms step_avg:59.06ms
+step:1433/1585 train_time:84659ms step_avg:59.08ms
+step:1434/1585 train_time:84745ms step_avg:59.10ms
+step:1435/1585 train_time:84835ms step_avg:59.12ms
+step:1436/1585 train_time:84920ms step_avg:59.14ms
+step:1437/1585 train_time:85011ms step_avg:59.16ms
+step:1438/1585 train_time:85097ms step_avg:59.18ms
+step:1439/1585 train_time:85186ms step_avg:59.20ms
+step:1440/1585 train_time:85272ms step_avg:59.22ms
+step:1441/1585 train_time:85362ms step_avg:59.24ms
+step:1442/1585 train_time:85448ms step_avg:59.26ms
+step:1443/1585 train_time:85537ms step_avg:59.28ms
+step:1444/1585 train_time:85623ms step_avg:59.30ms
+step:1445/1585 train_time:85714ms step_avg:59.32ms
+step:1446/1585 train_time:85800ms step_avg:59.34ms
+step:1447/1585 train_time:85890ms step_avg:59.36ms
+step:1448/1585 train_time:85976ms step_avg:59.38ms
+step:1449/1585 train_time:86065ms step_avg:59.40ms
+step:1450/1585 train_time:86151ms step_avg:59.41ms
+step:1451/1585 train_time:86241ms step_avg:59.44ms
+step:1452/1585 train_time:86327ms step_avg:59.45ms
+step:1453/1585 train_time:86416ms step_avg:59.47ms
+step:1454/1585 train_time:86504ms step_avg:59.49ms
+step:1455/1585 train_time:86594ms step_avg:59.51ms
+step:1456/1585 train_time:86680ms step_avg:59.53ms
+step:1457/1585 train_time:86769ms step_avg:59.55ms
+step:1458/1585 train_time:86856ms step_avg:59.57ms
+step:1459/1585 train_time:86946ms step_avg:59.59ms
+step:1460/1585 train_time:87032ms step_avg:59.61ms
+step:1461/1585 train_time:87121ms step_avg:59.63ms
+step:1462/1585 train_time:87208ms step_avg:59.65ms
+step:1463/1585 train_time:87297ms step_avg:59.67ms
+step:1464/1585 train_time:87383ms step_avg:59.69ms
+step:1465/1585 train_time:87473ms step_avg:59.71ms
+step:1466/1585 train_time:87559ms step_avg:59.73ms
+step:1467/1585 train_time:87649ms step_avg:59.75ms
+step:1468/1585 train_time:87736ms step_avg:59.77ms
+step:1469/1585 train_time:87825ms step_avg:59.79ms
+step:1470/1585 train_time:87911ms step_avg:59.80ms
+step:1471/1585 train_time:88001ms step_avg:59.82ms
+step:1472/1585 train_time:88087ms step_avg:59.84ms
+step:1473/1585 train_time:88176ms step_avg:59.86ms
+step:1474/1585 train_time:88263ms step_avg:59.88ms
+step:1475/1585 train_time:88352ms step_avg:59.90ms
+step:1476/1585 train_time:88439ms step_avg:59.92ms
+step:1477/1585 train_time:88527ms step_avg:59.94ms
+step:1478/1585 train_time:88615ms step_avg:59.96ms
+step:1479/1585 train_time:88704ms step_avg:59.98ms
+step:1480/1585 train_time:88790ms step_avg:59.99ms
+step:1481/1585 train_time:88879ms step_avg:60.01ms
+step:1482/1585 train_time:88965ms step_avg:60.03ms
+step:1483/1585 train_time:89055ms step_avg:60.05ms
+step:1484/1585 train_time:89140ms step_avg:60.07ms
+step:1485/1585 train_time:89231ms step_avg:60.09ms
+step:1486/1585 train_time:89317ms step_avg:60.11ms
+step:1487/1585 train_time:89407ms step_avg:60.13ms
+step:1488/1585 train_time:89493ms step_avg:60.14ms
+step:1489/1585 train_time:89582ms step_avg:60.16ms
+step:1490/1585 train_time:89668ms step_avg:60.18ms
+step:1491/1585 train_time:89758ms step_avg:60.20ms
+step:1492/1585 train_time:89844ms step_avg:60.22ms
+step:1493/1585 train_time:89934ms step_avg:60.24ms
+step:1494/1585 train_time:90021ms step_avg:60.26ms
+step:1495/1585 train_time:90111ms step_avg:60.27ms
+step:1496/1585 train_time:90198ms step_avg:60.29ms
+step:1497/1585 train_time:90287ms step_avg:60.31ms
+step:1498/1585 train_time:90374ms step_avg:60.33ms
+step:1499/1585 train_time:90462ms step_avg:60.35ms
+step:1500/1585 train_time:90548ms step_avg:60.37ms
+step:1500/1585 val_loss:3.3032 train_time:90618ms step_avg:60.41ms
+step:1501/1585 train_time:90639ms step_avg:60.39ms
+step:1502/1585 train_time:90728ms step_avg:60.40ms
+step:1503/1585 train_time:90818ms step_avg:60.42ms
+step:1504/1585 train_time:90904ms step_avg:60.44ms
+step:1505/1585 train_time:90992ms step_avg:60.46ms
+step:1506/1585 train_time:91078ms step_avg:60.48ms
+step:1507/1585 train_time:91166ms step_avg:60.50ms
+step:1508/1585 train_time:91252ms step_avg:60.51ms
+step:1509/1585 train_time:91341ms step_avg:60.53ms
+step:1510/1585 train_time:91428ms step_avg:60.55ms
+step:1511/1585 train_time:91518ms step_avg:60.57ms
+step:1512/1585 train_time:91605ms step_avg:60.59ms
+step:1513/1585 train_time:91697ms step_avg:60.61ms
+step:1514/1585 train_time:91783ms step_avg:60.62ms
+step:1515/1585 train_time:91873ms step_avg:60.64ms
+step:1516/1585 train_time:91959ms step_avg:60.66ms
+step:1517/1585 train_time:92047ms step_avg:60.68ms
+step:1518/1585 train_time:92132ms step_avg:60.69ms
+step:1519/1585 train_time:92221ms step_avg:60.71ms
+step:1520/1585 train_time:92307ms step_avg:60.73ms
+step:1521/1585 train_time:92396ms step_avg:60.75ms
+step:1522/1585 train_time:92483ms step_avg:60.76ms
+step:1523/1585 train_time:92573ms step_avg:60.78ms
+step:1524/1585 train_time:92661ms step_avg:60.80ms
+step:1525/1585 train_time:92751ms step_avg:60.82ms
+step:1526/1585 train_time:92837ms step_avg:60.84ms
+step:1527/1585 train_time:92926ms step_avg:60.86ms
+step:1528/1585 train_time:93013ms step_avg:60.87ms
+step:1529/1585 train_time:93102ms step_avg:60.89ms
+step:1530/1585 train_time:93188ms step_avg:60.91ms
+step:1531/1585 train_time:93277ms step_avg:60.93ms
+step:1532/1585 train_time:93362ms step_avg:60.94ms
+step:1533/1585 train_time:93452ms step_avg:60.96ms
+step:1534/1585 train_time:93539ms step_avg:60.98ms
+step:1535/1585 train_time:93629ms step_avg:61.00ms
+step:1536/1585 train_time:93716ms step_avg:61.01ms
+step:1537/1585 train_time:93806ms step_avg:61.03ms
+step:1538/1585 train_time:93892ms step_avg:61.05ms
+step:1539/1585 train_time:93980ms step_avg:61.07ms
+step:1540/1585 train_time:94066ms step_avg:61.08ms
+step:1541/1585 train_time:94156ms step_avg:61.10ms
+step:1542/1585 train_time:94242ms step_avg:61.12ms
+step:1543/1585 train_time:94331ms step_avg:61.13ms
+step:1544/1585 train_time:94417ms step_avg:61.15ms
+step:1545/1585 train_time:94506ms step_avg:61.17ms
+step:1546/1585 train_time:94599ms step_avg:61.19ms
+step:1547/1585 train_time:94688ms step_avg:61.21ms
+step:1548/1585 train_time:94775ms step_avg:61.22ms
+step:1549/1585 train_time:94864ms step_avg:61.24ms
+step:1550/1585 train_time:94951ms step_avg:61.26ms
+step:1551/1585 train_time:95040ms step_avg:61.28ms
+step:1552/1585 train_time:95127ms step_avg:61.29ms
+step:1553/1585 train_time:95216ms step_avg:61.31ms
+step:1554/1585 train_time:95303ms step_avg:61.33ms
+step:1555/1585 train_time:95392ms step_avg:61.35ms
+step:1556/1585 train_time:95479ms step_avg:61.36ms
+step:1557/1585 train_time:95569ms step_avg:61.38ms
+step:1558/1585 train_time:95656ms step_avg:61.40ms
+step:1559/1585 train_time:95746ms step_avg:61.42ms
+step:1560/1585 train_time:95833ms step_avg:61.43ms
+step:1561/1585 train_time:95923ms step_avg:61.45ms
+step:1562/1585 train_time:96010ms step_avg:61.47ms
+step:1563/1585 train_time:96100ms step_avg:61.48ms
+step:1564/1585 train_time:96186ms step_avg:61.50ms
+step:1565/1585 train_time:96275ms step_avg:61.52ms
+step:1566/1585 train_time:96362ms step_avg:61.53ms
+step:1567/1585 train_time:96453ms step_avg:61.55ms
+step:1568/1585 train_time:96539ms step_avg:61.57ms
+step:1569/1585 train_time:96630ms step_avg:61.59ms
+step:1570/1585 train_time:96717ms step_avg:61.60ms
+step:1571/1585 train_time:96807ms step_avg:61.62ms
+step:1572/1585 train_time:96893ms step_avg:61.64ms
+step:1573/1585 train_time:96983ms step_avg:61.65ms
+step:1574/1585 train_time:97069ms step_avg:61.67ms
+step:1575/1585 train_time:97158ms step_avg:61.69ms
+step:1576/1585 train_time:97245ms step_avg:61.70ms
+step:1577/1585 train_time:97334ms step_avg:61.72ms
+step:1578/1585 train_time:97421ms step_avg:61.74ms
+step:1579/1585 train_time:97511ms step_avg:61.75ms
+step:1580/1585 train_time:97598ms step_avg:61.77ms
+step:1581/1585 train_time:97688ms step_avg:61.79ms
+step:1582/1585 train_time:97774ms step_avg:61.80ms
+step:1583/1585 train_time:97864ms step_avg:61.82ms
+step:1584/1585 train_time:97951ms step_avg:61.84ms
+step:1585/1585 train_time:98041ms step_avg:61.86ms
+step:1585/1585 val_loss:3.2783 train_time:98106ms step_avg:61.90ms
+peak memory allocated: 30557 MiB reserved: 46658 MiB


### PR DESCRIPTION
# Tie First and Last VEs

Swapping the first two VEs reduces validation loss.

Our long-standing pattern of value embeddings has been:

`12------012`

Switching this to:

`21------012`

reduced loss by -0.0012

Consistent with the previous PR, I found that untying VE1 reduces it further as well.

If we rename VE2 to VE0, it becomes:

`01------230`

I haven't confirmed yet that any of the below outperform the recent PR, so I'll need to do some re-timing.

```
                             Runs  Time μ  Time σ  Time +/-  Time p  Loss μ  Loss σ  Loss +/-      p
baseline                        6 98.3442  0.0686    0.0000     NaN  3.2785  0.0013    0.0000 0.0184

ve_21------012 w/o PolarT       4 98.3590  0.0868    0.0148  0.6077  3.2774  0.0010   -0.0011 0.0077
ve_21------012                  4 98.3490  0.0336    0.0048  0.5569  3.2772  0.0011   -0.0012 0.0079
ve_21------012 -5stps           6 98.1192  0.0400   -0.2250  0.0001  3.2786  0.0004    0.0001 0.0002 - Remove more steps?

ve_01------230 -15stps          4 98.0825  0.0896   -0.2617  0.0018  3.2769  0.0010   -0.0016 0.0040 - Best so far

ve_210-----012                  4 98.5325  0.0455    0.1883  0.9996  3.2764  0.0010   -0.0021 0.0024
ve_210-----012 -10stps          6 97.8797  0.0898   -0.4645  0.0000  3.2791  0.0014    0.0006 0.0899 (Fail)
ve_210-----012 untie, -5stps    4 98.4843  0.1030    0.1401  0.9677  3.2792  0.0016    0.0007 0.1820 (Fail)
```


**Rationale**

Trying to make sense of why this unique VE pattern works well lead me to speculate that VE2 (which we've had on our second and last layer, tied) might be more semantic, and therefore relate well to both the first and last layers.

This also might offer some explanation for why shifting VE2 deeper into the model (e.g., via `012-----012`) hasn't worked.

## Polar Express Transpose

I've also included an improvement to the Polar Express kernel. It was written to work on "wide" matrices, but we've had our MLP weights stored vertically. The current Polar Express code handles this by transposing the matrix, resulting in a slow element-wise kernel for the Nesterov momentum step. 

The algebra can be re-ordered instead to allow for working directly on "tall" matrices:

```
# Polar express
X = g.bfloat16()

X = X / (X.norm(dim=(-2, -1), keepdim=True) * 1.02 + 1e-6)

if g.size(-2) > g.size(-1): # Tall matrix
    for a, b, c in polar_express_coeffs[:ns_steps]:
        A = X.mT @ X
        B = b * A + c * (A @ A)
        X = a * X + X @ B

else: # Wide matrix (original math)
    for a, b, c in polar_express_coeffs[:ns_steps]:
        A = X @ X.mT
        B = b * A + c * (A @ A)
        X = a * X + B @ X

return X
```

I had Claude write an XTX variant and verified that it was numerically equivalent.

The speed improvement is likely too small to be measurable, but it's clear in the trace files.

I came across it while exploring nanochat--here's the impact this fix has on a much larger (25-layer) model:

<img width="3968" height="998" alt="image" src="https://github.com/user-attachments/assets/8edd3eba-5ebb-4d27-a34e-b49f2f199d29" />


## A100 Support

I added a few things to make our code easier for anyone on a < H100 GPU.

It checks the compute capability to automate the decision on FP8, and also falls back to an FA2 implementation using the same interface we have for FA3 (there's a repo similar to Varun's for retrieving pre-built FA2).

I also added a fallback for the fused ReLU kernel, but need to review that change further.
