### PR TITLE
New Record: Mimetic V-O Initialization (-20 steps, -1.16s)

### DIFF
--- a/records/track_1_short/2026-01-30_MimeticValueOutput/runs/0f262f64-20c4-4268-9ae7-d7440c810abd.txt
+++ b/records/track_1_short/2026-01-30_MimeticValueOutput/runs/0f262f64-20c4-4268-9ae7-d7440c810abd.txt
@@ -1,0 +1,4131 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# Mimetic V-O Initialization (Trockman & Kolter, ICML 2023)
+# Initialize V and O such that V @ O^T ≈ -βI (negative identity-like)
+# This enables attention to make meaningful contributions from step 1
+
+def mimetic_vo_init(attn_bank, model_dim=768, num_heads=6, head_dim=128, beta=0.1, noise_std=0.01):
+    """
+    Initialize attention bank with mimetic structure for V and O.
+    Q and K use standard uniform init, V and O use identity-like structure.
+
+    Args:
+        attn_bank: Tensor of shape (num_layers, 4*model_dim, hdim)
+        model_dim: Model dimension (768)
+        num_heads: Number of attention heads (6)
+        head_dim: Dimension per head (128)
+        beta: Scale for identity structure (0.1 recommended with attn_scale=0.1)
+        noise_std: Standard deviation of noise for symmetry breaking
+    """
+    num_layers = attn_bank.shape[0]
+    dim = model_dim
+    sqrt_beta = beta ** 0.5
+
+    # Standard init for Q and K (existing behavior)
+    attn_std = model_dim ** -0.5
+    attn_bound = (3 ** 0.5) * attn_std
+
+    with torch.no_grad():
+        # Q and K: uniform init (first 2*dim rows)
+        attn_bank[:, :2*dim, :].uniform_(-attn_bound, attn_bound)
+
+        # V and O: mimetic identity structure
+        for layer_idx in range(num_layers):
+            W_V = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+            W_O = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+
+            # Create per-head identity blocks
+            for h in range(num_heads):
+                start, end = h * head_dim, (h + 1) * head_dim
+                eye = torch.eye(head_dim, dtype=attn_bank.dtype, device=attn_bank.device)
+                W_V[start:end, start:end] = sqrt_beta * eye
+                W_O[start:end, start:end] = -sqrt_beta * eye
+
+            # Add noise for symmetry breaking
+            W_V += noise_std * torch.randn_like(W_V)
+            W_O += noise_std * torch.randn_like(W_O)
+
+            # Store in attn_bank: V is rows [2*dim:3*dim], O is rows [3*dim:4*dim]
+            attn_bank[layer_idx, 2*dim:3*dim, :] = W_V
+            attn_bank[layer_idx, 3*dim:4*dim, :] = W_O
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # MLP uses 0.5 * dim^-0.5
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank with MIMETIC V-O initialization
+            # Q and K: uniform init, V and O: identity-like structure for faster convergence
+            mimetic_vo_init(
+                self.attn_bank,
+                model_dim=model_dim,
+                num_heads=num_heads,
+                head_dim=head_dim,
+                beta=0.05,       # Scale for V@O^T ≈ -βI (tuned down from 0.1)
+                noise_std=0.01   # Symmetry breaking noise
+            )
+            # Init MLP bank (c_fc uniform, c_proj zero)
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 234 structure on token value embeddings by @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1515  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.11.14 (main, Oct 21 2025, 18:31:21) [GCC 11.2.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Fri Jan 30 18:54:07 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          Off |   00000000:19:00.0 Off |                    0 |
+| N/A   35C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          Off |   00000000:3B:00.0 Off |                    0 |
+| N/A   28C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          Off |   00000000:4C:00.0 Off |                    0 |
+| N/A   25C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          Off |   00000000:5D:00.0 Off |                    0 |
+| N/A   34C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          Off |   00000000:9B:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          Off |   00000000:BB:00.0 Off |                    0 |
+| N/A   26C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          Off |   00000000:CB:00.0 Off |                    0 |
+| N/A   32C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          Off |   00000000:DB:00.0 Off |                    0 |
+| N/A   26C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1385612      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    1   N/A  N/A   1385613      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    2   N/A  N/A   1385614      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    3   N/A  N/A   1385615      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    4   N/A  N/A   1385616      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    5   N/A  N/A   1385617      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    6   N/A  N/A   1385618      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    7   N/A  N/A   1385619      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 504, 505, 506, 1009, 1010, 1011, 1514, 1515, 1516] for warmup
+Resetting Model
+step:0/1555 val_loss:10.8336 train_time:0ms step_avg:0.04ms
+step:1/1555 train_time:67ms step_avg:66.96ms
+step:2/1555 train_time:89ms step_avg:44.26ms
+step:3/1555 train_time:140ms step_avg:46.53ms
+step:4/1555 train_time:178ms step_avg:44.39ms
+step:5/1555 train_time:209ms step_avg:41.73ms
+step:6/1555 train_time:247ms step_avg:41.21ms
+step:7/1555 train_time:279ms step_avg:39.83ms
+step:8/1555 train_time:317ms step_avg:39.63ms
+step:9/1555 train_time:348ms step_avg:38.72ms
+step:10/1555 train_time:387ms step_avg:38.68ms
+step:11/1555 train_time:418ms step_avg:38.00ms
+step:12/1555 train_time:456ms step_avg:38.01ms
+step:13/1555 train_time:488ms step_avg:37.51ms
+step:14/1555 train_time:526ms step_avg:37.57ms
+step:15/1555 train_time:558ms step_avg:37.17ms
+step:16/1555 train_time:596ms step_avg:37.22ms
+step:17/1555 train_time:627ms step_avg:36.90ms
+step:18/1555 train_time:666ms step_avg:36.98ms
+step:19/1555 train_time:697ms step_avg:36.68ms
+step:20/1555 train_time:735ms step_avg:36.75ms
+step:21/1555 train_time:767ms step_avg:36.51ms
+step:22/1555 train_time:805ms step_avg:36.61ms
+step:23/1555 train_time:837ms step_avg:36.39ms
+step:24/1555 train_time:875ms step_avg:36.46ms
+step:25/1555 train_time:906ms step_avg:36.26ms
+step:26/1555 train_time:945ms step_avg:36.35ms
+step:27/1555 train_time:976ms step_avg:36.16ms
+step:28/1555 train_time:1014ms step_avg:36.23ms
+step:29/1555 train_time:1046ms step_avg:36.06ms
+step:30/1555 train_time:1084ms step_avg:36.13ms
+step:31/1555 train_time:1115ms step_avg:35.98ms
+step:32/1555 train_time:1153ms step_avg:36.04ms
+step:33/1555 train_time:1185ms step_avg:35.90ms
+step:34/1555 train_time:1223ms step_avg:35.97ms
+step:35/1555 train_time:1255ms step_avg:35.84ms
+step:36/1555 train_time:1293ms step_avg:35.91ms
+step:37/1555 train_time:1324ms step_avg:35.79ms
+step:38/1555 train_time:1363ms step_avg:35.86ms
+step:39/1555 train_time:1394ms step_avg:35.74ms
+step:40/1555 train_time:1432ms step_avg:35.80ms
+step:41/1555 train_time:1464ms step_avg:35.70ms
+step:42/1555 train_time:1502ms step_avg:35.77ms
+step:43/1555 train_time:1534ms step_avg:35.67ms
+step:44/1555 train_time:1572ms step_avg:35.72ms
+step:45/1555 train_time:1603ms step_avg:35.63ms
+step:46/1555 train_time:1642ms step_avg:35.69ms
+step:47/1555 train_time:1673ms step_avg:35.60ms
+step:48/1555 train_time:1711ms step_avg:35.65ms
+step:49/1555 train_time:1743ms step_avg:35.56ms
+step:50/1555 train_time:1781ms step_avg:35.62ms
+step:51/1555 train_time:1813ms step_avg:35.54ms
+step:52/1555 train_time:1851ms step_avg:35.60ms
+step:53/1555 train_time:1883ms step_avg:35.52ms
+step:54/1555 train_time:1921ms step_avg:35.57ms
+step:55/1555 train_time:1952ms step_avg:35.49ms
+step:56/1555 train_time:1991ms step_avg:35.55ms
+step:57/1555 train_time:2022ms step_avg:35.47ms
+step:58/1555 train_time:2060ms step_avg:35.52ms
+step:59/1555 train_time:2092ms step_avg:35.45ms
+step:60/1555 train_time:2130ms step_avg:35.51ms
+step:61/1555 train_time:2162ms step_avg:35.44ms
+step:62/1555 train_time:2200ms step_avg:35.48ms
+step:63/1555 train_time:2231ms step_avg:35.42ms
+step:64/1555 train_time:2270ms step_avg:35.46ms
+step:65/1555 train_time:2301ms step_avg:35.40ms
+step:66/1555 train_time:2339ms step_avg:35.44ms
+step:67/1555 train_time:2370ms step_avg:35.38ms
+step:68/1555 train_time:2408ms step_avg:35.42ms
+step:69/1555 train_time:2440ms step_avg:35.36ms
+step:70/1555 train_time:2478ms step_avg:35.39ms
+step:71/1555 train_time:2509ms step_avg:35.34ms
+step:72/1555 train_time:2547ms step_avg:35.38ms
+step:73/1555 train_time:2579ms step_avg:35.33ms
+step:74/1555 train_time:2617ms step_avg:35.36ms
+step:75/1555 train_time:2648ms step_avg:35.31ms
+step:76/1555 train_time:2686ms step_avg:35.35ms
+step:77/1555 train_time:2718ms step_avg:35.30ms
+step:78/1555 train_time:2756ms step_avg:35.33ms
+step:79/1555 train_time:2788ms step_avg:35.29ms
+step:80/1555 train_time:2826ms step_avg:35.33ms
+step:81/1555 train_time:2858ms step_avg:35.28ms
+step:82/1555 train_time:2896ms step_avg:35.32ms
+step:83/1555 train_time:2928ms step_avg:35.27ms
+step:84/1555 train_time:2966ms step_avg:35.31ms
+step:85/1555 train_time:2997ms step_avg:35.26ms
+step:86/1555 train_time:3035ms step_avg:35.29ms
+step:87/1555 train_time:3067ms step_avg:35.25ms
+step:88/1555 train_time:3105ms step_avg:35.28ms
+step:89/1555 train_time:3137ms step_avg:35.24ms
+step:90/1555 train_time:3175ms step_avg:35.28ms
+step:91/1555 train_time:3206ms step_avg:35.23ms
+step:92/1555 train_time:3244ms step_avg:35.27ms
+step:93/1555 train_time:3276ms step_avg:35.22ms
+step:94/1555 train_time:3314ms step_avg:35.25ms
+step:95/1555 train_time:3345ms step_avg:35.21ms
+step:96/1555 train_time:3384ms step_avg:35.25ms
+step:97/1555 train_time:3415ms step_avg:35.20ms
+step:98/1555 train_time:3453ms step_avg:35.24ms
+step:99/1555 train_time:3484ms step_avg:35.20ms
+step:100/1555 train_time:3523ms step_avg:35.23ms
+step:101/1555 train_time:3554ms step_avg:35.19ms
+step:102/1555 train_time:3592ms step_avg:35.22ms
+step:103/1555 train_time:3624ms step_avg:35.18ms
+step:104/1555 train_time:3662ms step_avg:35.21ms
+step:105/1555 train_time:3693ms step_avg:35.18ms
+step:106/1555 train_time:3731ms step_avg:35.20ms
+step:107/1555 train_time:3763ms step_avg:35.17ms
+step:108/1555 train_time:3801ms step_avg:35.19ms
+step:109/1555 train_time:3832ms step_avg:35.16ms
+step:110/1555 train_time:3870ms step_avg:35.18ms
+step:111/1555 train_time:3901ms step_avg:35.15ms
+step:112/1555 train_time:3940ms step_avg:35.17ms
+step:113/1555 train_time:3971ms step_avg:35.14ms
+step:114/1555 train_time:4009ms step_avg:35.17ms
+step:115/1555 train_time:4040ms step_avg:35.13ms
+step:116/1555 train_time:4078ms step_avg:35.16ms
+step:117/1555 train_time:4110ms step_avg:35.13ms
+step:118/1555 train_time:4148ms step_avg:35.15ms
+step:119/1555 train_time:4179ms step_avg:35.12ms
+step:120/1555 train_time:4217ms step_avg:35.14ms
+step:121/1555 train_time:4248ms step_avg:35.11ms
+step:122/1555 train_time:4287ms step_avg:35.14ms
+step:123/1555 train_time:4318ms step_avg:35.10ms
+step:124/1555 train_time:4356ms step_avg:35.13ms
+step:125/1555 train_time:4387ms step_avg:35.10ms
+step:126/1555 train_time:4426ms step_avg:35.12ms
+step:127/1555 train_time:4457ms step_avg:35.10ms
+step:128/1555 train_time:4495ms step_avg:35.12ms
+step:129/1555 train_time:4527ms step_avg:35.09ms
+step:130/1555 train_time:4565ms step_avg:35.12ms
+step:131/1555 train_time:4597ms step_avg:35.09ms
+step:132/1555 train_time:4635ms step_avg:35.11ms
+step:133/1555 train_time:4666ms step_avg:35.08ms
+step:134/1555 train_time:4704ms step_avg:35.11ms
+step:135/1555 train_time:4736ms step_avg:35.08ms
+step:136/1555 train_time:4774ms step_avg:35.10ms
+step:137/1555 train_time:4805ms step_avg:35.07ms
+step:138/1555 train_time:4843ms step_avg:35.09ms
+step:139/1555 train_time:4874ms step_avg:35.07ms
+step:140/1555 train_time:4913ms step_avg:35.09ms
+step:141/1555 train_time:4944ms step_avg:35.06ms
+step:142/1555 train_time:4982ms step_avg:35.09ms
+step:143/1555 train_time:5014ms step_avg:35.06ms
+step:144/1555 train_time:5052ms step_avg:35.08ms
+step:145/1555 train_time:5083ms step_avg:35.06ms
+step:146/1555 train_time:5121ms step_avg:35.08ms
+step:147/1555 train_time:5153ms step_avg:35.05ms
+step:148/1555 train_time:5191ms step_avg:35.07ms
+step:149/1555 train_time:5222ms step_avg:35.05ms
+step:150/1555 train_time:5260ms step_avg:35.07ms
+step:151/1555 train_time:5291ms step_avg:35.04ms
+step:152/1555 train_time:5329ms step_avg:35.06ms
+step:153/1555 train_time:5361ms step_avg:35.04ms
+step:154/1555 train_time:5399ms step_avg:35.06ms
+step:155/1555 train_time:5430ms step_avg:35.03ms
+step:156/1555 train_time:5468ms step_avg:35.05ms
+step:157/1555 train_time:5500ms step_avg:35.03ms
+step:158/1555 train_time:5538ms step_avg:35.05ms
+step:159/1555 train_time:5569ms step_avg:35.02ms
+step:160/1555 train_time:5607ms step_avg:35.04ms
+step:161/1555 train_time:5638ms step_avg:35.02ms
+step:162/1555 train_time:5676ms step_avg:35.04ms
+step:163/1555 train_time:5708ms step_avg:35.02ms
+step:164/1555 train_time:5746ms step_avg:35.04ms
+step:165/1555 train_time:5777ms step_avg:35.01ms
+step:166/1555 train_time:5815ms step_avg:35.03ms
+step:167/1555 train_time:5846ms step_avg:35.01ms
+step:168/1555 train_time:5885ms step_avg:35.03ms
+step:169/1555 train_time:5916ms step_avg:35.00ms
+step:170/1555 train_time:5954ms step_avg:35.02ms
+step:171/1555 train_time:5985ms step_avg:35.00ms
+step:172/1555 train_time:6023ms step_avg:35.02ms
+step:173/1555 train_time:6055ms step_avg:35.00ms
+step:174/1555 train_time:6093ms step_avg:35.02ms
+step:175/1555 train_time:6124ms step_avg:34.99ms
+step:176/1555 train_time:6162ms step_avg:35.01ms
+step:177/1555 train_time:6193ms step_avg:34.99ms
+step:178/1555 train_time:6231ms step_avg:35.01ms
+step:179/1555 train_time:6262ms step_avg:34.99ms
+step:180/1555 train_time:6301ms step_avg:35.00ms
+step:181/1555 train_time:6332ms step_avg:34.98ms
+step:182/1555 train_time:6370ms step_avg:35.00ms
+step:183/1555 train_time:6401ms step_avg:34.98ms
+step:184/1555 train_time:6439ms step_avg:34.99ms
+step:185/1555 train_time:6470ms step_avg:34.98ms
+step:186/1555 train_time:6509ms step_avg:34.99ms
+step:187/1555 train_time:6540ms step_avg:34.97ms
+step:188/1555 train_time:6578ms step_avg:34.99ms
+step:189/1555 train_time:6609ms step_avg:34.97ms
+step:190/1555 train_time:6648ms step_avg:34.99ms
+step:191/1555 train_time:6679ms step_avg:34.97ms
+step:192/1555 train_time:6717ms step_avg:34.98ms
+step:193/1555 train_time:6748ms step_avg:34.96ms
+step:194/1555 train_time:6786ms step_avg:34.98ms
+step:195/1555 train_time:6817ms step_avg:34.96ms
+step:196/1555 train_time:6855ms step_avg:34.98ms
+step:197/1555 train_time:6887ms step_avg:34.96ms
+step:198/1555 train_time:6925ms step_avg:34.98ms
+step:199/1555 train_time:6956ms step_avg:34.96ms
+step:200/1555 train_time:6994ms step_avg:34.97ms
+step:201/1555 train_time:7026ms step_avg:34.95ms
+step:202/1555 train_time:7064ms step_avg:34.97ms
+step:203/1555 train_time:7095ms step_avg:34.95ms
+step:204/1555 train_time:7133ms step_avg:34.97ms
+step:205/1555 train_time:7165ms step_avg:34.95ms
+step:206/1555 train_time:7203ms step_avg:34.97ms
+step:207/1555 train_time:7234ms step_avg:34.95ms
+step:208/1555 train_time:7272ms step_avg:34.96ms
+step:209/1555 train_time:7304ms step_avg:34.95ms
+step:210/1555 train_time:7342ms step_avg:34.96ms
+step:211/1555 train_time:7373ms step_avg:34.94ms
+step:212/1555 train_time:7411ms step_avg:34.96ms
+step:213/1555 train_time:7443ms step_avg:34.94ms
+step:214/1555 train_time:7481ms step_avg:34.96ms
+step:215/1555 train_time:7512ms step_avg:34.94ms
+step:216/1555 train_time:7550ms step_avg:34.95ms
+step:217/1555 train_time:7581ms step_avg:34.94ms
+step:218/1555 train_time:7619ms step_avg:34.95ms
+step:219/1555 train_time:7651ms step_avg:34.93ms
+step:220/1555 train_time:7689ms step_avg:34.95ms
+step:221/1555 train_time:7720ms step_avg:34.93ms
+step:222/1555 train_time:7758ms step_avg:34.95ms
+step:223/1555 train_time:7789ms step_avg:34.93ms
+step:224/1555 train_time:7828ms step_avg:34.94ms
+step:225/1555 train_time:7859ms step_avg:34.93ms
+step:226/1555 train_time:7897ms step_avg:34.94ms
+step:227/1555 train_time:7928ms step_avg:34.93ms
+step:228/1555 train_time:7966ms step_avg:34.94ms
+step:229/1555 train_time:7997ms step_avg:34.92ms
+step:230/1555 train_time:8035ms step_avg:34.94ms
+step:231/1555 train_time:8067ms step_avg:34.92ms
+step:232/1555 train_time:8105ms step_avg:34.93ms
+step:233/1555 train_time:8136ms step_avg:34.92ms
+step:234/1555 train_time:8174ms step_avg:34.93ms
+step:235/1555 train_time:8206ms step_avg:34.92ms
+step:236/1555 train_time:8244ms step_avg:34.93ms
+step:237/1555 train_time:8275ms step_avg:34.92ms
+step:238/1555 train_time:8313ms step_avg:34.93ms
+step:239/1555 train_time:8345ms step_avg:34.92ms
+step:240/1555 train_time:8383ms step_avg:34.93ms
+step:241/1555 train_time:8414ms step_avg:34.91ms
+step:242/1555 train_time:8452ms step_avg:34.93ms
+step:243/1555 train_time:8483ms step_avg:34.91ms
+step:244/1555 train_time:8522ms step_avg:34.92ms
+step:245/1555 train_time:8553ms step_avg:34.91ms
+step:246/1555 train_time:8591ms step_avg:34.92ms
+step:247/1555 train_time:8622ms step_avg:34.91ms
+step:248/1555 train_time:8661ms step_avg:34.92ms
+step:249/1555 train_time:8692ms step_avg:34.91ms
+step:250/1555 train_time:8730ms step_avg:34.92ms
+step:250/1555 val_loss:4.5770 train_time:8779ms step_avg:35.12ms
+step:251/1555 train_time:8798ms step_avg:35.05ms
+step:252/1555 train_time:8816ms step_avg:34.98ms
+step:253/1555 train_time:8833ms step_avg:34.91ms
+step:254/1555 train_time:8872ms step_avg:34.93ms
+step:255/1555 train_time:8904ms step_avg:34.92ms
+step:256/1555 train_time:8944ms step_avg:34.94ms
+step:257/1555 train_time:8977ms step_avg:34.93ms
+step:258/1555 train_time:9017ms step_avg:34.95ms
+step:259/1555 train_time:9049ms step_avg:34.94ms
+step:260/1555 train_time:9087ms step_avg:34.95ms
+step:261/1555 train_time:9118ms step_avg:34.94ms
+step:262/1555 train_time:9157ms step_avg:34.95ms
+step:263/1555 train_time:9188ms step_avg:34.93ms
+step:264/1555 train_time:9226ms step_avg:34.95ms
+step:265/1555 train_time:9257ms step_avg:34.93ms
+step:266/1555 train_time:9295ms step_avg:34.95ms
+step:267/1555 train_time:9327ms step_avg:34.93ms
+step:268/1555 train_time:9365ms step_avg:34.94ms
+step:269/1555 train_time:9396ms step_avg:34.93ms
+step:270/1555 train_time:9434ms step_avg:34.94ms
+step:271/1555 train_time:9465ms step_avg:34.93ms
+step:272/1555 train_time:9503ms step_avg:34.94ms
+step:273/1555 train_time:9534ms step_avg:34.92ms
+step:274/1555 train_time:9572ms step_avg:34.94ms
+step:275/1555 train_time:9604ms step_avg:34.92ms
+step:276/1555 train_time:9642ms step_avg:34.94ms
+step:277/1555 train_time:9673ms step_avg:34.92ms
+step:278/1555 train_time:9711ms step_avg:34.93ms
+step:279/1555 train_time:9743ms step_avg:34.92ms
+step:280/1555 train_time:9781ms step_avg:34.93ms
+step:281/1555 train_time:9812ms step_avg:34.92ms
+step:282/1555 train_time:9850ms step_avg:34.93ms
+step:283/1555 train_time:9881ms step_avg:34.92ms
+step:284/1555 train_time:9919ms step_avg:34.93ms
+step:285/1555 train_time:9951ms step_avg:34.91ms
+step:286/1555 train_time:9989ms step_avg:34.92ms
+step:287/1555 train_time:10020ms step_avg:34.91ms
+step:288/1555 train_time:10058ms step_avg:34.93ms
+step:289/1555 train_time:10090ms step_avg:34.91ms
+step:290/1555 train_time:10128ms step_avg:34.92ms
+step:291/1555 train_time:10159ms step_avg:34.91ms
+step:292/1555 train_time:10197ms step_avg:34.92ms
+step:293/1555 train_time:10229ms step_avg:34.91ms
+step:294/1555 train_time:10267ms step_avg:34.92ms
+step:295/1555 train_time:10298ms step_avg:34.91ms
+step:296/1555 train_time:10336ms step_avg:34.92ms
+step:297/1555 train_time:10368ms step_avg:34.91ms
+step:298/1555 train_time:10406ms step_avg:34.92ms
+step:299/1555 train_time:10437ms step_avg:34.91ms
+step:300/1555 train_time:10475ms step_avg:34.92ms
+step:301/1555 train_time:10507ms step_avg:34.91ms
+step:302/1555 train_time:10545ms step_avg:34.92ms
+step:303/1555 train_time:10576ms step_avg:34.90ms
+step:304/1555 train_time:10614ms step_avg:34.92ms
+step:305/1555 train_time:10646ms step_avg:34.90ms
+step:306/1555 train_time:10684ms step_avg:34.92ms
+step:307/1555 train_time:10715ms step_avg:34.90ms
+step:308/1555 train_time:10753ms step_avg:34.91ms
+step:309/1555 train_time:10785ms step_avg:34.90ms
+step:310/1555 train_time:10823ms step_avg:34.91ms
+step:311/1555 train_time:10854ms step_avg:34.90ms
+step:312/1555 train_time:10892ms step_avg:34.91ms
+step:313/1555 train_time:10923ms step_avg:34.90ms
+step:314/1555 train_time:10962ms step_avg:34.91ms
+step:315/1555 train_time:10993ms step_avg:34.90ms
+step:316/1555 train_time:11031ms step_avg:34.91ms
+step:317/1555 train_time:11062ms step_avg:34.90ms
+step:318/1555 train_time:11100ms step_avg:34.91ms
+step:319/1555 train_time:11131ms step_avg:34.89ms
+step:320/1555 train_time:11169ms step_avg:34.90ms
+step:321/1555 train_time:11201ms step_avg:34.89ms
+step:322/1555 train_time:11239ms step_avg:34.90ms
+step:323/1555 train_time:11270ms step_avg:34.89ms
+step:324/1555 train_time:11308ms step_avg:34.90ms
+step:325/1555 train_time:11339ms step_avg:34.89ms
+step:326/1555 train_time:11378ms step_avg:34.90ms
+step:327/1555 train_time:11409ms step_avg:34.89ms
+step:328/1555 train_time:11447ms step_avg:34.90ms
+step:329/1555 train_time:11479ms step_avg:34.89ms
+step:330/1555 train_time:11518ms step_avg:34.90ms
+step:331/1555 train_time:11549ms step_avg:34.89ms
+step:332/1555 train_time:11587ms step_avg:34.90ms
+step:333/1555 train_time:11619ms step_avg:34.89ms
+step:334/1555 train_time:11657ms step_avg:34.90ms
+step:335/1555 train_time:11688ms step_avg:34.89ms
+step:336/1555 train_time:11726ms step_avg:34.90ms
+step:337/1555 train_time:11757ms step_avg:34.89ms
+step:338/1555 train_time:11796ms step_avg:34.90ms
+step:339/1555 train_time:11827ms step_avg:34.89ms
+step:340/1555 train_time:11865ms step_avg:34.90ms
+step:341/1555 train_time:11896ms step_avg:34.89ms
+step:342/1555 train_time:11934ms step_avg:34.89ms
+step:343/1555 train_time:11965ms step_avg:34.88ms
+step:344/1555 train_time:12004ms step_avg:34.89ms
+step:345/1555 train_time:12035ms step_avg:34.88ms
+step:346/1555 train_time:12073ms step_avg:34.89ms
+step:347/1555 train_time:12104ms step_avg:34.88ms
+step:348/1555 train_time:12142ms step_avg:34.89ms
+step:349/1555 train_time:12174ms step_avg:34.88ms
+step:350/1555 train_time:12212ms step_avg:34.89ms
+step:351/1555 train_time:12243ms step_avg:34.88ms
+step:352/1555 train_time:12281ms step_avg:34.89ms
+step:353/1555 train_time:12312ms step_avg:34.88ms
+step:354/1555 train_time:12350ms step_avg:34.89ms
+step:355/1555 train_time:12382ms step_avg:34.88ms
+step:356/1555 train_time:12420ms step_avg:34.89ms
+step:357/1555 train_time:12451ms step_avg:34.88ms
+step:358/1555 train_time:12489ms step_avg:34.89ms
+step:359/1555 train_time:12521ms step_avg:34.88ms
+step:360/1555 train_time:12559ms step_avg:34.89ms
+step:361/1555 train_time:12590ms step_avg:34.88ms
+step:362/1555 train_time:12628ms step_avg:34.88ms
+step:363/1555 train_time:12659ms step_avg:34.87ms
+step:364/1555 train_time:12698ms step_avg:34.88ms
+step:365/1555 train_time:12729ms step_avg:34.87ms
+step:366/1555 train_time:12767ms step_avg:34.88ms
+step:367/1555 train_time:12798ms step_avg:34.87ms
+step:368/1555 train_time:12837ms step_avg:34.88ms
+step:369/1555 train_time:12868ms step_avg:34.87ms
+step:370/1555 train_time:12906ms step_avg:34.88ms
+step:371/1555 train_time:12938ms step_avg:34.87ms
+step:372/1555 train_time:12976ms step_avg:34.88ms
+step:373/1555 train_time:13007ms step_avg:34.87ms
+step:374/1555 train_time:13045ms step_avg:34.88ms
+step:375/1555 train_time:13076ms step_avg:34.87ms
+step:376/1555 train_time:13115ms step_avg:34.88ms
+step:377/1555 train_time:13146ms step_avg:34.87ms
+step:378/1555 train_time:13184ms step_avg:34.88ms
+step:379/1555 train_time:13215ms step_avg:34.87ms
+step:380/1555 train_time:13253ms step_avg:34.88ms
+step:381/1555 train_time:13284ms step_avg:34.87ms
+step:382/1555 train_time:13322ms step_avg:34.87ms
+step:383/1555 train_time:13353ms step_avg:34.86ms
+step:384/1555 train_time:13391ms step_avg:34.87ms
+step:385/1555 train_time:13422ms step_avg:34.86ms
+step:386/1555 train_time:13460ms step_avg:34.87ms
+step:387/1555 train_time:13492ms step_avg:34.86ms
+step:388/1555 train_time:13529ms step_avg:34.87ms
+step:389/1555 train_time:13561ms step_avg:34.86ms
+step:390/1555 train_time:13599ms step_avg:34.87ms
+step:391/1555 train_time:13630ms step_avg:34.86ms
+step:392/1555 train_time:13668ms step_avg:34.87ms
+step:393/1555 train_time:13699ms step_avg:34.86ms
+step:394/1555 train_time:13738ms step_avg:34.87ms
+step:395/1555 train_time:13769ms step_avg:34.86ms
+step:396/1555 train_time:13807ms step_avg:34.87ms
+step:397/1555 train_time:13838ms step_avg:34.86ms
+step:398/1555 train_time:13876ms step_avg:34.86ms
+step:399/1555 train_time:13908ms step_avg:34.86ms
+step:400/1555 train_time:13946ms step_avg:34.86ms
+step:401/1555 train_time:13977ms step_avg:34.86ms
+step:402/1555 train_time:14015ms step_avg:34.86ms
+step:403/1555 train_time:14046ms step_avg:34.85ms
+step:404/1555 train_time:14084ms step_avg:34.86ms
+step:405/1555 train_time:14116ms step_avg:34.85ms
+step:406/1555 train_time:14154ms step_avg:34.86ms
+step:407/1555 train_time:14185ms step_avg:34.85ms
+step:408/1555 train_time:14223ms step_avg:34.86ms
+step:409/1555 train_time:14254ms step_avg:34.85ms
+step:410/1555 train_time:14292ms step_avg:34.86ms
+step:411/1555 train_time:14323ms step_avg:34.85ms
+step:412/1555 train_time:14361ms step_avg:34.86ms
+step:413/1555 train_time:14393ms step_avg:34.85ms
+step:414/1555 train_time:14430ms step_avg:34.86ms
+step:415/1555 train_time:14462ms step_avg:34.85ms
+step:416/1555 train_time:14500ms step_avg:34.86ms
+step:417/1555 train_time:14531ms step_avg:34.85ms
+step:418/1555 train_time:14569ms step_avg:34.85ms
+step:419/1555 train_time:14600ms step_avg:34.85ms
+step:420/1555 train_time:14639ms step_avg:34.85ms
+step:421/1555 train_time:14671ms step_avg:34.85ms
+step:422/1555 train_time:14709ms step_avg:34.85ms
+step:423/1555 train_time:14740ms step_avg:34.85ms
+step:424/1555 train_time:14778ms step_avg:34.85ms
+step:425/1555 train_time:14810ms step_avg:34.85ms
+step:426/1555 train_time:14848ms step_avg:34.85ms
+step:427/1555 train_time:14879ms step_avg:34.85ms
+step:428/1555 train_time:14917ms step_avg:34.85ms
+step:429/1555 train_time:14948ms step_avg:34.84ms
+step:430/1555 train_time:14986ms step_avg:34.85ms
+step:431/1555 train_time:15017ms step_avg:34.84ms
+step:432/1555 train_time:15056ms step_avg:34.85ms
+step:433/1555 train_time:15087ms step_avg:34.84ms
+step:434/1555 train_time:15125ms step_avg:34.85ms
+step:435/1555 train_time:15156ms step_avg:34.84ms
+step:436/1555 train_time:15195ms step_avg:34.85ms
+step:437/1555 train_time:15226ms step_avg:34.84ms
+step:438/1555 train_time:15264ms step_avg:34.85ms
+step:439/1555 train_time:15295ms step_avg:34.84ms
+step:440/1555 train_time:15334ms step_avg:34.85ms
+step:441/1555 train_time:15365ms step_avg:34.84ms
+step:442/1555 train_time:15403ms step_avg:34.85ms
+step:443/1555 train_time:15434ms step_avg:34.84ms
+step:444/1555 train_time:15472ms step_avg:34.85ms
+step:445/1555 train_time:15503ms step_avg:34.84ms
+step:446/1555 train_time:15541ms step_avg:34.85ms
+step:447/1555 train_time:15573ms step_avg:34.84ms
+step:448/1555 train_time:15610ms step_avg:34.84ms
+step:449/1555 train_time:15642ms step_avg:34.84ms
+step:450/1555 train_time:15680ms step_avg:34.84ms
+step:451/1555 train_time:15711ms step_avg:34.84ms
+step:452/1555 train_time:15749ms step_avg:34.84ms
+step:453/1555 train_time:15780ms step_avg:34.84ms
+step:454/1555 train_time:15818ms step_avg:34.84ms
+step:455/1555 train_time:15850ms step_avg:34.83ms
+step:456/1555 train_time:15888ms step_avg:34.84ms
+step:457/1555 train_time:15919ms step_avg:34.83ms
+step:458/1555 train_time:15958ms step_avg:34.84ms
+step:459/1555 train_time:15989ms step_avg:34.83ms
+step:460/1555 train_time:16027ms step_avg:34.84ms
+step:461/1555 train_time:16059ms step_avg:34.83ms
+step:462/1555 train_time:16097ms step_avg:34.84ms
+step:463/1555 train_time:16128ms step_avg:34.83ms
+step:464/1555 train_time:16166ms step_avg:34.84ms
+step:465/1555 train_time:16198ms step_avg:34.83ms
+step:466/1555 train_time:16236ms step_avg:34.84ms
+step:467/1555 train_time:16267ms step_avg:34.83ms
+step:468/1555 train_time:16305ms step_avg:34.84ms
+step:469/1555 train_time:16336ms step_avg:34.83ms
+step:470/1555 train_time:16375ms step_avg:34.84ms
+step:471/1555 train_time:16406ms step_avg:34.83ms
+step:472/1555 train_time:16445ms step_avg:34.84ms
+step:473/1555 train_time:16476ms step_avg:34.83ms
+step:474/1555 train_time:16514ms step_avg:34.84ms
+step:475/1555 train_time:16545ms step_avg:34.83ms
+step:476/1555 train_time:16583ms step_avg:34.84ms
+step:477/1555 train_time:16614ms step_avg:34.83ms
+step:478/1555 train_time:16652ms step_avg:34.84ms
+step:479/1555 train_time:16684ms step_avg:34.83ms
+step:480/1555 train_time:16722ms step_avg:34.84ms
+step:481/1555 train_time:16753ms step_avg:34.83ms
+step:482/1555 train_time:16791ms step_avg:34.84ms
+step:483/1555 train_time:16822ms step_avg:34.83ms
+step:484/1555 train_time:16860ms step_avg:34.84ms
+step:485/1555 train_time:16891ms step_avg:34.83ms
+step:486/1555 train_time:16929ms step_avg:34.83ms
+step:487/1555 train_time:16961ms step_avg:34.83ms
+step:488/1555 train_time:16999ms step_avg:34.83ms
+step:489/1555 train_time:17030ms step_avg:34.83ms
+step:490/1555 train_time:17068ms step_avg:34.83ms
+step:491/1555 train_time:17100ms step_avg:34.83ms
+step:492/1555 train_time:17138ms step_avg:34.83ms
+step:493/1555 train_time:17169ms step_avg:34.83ms
+step:494/1555 train_time:17207ms step_avg:34.83ms
+step:495/1555 train_time:17238ms step_avg:34.82ms
+step:496/1555 train_time:17276ms step_avg:34.83ms
+step:497/1555 train_time:17308ms step_avg:34.82ms
+step:498/1555 train_time:17346ms step_avg:34.83ms
+step:499/1555 train_time:17377ms step_avg:34.82ms
+step:500/1555 train_time:17415ms step_avg:34.83ms
+step:500/1555 val_loss:4.2343 train_time:17464ms step_avg:34.93ms
+step:501/1555 train_time:17484ms step_avg:34.90ms
+step:502/1555 train_time:17501ms step_avg:34.86ms
+step:503/1555 train_time:17518ms step_avg:34.83ms
+step:504/1555 train_time:17558ms step_avg:34.84ms
+step:505/1555 train_time:17591ms step_avg:34.83ms
+step:506/1555 train_time:17667ms step_avg:34.92ms
+step:507/1555 train_time:17727ms step_avg:34.96ms
+step:508/1555 train_time:17786ms step_avg:35.01ms
+step:509/1555 train_time:17849ms step_avg:35.07ms
+step:510/1555 train_time:17910ms step_avg:35.12ms
+step:511/1555 train_time:17971ms step_avg:35.17ms
+step:512/1555 train_time:18030ms step_avg:35.21ms
+step:513/1555 train_time:18093ms step_avg:35.27ms
+step:514/1555 train_time:18152ms step_avg:35.31ms
+step:515/1555 train_time:18215ms step_avg:35.37ms
+step:516/1555 train_time:18273ms step_avg:35.41ms
+step:517/1555 train_time:18336ms step_avg:35.47ms
+step:518/1555 train_time:18396ms step_avg:35.51ms
+step:519/1555 train_time:18460ms step_avg:35.57ms
+step:520/1555 train_time:18520ms step_avg:35.61ms
+step:521/1555 train_time:18585ms step_avg:35.67ms
+step:522/1555 train_time:18645ms step_avg:35.72ms
+step:523/1555 train_time:18709ms step_avg:35.77ms
+step:524/1555 train_time:18767ms step_avg:35.82ms
+step:525/1555 train_time:18831ms step_avg:35.87ms
+step:526/1555 train_time:18890ms step_avg:35.91ms
+step:527/1555 train_time:18953ms step_avg:35.96ms
+step:528/1555 train_time:19012ms step_avg:36.01ms
+step:529/1555 train_time:19075ms step_avg:36.06ms
+step:530/1555 train_time:19134ms step_avg:36.10ms
+step:531/1555 train_time:19197ms step_avg:36.15ms
+step:532/1555 train_time:19256ms step_avg:36.20ms
+step:533/1555 train_time:19319ms step_avg:36.25ms
+step:534/1555 train_time:19378ms step_avg:36.29ms
+step:535/1555 train_time:19442ms step_avg:36.34ms
+step:536/1555 train_time:19501ms step_avg:36.38ms
+step:537/1555 train_time:19565ms step_avg:36.43ms
+step:538/1555 train_time:19624ms step_avg:36.48ms
+step:539/1555 train_time:19687ms step_avg:36.53ms
+step:540/1555 train_time:19748ms step_avg:36.57ms
+step:541/1555 train_time:19811ms step_avg:36.62ms
+step:542/1555 train_time:19870ms step_avg:36.66ms
+step:543/1555 train_time:19933ms step_avg:36.71ms
+step:544/1555 train_time:19992ms step_avg:36.75ms
+step:545/1555 train_time:20056ms step_avg:36.80ms
+step:546/1555 train_time:20115ms step_avg:36.84ms
+step:547/1555 train_time:20177ms step_avg:36.89ms
+step:548/1555 train_time:20236ms step_avg:36.93ms
+step:549/1555 train_time:20299ms step_avg:36.98ms
+step:550/1555 train_time:20358ms step_avg:37.02ms
+step:551/1555 train_time:20421ms step_avg:37.06ms
+step:552/1555 train_time:20481ms step_avg:37.10ms
+step:553/1555 train_time:20544ms step_avg:37.15ms
+step:554/1555 train_time:20603ms step_avg:37.19ms
+step:555/1555 train_time:20667ms step_avg:37.24ms
+step:556/1555 train_time:20726ms step_avg:37.28ms
+step:557/1555 train_time:20789ms step_avg:37.32ms
+step:558/1555 train_time:20849ms step_avg:37.36ms
+step:559/1555 train_time:20912ms step_avg:37.41ms
+step:560/1555 train_time:20971ms step_avg:37.45ms
+step:561/1555 train_time:21036ms step_avg:37.50ms
+step:562/1555 train_time:21095ms step_avg:37.54ms
+step:563/1555 train_time:21159ms step_avg:37.58ms
+step:564/1555 train_time:21218ms step_avg:37.62ms
+step:565/1555 train_time:21281ms step_avg:37.67ms
+step:566/1555 train_time:21345ms step_avg:37.71ms
+step:567/1555 train_time:21407ms step_avg:37.75ms
+step:568/1555 train_time:21464ms step_avg:37.79ms
+step:569/1555 train_time:21527ms step_avg:37.83ms
+step:570/1555 train_time:21586ms step_avg:37.87ms
+step:571/1555 train_time:21649ms step_avg:37.91ms
+step:572/1555 train_time:21708ms step_avg:37.95ms
+step:573/1555 train_time:21772ms step_avg:38.00ms
+step:574/1555 train_time:21831ms step_avg:38.03ms
+step:575/1555 train_time:21894ms step_avg:38.08ms
+step:576/1555 train_time:21954ms step_avg:38.12ms
+step:577/1555 train_time:22017ms step_avg:38.16ms
+step:578/1555 train_time:22076ms step_avg:38.19ms
+step:579/1555 train_time:22140ms step_avg:38.24ms
+step:580/1555 train_time:22200ms step_avg:38.28ms
+step:581/1555 train_time:22263ms step_avg:38.32ms
+step:582/1555 train_time:22322ms step_avg:38.35ms
+step:583/1555 train_time:22384ms step_avg:38.40ms
+step:584/1555 train_time:22444ms step_avg:38.43ms
+step:585/1555 train_time:22507ms step_avg:38.47ms
+step:586/1555 train_time:22566ms step_avg:38.51ms
+step:587/1555 train_time:22630ms step_avg:38.55ms
+step:588/1555 train_time:22689ms step_avg:38.59ms
+step:589/1555 train_time:22752ms step_avg:38.63ms
+step:590/1555 train_time:22811ms step_avg:38.66ms
+step:591/1555 train_time:22875ms step_avg:38.71ms
+step:592/1555 train_time:22934ms step_avg:38.74ms
+step:593/1555 train_time:22998ms step_avg:38.78ms
+step:594/1555 train_time:23057ms step_avg:38.82ms
+step:595/1555 train_time:23120ms step_avg:38.86ms
+step:596/1555 train_time:23179ms step_avg:38.89ms
+step:597/1555 train_time:23242ms step_avg:38.93ms
+step:598/1555 train_time:23302ms step_avg:38.97ms
+step:599/1555 train_time:23365ms step_avg:39.01ms
+step:600/1555 train_time:23424ms step_avg:39.04ms
+step:601/1555 train_time:23488ms step_avg:39.08ms
+step:602/1555 train_time:23547ms step_avg:39.11ms
+step:603/1555 train_time:23611ms step_avg:39.16ms
+step:604/1555 train_time:23670ms step_avg:39.19ms
+step:605/1555 train_time:23734ms step_avg:39.23ms
+step:606/1555 train_time:23793ms step_avg:39.26ms
+step:607/1555 train_time:23857ms step_avg:39.30ms
+step:608/1555 train_time:23916ms step_avg:39.34ms
+step:609/1555 train_time:23980ms step_avg:39.38ms
+step:610/1555 train_time:24039ms step_avg:39.41ms
+step:611/1555 train_time:24102ms step_avg:39.45ms
+step:612/1555 train_time:24162ms step_avg:39.48ms
+step:613/1555 train_time:24226ms step_avg:39.52ms
+step:614/1555 train_time:24285ms step_avg:39.55ms
+step:615/1555 train_time:24348ms step_avg:39.59ms
+step:616/1555 train_time:24407ms step_avg:39.62ms
+step:617/1555 train_time:24471ms step_avg:39.66ms
+step:618/1555 train_time:24530ms step_avg:39.69ms
+step:619/1555 train_time:24594ms step_avg:39.73ms
+step:620/1555 train_time:24653ms step_avg:39.76ms
+step:621/1555 train_time:24716ms step_avg:39.80ms
+step:622/1555 train_time:24774ms step_avg:39.83ms
+step:623/1555 train_time:24838ms step_avg:39.87ms
+step:624/1555 train_time:24897ms step_avg:39.90ms
+step:625/1555 train_time:24960ms step_avg:39.94ms
+step:626/1555 train_time:25019ms step_avg:39.97ms
+step:627/1555 train_time:25082ms step_avg:40.00ms
+step:628/1555 train_time:25142ms step_avg:40.03ms
+step:629/1555 train_time:25205ms step_avg:40.07ms
+step:630/1555 train_time:25264ms step_avg:40.10ms
+step:631/1555 train_time:25328ms step_avg:40.14ms
+step:632/1555 train_time:25387ms step_avg:40.17ms
+step:633/1555 train_time:25451ms step_avg:40.21ms
+step:634/1555 train_time:25510ms step_avg:40.24ms
+step:635/1555 train_time:25574ms step_avg:40.27ms
+step:636/1555 train_time:25632ms step_avg:40.30ms
+step:637/1555 train_time:25696ms step_avg:40.34ms
+step:638/1555 train_time:25755ms step_avg:40.37ms
+step:639/1555 train_time:25818ms step_avg:40.40ms
+step:640/1555 train_time:25877ms step_avg:40.43ms
+step:641/1555 train_time:25940ms step_avg:40.47ms
+step:642/1555 train_time:26000ms step_avg:40.50ms
+step:643/1555 train_time:26063ms step_avg:40.53ms
+step:644/1555 train_time:26122ms step_avg:40.56ms
+step:645/1555 train_time:26184ms step_avg:40.60ms
+step:646/1555 train_time:26243ms step_avg:40.62ms
+step:647/1555 train_time:26307ms step_avg:40.66ms
+step:648/1555 train_time:26365ms step_avg:40.69ms
+step:649/1555 train_time:26430ms step_avg:40.72ms
+step:650/1555 train_time:26489ms step_avg:40.75ms
+step:651/1555 train_time:26553ms step_avg:40.79ms
+step:652/1555 train_time:26614ms step_avg:40.82ms
+step:653/1555 train_time:26676ms step_avg:40.85ms
+step:654/1555 train_time:26735ms step_avg:40.88ms
+step:655/1555 train_time:26799ms step_avg:40.91ms
+step:656/1555 train_time:26859ms step_avg:40.94ms
+step:657/1555 train_time:26922ms step_avg:40.98ms
+step:658/1555 train_time:26981ms step_avg:41.00ms
+step:659/1555 train_time:27045ms step_avg:41.04ms
+step:660/1555 train_time:27104ms step_avg:41.07ms
+step:661/1555 train_time:27167ms step_avg:41.10ms
+step:662/1555 train_time:27226ms step_avg:41.13ms
+step:663/1555 train_time:27290ms step_avg:41.16ms
+step:664/1555 train_time:27350ms step_avg:41.19ms
+step:665/1555 train_time:27413ms step_avg:41.22ms
+step:666/1555 train_time:27471ms step_avg:41.25ms
+step:667/1555 train_time:27536ms step_avg:41.28ms
+step:668/1555 train_time:27595ms step_avg:41.31ms
+step:669/1555 train_time:27659ms step_avg:41.34ms
+step:670/1555 train_time:27718ms step_avg:41.37ms
+step:671/1555 train_time:27781ms step_avg:41.40ms
+step:672/1555 train_time:27840ms step_avg:41.43ms
+step:673/1555 train_time:27903ms step_avg:41.46ms
+step:674/1555 train_time:27962ms step_avg:41.49ms
+step:675/1555 train_time:28026ms step_avg:41.52ms
+step:676/1555 train_time:28084ms step_avg:41.54ms
+step:677/1555 train_time:28148ms step_avg:41.58ms
+step:678/1555 train_time:28208ms step_avg:41.60ms
+step:679/1555 train_time:28271ms step_avg:41.64ms
+step:680/1555 train_time:28330ms step_avg:41.66ms
+step:681/1555 train_time:28395ms step_avg:41.70ms
+step:682/1555 train_time:28456ms step_avg:41.72ms
+step:683/1555 train_time:28518ms step_avg:41.75ms
+step:684/1555 train_time:28577ms step_avg:41.78ms
+step:685/1555 train_time:28640ms step_avg:41.81ms
+step:686/1555 train_time:28700ms step_avg:41.84ms
+step:687/1555 train_time:28763ms step_avg:41.87ms
+step:688/1555 train_time:28823ms step_avg:41.89ms
+step:689/1555 train_time:28888ms step_avg:41.93ms
+step:690/1555 train_time:28948ms step_avg:41.95ms
+step:691/1555 train_time:29011ms step_avg:41.98ms
+step:692/1555 train_time:29070ms step_avg:42.01ms
+step:693/1555 train_time:29133ms step_avg:42.04ms
+step:694/1555 train_time:29193ms step_avg:42.07ms
+step:695/1555 train_time:29256ms step_avg:42.10ms
+step:696/1555 train_time:29316ms step_avg:42.12ms
+step:697/1555 train_time:29380ms step_avg:42.15ms
+step:698/1555 train_time:29438ms step_avg:42.18ms
+step:699/1555 train_time:29501ms step_avg:42.21ms
+step:700/1555 train_time:29560ms step_avg:42.23ms
+step:701/1555 train_time:29624ms step_avg:42.26ms
+step:702/1555 train_time:29682ms step_avg:42.28ms
+step:703/1555 train_time:29746ms step_avg:42.31ms
+step:704/1555 train_time:29806ms step_avg:42.34ms
+step:705/1555 train_time:29870ms step_avg:42.37ms
+step:706/1555 train_time:29929ms step_avg:42.39ms
+step:707/1555 train_time:29993ms step_avg:42.42ms
+step:708/1555 train_time:30052ms step_avg:42.45ms
+step:709/1555 train_time:30116ms step_avg:42.48ms
+step:710/1555 train_time:30175ms step_avg:42.50ms
+step:711/1555 train_time:30238ms step_avg:42.53ms
+step:712/1555 train_time:30298ms step_avg:42.55ms
+step:713/1555 train_time:30360ms step_avg:42.58ms
+step:714/1555 train_time:30419ms step_avg:42.60ms
+step:715/1555 train_time:30482ms step_avg:42.63ms
+step:716/1555 train_time:30541ms step_avg:42.66ms
+step:717/1555 train_time:30604ms step_avg:42.68ms
+step:718/1555 train_time:30663ms step_avg:42.71ms
+step:719/1555 train_time:30726ms step_avg:42.73ms
+step:720/1555 train_time:30786ms step_avg:42.76ms
+step:721/1555 train_time:30851ms step_avg:42.79ms
+step:722/1555 train_time:30910ms step_avg:42.81ms
+step:723/1555 train_time:30974ms step_avg:42.84ms
+step:724/1555 train_time:31033ms step_avg:42.86ms
+step:725/1555 train_time:31096ms step_avg:42.89ms
+step:726/1555 train_time:31157ms step_avg:42.92ms
+step:727/1555 train_time:31219ms step_avg:42.94ms
+step:728/1555 train_time:31278ms step_avg:42.96ms
+step:729/1555 train_time:31341ms step_avg:42.99ms
+step:730/1555 train_time:31400ms step_avg:43.01ms
+step:731/1555 train_time:31463ms step_avg:43.04ms
+step:732/1555 train_time:31522ms step_avg:43.06ms
+step:733/1555 train_time:31585ms step_avg:43.09ms
+step:734/1555 train_time:31645ms step_avg:43.11ms
+step:735/1555 train_time:31708ms step_avg:43.14ms
+step:736/1555 train_time:31767ms step_avg:43.16ms
+step:737/1555 train_time:31831ms step_avg:43.19ms
+step:738/1555 train_time:31890ms step_avg:43.21ms
+step:739/1555 train_time:31954ms step_avg:43.24ms
+step:740/1555 train_time:32013ms step_avg:43.26ms
+step:741/1555 train_time:32078ms step_avg:43.29ms
+step:742/1555 train_time:32136ms step_avg:43.31ms
+step:743/1555 train_time:32200ms step_avg:43.34ms
+step:744/1555 train_time:32260ms step_avg:43.36ms
+step:745/1555 train_time:32323ms step_avg:43.39ms
+step:746/1555 train_time:32382ms step_avg:43.41ms
+step:747/1555 train_time:32445ms step_avg:43.43ms
+step:748/1555 train_time:32505ms step_avg:43.46ms
+step:749/1555 train_time:32568ms step_avg:43.48ms
+step:750/1555 train_time:32627ms step_avg:43.50ms
+step:750/1555 val_loss:3.8819 train_time:32676ms step_avg:43.57ms
+step:751/1555 train_time:32694ms step_avg:43.53ms
+step:752/1555 train_time:32753ms step_avg:43.55ms
+step:753/1555 train_time:32820ms step_avg:43.59ms
+step:754/1555 train_time:32882ms step_avg:43.61ms
+step:755/1555 train_time:32947ms step_avg:43.64ms
+step:756/1555 train_time:33006ms step_avg:43.66ms
+step:757/1555 train_time:33069ms step_avg:43.68ms
+step:758/1555 train_time:33128ms step_avg:43.70ms
+step:759/1555 train_time:33191ms step_avg:43.73ms
+step:760/1555 train_time:33250ms step_avg:43.75ms
+step:761/1555 train_time:33314ms step_avg:43.78ms
+step:762/1555 train_time:33374ms step_avg:43.80ms
+step:763/1555 train_time:33436ms step_avg:43.82ms
+step:764/1555 train_time:33496ms step_avg:43.84ms
+step:765/1555 train_time:33559ms step_avg:43.87ms
+step:766/1555 train_time:33618ms step_avg:43.89ms
+step:767/1555 train_time:33682ms step_avg:43.91ms
+step:768/1555 train_time:33742ms step_avg:43.93ms
+step:769/1555 train_time:33806ms step_avg:43.96ms
+step:770/1555 train_time:33866ms step_avg:43.98ms
+step:771/1555 train_time:33930ms step_avg:44.01ms
+step:772/1555 train_time:33990ms step_avg:44.03ms
+step:773/1555 train_time:34053ms step_avg:44.05ms
+step:774/1555 train_time:34112ms step_avg:44.07ms
+step:775/1555 train_time:34175ms step_avg:44.10ms
+step:776/1555 train_time:34234ms step_avg:44.12ms
+step:777/1555 train_time:34298ms step_avg:44.14ms
+step:778/1555 train_time:34357ms step_avg:44.16ms
+step:779/1555 train_time:34420ms step_avg:44.18ms
+step:780/1555 train_time:34479ms step_avg:44.20ms
+step:781/1555 train_time:34542ms step_avg:44.23ms
+step:782/1555 train_time:34601ms step_avg:44.25ms
+step:783/1555 train_time:34664ms step_avg:44.27ms
+step:784/1555 train_time:34724ms step_avg:44.29ms
+step:785/1555 train_time:34788ms step_avg:44.32ms
+step:786/1555 train_time:34847ms step_avg:44.33ms
+step:787/1555 train_time:34911ms step_avg:44.36ms
+step:788/1555 train_time:34970ms step_avg:44.38ms
+step:789/1555 train_time:35035ms step_avg:44.40ms
+step:790/1555 train_time:35094ms step_avg:44.42ms
+step:791/1555 train_time:35157ms step_avg:44.45ms
+step:792/1555 train_time:35216ms step_avg:44.46ms
+step:793/1555 train_time:35280ms step_avg:44.49ms
+step:794/1555 train_time:35339ms step_avg:44.51ms
+step:795/1555 train_time:35402ms step_avg:44.53ms
+step:796/1555 train_time:35461ms step_avg:44.55ms
+step:797/1555 train_time:35525ms step_avg:44.57ms
+step:798/1555 train_time:35584ms step_avg:44.59ms
+step:799/1555 train_time:35647ms step_avg:44.61ms
+step:800/1555 train_time:35706ms step_avg:44.63ms
+step:801/1555 train_time:35769ms step_avg:44.66ms
+step:802/1555 train_time:35829ms step_avg:44.67ms
+step:803/1555 train_time:35893ms step_avg:44.70ms
+step:804/1555 train_time:35952ms step_avg:44.72ms
+step:805/1555 train_time:36015ms step_avg:44.74ms
+step:806/1555 train_time:36075ms step_avg:44.76ms
+step:807/1555 train_time:36138ms step_avg:44.78ms
+step:808/1555 train_time:36197ms step_avg:44.80ms
+step:809/1555 train_time:36261ms step_avg:44.82ms
+step:810/1555 train_time:36321ms step_avg:44.84ms
+step:811/1555 train_time:36385ms step_avg:44.86ms
+step:812/1555 train_time:36444ms step_avg:44.88ms
+step:813/1555 train_time:36507ms step_avg:44.90ms
+step:814/1555 train_time:36566ms step_avg:44.92ms
+step:815/1555 train_time:36629ms step_avg:44.94ms
+step:816/1555 train_time:36688ms step_avg:44.96ms
+step:817/1555 train_time:36751ms step_avg:44.98ms
+step:818/1555 train_time:36810ms step_avg:45.00ms
+step:819/1555 train_time:36874ms step_avg:45.02ms
+step:820/1555 train_time:36934ms step_avg:45.04ms
+step:821/1555 train_time:36998ms step_avg:45.06ms
+step:822/1555 train_time:37057ms step_avg:45.08ms
+step:823/1555 train_time:37121ms step_avg:45.10ms
+step:824/1555 train_time:37179ms step_avg:45.12ms
+step:825/1555 train_time:37243ms step_avg:45.14ms
+step:826/1555 train_time:37302ms step_avg:45.16ms
+step:827/1555 train_time:37366ms step_avg:45.18ms
+step:828/1555 train_time:37425ms step_avg:45.20ms
+step:829/1555 train_time:37488ms step_avg:45.22ms
+step:830/1555 train_time:37547ms step_avg:45.24ms
+step:831/1555 train_time:37610ms step_avg:45.26ms
+step:832/1555 train_time:37669ms step_avg:45.28ms
+step:833/1555 train_time:37733ms step_avg:45.30ms
+step:834/1555 train_time:37792ms step_avg:45.31ms
+step:835/1555 train_time:37856ms step_avg:45.34ms
+step:836/1555 train_time:37915ms step_avg:45.35ms
+step:837/1555 train_time:37979ms step_avg:45.38ms
+step:838/1555 train_time:38039ms step_avg:45.39ms
+step:839/1555 train_time:38102ms step_avg:45.41ms
+step:840/1555 train_time:38161ms step_avg:45.43ms
+step:841/1555 train_time:38224ms step_avg:45.45ms
+step:842/1555 train_time:38283ms step_avg:45.47ms
+step:843/1555 train_time:38347ms step_avg:45.49ms
+step:844/1555 train_time:38406ms step_avg:45.50ms
+step:845/1555 train_time:38469ms step_avg:45.53ms
+step:846/1555 train_time:38528ms step_avg:45.54ms
+step:847/1555 train_time:38591ms step_avg:45.56ms
+step:848/1555 train_time:38650ms step_avg:45.58ms
+step:849/1555 train_time:38714ms step_avg:45.60ms
+step:850/1555 train_time:38774ms step_avg:45.62ms
+step:851/1555 train_time:38837ms step_avg:45.64ms
+step:852/1555 train_time:38897ms step_avg:45.65ms
+step:853/1555 train_time:38961ms step_avg:45.68ms
+step:854/1555 train_time:39020ms step_avg:45.69ms
+step:855/1555 train_time:39084ms step_avg:45.71ms
+step:856/1555 train_time:39143ms step_avg:45.73ms
+step:857/1555 train_time:39207ms step_avg:45.75ms
+step:858/1555 train_time:39266ms step_avg:45.76ms
+step:859/1555 train_time:39329ms step_avg:45.78ms
+step:860/1555 train_time:39388ms step_avg:45.80ms
+step:861/1555 train_time:39452ms step_avg:45.82ms
+step:862/1555 train_time:39511ms step_avg:45.84ms
+step:863/1555 train_time:39575ms step_avg:45.86ms
+step:864/1555 train_time:39634ms step_avg:45.87ms
+step:865/1555 train_time:39698ms step_avg:45.89ms
+step:866/1555 train_time:39756ms step_avg:45.91ms
+step:867/1555 train_time:39819ms step_avg:45.93ms
+step:868/1555 train_time:39878ms step_avg:45.94ms
+step:869/1555 train_time:39942ms step_avg:45.96ms
+step:870/1555 train_time:40001ms step_avg:45.98ms
+step:871/1555 train_time:40065ms step_avg:46.00ms
+step:872/1555 train_time:40124ms step_avg:46.01ms
+step:873/1555 train_time:40187ms step_avg:46.03ms
+step:874/1555 train_time:40247ms step_avg:46.05ms
+step:875/1555 train_time:40310ms step_avg:46.07ms
+step:876/1555 train_time:40369ms step_avg:46.08ms
+step:877/1555 train_time:40432ms step_avg:46.10ms
+step:878/1555 train_time:40491ms step_avg:46.12ms
+step:879/1555 train_time:40554ms step_avg:46.14ms
+step:880/1555 train_time:40613ms step_avg:46.15ms
+step:881/1555 train_time:40677ms step_avg:46.17ms
+step:882/1555 train_time:40736ms step_avg:46.19ms
+step:883/1555 train_time:40804ms step_avg:46.21ms
+step:884/1555 train_time:40862ms step_avg:46.22ms
+step:885/1555 train_time:40924ms step_avg:46.24ms
+step:886/1555 train_time:40983ms step_avg:46.26ms
+step:887/1555 train_time:41046ms step_avg:46.28ms
+step:888/1555 train_time:41105ms step_avg:46.29ms
+step:889/1555 train_time:41169ms step_avg:46.31ms
+step:890/1555 train_time:41229ms step_avg:46.32ms
+step:891/1555 train_time:41293ms step_avg:46.34ms
+step:892/1555 train_time:41351ms step_avg:46.36ms
+step:893/1555 train_time:41415ms step_avg:46.38ms
+step:894/1555 train_time:41474ms step_avg:46.39ms
+step:895/1555 train_time:41538ms step_avg:46.41ms
+step:896/1555 train_time:41597ms step_avg:46.43ms
+step:897/1555 train_time:41661ms step_avg:46.44ms
+step:898/1555 train_time:41720ms step_avg:46.46ms
+step:899/1555 train_time:41784ms step_avg:46.48ms
+step:900/1555 train_time:41843ms step_avg:46.49ms
+step:901/1555 train_time:41907ms step_avg:46.51ms
+step:902/1555 train_time:41966ms step_avg:46.53ms
+step:903/1555 train_time:42029ms step_avg:46.54ms
+step:904/1555 train_time:42088ms step_avg:46.56ms
+step:905/1555 train_time:42151ms step_avg:46.58ms
+step:906/1555 train_time:42210ms step_avg:46.59ms
+step:907/1555 train_time:42274ms step_avg:46.61ms
+step:908/1555 train_time:42334ms step_avg:46.62ms
+step:909/1555 train_time:42397ms step_avg:46.64ms
+step:910/1555 train_time:42456ms step_avg:46.65ms
+step:911/1555 train_time:42519ms step_avg:46.67ms
+step:912/1555 train_time:42578ms step_avg:46.69ms
+step:913/1555 train_time:42642ms step_avg:46.70ms
+step:914/1555 train_time:42700ms step_avg:46.72ms
+step:915/1555 train_time:42764ms step_avg:46.74ms
+step:916/1555 train_time:42824ms step_avg:46.75ms
+step:917/1555 train_time:42887ms step_avg:46.77ms
+step:918/1555 train_time:42946ms step_avg:46.78ms
+step:919/1555 train_time:43010ms step_avg:46.80ms
+step:920/1555 train_time:43069ms step_avg:46.81ms
+step:921/1555 train_time:43132ms step_avg:46.83ms
+step:922/1555 train_time:43191ms step_avg:46.85ms
+step:923/1555 train_time:43255ms step_avg:46.86ms
+step:924/1555 train_time:43314ms step_avg:46.88ms
+step:925/1555 train_time:43378ms step_avg:46.90ms
+step:926/1555 train_time:43437ms step_avg:46.91ms
+step:927/1555 train_time:43501ms step_avg:46.93ms
+step:928/1555 train_time:43560ms step_avg:46.94ms
+step:929/1555 train_time:43624ms step_avg:46.96ms
+step:930/1555 train_time:43683ms step_avg:46.97ms
+step:931/1555 train_time:43746ms step_avg:46.99ms
+step:932/1555 train_time:43805ms step_avg:47.00ms
+step:933/1555 train_time:43869ms step_avg:47.02ms
+step:934/1555 train_time:43927ms step_avg:47.03ms
+step:935/1555 train_time:43991ms step_avg:47.05ms
+step:936/1555 train_time:44050ms step_avg:47.06ms
+step:937/1555 train_time:44115ms step_avg:47.08ms
+step:938/1555 train_time:44175ms step_avg:47.09ms
+step:939/1555 train_time:44238ms step_avg:47.11ms
+step:940/1555 train_time:44297ms step_avg:47.12ms
+step:941/1555 train_time:44360ms step_avg:47.14ms
+step:942/1555 train_time:44420ms step_avg:47.15ms
+step:943/1555 train_time:44483ms step_avg:47.17ms
+step:944/1555 train_time:44542ms step_avg:47.18ms
+step:945/1555 train_time:44606ms step_avg:47.20ms
+step:946/1555 train_time:44665ms step_avg:47.21ms
+step:947/1555 train_time:44728ms step_avg:47.23ms
+step:948/1555 train_time:44788ms step_avg:47.24ms
+step:949/1555 train_time:44851ms step_avg:47.26ms
+step:950/1555 train_time:44909ms step_avg:47.27ms
+step:951/1555 train_time:44973ms step_avg:47.29ms
+step:952/1555 train_time:45032ms step_avg:47.30ms
+step:953/1555 train_time:45096ms step_avg:47.32ms
+step:954/1555 train_time:45155ms step_avg:47.33ms
+step:955/1555 train_time:45219ms step_avg:47.35ms
+step:956/1555 train_time:45278ms step_avg:47.36ms
+step:957/1555 train_time:45342ms step_avg:47.38ms
+step:958/1555 train_time:45401ms step_avg:47.39ms
+step:959/1555 train_time:45464ms step_avg:47.41ms
+step:960/1555 train_time:45524ms step_avg:47.42ms
+step:961/1555 train_time:45587ms step_avg:47.44ms
+step:962/1555 train_time:45646ms step_avg:47.45ms
+step:963/1555 train_time:45710ms step_avg:47.47ms
+step:964/1555 train_time:45769ms step_avg:47.48ms
+step:965/1555 train_time:45832ms step_avg:47.49ms
+step:966/1555 train_time:45891ms step_avg:47.51ms
+step:967/1555 train_time:45954ms step_avg:47.52ms
+step:968/1555 train_time:46013ms step_avg:47.53ms
+step:969/1555 train_time:46076ms step_avg:47.55ms
+step:970/1555 train_time:46135ms step_avg:47.56ms
+step:971/1555 train_time:46199ms step_avg:47.58ms
+step:972/1555 train_time:46258ms step_avg:47.59ms
+step:973/1555 train_time:46323ms step_avg:47.61ms
+step:974/1555 train_time:46383ms step_avg:47.62ms
+step:975/1555 train_time:46445ms step_avg:47.64ms
+step:976/1555 train_time:46505ms step_avg:47.65ms
+step:977/1555 train_time:46569ms step_avg:47.67ms
+step:978/1555 train_time:46628ms step_avg:47.68ms
+step:979/1555 train_time:46691ms step_avg:47.69ms
+step:980/1555 train_time:46750ms step_avg:47.70ms
+step:981/1555 train_time:46813ms step_avg:47.72ms
+step:982/1555 train_time:46872ms step_avg:47.73ms
+step:983/1555 train_time:46936ms step_avg:47.75ms
+step:984/1555 train_time:46995ms step_avg:47.76ms
+step:985/1555 train_time:47059ms step_avg:47.78ms
+step:986/1555 train_time:47118ms step_avg:47.79ms
+step:987/1555 train_time:47181ms step_avg:47.80ms
+step:988/1555 train_time:47241ms step_avg:47.81ms
+step:989/1555 train_time:47304ms step_avg:47.83ms
+step:990/1555 train_time:47363ms step_avg:47.84ms
+step:991/1555 train_time:47427ms step_avg:47.86ms
+step:992/1555 train_time:47486ms step_avg:47.87ms
+step:993/1555 train_time:47549ms step_avg:47.88ms
+step:994/1555 train_time:47608ms step_avg:47.90ms
+step:995/1555 train_time:47672ms step_avg:47.91ms
+step:996/1555 train_time:47732ms step_avg:47.92ms
+step:997/1555 train_time:47795ms step_avg:47.94ms
+step:998/1555 train_time:47854ms step_avg:47.95ms
+step:999/1555 train_time:47918ms step_avg:47.97ms
+step:1000/1555 train_time:47977ms step_avg:47.98ms
+step:1000/1555 val_loss:3.5720 train_time:48025ms step_avg:48.03ms
+step:1001/1555 train_time:48043ms step_avg:47.99ms
+step:1002/1555 train_time:48106ms step_avg:48.01ms
+step:1003/1555 train_time:48173ms step_avg:48.03ms
+step:1004/1555 train_time:48233ms step_avg:48.04ms
+step:1005/1555 train_time:48298ms step_avg:48.06ms
+step:1006/1555 train_time:48357ms step_avg:48.07ms
+step:1007/1555 train_time:48420ms step_avg:48.08ms
+step:1008/1555 train_time:48478ms step_avg:48.09ms
+step:1009/1555 train_time:48541ms step_avg:48.11ms
+step:1010/1555 train_time:48600ms step_avg:48.12ms
+step:1011/1555 train_time:48671ms step_avg:48.14ms
+step:1012/1555 train_time:48752ms step_avg:48.17ms
+step:1013/1555 train_time:48841ms step_avg:48.21ms
+step:1014/1555 train_time:48926ms step_avg:48.25ms
+step:1015/1555 train_time:49017ms step_avg:48.29ms
+step:1016/1555 train_time:49106ms step_avg:48.33ms
+step:1017/1555 train_time:49195ms step_avg:48.37ms
+step:1018/1555 train_time:49282ms step_avg:48.41ms
+step:1019/1555 train_time:49372ms step_avg:48.45ms
+step:1020/1555 train_time:49458ms step_avg:48.49ms
+step:1021/1555 train_time:49548ms step_avg:48.53ms
+step:1022/1555 train_time:49633ms step_avg:48.56ms
+step:1023/1555 train_time:49723ms step_avg:48.60ms
+step:1024/1555 train_time:49807ms step_avg:48.64ms
+step:1025/1555 train_time:49896ms step_avg:48.68ms
+step:1026/1555 train_time:49981ms step_avg:48.71ms
+step:1027/1555 train_time:50071ms step_avg:48.75ms
+step:1028/1555 train_time:50158ms step_avg:48.79ms
+step:1029/1555 train_time:50249ms step_avg:48.83ms
+step:1030/1555 train_time:50335ms step_avg:48.87ms
+step:1031/1555 train_time:50426ms step_avg:48.91ms
+step:1032/1555 train_time:50511ms step_avg:48.94ms
+step:1033/1555 train_time:50601ms step_avg:48.98ms
+step:1034/1555 train_time:50687ms step_avg:49.02ms
+step:1035/1555 train_time:50776ms step_avg:49.06ms
+step:1036/1555 train_time:50862ms step_avg:49.09ms
+step:1037/1555 train_time:50951ms step_avg:49.13ms
+step:1038/1555 train_time:51038ms step_avg:49.17ms
+step:1039/1555 train_time:51127ms step_avg:49.21ms
+step:1040/1555 train_time:51217ms step_avg:49.25ms
+step:1041/1555 train_time:51307ms step_avg:49.29ms
+step:1042/1555 train_time:51391ms step_avg:49.32ms
+step:1043/1555 train_time:51482ms step_avg:49.36ms
+step:1044/1555 train_time:51567ms step_avg:49.39ms
+step:1045/1555 train_time:51655ms step_avg:49.43ms
+step:1046/1555 train_time:51740ms step_avg:49.47ms
+step:1047/1555 train_time:51830ms step_avg:49.50ms
+step:1048/1555 train_time:51915ms step_avg:49.54ms
+step:1049/1555 train_time:52006ms step_avg:49.58ms
+step:1050/1555 train_time:52090ms step_avg:49.61ms
+step:1051/1555 train_time:52180ms step_avg:49.65ms
+step:1052/1555 train_time:52266ms step_avg:49.68ms
+step:1053/1555 train_time:52356ms step_avg:49.72ms
+step:1054/1555 train_time:52441ms step_avg:49.75ms
+step:1055/1555 train_time:52532ms step_avg:49.79ms
+step:1056/1555 train_time:52619ms step_avg:49.83ms
+step:1057/1555 train_time:52708ms step_avg:49.87ms
+step:1058/1555 train_time:52793ms step_avg:49.90ms
+step:1059/1555 train_time:52882ms step_avg:49.94ms
+step:1060/1555 train_time:52967ms step_avg:49.97ms
+step:1061/1555 train_time:53057ms step_avg:50.01ms
+step:1062/1555 train_time:53143ms step_avg:50.04ms
+step:1063/1555 train_time:53232ms step_avg:50.08ms
+step:1064/1555 train_time:53319ms step_avg:50.11ms
+step:1065/1555 train_time:53409ms step_avg:50.15ms
+step:1066/1555 train_time:53497ms step_avg:50.18ms
+step:1067/1555 train_time:53586ms step_avg:50.22ms
+step:1068/1555 train_time:53672ms step_avg:50.25ms
+step:1069/1555 train_time:53762ms step_avg:50.29ms
+step:1070/1555 train_time:53847ms step_avg:50.32ms
+step:1071/1555 train_time:53936ms step_avg:50.36ms
+step:1072/1555 train_time:54022ms step_avg:50.39ms
+step:1073/1555 train_time:54111ms step_avg:50.43ms
+step:1074/1555 train_time:54197ms step_avg:50.46ms
+step:1075/1555 train_time:54286ms step_avg:50.50ms
+step:1076/1555 train_time:54374ms step_avg:50.53ms
+step:1077/1555 train_time:54480ms step_avg:50.58ms
+step:1078/1555 train_time:54564ms step_avg:50.62ms
+step:1079/1555 train_time:54652ms step_avg:50.65ms
+step:1080/1555 train_time:54738ms step_avg:50.68ms
+step:1081/1555 train_time:54826ms step_avg:50.72ms
+step:1082/1555 train_time:54912ms step_avg:50.75ms
+step:1083/1555 train_time:55002ms step_avg:50.79ms
+step:1084/1555 train_time:55087ms step_avg:50.82ms
+step:1085/1555 train_time:55176ms step_avg:50.85ms
+step:1086/1555 train_time:55263ms step_avg:50.89ms
+step:1087/1555 train_time:55353ms step_avg:50.92ms
+step:1088/1555 train_time:55441ms step_avg:50.96ms
+step:1089/1555 train_time:55532ms step_avg:50.99ms
+step:1090/1555 train_time:55617ms step_avg:51.02ms
+step:1091/1555 train_time:55706ms step_avg:51.06ms
+step:1092/1555 train_time:55791ms step_avg:51.09ms
+step:1093/1555 train_time:55880ms step_avg:51.13ms
+step:1094/1555 train_time:55966ms step_avg:51.16ms
+step:1095/1555 train_time:56056ms step_avg:51.19ms
+step:1096/1555 train_time:56143ms step_avg:51.23ms
+step:1097/1555 train_time:56233ms step_avg:51.26ms
+step:1098/1555 train_time:56320ms step_avg:51.29ms
+step:1099/1555 train_time:56410ms step_avg:51.33ms
+step:1100/1555 train_time:56496ms step_avg:51.36ms
+step:1101/1555 train_time:56586ms step_avg:51.39ms
+step:1102/1555 train_time:56671ms step_avg:51.43ms
+step:1103/1555 train_time:56760ms step_avg:51.46ms
+step:1104/1555 train_time:56845ms step_avg:51.49ms
+step:1105/1555 train_time:56935ms step_avg:51.52ms
+step:1106/1555 train_time:57020ms step_avg:51.56ms
+step:1107/1555 train_time:57110ms step_avg:51.59ms
+step:1108/1555 train_time:57197ms step_avg:51.62ms
+step:1109/1555 train_time:57288ms step_avg:51.66ms
+step:1110/1555 train_time:57374ms step_avg:51.69ms
+step:1111/1555 train_time:57465ms step_avg:51.72ms
+step:1112/1555 train_time:57550ms step_avg:51.75ms
+step:1113/1555 train_time:57640ms step_avg:51.79ms
+step:1114/1555 train_time:57725ms step_avg:51.82ms
+step:1115/1555 train_time:57814ms step_avg:51.85ms
+step:1116/1555 train_time:57899ms step_avg:51.88ms
+step:1117/1555 train_time:57988ms step_avg:51.91ms
+step:1118/1555 train_time:58074ms step_avg:51.94ms
+step:1119/1555 train_time:58166ms step_avg:51.98ms
+step:1120/1555 train_time:58252ms step_avg:52.01ms
+step:1121/1555 train_time:58342ms step_avg:52.04ms
+step:1122/1555 train_time:58428ms step_avg:52.07ms
+step:1123/1555 train_time:58518ms step_avg:52.11ms
+step:1124/1555 train_time:58604ms step_avg:52.14ms
+step:1125/1555 train_time:58693ms step_avg:52.17ms
+step:1126/1555 train_time:58779ms step_avg:52.20ms
+step:1127/1555 train_time:58868ms step_avg:52.23ms
+step:1128/1555 train_time:58953ms step_avg:52.26ms
+step:1129/1555 train_time:59043ms step_avg:52.30ms
+step:1130/1555 train_time:59128ms step_avg:52.33ms
+step:1131/1555 train_time:59218ms step_avg:52.36ms
+step:1132/1555 train_time:59304ms step_avg:52.39ms
+step:1133/1555 train_time:59394ms step_avg:52.42ms
+step:1134/1555 train_time:59479ms step_avg:52.45ms
+step:1135/1555 train_time:59569ms step_avg:52.48ms
+step:1136/1555 train_time:59655ms step_avg:52.51ms
+step:1137/1555 train_time:59745ms step_avg:52.55ms
+step:1138/1555 train_time:59830ms step_avg:52.57ms
+step:1139/1555 train_time:59922ms step_avg:52.61ms
+step:1140/1555 train_time:60008ms step_avg:52.64ms
+step:1141/1555 train_time:60096ms step_avg:52.67ms
+step:1142/1555 train_time:60182ms step_avg:52.70ms
+step:1143/1555 train_time:60271ms step_avg:52.73ms
+step:1144/1555 train_time:60358ms step_avg:52.76ms
+step:1145/1555 train_time:60447ms step_avg:52.79ms
+step:1146/1555 train_time:60534ms step_avg:52.82ms
+step:1147/1555 train_time:60623ms step_avg:52.85ms
+step:1148/1555 train_time:60708ms step_avg:52.88ms
+step:1149/1555 train_time:60797ms step_avg:52.91ms
+step:1150/1555 train_time:60882ms step_avg:52.94ms
+step:1151/1555 train_time:60971ms step_avg:52.97ms
+step:1152/1555 train_time:61057ms step_avg:53.00ms
+step:1153/1555 train_time:61147ms step_avg:53.03ms
+step:1154/1555 train_time:61232ms step_avg:53.06ms
+step:1155/1555 train_time:61322ms step_avg:53.09ms
+step:1156/1555 train_time:61408ms step_avg:53.12ms
+step:1157/1555 train_time:61498ms step_avg:53.15ms
+step:1158/1555 train_time:61585ms step_avg:53.18ms
+step:1159/1555 train_time:61675ms step_avg:53.21ms
+step:1160/1555 train_time:61761ms step_avg:53.24ms
+step:1161/1555 train_time:61850ms step_avg:53.27ms
+step:1162/1555 train_time:61936ms step_avg:53.30ms
+step:1163/1555 train_time:62025ms step_avg:53.33ms
+step:1164/1555 train_time:62110ms step_avg:53.36ms
+step:1165/1555 train_time:62200ms step_avg:53.39ms
+step:1166/1555 train_time:62286ms step_avg:53.42ms
+step:1167/1555 train_time:62375ms step_avg:53.45ms
+step:1168/1555 train_time:62461ms step_avg:53.48ms
+step:1169/1555 train_time:62551ms step_avg:53.51ms
+step:1170/1555 train_time:62638ms step_avg:53.54ms
+step:1171/1555 train_time:62727ms step_avg:53.57ms
+step:1172/1555 train_time:62812ms step_avg:53.59ms
+step:1173/1555 train_time:62901ms step_avg:53.62ms
+step:1174/1555 train_time:62986ms step_avg:53.65ms
+step:1175/1555 train_time:63076ms step_avg:53.68ms
+step:1176/1555 train_time:63162ms step_avg:53.71ms
+step:1177/1555 train_time:63252ms step_avg:53.74ms
+step:1178/1555 train_time:63338ms step_avg:53.77ms
+step:1179/1555 train_time:63428ms step_avg:53.80ms
+step:1180/1555 train_time:63513ms step_avg:53.82ms
+step:1181/1555 train_time:63604ms step_avg:53.86ms
+step:1182/1555 train_time:63689ms step_avg:53.88ms
+step:1183/1555 train_time:63778ms step_avg:53.91ms
+step:1184/1555 train_time:63864ms step_avg:53.94ms
+step:1185/1555 train_time:63953ms step_avg:53.97ms
+step:1186/1555 train_time:64039ms step_avg:54.00ms
+step:1187/1555 train_time:64128ms step_avg:54.03ms
+step:1188/1555 train_time:64214ms step_avg:54.05ms
+step:1189/1555 train_time:64304ms step_avg:54.08ms
+step:1190/1555 train_time:64389ms step_avg:54.11ms
+step:1191/1555 train_time:64479ms step_avg:54.14ms
+step:1192/1555 train_time:64565ms step_avg:54.16ms
+step:1193/1555 train_time:64654ms step_avg:54.19ms
+step:1194/1555 train_time:64741ms step_avg:54.22ms
+step:1195/1555 train_time:64830ms step_avg:54.25ms
+step:1196/1555 train_time:64916ms step_avg:54.28ms
+step:1197/1555 train_time:65006ms step_avg:54.31ms
+step:1198/1555 train_time:65094ms step_avg:54.34ms
+step:1199/1555 train_time:65183ms step_avg:54.36ms
+step:1200/1555 train_time:65269ms step_avg:54.39ms
+step:1201/1555 train_time:65359ms step_avg:54.42ms
+step:1202/1555 train_time:65444ms step_avg:54.45ms
+step:1203/1555 train_time:65534ms step_avg:54.48ms
+step:1204/1555 train_time:65620ms step_avg:54.50ms
+step:1205/1555 train_time:65710ms step_avg:54.53ms
+step:1206/1555 train_time:65795ms step_avg:54.56ms
+step:1207/1555 train_time:65886ms step_avg:54.59ms
+step:1208/1555 train_time:65971ms step_avg:54.61ms
+step:1209/1555 train_time:66060ms step_avg:54.64ms
+step:1210/1555 train_time:66146ms step_avg:54.67ms
+step:1211/1555 train_time:66235ms step_avg:54.69ms
+step:1212/1555 train_time:66321ms step_avg:54.72ms
+step:1213/1555 train_time:66410ms step_avg:54.75ms
+step:1214/1555 train_time:66496ms step_avg:54.77ms
+step:1215/1555 train_time:66588ms step_avg:54.80ms
+step:1216/1555 train_time:66673ms step_avg:54.83ms
+step:1217/1555 train_time:66763ms step_avg:54.86ms
+step:1218/1555 train_time:66848ms step_avg:54.88ms
+step:1219/1555 train_time:66938ms step_avg:54.91ms
+step:1220/1555 train_time:67024ms step_avg:54.94ms
+step:1221/1555 train_time:67114ms step_avg:54.97ms
+step:1222/1555 train_time:67200ms step_avg:54.99ms
+step:1223/1555 train_time:67289ms step_avg:55.02ms
+step:1224/1555 train_time:67375ms step_avg:55.04ms
+step:1225/1555 train_time:67464ms step_avg:55.07ms
+step:1226/1555 train_time:67551ms step_avg:55.10ms
+step:1227/1555 train_time:67640ms step_avg:55.13ms
+step:1228/1555 train_time:67726ms step_avg:55.15ms
+step:1229/1555 train_time:67815ms step_avg:55.18ms
+step:1230/1555 train_time:67901ms step_avg:55.20ms
+step:1231/1555 train_time:67990ms step_avg:55.23ms
+step:1232/1555 train_time:68077ms step_avg:55.26ms
+step:1233/1555 train_time:68167ms step_avg:55.29ms
+step:1234/1555 train_time:68252ms step_avg:55.31ms
+step:1235/1555 train_time:68342ms step_avg:55.34ms
+step:1236/1555 train_time:68427ms step_avg:55.36ms
+step:1237/1555 train_time:68517ms step_avg:55.39ms
+step:1238/1555 train_time:68603ms step_avg:55.41ms
+step:1239/1555 train_time:68693ms step_avg:55.44ms
+step:1240/1555 train_time:68779ms step_avg:55.47ms
+step:1241/1555 train_time:68869ms step_avg:55.49ms
+step:1242/1555 train_time:68955ms step_avg:55.52ms
+step:1243/1555 train_time:69045ms step_avg:55.55ms
+step:1244/1555 train_time:69130ms step_avg:55.57ms
+step:1245/1555 train_time:69220ms step_avg:55.60ms
+step:1246/1555 train_time:69306ms step_avg:55.62ms
+step:1247/1555 train_time:69395ms step_avg:55.65ms
+step:1248/1555 train_time:69481ms step_avg:55.67ms
+step:1249/1555 train_time:69570ms step_avg:55.70ms
+step:1250/1555 train_time:69656ms step_avg:55.72ms
+step:1250/1555 val_loss:3.3986 train_time:69731ms step_avg:55.78ms
+step:1251/1555 train_time:69755ms step_avg:55.76ms
+step:1252/1555 train_time:69846ms step_avg:55.79ms
+step:1253/1555 train_time:69940ms step_avg:55.82ms
+step:1254/1555 train_time:70025ms step_avg:55.84ms
+step:1255/1555 train_time:70114ms step_avg:55.87ms
+step:1256/1555 train_time:70204ms step_avg:55.89ms
+step:1257/1555 train_time:70288ms step_avg:55.92ms
+step:1258/1555 train_time:70372ms step_avg:55.94ms
+step:1259/1555 train_time:70461ms step_avg:55.97ms
+step:1260/1555 train_time:70545ms step_avg:55.99ms
+step:1261/1555 train_time:70637ms step_avg:56.02ms
+step:1262/1555 train_time:70721ms step_avg:56.04ms
+step:1263/1555 train_time:70816ms step_avg:56.07ms
+step:1264/1555 train_time:70903ms step_avg:56.09ms
+step:1265/1555 train_time:70993ms step_avg:56.12ms
+step:1266/1555 train_time:71080ms step_avg:56.15ms
+step:1267/1555 train_time:71168ms step_avg:56.17ms
+step:1268/1555 train_time:71254ms step_avg:56.19ms
+step:1269/1555 train_time:71343ms step_avg:56.22ms
+step:1270/1555 train_time:71428ms step_avg:56.24ms
+step:1271/1555 train_time:71516ms step_avg:56.27ms
+step:1272/1555 train_time:71602ms step_avg:56.29ms
+step:1273/1555 train_time:71694ms step_avg:56.32ms
+step:1274/1555 train_time:71780ms step_avg:56.34ms
+step:1275/1555 train_time:71871ms step_avg:56.37ms
+step:1276/1555 train_time:71958ms step_avg:56.39ms
+step:1277/1555 train_time:72048ms step_avg:56.42ms
+step:1278/1555 train_time:72134ms step_avg:56.44ms
+step:1279/1555 train_time:72223ms step_avg:56.47ms
+step:1280/1555 train_time:72308ms step_avg:56.49ms
+step:1281/1555 train_time:72397ms step_avg:56.52ms
+step:1282/1555 train_time:72482ms step_avg:56.54ms
+step:1283/1555 train_time:72571ms step_avg:56.56ms
+step:1284/1555 train_time:72657ms step_avg:56.59ms
+step:1285/1555 train_time:72748ms step_avg:56.61ms
+step:1286/1555 train_time:72835ms step_avg:56.64ms
+step:1287/1555 train_time:72927ms step_avg:56.66ms
+step:1288/1555 train_time:73012ms step_avg:56.69ms
+step:1289/1555 train_time:73102ms step_avg:56.71ms
+step:1290/1555 train_time:73187ms step_avg:56.73ms
+step:1291/1555 train_time:73276ms step_avg:56.76ms
+step:1292/1555 train_time:73361ms step_avg:56.78ms
+step:1293/1555 train_time:73451ms step_avg:56.81ms
+step:1294/1555 train_time:73536ms step_avg:56.83ms
+step:1295/1555 train_time:73626ms step_avg:56.85ms
+step:1296/1555 train_time:73711ms step_avg:56.88ms
+step:1297/1555 train_time:73802ms step_avg:56.90ms
+step:1298/1555 train_time:73888ms step_avg:56.92ms
+step:1299/1555 train_time:73978ms step_avg:56.95ms
+step:1300/1555 train_time:74064ms step_avg:56.97ms
+step:1301/1555 train_time:74154ms step_avg:57.00ms
+step:1302/1555 train_time:74240ms step_avg:57.02ms
+step:1303/1555 train_time:74329ms step_avg:57.04ms
+step:1304/1555 train_time:74415ms step_avg:57.07ms
+step:1305/1555 train_time:74503ms step_avg:57.09ms
+step:1306/1555 train_time:74589ms step_avg:57.11ms
+step:1307/1555 train_time:74679ms step_avg:57.14ms
+step:1308/1555 train_time:74765ms step_avg:57.16ms
+step:1309/1555 train_time:74855ms step_avg:57.18ms
+step:1310/1555 train_time:74942ms step_avg:57.21ms
+step:1311/1555 train_time:75033ms step_avg:57.23ms
+step:1312/1555 train_time:75120ms step_avg:57.26ms
+step:1313/1555 train_time:75209ms step_avg:57.28ms
+step:1314/1555 train_time:75295ms step_avg:57.30ms
+step:1315/1555 train_time:75385ms step_avg:57.33ms
+step:1316/1555 train_time:75470ms step_avg:57.35ms
+step:1317/1555 train_time:75560ms step_avg:57.37ms
+step:1318/1555 train_time:75646ms step_avg:57.39ms
+step:1319/1555 train_time:75736ms step_avg:57.42ms
+step:1320/1555 train_time:75822ms step_avg:57.44ms
+step:1321/1555 train_time:75912ms step_avg:57.47ms
+step:1322/1555 train_time:75998ms step_avg:57.49ms
+step:1323/1555 train_time:76089ms step_avg:57.51ms
+step:1324/1555 train_time:76174ms step_avg:57.53ms
+step:1325/1555 train_time:76263ms step_avg:57.56ms
+step:1326/1555 train_time:76348ms step_avg:57.58ms
+step:1327/1555 train_time:76438ms step_avg:57.60ms
+step:1328/1555 train_time:76523ms step_avg:57.62ms
+step:1329/1555 train_time:76613ms step_avg:57.65ms
+step:1330/1555 train_time:76699ms step_avg:57.67ms
+step:1331/1555 train_time:76789ms step_avg:57.69ms
+step:1332/1555 train_time:76875ms step_avg:57.71ms
+step:1333/1555 train_time:76966ms step_avg:57.74ms
+step:1334/1555 train_time:77051ms step_avg:57.76ms
+step:1335/1555 train_time:77141ms step_avg:57.78ms
+step:1336/1555 train_time:77227ms step_avg:57.80ms
+step:1337/1555 train_time:77316ms step_avg:57.83ms
+step:1338/1555 train_time:77402ms step_avg:57.85ms
+step:1339/1555 train_time:77492ms step_avg:57.87ms
+step:1340/1555 train_time:77577ms step_avg:57.89ms
+step:1341/1555 train_time:77666ms step_avg:57.92ms
+step:1342/1555 train_time:77752ms step_avg:57.94ms
+step:1343/1555 train_time:77842ms step_avg:57.96ms
+step:1344/1555 train_time:77928ms step_avg:57.98ms
+step:1345/1555 train_time:78018ms step_avg:58.01ms
+step:1346/1555 train_time:78103ms step_avg:58.03ms
+step:1347/1555 train_time:78192ms step_avg:58.05ms
+step:1348/1555 train_time:78278ms step_avg:58.07ms
+step:1349/1555 train_time:78368ms step_avg:58.09ms
+step:1350/1555 train_time:78454ms step_avg:58.11ms
+step:1351/1555 train_time:78548ms step_avg:58.14ms
+step:1352/1555 train_time:78632ms step_avg:58.16ms
+step:1353/1555 train_time:78721ms step_avg:58.18ms
+step:1354/1555 train_time:78806ms step_avg:58.20ms
+step:1355/1555 train_time:78896ms step_avg:58.23ms
+step:1356/1555 train_time:78982ms step_avg:58.25ms
+step:1357/1555 train_time:79073ms step_avg:58.27ms
+step:1358/1555 train_time:79159ms step_avg:58.29ms
+step:1359/1555 train_time:79248ms step_avg:58.31ms
+step:1360/1555 train_time:79334ms step_avg:58.33ms
+step:1361/1555 train_time:79425ms step_avg:58.36ms
+step:1362/1555 train_time:79511ms step_avg:58.38ms
+step:1363/1555 train_time:79600ms step_avg:58.40ms
+step:1364/1555 train_time:79686ms step_avg:58.42ms
+step:1365/1555 train_time:79775ms step_avg:58.44ms
+step:1366/1555 train_time:79861ms step_avg:58.46ms
+step:1367/1555 train_time:79950ms step_avg:58.49ms
+step:1368/1555 train_time:80036ms step_avg:58.51ms
+step:1369/1555 train_time:80126ms step_avg:58.53ms
+step:1370/1555 train_time:80212ms step_avg:58.55ms
+step:1371/1555 train_time:80301ms step_avg:58.57ms
+step:1372/1555 train_time:80387ms step_avg:58.59ms
+step:1373/1555 train_time:80477ms step_avg:58.61ms
+step:1374/1555 train_time:80563ms step_avg:58.63ms
+step:1375/1555 train_time:80652ms step_avg:58.66ms
+step:1376/1555 train_time:80739ms step_avg:58.68ms
+step:1377/1555 train_time:80829ms step_avg:58.70ms
+step:1378/1555 train_time:80915ms step_avg:58.72ms
+step:1379/1555 train_time:81005ms step_avg:58.74ms
+step:1380/1555 train_time:81090ms step_avg:58.76ms
+step:1381/1555 train_time:81179ms step_avg:58.78ms
+step:1382/1555 train_time:81265ms step_avg:58.80ms
+step:1383/1555 train_time:81356ms step_avg:58.83ms
+step:1384/1555 train_time:81442ms step_avg:58.85ms
+step:1385/1555 train_time:81531ms step_avg:58.87ms
+step:1386/1555 train_time:81616ms step_avg:58.89ms
+step:1387/1555 train_time:81706ms step_avg:58.91ms
+step:1388/1555 train_time:81791ms step_avg:58.93ms
+step:1389/1555 train_time:81880ms step_avg:58.95ms
+step:1390/1555 train_time:81967ms step_avg:58.97ms
+step:1391/1555 train_time:82056ms step_avg:58.99ms
+step:1392/1555 train_time:82143ms step_avg:59.01ms
+step:1393/1555 train_time:82233ms step_avg:59.03ms
+step:1394/1555 train_time:82320ms step_avg:59.05ms
+step:1395/1555 train_time:82410ms step_avg:59.08ms
+step:1396/1555 train_time:82496ms step_avg:59.09ms
+step:1397/1555 train_time:82585ms step_avg:59.12ms
+step:1398/1555 train_time:82670ms step_avg:59.13ms
+step:1399/1555 train_time:82760ms step_avg:59.16ms
+step:1400/1555 train_time:82846ms step_avg:59.18ms
+step:1401/1555 train_time:82936ms step_avg:59.20ms
+step:1402/1555 train_time:83022ms step_avg:59.22ms
+step:1403/1555 train_time:83112ms step_avg:59.24ms
+step:1404/1555 train_time:83197ms step_avg:59.26ms
+step:1405/1555 train_time:83287ms step_avg:59.28ms
+step:1406/1555 train_time:83373ms step_avg:59.30ms
+step:1407/1555 train_time:83462ms step_avg:59.32ms
+step:1408/1555 train_time:83547ms step_avg:59.34ms
+step:1409/1555 train_time:83636ms step_avg:59.36ms
+step:1410/1555 train_time:83724ms step_avg:59.38ms
+step:1411/1555 train_time:83812ms step_avg:59.40ms
+step:1412/1555 train_time:83898ms step_avg:59.42ms
+step:1413/1555 train_time:83988ms step_avg:59.44ms
+step:1414/1555 train_time:84075ms step_avg:59.46ms
+step:1415/1555 train_time:84166ms step_avg:59.48ms
+step:1416/1555 train_time:84251ms step_avg:59.50ms
+step:1417/1555 train_time:84341ms step_avg:59.52ms
+step:1418/1555 train_time:84426ms step_avg:59.54ms
+step:1419/1555 train_time:84516ms step_avg:59.56ms
+step:1420/1555 train_time:84602ms step_avg:59.58ms
+step:1421/1555 train_time:84692ms step_avg:59.60ms
+step:1422/1555 train_time:84778ms step_avg:59.62ms
+step:1423/1555 train_time:84870ms step_avg:59.64ms
+step:1424/1555 train_time:84955ms step_avg:59.66ms
+step:1425/1555 train_time:85045ms step_avg:59.68ms
+step:1426/1555 train_time:85131ms step_avg:59.70ms
+step:1427/1555 train_time:85220ms step_avg:59.72ms
+step:1428/1555 train_time:85307ms step_avg:59.74ms
+step:1429/1555 train_time:85397ms step_avg:59.76ms
+step:1430/1555 train_time:85484ms step_avg:59.78ms
+step:1431/1555 train_time:85572ms step_avg:59.80ms
+step:1432/1555 train_time:85657ms step_avg:59.82ms
+step:1433/1555 train_time:85747ms step_avg:59.84ms
+step:1434/1555 train_time:85834ms step_avg:59.86ms
+step:1435/1555 train_time:85922ms step_avg:59.88ms
+step:1436/1555 train_time:86010ms step_avg:59.90ms
+step:1437/1555 train_time:86097ms step_avg:59.91ms
+step:1438/1555 train_time:86186ms step_avg:59.93ms
+step:1439/1555 train_time:86274ms step_avg:59.95ms
+step:1440/1555 train_time:86360ms step_avg:59.97ms
+step:1441/1555 train_time:86449ms step_avg:59.99ms
+step:1442/1555 train_time:86536ms step_avg:60.01ms
+step:1443/1555 train_time:86625ms step_avg:60.03ms
+step:1444/1555 train_time:86711ms step_avg:60.05ms
+step:1445/1555 train_time:86801ms step_avg:60.07ms
+step:1446/1555 train_time:86889ms step_avg:60.09ms
+step:1447/1555 train_time:86977ms step_avg:60.11ms
+step:1448/1555 train_time:87063ms step_avg:60.13ms
+step:1449/1555 train_time:87153ms step_avg:60.15ms
+step:1450/1555 train_time:87239ms step_avg:60.16ms
+step:1451/1555 train_time:87329ms step_avg:60.19ms
+step:1452/1555 train_time:87414ms step_avg:60.20ms
+step:1453/1555 train_time:87504ms step_avg:60.22ms
+step:1454/1555 train_time:87589ms step_avg:60.24ms
+step:1455/1555 train_time:87679ms step_avg:60.26ms
+step:1456/1555 train_time:87765ms step_avg:60.28ms
+step:1457/1555 train_time:87854ms step_avg:60.30ms
+step:1458/1555 train_time:87941ms step_avg:60.32ms
+step:1459/1555 train_time:88030ms step_avg:60.34ms
+step:1460/1555 train_time:88116ms step_avg:60.35ms
+step:1461/1555 train_time:88206ms step_avg:60.37ms
+step:1462/1555 train_time:88291ms step_avg:60.39ms
+step:1463/1555 train_time:88381ms step_avg:60.41ms
+step:1464/1555 train_time:88467ms step_avg:60.43ms
+step:1465/1555 train_time:88557ms step_avg:60.45ms
+step:1466/1555 train_time:88642ms step_avg:60.47ms
+step:1467/1555 train_time:88732ms step_avg:60.49ms
+step:1468/1555 train_time:88818ms step_avg:60.50ms
+step:1469/1555 train_time:88908ms step_avg:60.52ms
+step:1470/1555 train_time:88995ms step_avg:60.54ms
+step:1471/1555 train_time:89085ms step_avg:60.56ms
+step:1472/1555 train_time:89170ms step_avg:60.58ms
+step:1473/1555 train_time:89260ms step_avg:60.60ms
+step:1474/1555 train_time:89345ms step_avg:60.61ms
+step:1475/1555 train_time:89434ms step_avg:60.63ms
+step:1476/1555 train_time:89520ms step_avg:60.65ms
+step:1477/1555 train_time:89610ms step_avg:60.67ms
+step:1478/1555 train_time:89696ms step_avg:60.69ms
+step:1479/1555 train_time:89785ms step_avg:60.71ms
+step:1480/1555 train_time:89871ms step_avg:60.72ms
+step:1481/1555 train_time:89961ms step_avg:60.74ms
+step:1482/1555 train_time:90047ms step_avg:60.76ms
+step:1483/1555 train_time:90136ms step_avg:60.78ms
+step:1484/1555 train_time:90223ms step_avg:60.80ms
+step:1485/1555 train_time:90312ms step_avg:60.82ms
+step:1486/1555 train_time:90398ms step_avg:60.83ms
+step:1487/1555 train_time:90487ms step_avg:60.85ms
+step:1488/1555 train_time:90572ms step_avg:60.87ms
+step:1489/1555 train_time:90662ms step_avg:60.89ms
+step:1490/1555 train_time:90748ms step_avg:60.90ms
+step:1491/1555 train_time:90837ms step_avg:60.92ms
+step:1492/1555 train_time:90923ms step_avg:60.94ms
+step:1493/1555 train_time:91013ms step_avg:60.96ms
+step:1494/1555 train_time:91099ms step_avg:60.98ms
+step:1495/1555 train_time:91189ms step_avg:61.00ms
+step:1496/1555 train_time:91275ms step_avg:61.01ms
+step:1497/1555 train_time:91365ms step_avg:61.03ms
+step:1498/1555 train_time:91450ms step_avg:61.05ms
+step:1499/1555 train_time:91540ms step_avg:61.07ms
+step:1500/1555 train_time:91626ms step_avg:61.08ms
+step:1500/1555 val_loss:3.2942 train_time:91700ms step_avg:61.13ms
+step:1501/1555 train_time:91719ms step_avg:61.11ms
+step:1502/1555 train_time:91813ms step_avg:61.13ms
+step:1503/1555 train_time:91908ms step_avg:61.15ms
+step:1504/1555 train_time:91994ms step_avg:61.17ms
+step:1505/1555 train_time:92082ms step_avg:61.18ms
+step:1506/1555 train_time:92167ms step_avg:61.20ms
+step:1507/1555 train_time:92256ms step_avg:61.22ms
+step:1508/1555 train_time:92339ms step_avg:61.23ms
+step:1509/1555 train_time:92428ms step_avg:61.25ms
+step:1510/1555 train_time:92513ms step_avg:61.27ms
+step:1511/1555 train_time:92601ms step_avg:61.28ms
+step:1512/1555 train_time:92687ms step_avg:61.30ms
+step:1513/1555 train_time:92785ms step_avg:61.32ms
+step:1514/1555 train_time:92873ms step_avg:61.34ms
+step:1515/1555 train_time:92964ms step_avg:61.36ms
+step:1516/1555 train_time:93060ms step_avg:61.39ms
+step:1517/1555 train_time:93145ms step_avg:61.40ms
+step:1518/1555 train_time:93231ms step_avg:61.42ms
+step:1519/1555 train_time:93320ms step_avg:61.44ms
+step:1520/1555 train_time:93405ms step_avg:61.45ms
+step:1521/1555 train_time:93495ms step_avg:61.47ms
+step:1522/1555 train_time:93580ms step_avg:61.48ms
+step:1523/1555 train_time:93670ms step_avg:61.50ms
+step:1524/1555 train_time:93759ms step_avg:61.52ms
+step:1525/1555 train_time:93850ms step_avg:61.54ms
+step:1526/1555 train_time:93937ms step_avg:61.56ms
+step:1527/1555 train_time:94028ms step_avg:61.58ms
+step:1528/1555 train_time:94114ms step_avg:61.59ms
+step:1529/1555 train_time:94204ms step_avg:61.61ms
+step:1530/1555 train_time:94290ms step_avg:61.63ms
+step:1531/1555 train_time:94378ms step_avg:61.64ms
+step:1532/1555 train_time:94463ms step_avg:61.66ms
+step:1533/1555 train_time:94552ms step_avg:61.68ms
+step:1534/1555 train_time:94638ms step_avg:61.69ms
+step:1535/1555 train_time:94729ms step_avg:61.71ms
+step:1536/1555 train_time:94816ms step_avg:61.73ms
+step:1537/1555 train_time:94907ms step_avg:61.75ms
+step:1538/1555 train_time:94994ms step_avg:61.76ms
+step:1539/1555 train_time:95084ms step_avg:61.78ms
+step:1540/1555 train_time:95170ms step_avg:61.80ms
+step:1541/1555 train_time:95259ms step_avg:61.82ms
+step:1542/1555 train_time:95344ms step_avg:61.83ms
+step:1543/1555 train_time:95434ms step_avg:61.85ms
+step:1544/1555 train_time:95519ms step_avg:61.86ms
+step:1545/1555 train_time:95608ms step_avg:61.88ms
+step:1546/1555 train_time:95695ms step_avg:61.90ms
+step:1547/1555 train_time:95785ms step_avg:61.92ms
+step:1548/1555 train_time:95872ms step_avg:61.93ms
+step:1549/1555 train_time:95963ms step_avg:61.95ms
+step:1550/1555 train_time:96050ms step_avg:61.97ms
+step:1551/1555 train_time:96140ms step_avg:61.99ms
+step:1552/1555 train_time:96225ms step_avg:62.00ms
+step:1553/1555 train_time:96315ms step_avg:62.02ms
+step:1554/1555 train_time:96400ms step_avg:62.03ms
+step:1555/1555 train_time:96490ms step_avg:62.05ms
+step:1555/1555 val_loss:3.2777 train_time:96559ms step_avg:62.10ms
+peak memory allocated: 31016 MiB reserved: 47038 MiB

--- a/records/track_1_short/2026-01-30_MimeticValueOutput/runs/6037e443-df16-4eeb-ba71-282b5f7096d0.txt
+++ b/records/track_1_short/2026-01-30_MimeticValueOutput/runs/6037e443-df16-4eeb-ba71-282b5f7096d0.txt
@@ -1,0 +1,4129 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# Mimetic V-O Initialization (Trockman & Kolter, ICML 2023)
+# Initialize V and O such that V @ O^T ≈ -βI (negative identity-like)
+# This enables attention to make meaningful contributions from step 1
+
+def mimetic_vo_init(attn_bank, model_dim=768, num_heads=6, head_dim=128, beta=0.1, noise_std=0.01):
+    """
+    Initialize attention bank with mimetic structure for V and O.
+    Q and K use standard uniform init, V and O use identity-like structure.
+
+    Args:
+        attn_bank: Tensor of shape (num_layers, 4*model_dim, hdim)
+        model_dim: Model dimension (768)
+        num_heads: Number of attention heads (6)
+        head_dim: Dimension per head (128)
+        beta: Scale for identity structure (0.1 recommended with attn_scale=0.1)
+        noise_std: Standard deviation of noise for symmetry breaking
+    """
+    num_layers = attn_bank.shape[0]
+    dim = model_dim
+    sqrt_beta = beta ** 0.5
+
+    # Standard init for Q and K (existing behavior)
+    attn_std = model_dim ** -0.5
+    attn_bound = (3 ** 0.5) * attn_std
+
+    with torch.no_grad():
+        # Q and K: uniform init (first 2*dim rows)
+        attn_bank[:, :2*dim, :].uniform_(-attn_bound, attn_bound)
+
+        # V and O: mimetic identity structure
+        for layer_idx in range(num_layers):
+            W_V = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+            W_O = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+
+            # Create per-head identity blocks
+            for h in range(num_heads):
+                start, end = h * head_dim, (h + 1) * head_dim
+                eye = torch.eye(head_dim, dtype=attn_bank.dtype, device=attn_bank.device)
+                W_V[start:end, start:end] = sqrt_beta * eye
+                W_O[start:end, start:end] = -sqrt_beta * eye
+
+            # Add noise for symmetry breaking
+            W_V += noise_std * torch.randn_like(W_V)
+            W_O += noise_std * torch.randn_like(W_O)
+
+            # Store in attn_bank: V is rows [2*dim:3*dim], O is rows [3*dim:4*dim]
+            attn_bank[layer_idx, 2*dim:3*dim, :] = W_V
+            attn_bank[layer_idx, 3*dim:4*dim, :] = W_O
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # MLP uses 0.5 * dim^-0.5
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank with MIMETIC V-O initialization
+            # Q and K: uniform init, V and O: identity-like structure for faster convergence
+            mimetic_vo_init(
+                self.attn_bank,
+                model_dim=model_dim,
+                num_heads=num_heads,
+                head_dim=head_dim,
+                beta=0.05,       # Scale for V@O^T ≈ -βI (tuned down from 0.1)
+                noise_std=0.01   # Symmetry breaking noise
+            )
+            # Init MLP bank (c_fc uniform, c_proj zero)
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 234 structure on token value embeddings by @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1515  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.11.14 (main, Oct 21 2025, 18:31:21) [GCC 11.2.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Fri Jan 30 18:29:41 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          Off |   00000000:19:00.0 Off |                    0 |
+| N/A   23C    P0            118W /  700W |    1520MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          Off |   00000000:3B:00.0 Off |                    0 |
+| N/A   22C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          Off |   00000000:4C:00.0 Off |                    0 |
+| N/A   19C    P0            114W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          Off |   00000000:5D:00.0 Off |                    0 |
+| N/A   23C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          Off |   00000000:9B:00.0 Off |                    0 |
+| N/A   22C    P0            111W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          Off |   00000000:BB:00.0 Off |                    0 |
+| N/A   20C    P0            112W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          Off |   00000000:CB:00.0 Off |                    0 |
+| N/A   20C    P0            113W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          Off |   00000000:DB:00.0 Off |                    0 |
+| N/A   21C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1354188      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    1   N/A  N/A   1354189      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    2   N/A  N/A   1354190      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    3   N/A  N/A   1354191      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    4   N/A  N/A   1354192      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    5   N/A  N/A   1354193      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    6   N/A  N/A   1354194      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    7   N/A  N/A   1354195      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 504, 505, 506, 1009, 1010, 1011, 1514, 1515, 1516] for warmup
+Resetting Model
+step:0/1555 val_loss:10.8327 train_time:0ms step_avg:0.04ms
+step:1/1555 train_time:93ms step_avg:92.83ms
+step:2/1555 train_time:114ms step_avg:57.18ms
+step:3/1555 train_time:156ms step_avg:52.16ms
+step:4/1555 train_time:195ms step_avg:48.69ms
+step:5/1555 train_time:226ms step_avg:45.14ms
+step:6/1555 train_time:264ms step_avg:43.95ms
+step:7/1555 train_time:295ms step_avg:42.20ms
+step:8/1555 train_time:334ms step_avg:41.75ms
+step:9/1555 train_time:366ms step_avg:40.61ms
+step:10/1555 train_time:403ms step_avg:40.35ms
+step:11/1555 train_time:435ms step_avg:39.54ms
+step:12/1555 train_time:473ms step_avg:39.45ms
+step:13/1555 train_time:505ms step_avg:38.83ms
+step:14/1555 train_time:543ms step_avg:38.79ms
+step:15/1555 train_time:575ms step_avg:38.32ms
+step:16/1555 train_time:613ms step_avg:38.33ms
+step:17/1555 train_time:645ms step_avg:37.94ms
+step:18/1555 train_time:683ms step_avg:37.95ms
+step:19/1555 train_time:715ms step_avg:37.61ms
+step:20/1555 train_time:753ms step_avg:37.64ms
+step:21/1555 train_time:784ms step_avg:37.34ms
+step:22/1555 train_time:822ms step_avg:37.38ms
+step:23/1555 train_time:854ms step_avg:37.13ms
+step:24/1555 train_time:893ms step_avg:37.20ms
+step:25/1555 train_time:924ms step_avg:36.97ms
+step:26/1555 train_time:962ms step_avg:37.01ms
+step:27/1555 train_time:994ms step_avg:36.80ms
+step:28/1555 train_time:1033ms step_avg:36.88ms
+step:29/1555 train_time:1064ms step_avg:36.71ms
+step:30/1555 train_time:1103ms step_avg:36.75ms
+step:31/1555 train_time:1134ms step_avg:36.58ms
+step:32/1555 train_time:1173ms step_avg:36.65ms
+step:33/1555 train_time:1204ms step_avg:36.49ms
+step:34/1555 train_time:1242ms step_avg:36.54ms
+step:35/1555 train_time:1274ms step_avg:36.39ms
+step:36/1555 train_time:1314ms step_avg:36.50ms
+step:37/1555 train_time:1344ms step_avg:36.33ms
+step:38/1555 train_time:1383ms step_avg:36.38ms
+step:39/1555 train_time:1414ms step_avg:36.25ms
+step:40/1555 train_time:1452ms step_avg:36.30ms
+step:41/1555 train_time:1483ms step_avg:36.18ms
+step:42/1555 train_time:1521ms step_avg:36.22ms
+step:43/1555 train_time:1553ms step_avg:36.11ms
+step:44/1555 train_time:1592ms step_avg:36.19ms
+step:45/1555 train_time:1622ms step_avg:36.06ms
+step:46/1555 train_time:1661ms step_avg:36.10ms
+step:47/1555 train_time:1693ms step_avg:36.01ms
+step:48/1555 train_time:1731ms step_avg:36.06ms
+step:49/1555 train_time:1763ms step_avg:35.97ms
+step:50/1555 train_time:1801ms step_avg:36.02ms
+step:51/1555 train_time:1832ms step_avg:35.92ms
+step:52/1555 train_time:1871ms step_avg:35.98ms
+step:53/1555 train_time:1903ms step_avg:35.90ms
+step:54/1555 train_time:1941ms step_avg:35.94ms
+step:55/1555 train_time:1972ms step_avg:35.85ms
+step:56/1555 train_time:2011ms step_avg:35.90ms
+step:57/1555 train_time:2042ms step_avg:35.82ms
+step:58/1555 train_time:2080ms step_avg:35.86ms
+step:59/1555 train_time:2112ms step_avg:35.79ms
+step:60/1555 train_time:2150ms step_avg:35.83ms
+step:61/1555 train_time:2181ms step_avg:35.76ms
+step:62/1555 train_time:2220ms step_avg:35.81ms
+step:63/1555 train_time:2251ms step_avg:35.73ms
+step:64/1555 train_time:2289ms step_avg:35.77ms
+step:65/1555 train_time:2321ms step_avg:35.70ms
+step:66/1555 train_time:2359ms step_avg:35.74ms
+step:67/1555 train_time:2391ms step_avg:35.68ms
+step:68/1555 train_time:2429ms step_avg:35.72ms
+step:69/1555 train_time:2460ms step_avg:35.66ms
+step:70/1555 train_time:2499ms step_avg:35.70ms
+step:71/1555 train_time:2531ms step_avg:35.64ms
+step:72/1555 train_time:2569ms step_avg:35.68ms
+step:73/1555 train_time:2600ms step_avg:35.62ms
+step:74/1555 train_time:2639ms step_avg:35.66ms
+step:75/1555 train_time:2670ms step_avg:35.60ms
+step:76/1555 train_time:2710ms step_avg:35.66ms
+step:77/1555 train_time:2740ms step_avg:35.58ms
+step:78/1555 train_time:2778ms step_avg:35.61ms
+step:79/1555 train_time:2809ms step_avg:35.56ms
+step:80/1555 train_time:2847ms step_avg:35.59ms
+step:81/1555 train_time:2878ms step_avg:35.54ms
+step:82/1555 train_time:2917ms step_avg:35.57ms
+step:83/1555 train_time:2948ms step_avg:35.52ms
+step:84/1555 train_time:2987ms step_avg:35.55ms
+step:85/1555 train_time:3018ms step_avg:35.50ms
+step:86/1555 train_time:3056ms step_avg:35.53ms
+step:87/1555 train_time:3087ms step_avg:35.48ms
+step:88/1555 train_time:3125ms step_avg:35.51ms
+step:89/1555 train_time:3156ms step_avg:35.47ms
+step:90/1555 train_time:3195ms step_avg:35.50ms
+step:91/1555 train_time:3226ms step_avg:35.45ms
+step:92/1555 train_time:3264ms step_avg:35.48ms
+step:93/1555 train_time:3296ms step_avg:35.44ms
+step:94/1555 train_time:3334ms step_avg:35.47ms
+step:95/1555 train_time:3365ms step_avg:35.42ms
+step:96/1555 train_time:3403ms step_avg:35.45ms
+step:97/1555 train_time:3434ms step_avg:35.41ms
+step:98/1555 train_time:3473ms step_avg:35.44ms
+step:99/1555 train_time:3504ms step_avg:35.40ms
+step:100/1555 train_time:3543ms step_avg:35.43ms
+step:101/1555 train_time:3574ms step_avg:35.38ms
+step:102/1555 train_time:3612ms step_avg:35.41ms
+step:103/1555 train_time:3643ms step_avg:35.37ms
+step:104/1555 train_time:3681ms step_avg:35.39ms
+step:105/1555 train_time:3712ms step_avg:35.36ms
+step:106/1555 train_time:3751ms step_avg:35.38ms
+step:107/1555 train_time:3782ms step_avg:35.34ms
+step:108/1555 train_time:3820ms step_avg:35.37ms
+step:109/1555 train_time:3852ms step_avg:35.34ms
+step:110/1555 train_time:3890ms step_avg:35.36ms
+step:111/1555 train_time:3921ms step_avg:35.33ms
+step:112/1555 train_time:3959ms step_avg:35.35ms
+step:113/1555 train_time:3991ms step_avg:35.31ms
+step:114/1555 train_time:4029ms step_avg:35.34ms
+step:115/1555 train_time:4060ms step_avg:35.30ms
+step:116/1555 train_time:4098ms step_avg:35.33ms
+step:117/1555 train_time:4129ms step_avg:35.29ms
+step:118/1555 train_time:4167ms step_avg:35.32ms
+step:119/1555 train_time:4199ms step_avg:35.28ms
+step:120/1555 train_time:4237ms step_avg:35.31ms
+step:121/1555 train_time:4268ms step_avg:35.28ms
+step:122/1555 train_time:4306ms step_avg:35.30ms
+step:123/1555 train_time:4337ms step_avg:35.26ms
+step:124/1555 train_time:4376ms step_avg:35.29ms
+step:125/1555 train_time:4407ms step_avg:35.26ms
+step:126/1555 train_time:4445ms step_avg:35.28ms
+step:127/1555 train_time:4476ms step_avg:35.25ms
+step:128/1555 train_time:4515ms step_avg:35.27ms
+step:129/1555 train_time:4546ms step_avg:35.24ms
+step:130/1555 train_time:4583ms step_avg:35.26ms
+step:131/1555 train_time:4615ms step_avg:35.23ms
+step:132/1555 train_time:4653ms step_avg:35.25ms
+step:133/1555 train_time:4684ms step_avg:35.22ms
+step:134/1555 train_time:4722ms step_avg:35.24ms
+step:135/1555 train_time:4753ms step_avg:35.21ms
+step:136/1555 train_time:4792ms step_avg:35.23ms
+step:137/1555 train_time:4823ms step_avg:35.20ms
+step:138/1555 train_time:4861ms step_avg:35.22ms
+step:139/1555 train_time:4892ms step_avg:35.20ms
+step:140/1555 train_time:4931ms step_avg:35.22ms
+step:141/1555 train_time:4962ms step_avg:35.19ms
+step:142/1555 train_time:5000ms step_avg:35.21ms
+step:143/1555 train_time:5031ms step_avg:35.18ms
+step:144/1555 train_time:5069ms step_avg:35.20ms
+step:145/1555 train_time:5101ms step_avg:35.18ms
+step:146/1555 train_time:5139ms step_avg:35.20ms
+step:147/1555 train_time:5170ms step_avg:35.17ms
+step:148/1555 train_time:5208ms step_avg:35.19ms
+step:149/1555 train_time:5239ms step_avg:35.16ms
+step:150/1555 train_time:5277ms step_avg:35.18ms
+step:151/1555 train_time:5309ms step_avg:35.16ms
+step:152/1555 train_time:5347ms step_avg:35.18ms
+step:153/1555 train_time:5378ms step_avg:35.15ms
+step:154/1555 train_time:5416ms step_avg:35.17ms
+step:155/1555 train_time:5447ms step_avg:35.14ms
+step:156/1555 train_time:5485ms step_avg:35.16ms
+step:157/1555 train_time:5517ms step_avg:35.14ms
+step:158/1555 train_time:5555ms step_avg:35.16ms
+step:159/1555 train_time:5586ms step_avg:35.13ms
+step:160/1555 train_time:5624ms step_avg:35.15ms
+step:161/1555 train_time:5656ms step_avg:35.13ms
+step:162/1555 train_time:5694ms step_avg:35.15ms
+step:163/1555 train_time:5725ms step_avg:35.12ms
+step:164/1555 train_time:5763ms step_avg:35.14ms
+step:165/1555 train_time:5794ms step_avg:35.12ms
+step:166/1555 train_time:5833ms step_avg:35.14ms
+step:167/1555 train_time:5864ms step_avg:35.11ms
+step:168/1555 train_time:5902ms step_avg:35.13ms
+step:169/1555 train_time:5933ms step_avg:35.11ms
+step:170/1555 train_time:5972ms step_avg:35.13ms
+step:171/1555 train_time:6003ms step_avg:35.10ms
+step:172/1555 train_time:6041ms step_avg:35.12ms
+step:173/1555 train_time:6072ms step_avg:35.10ms
+step:174/1555 train_time:6111ms step_avg:35.12ms
+step:175/1555 train_time:6142ms step_avg:35.10ms
+step:176/1555 train_time:6180ms step_avg:35.11ms
+step:177/1555 train_time:6211ms step_avg:35.09ms
+step:178/1555 train_time:6249ms step_avg:35.11ms
+step:179/1555 train_time:6280ms step_avg:35.08ms
+step:180/1555 train_time:6318ms step_avg:35.10ms
+step:181/1555 train_time:6349ms step_avg:35.08ms
+step:182/1555 train_time:6387ms step_avg:35.10ms
+step:183/1555 train_time:6419ms step_avg:35.08ms
+step:184/1555 train_time:6457ms step_avg:35.09ms
+step:185/1555 train_time:6488ms step_avg:35.07ms
+step:186/1555 train_time:6527ms step_avg:35.09ms
+step:187/1555 train_time:6558ms step_avg:35.07ms
+step:188/1555 train_time:6596ms step_avg:35.08ms
+step:189/1555 train_time:6627ms step_avg:35.06ms
+step:190/1555 train_time:6665ms step_avg:35.08ms
+step:191/1555 train_time:6696ms step_avg:35.06ms
+step:192/1555 train_time:6734ms step_avg:35.07ms
+step:193/1555 train_time:6765ms step_avg:35.05ms
+step:194/1555 train_time:6803ms step_avg:35.07ms
+step:195/1555 train_time:6834ms step_avg:35.05ms
+step:196/1555 train_time:6872ms step_avg:35.06ms
+step:197/1555 train_time:6904ms step_avg:35.05ms
+step:198/1555 train_time:6942ms step_avg:35.06ms
+step:199/1555 train_time:6973ms step_avg:35.04ms
+step:200/1555 train_time:7013ms step_avg:35.06ms
+step:201/1555 train_time:7043ms step_avg:35.04ms
+step:202/1555 train_time:7081ms step_avg:35.05ms
+step:203/1555 train_time:7112ms step_avg:35.04ms
+step:204/1555 train_time:7150ms step_avg:35.05ms
+step:205/1555 train_time:7182ms step_avg:35.03ms
+step:206/1555 train_time:7220ms step_avg:35.05ms
+step:207/1555 train_time:7251ms step_avg:35.03ms
+step:208/1555 train_time:7289ms step_avg:35.04ms
+step:209/1555 train_time:7321ms step_avg:35.03ms
+step:210/1555 train_time:7359ms step_avg:35.04ms
+step:211/1555 train_time:7390ms step_avg:35.02ms
+step:212/1555 train_time:7428ms step_avg:35.04ms
+step:213/1555 train_time:7459ms step_avg:35.02ms
+step:214/1555 train_time:7497ms step_avg:35.03ms
+step:215/1555 train_time:7528ms step_avg:35.02ms
+step:216/1555 train_time:7566ms step_avg:35.03ms
+step:217/1555 train_time:7598ms step_avg:35.01ms
+step:218/1555 train_time:7636ms step_avg:35.03ms
+step:219/1555 train_time:7667ms step_avg:35.01ms
+step:220/1555 train_time:7705ms step_avg:35.02ms
+step:221/1555 train_time:7736ms step_avg:35.01ms
+step:222/1555 train_time:7774ms step_avg:35.02ms
+step:223/1555 train_time:7806ms step_avg:35.00ms
+step:224/1555 train_time:7844ms step_avg:35.02ms
+step:225/1555 train_time:7875ms step_avg:35.00ms
+step:226/1555 train_time:7914ms step_avg:35.02ms
+step:227/1555 train_time:7945ms step_avg:35.00ms
+step:228/1555 train_time:7983ms step_avg:35.01ms
+step:229/1555 train_time:8014ms step_avg:35.00ms
+step:230/1555 train_time:8052ms step_avg:35.01ms
+step:231/1555 train_time:8084ms step_avg:34.99ms
+step:232/1555 train_time:8121ms step_avg:35.01ms
+step:233/1555 train_time:8153ms step_avg:34.99ms
+step:234/1555 train_time:8191ms step_avg:35.01ms
+step:235/1555 train_time:8222ms step_avg:34.99ms
+step:236/1555 train_time:8260ms step_avg:35.00ms
+step:237/1555 train_time:8292ms step_avg:34.99ms
+step:238/1555 train_time:8330ms step_avg:35.00ms
+step:239/1555 train_time:8361ms step_avg:34.98ms
+step:240/1555 train_time:8399ms step_avg:35.00ms
+step:241/1555 train_time:8430ms step_avg:34.98ms
+step:242/1555 train_time:8468ms step_avg:34.99ms
+step:243/1555 train_time:8499ms step_avg:34.98ms
+step:244/1555 train_time:8538ms step_avg:34.99ms
+step:245/1555 train_time:8569ms step_avg:34.97ms
+step:246/1555 train_time:8607ms step_avg:34.99ms
+step:247/1555 train_time:8638ms step_avg:34.97ms
+step:248/1555 train_time:8676ms step_avg:34.99ms
+step:249/1555 train_time:8708ms step_avg:34.97ms
+step:250/1555 train_time:8746ms step_avg:34.98ms
+step:250/1555 val_loss:4.5537 train_time:8794ms step_avg:35.18ms
+step:251/1555 train_time:8816ms step_avg:35.12ms
+step:252/1555 train_time:8835ms step_avg:35.06ms
+step:253/1555 train_time:8850ms step_avg:34.98ms
+step:254/1555 train_time:8888ms step_avg:34.99ms
+step:255/1555 train_time:8920ms step_avg:34.98ms
+step:256/1555 train_time:8959ms step_avg:35.00ms
+step:257/1555 train_time:8992ms step_avg:34.99ms
+step:258/1555 train_time:9031ms step_avg:35.00ms
+step:259/1555 train_time:9063ms step_avg:34.99ms
+step:260/1555 train_time:9101ms step_avg:35.00ms
+step:261/1555 train_time:9132ms step_avg:34.99ms
+step:262/1555 train_time:9171ms step_avg:35.00ms
+step:263/1555 train_time:9202ms step_avg:34.99ms
+step:264/1555 train_time:9240ms step_avg:35.00ms
+step:265/1555 train_time:9271ms step_avg:34.98ms
+step:266/1555 train_time:9309ms step_avg:35.00ms
+step:267/1555 train_time:9340ms step_avg:34.98ms
+step:268/1555 train_time:9378ms step_avg:34.99ms
+step:269/1555 train_time:9410ms step_avg:34.98ms
+step:270/1555 train_time:9447ms step_avg:34.99ms
+step:271/1555 train_time:9479ms step_avg:34.98ms
+step:272/1555 train_time:9516ms step_avg:34.99ms
+step:273/1555 train_time:9548ms step_avg:34.97ms
+step:274/1555 train_time:9586ms step_avg:34.99ms
+step:275/1555 train_time:9617ms step_avg:34.97ms
+step:276/1555 train_time:9655ms step_avg:34.98ms
+step:277/1555 train_time:9686ms step_avg:34.97ms
+step:278/1555 train_time:9725ms step_avg:34.98ms
+step:279/1555 train_time:9756ms step_avg:34.97ms
+step:280/1555 train_time:9794ms step_avg:34.98ms
+step:281/1555 train_time:9825ms step_avg:34.97ms
+step:282/1555 train_time:9863ms step_avg:34.98ms
+step:283/1555 train_time:9894ms step_avg:34.96ms
+step:284/1555 train_time:9933ms step_avg:34.97ms
+step:285/1555 train_time:9964ms step_avg:34.96ms
+step:286/1555 train_time:10002ms step_avg:34.97ms
+step:287/1555 train_time:10033ms step_avg:34.96ms
+step:288/1555 train_time:10072ms step_avg:34.97ms
+step:289/1555 train_time:10103ms step_avg:34.96ms
+step:290/1555 train_time:10141ms step_avg:34.97ms
+step:291/1555 train_time:10172ms step_avg:34.96ms
+step:292/1555 train_time:10210ms step_avg:34.97ms
+step:293/1555 train_time:10242ms step_avg:34.95ms
+step:294/1555 train_time:10280ms step_avg:34.96ms
+step:295/1555 train_time:10311ms step_avg:34.95ms
+step:296/1555 train_time:10349ms step_avg:34.96ms
+step:297/1555 train_time:10380ms step_avg:34.95ms
+step:298/1555 train_time:10418ms step_avg:34.96ms
+step:299/1555 train_time:10449ms step_avg:34.95ms
+step:300/1555 train_time:10487ms step_avg:34.96ms
+step:301/1555 train_time:10519ms step_avg:34.95ms
+step:302/1555 train_time:10557ms step_avg:34.96ms
+step:303/1555 train_time:10588ms step_avg:34.94ms
+step:304/1555 train_time:10626ms step_avg:34.95ms
+step:305/1555 train_time:10657ms step_avg:34.94ms
+step:306/1555 train_time:10696ms step_avg:34.95ms
+step:307/1555 train_time:10726ms step_avg:34.94ms
+step:308/1555 train_time:10764ms step_avg:34.95ms
+step:309/1555 train_time:10795ms step_avg:34.94ms
+step:310/1555 train_time:10834ms step_avg:34.95ms
+step:311/1555 train_time:10865ms step_avg:34.94ms
+step:312/1555 train_time:10903ms step_avg:34.94ms
+step:313/1555 train_time:10934ms step_avg:34.93ms
+step:314/1555 train_time:10972ms step_avg:34.94ms
+step:315/1555 train_time:11004ms step_avg:34.93ms
+step:316/1555 train_time:11041ms step_avg:34.94ms
+step:317/1555 train_time:11073ms step_avg:34.93ms
+step:318/1555 train_time:11111ms step_avg:34.94ms
+step:319/1555 train_time:11143ms step_avg:34.93ms
+step:320/1555 train_time:11180ms step_avg:34.94ms
+step:321/1555 train_time:11212ms step_avg:34.93ms
+step:322/1555 train_time:11250ms step_avg:34.94ms
+step:323/1555 train_time:11281ms step_avg:34.93ms
+step:324/1555 train_time:11320ms step_avg:34.94ms
+step:325/1555 train_time:11350ms step_avg:34.92ms
+step:326/1555 train_time:11388ms step_avg:34.93ms
+step:327/1555 train_time:11420ms step_avg:34.92ms
+step:328/1555 train_time:11458ms step_avg:34.93ms
+step:329/1555 train_time:11489ms step_avg:34.92ms
+step:330/1555 train_time:11527ms step_avg:34.93ms
+step:331/1555 train_time:11558ms step_avg:34.92ms
+step:332/1555 train_time:11596ms step_avg:34.93ms
+step:333/1555 train_time:11627ms step_avg:34.92ms
+step:334/1555 train_time:11665ms step_avg:34.93ms
+step:335/1555 train_time:11697ms step_avg:34.91ms
+step:336/1555 train_time:11734ms step_avg:34.92ms
+step:337/1555 train_time:11766ms step_avg:34.91ms
+step:338/1555 train_time:11804ms step_avg:34.92ms
+step:339/1555 train_time:11835ms step_avg:34.91ms
+step:340/1555 train_time:11873ms step_avg:34.92ms
+step:341/1555 train_time:11905ms step_avg:34.91ms
+step:342/1555 train_time:11943ms step_avg:34.92ms
+step:343/1555 train_time:11974ms step_avg:34.91ms
+step:344/1555 train_time:12012ms step_avg:34.92ms
+step:345/1555 train_time:12043ms step_avg:34.91ms
+step:346/1555 train_time:12081ms step_avg:34.92ms
+step:347/1555 train_time:12113ms step_avg:34.91ms
+step:348/1555 train_time:12151ms step_avg:34.92ms
+step:349/1555 train_time:12182ms step_avg:34.91ms
+step:350/1555 train_time:12220ms step_avg:34.91ms
+step:351/1555 train_time:12251ms step_avg:34.90ms
+step:352/1555 train_time:12289ms step_avg:34.91ms
+step:353/1555 train_time:12320ms step_avg:34.90ms
+step:354/1555 train_time:12359ms step_avg:34.91ms
+step:355/1555 train_time:12390ms step_avg:34.90ms
+step:356/1555 train_time:12428ms step_avg:34.91ms
+step:357/1555 train_time:12459ms step_avg:34.90ms
+step:358/1555 train_time:12497ms step_avg:34.91ms
+step:359/1555 train_time:12528ms step_avg:34.90ms
+step:360/1555 train_time:12566ms step_avg:34.91ms
+step:361/1555 train_time:12598ms step_avg:34.90ms
+step:362/1555 train_time:12636ms step_avg:34.91ms
+step:363/1555 train_time:12667ms step_avg:34.90ms
+step:364/1555 train_time:12705ms step_avg:34.90ms
+step:365/1555 train_time:12736ms step_avg:34.89ms
+step:366/1555 train_time:12774ms step_avg:34.90ms
+step:367/1555 train_time:12806ms step_avg:34.89ms
+step:368/1555 train_time:12844ms step_avg:34.90ms
+step:369/1555 train_time:12875ms step_avg:34.89ms
+step:370/1555 train_time:12913ms step_avg:34.90ms
+step:371/1555 train_time:12944ms step_avg:34.89ms
+step:372/1555 train_time:12982ms step_avg:34.90ms
+step:373/1555 train_time:13013ms step_avg:34.89ms
+step:374/1555 train_time:13051ms step_avg:34.90ms
+step:375/1555 train_time:13083ms step_avg:34.89ms
+step:376/1555 train_time:13121ms step_avg:34.90ms
+step:377/1555 train_time:13152ms step_avg:34.89ms
+step:378/1555 train_time:13190ms step_avg:34.89ms
+step:379/1555 train_time:13221ms step_avg:34.88ms
+step:380/1555 train_time:13259ms step_avg:34.89ms
+step:381/1555 train_time:13290ms step_avg:34.88ms
+step:382/1555 train_time:13328ms step_avg:34.89ms
+step:383/1555 train_time:13360ms step_avg:34.88ms
+step:384/1555 train_time:13398ms step_avg:34.89ms
+step:385/1555 train_time:13429ms step_avg:34.88ms
+step:386/1555 train_time:13467ms step_avg:34.89ms
+step:387/1555 train_time:13498ms step_avg:34.88ms
+step:388/1555 train_time:13536ms step_avg:34.89ms
+step:389/1555 train_time:13568ms step_avg:34.88ms
+step:390/1555 train_time:13605ms step_avg:34.89ms
+step:391/1555 train_time:13637ms step_avg:34.88ms
+step:392/1555 train_time:13676ms step_avg:34.89ms
+step:393/1555 train_time:13707ms step_avg:34.88ms
+step:394/1555 train_time:13745ms step_avg:34.88ms
+step:395/1555 train_time:13776ms step_avg:34.88ms
+step:396/1555 train_time:13814ms step_avg:34.88ms
+step:397/1555 train_time:13845ms step_avg:34.87ms
+step:398/1555 train_time:13883ms step_avg:34.88ms
+step:399/1555 train_time:13914ms step_avg:34.87ms
+step:400/1555 train_time:13953ms step_avg:34.88ms
+step:401/1555 train_time:13984ms step_avg:34.87ms
+step:402/1555 train_time:14022ms step_avg:34.88ms
+step:403/1555 train_time:14053ms step_avg:34.87ms
+step:404/1555 train_time:14090ms step_avg:34.88ms
+step:405/1555 train_time:14122ms step_avg:34.87ms
+step:406/1555 train_time:14159ms step_avg:34.88ms
+step:407/1555 train_time:14191ms step_avg:34.87ms
+step:408/1555 train_time:14229ms step_avg:34.87ms
+step:409/1555 train_time:14260ms step_avg:34.87ms
+step:410/1555 train_time:14298ms step_avg:34.87ms
+step:411/1555 train_time:14329ms step_avg:34.86ms
+step:412/1555 train_time:14367ms step_avg:34.87ms
+step:413/1555 train_time:14398ms step_avg:34.86ms
+step:414/1555 train_time:14437ms step_avg:34.87ms
+step:415/1555 train_time:14468ms step_avg:34.86ms
+step:416/1555 train_time:14506ms step_avg:34.87ms
+step:417/1555 train_time:14537ms step_avg:34.86ms
+step:418/1555 train_time:14575ms step_avg:34.87ms
+step:419/1555 train_time:14607ms step_avg:34.86ms
+step:420/1555 train_time:14644ms step_avg:34.87ms
+step:421/1555 train_time:14676ms step_avg:34.86ms
+step:422/1555 train_time:14715ms step_avg:34.87ms
+step:423/1555 train_time:14745ms step_avg:34.86ms
+step:424/1555 train_time:14783ms step_avg:34.87ms
+step:425/1555 train_time:14814ms step_avg:34.86ms
+step:426/1555 train_time:14853ms step_avg:34.87ms
+step:427/1555 train_time:14884ms step_avg:34.86ms
+step:428/1555 train_time:14922ms step_avg:34.86ms
+step:429/1555 train_time:14953ms step_avg:34.86ms
+step:430/1555 train_time:14992ms step_avg:34.87ms
+step:431/1555 train_time:15022ms step_avg:34.85ms
+step:432/1555 train_time:15060ms step_avg:34.86ms
+step:433/1555 train_time:15091ms step_avg:34.85ms
+step:434/1555 train_time:15129ms step_avg:34.86ms
+step:435/1555 train_time:15161ms step_avg:34.85ms
+step:436/1555 train_time:15199ms step_avg:34.86ms
+step:437/1555 train_time:15230ms step_avg:34.85ms
+step:438/1555 train_time:15268ms step_avg:34.86ms
+step:439/1555 train_time:15299ms step_avg:34.85ms
+step:440/1555 train_time:15337ms step_avg:34.86ms
+step:441/1555 train_time:15368ms step_avg:34.85ms
+step:442/1555 train_time:15406ms step_avg:34.86ms
+step:443/1555 train_time:15438ms step_avg:34.85ms
+step:444/1555 train_time:15476ms step_avg:34.85ms
+step:445/1555 train_time:15507ms step_avg:34.85ms
+step:446/1555 train_time:15545ms step_avg:34.85ms
+step:447/1555 train_time:15576ms step_avg:34.85ms
+step:448/1555 train_time:15614ms step_avg:34.85ms
+step:449/1555 train_time:15645ms step_avg:34.84ms
+step:450/1555 train_time:15683ms step_avg:34.85ms
+step:451/1555 train_time:15714ms step_avg:34.84ms
+step:452/1555 train_time:15753ms step_avg:34.85ms
+step:453/1555 train_time:15784ms step_avg:34.84ms
+step:454/1555 train_time:15822ms step_avg:34.85ms
+step:455/1555 train_time:15853ms step_avg:34.84ms
+step:456/1555 train_time:15891ms step_avg:34.85ms
+step:457/1555 train_time:15922ms step_avg:34.84ms
+step:458/1555 train_time:15960ms step_avg:34.85ms
+step:459/1555 train_time:15991ms step_avg:34.84ms
+step:460/1555 train_time:16029ms step_avg:34.85ms
+step:461/1555 train_time:16060ms step_avg:34.84ms
+step:462/1555 train_time:16098ms step_avg:34.84ms
+step:463/1555 train_time:16129ms step_avg:34.84ms
+step:464/1555 train_time:16168ms step_avg:34.84ms
+step:465/1555 train_time:16198ms step_avg:34.84ms
+step:466/1555 train_time:16236ms step_avg:34.84ms
+step:467/1555 train_time:16268ms step_avg:34.83ms
+step:468/1555 train_time:16305ms step_avg:34.84ms
+step:469/1555 train_time:16337ms step_avg:34.83ms
+step:470/1555 train_time:16375ms step_avg:34.84ms
+step:471/1555 train_time:16406ms step_avg:34.83ms
+step:472/1555 train_time:16444ms step_avg:34.84ms
+step:473/1555 train_time:16475ms step_avg:34.83ms
+step:474/1555 train_time:16513ms step_avg:34.84ms
+step:475/1555 train_time:16545ms step_avg:34.83ms
+step:476/1555 train_time:16583ms step_avg:34.84ms
+step:477/1555 train_time:16614ms step_avg:34.83ms
+step:478/1555 train_time:16652ms step_avg:34.84ms
+step:479/1555 train_time:16683ms step_avg:34.83ms
+step:480/1555 train_time:16721ms step_avg:34.84ms
+step:481/1555 train_time:16752ms step_avg:34.83ms
+step:482/1555 train_time:16790ms step_avg:34.83ms
+step:483/1555 train_time:16822ms step_avg:34.83ms
+step:484/1555 train_time:16860ms step_avg:34.83ms
+step:485/1555 train_time:16891ms step_avg:34.83ms
+step:486/1555 train_time:16929ms step_avg:34.83ms
+step:487/1555 train_time:16960ms step_avg:34.83ms
+step:488/1555 train_time:16998ms step_avg:34.83ms
+step:489/1555 train_time:17029ms step_avg:34.82ms
+step:490/1555 train_time:17067ms step_avg:34.83ms
+step:491/1555 train_time:17098ms step_avg:34.82ms
+step:492/1555 train_time:17136ms step_avg:34.83ms
+step:493/1555 train_time:17168ms step_avg:34.82ms
+step:494/1555 train_time:17205ms step_avg:34.83ms
+step:495/1555 train_time:17237ms step_avg:34.82ms
+step:496/1555 train_time:17275ms step_avg:34.83ms
+step:497/1555 train_time:17306ms step_avg:34.82ms
+step:498/1555 train_time:17344ms step_avg:34.83ms
+step:499/1555 train_time:17376ms step_avg:34.82ms
+step:500/1555 train_time:17413ms step_avg:34.83ms
+step:500/1555 val_loss:4.2215 train_time:17463ms step_avg:34.93ms
+step:501/1555 train_time:17480ms step_avg:34.89ms
+step:502/1555 train_time:17498ms step_avg:34.86ms
+step:503/1555 train_time:17517ms step_avg:34.82ms
+step:504/1555 train_time:17556ms step_avg:34.83ms
+step:505/1555 train_time:17588ms step_avg:34.83ms
+step:506/1555 train_time:17664ms step_avg:34.91ms
+step:507/1555 train_time:17722ms step_avg:34.96ms
+step:508/1555 train_time:17781ms step_avg:35.00ms
+step:509/1555 train_time:17844ms step_avg:35.06ms
+step:510/1555 train_time:17903ms step_avg:35.10ms
+step:511/1555 train_time:17967ms step_avg:35.16ms
+step:512/1555 train_time:18026ms step_avg:35.21ms
+step:513/1555 train_time:18090ms step_avg:35.26ms
+step:514/1555 train_time:18148ms step_avg:35.31ms
+step:515/1555 train_time:18210ms step_avg:35.36ms
+step:516/1555 train_time:18269ms step_avg:35.40ms
+step:517/1555 train_time:18332ms step_avg:35.46ms
+step:518/1555 train_time:18391ms step_avg:35.50ms
+step:519/1555 train_time:18455ms step_avg:35.56ms
+step:520/1555 train_time:18516ms step_avg:35.61ms
+step:521/1555 train_time:18579ms step_avg:35.66ms
+step:522/1555 train_time:18639ms step_avg:35.71ms
+step:523/1555 train_time:18702ms step_avg:35.76ms
+step:524/1555 train_time:18762ms step_avg:35.80ms
+step:525/1555 train_time:18825ms step_avg:35.86ms
+step:526/1555 train_time:18883ms step_avg:35.90ms
+step:527/1555 train_time:18948ms step_avg:35.95ms
+step:528/1555 train_time:19007ms step_avg:36.00ms
+step:529/1555 train_time:19071ms step_avg:36.05ms
+step:530/1555 train_time:19130ms step_avg:36.09ms
+step:531/1555 train_time:19193ms step_avg:36.14ms
+step:532/1555 train_time:19251ms step_avg:36.19ms
+step:533/1555 train_time:19314ms step_avg:36.24ms
+step:534/1555 train_time:19373ms step_avg:36.28ms
+step:535/1555 train_time:19438ms step_avg:36.33ms
+step:536/1555 train_time:19498ms step_avg:36.38ms
+step:537/1555 train_time:19562ms step_avg:36.43ms
+step:538/1555 train_time:19622ms step_avg:36.47ms
+step:539/1555 train_time:19685ms step_avg:36.52ms
+step:540/1555 train_time:19745ms step_avg:36.56ms
+step:541/1555 train_time:19808ms step_avg:36.61ms
+step:542/1555 train_time:19867ms step_avg:36.66ms
+step:543/1555 train_time:19931ms step_avg:36.71ms
+step:544/1555 train_time:19990ms step_avg:36.75ms
+step:545/1555 train_time:20053ms step_avg:36.79ms
+step:546/1555 train_time:20112ms step_avg:36.84ms
+step:547/1555 train_time:20175ms step_avg:36.88ms
+step:548/1555 train_time:20234ms step_avg:36.92ms
+step:549/1555 train_time:20297ms step_avg:36.97ms
+step:550/1555 train_time:20356ms step_avg:37.01ms
+step:551/1555 train_time:20420ms step_avg:37.06ms
+step:552/1555 train_time:20480ms step_avg:37.10ms
+step:553/1555 train_time:20544ms step_avg:37.15ms
+step:554/1555 train_time:20605ms step_avg:37.19ms
+step:555/1555 train_time:20668ms step_avg:37.24ms
+step:556/1555 train_time:20728ms step_avg:37.28ms
+step:557/1555 train_time:20791ms step_avg:37.33ms
+step:558/1555 train_time:20851ms step_avg:37.37ms
+step:559/1555 train_time:20913ms step_avg:37.41ms
+step:560/1555 train_time:20974ms step_avg:37.45ms
+step:561/1555 train_time:21037ms step_avg:37.50ms
+step:562/1555 train_time:21097ms step_avg:37.54ms
+step:563/1555 train_time:21160ms step_avg:37.58ms
+step:564/1555 train_time:21218ms step_avg:37.62ms
+step:565/1555 train_time:21282ms step_avg:37.67ms
+step:566/1555 train_time:21344ms step_avg:37.71ms
+step:567/1555 train_time:21408ms step_avg:37.76ms
+step:568/1555 train_time:21469ms step_avg:37.80ms
+step:569/1555 train_time:21529ms step_avg:37.84ms
+step:570/1555 train_time:21588ms step_avg:37.87ms
+step:571/1555 train_time:21651ms step_avg:37.92ms
+step:572/1555 train_time:21711ms step_avg:37.96ms
+step:573/1555 train_time:21774ms step_avg:38.00ms
+step:574/1555 train_time:21834ms step_avg:38.04ms
+step:575/1555 train_time:21897ms step_avg:38.08ms
+step:576/1555 train_time:21958ms step_avg:38.12ms
+step:577/1555 train_time:22021ms step_avg:38.16ms
+step:578/1555 train_time:22080ms step_avg:38.20ms
+step:579/1555 train_time:22143ms step_avg:38.24ms
+step:580/1555 train_time:22202ms step_avg:38.28ms
+step:581/1555 train_time:22265ms step_avg:38.32ms
+step:582/1555 train_time:22325ms step_avg:38.36ms
+step:583/1555 train_time:22388ms step_avg:38.40ms
+step:584/1555 train_time:22447ms step_avg:38.44ms
+step:585/1555 train_time:22512ms step_avg:38.48ms
+step:586/1555 train_time:22569ms step_avg:38.51ms
+step:587/1555 train_time:22633ms step_avg:38.56ms
+step:588/1555 train_time:22692ms step_avg:38.59ms
+step:589/1555 train_time:22755ms step_avg:38.63ms
+step:590/1555 train_time:22815ms step_avg:38.67ms
+step:591/1555 train_time:22878ms step_avg:38.71ms
+step:592/1555 train_time:22937ms step_avg:38.75ms
+step:593/1555 train_time:23002ms step_avg:38.79ms
+step:594/1555 train_time:23060ms step_avg:38.82ms
+step:595/1555 train_time:23123ms step_avg:38.86ms
+step:596/1555 train_time:23182ms step_avg:38.90ms
+step:597/1555 train_time:23246ms step_avg:38.94ms
+step:598/1555 train_time:23305ms step_avg:38.97ms
+step:599/1555 train_time:23368ms step_avg:39.01ms
+step:600/1555 train_time:23427ms step_avg:39.05ms
+step:601/1555 train_time:23493ms step_avg:39.09ms
+step:602/1555 train_time:23550ms step_avg:39.12ms
+step:603/1555 train_time:23613ms step_avg:39.16ms
+step:604/1555 train_time:23672ms step_avg:39.19ms
+step:605/1555 train_time:23736ms step_avg:39.23ms
+step:606/1555 train_time:23795ms step_avg:39.27ms
+step:607/1555 train_time:23858ms step_avg:39.30ms
+step:608/1555 train_time:23917ms step_avg:39.34ms
+step:609/1555 train_time:23981ms step_avg:39.38ms
+step:610/1555 train_time:24040ms step_avg:39.41ms
+step:611/1555 train_time:24105ms step_avg:39.45ms
+step:612/1555 train_time:24163ms step_avg:39.48ms
+step:613/1555 train_time:24227ms step_avg:39.52ms
+step:614/1555 train_time:24286ms step_avg:39.55ms
+step:615/1555 train_time:24349ms step_avg:39.59ms
+step:616/1555 train_time:24408ms step_avg:39.62ms
+step:617/1555 train_time:24471ms step_avg:39.66ms
+step:618/1555 train_time:24530ms step_avg:39.69ms
+step:619/1555 train_time:24593ms step_avg:39.73ms
+step:620/1555 train_time:24653ms step_avg:39.76ms
+step:621/1555 train_time:24717ms step_avg:39.80ms
+step:622/1555 train_time:24775ms step_avg:39.83ms
+step:623/1555 train_time:24838ms step_avg:39.87ms
+step:624/1555 train_time:24898ms step_avg:39.90ms
+step:625/1555 train_time:24961ms step_avg:39.94ms
+step:626/1555 train_time:25020ms step_avg:39.97ms
+step:627/1555 train_time:25084ms step_avg:40.01ms
+step:628/1555 train_time:25144ms step_avg:40.04ms
+step:629/1555 train_time:25206ms step_avg:40.07ms
+step:630/1555 train_time:25266ms step_avg:40.11ms
+step:631/1555 train_time:25330ms step_avg:40.14ms
+step:632/1555 train_time:25389ms step_avg:40.17ms
+step:633/1555 train_time:25452ms step_avg:40.21ms
+step:634/1555 train_time:25511ms step_avg:40.24ms
+step:635/1555 train_time:25575ms step_avg:40.27ms
+step:636/1555 train_time:25634ms step_avg:40.30ms
+step:637/1555 train_time:25697ms step_avg:40.34ms
+step:638/1555 train_time:25756ms step_avg:40.37ms
+step:639/1555 train_time:25819ms step_avg:40.41ms
+step:640/1555 train_time:25879ms step_avg:40.44ms
+step:641/1555 train_time:25944ms step_avg:40.47ms
+step:642/1555 train_time:26002ms step_avg:40.50ms
+step:643/1555 train_time:26066ms step_avg:40.54ms
+step:644/1555 train_time:26125ms step_avg:40.57ms
+step:645/1555 train_time:26188ms step_avg:40.60ms
+step:646/1555 train_time:26248ms step_avg:40.63ms
+step:647/1555 train_time:26311ms step_avg:40.67ms
+step:648/1555 train_time:26370ms step_avg:40.69ms
+step:649/1555 train_time:26433ms step_avg:40.73ms
+step:650/1555 train_time:26492ms step_avg:40.76ms
+step:651/1555 train_time:26557ms step_avg:40.79ms
+step:652/1555 train_time:26616ms step_avg:40.82ms
+step:653/1555 train_time:26679ms step_avg:40.86ms
+step:654/1555 train_time:26738ms step_avg:40.88ms
+step:655/1555 train_time:26802ms step_avg:40.92ms
+step:656/1555 train_time:26861ms step_avg:40.95ms
+step:657/1555 train_time:26924ms step_avg:40.98ms
+step:658/1555 train_time:26983ms step_avg:41.01ms
+step:659/1555 train_time:27047ms step_avg:41.04ms
+step:660/1555 train_time:27106ms step_avg:41.07ms
+step:661/1555 train_time:27171ms step_avg:41.11ms
+step:662/1555 train_time:27228ms step_avg:41.13ms
+step:663/1555 train_time:27292ms step_avg:41.16ms
+step:664/1555 train_time:27351ms step_avg:41.19ms
+step:665/1555 train_time:27414ms step_avg:41.22ms
+step:666/1555 train_time:27473ms step_avg:41.25ms
+step:667/1555 train_time:27536ms step_avg:41.28ms
+step:668/1555 train_time:27595ms step_avg:41.31ms
+step:669/1555 train_time:27658ms step_avg:41.34ms
+step:670/1555 train_time:27717ms step_avg:41.37ms
+step:671/1555 train_time:27782ms step_avg:41.40ms
+step:672/1555 train_time:27840ms step_avg:41.43ms
+step:673/1555 train_time:27903ms step_avg:41.46ms
+step:674/1555 train_time:27962ms step_avg:41.49ms
+step:675/1555 train_time:28026ms step_avg:41.52ms
+step:676/1555 train_time:28085ms step_avg:41.55ms
+step:677/1555 train_time:28149ms step_avg:41.58ms
+step:678/1555 train_time:28209ms step_avg:41.61ms
+step:679/1555 train_time:28272ms step_avg:41.64ms
+step:680/1555 train_time:28332ms step_avg:41.66ms
+step:681/1555 train_time:28396ms step_avg:41.70ms
+step:682/1555 train_time:28454ms step_avg:41.72ms
+step:683/1555 train_time:28517ms step_avg:41.75ms
+step:684/1555 train_time:28576ms step_avg:41.78ms
+step:685/1555 train_time:28639ms step_avg:41.81ms
+step:686/1555 train_time:28699ms step_avg:41.84ms
+step:687/1555 train_time:28762ms step_avg:41.87ms
+step:688/1555 train_time:28821ms step_avg:41.89ms
+step:689/1555 train_time:28884ms step_avg:41.92ms
+step:690/1555 train_time:28944ms step_avg:41.95ms
+step:691/1555 train_time:29008ms step_avg:41.98ms
+step:692/1555 train_time:29066ms step_avg:42.00ms
+step:693/1555 train_time:29129ms step_avg:42.03ms
+step:694/1555 train_time:29189ms step_avg:42.06ms
+step:695/1555 train_time:29252ms step_avg:42.09ms
+step:696/1555 train_time:29311ms step_avg:42.11ms
+step:697/1555 train_time:29375ms step_avg:42.15ms
+step:698/1555 train_time:29434ms step_avg:42.17ms
+step:699/1555 train_time:29497ms step_avg:42.20ms
+step:700/1555 train_time:29556ms step_avg:42.22ms
+step:701/1555 train_time:29619ms step_avg:42.25ms
+step:702/1555 train_time:29678ms step_avg:42.28ms
+step:703/1555 train_time:29743ms step_avg:42.31ms
+step:704/1555 train_time:29801ms step_avg:42.33ms
+step:705/1555 train_time:29865ms step_avg:42.36ms
+step:706/1555 train_time:29924ms step_avg:42.39ms
+step:707/1555 train_time:29988ms step_avg:42.42ms
+step:708/1555 train_time:30048ms step_avg:42.44ms
+step:709/1555 train_time:30111ms step_avg:42.47ms
+step:710/1555 train_time:30171ms step_avg:42.49ms
+step:711/1555 train_time:30234ms step_avg:42.52ms
+step:712/1555 train_time:30294ms step_avg:42.55ms
+step:713/1555 train_time:30357ms step_avg:42.58ms
+step:714/1555 train_time:30416ms step_avg:42.60ms
+step:715/1555 train_time:30481ms step_avg:42.63ms
+step:716/1555 train_time:30539ms step_avg:42.65ms
+step:717/1555 train_time:30602ms step_avg:42.68ms
+step:718/1555 train_time:30661ms step_avg:42.70ms
+step:719/1555 train_time:30724ms step_avg:42.73ms
+step:720/1555 train_time:30783ms step_avg:42.75ms
+step:721/1555 train_time:30847ms step_avg:42.78ms
+step:722/1555 train_time:30906ms step_avg:42.81ms
+step:723/1555 train_time:30969ms step_avg:42.83ms
+step:724/1555 train_time:31029ms step_avg:42.86ms
+step:725/1555 train_time:31092ms step_avg:42.88ms
+step:726/1555 train_time:31151ms step_avg:42.91ms
+step:727/1555 train_time:31215ms step_avg:42.94ms
+step:728/1555 train_time:31274ms step_avg:42.96ms
+step:729/1555 train_time:31337ms step_avg:42.99ms
+step:730/1555 train_time:31396ms step_avg:43.01ms
+step:731/1555 train_time:31459ms step_avg:43.04ms
+step:732/1555 train_time:31518ms step_avg:43.06ms
+step:733/1555 train_time:31582ms step_avg:43.09ms
+step:734/1555 train_time:31640ms step_avg:43.11ms
+step:735/1555 train_time:31704ms step_avg:43.13ms
+step:736/1555 train_time:31763ms step_avg:43.16ms
+step:737/1555 train_time:31826ms step_avg:43.18ms
+step:738/1555 train_time:31886ms step_avg:43.21ms
+step:739/1555 train_time:31950ms step_avg:43.23ms
+step:740/1555 train_time:32008ms step_avg:43.25ms
+step:741/1555 train_time:32071ms step_avg:43.28ms
+step:742/1555 train_time:32131ms step_avg:43.30ms
+step:743/1555 train_time:32195ms step_avg:43.33ms
+step:744/1555 train_time:32254ms step_avg:43.35ms
+step:745/1555 train_time:32317ms step_avg:43.38ms
+step:746/1555 train_time:32377ms step_avg:43.40ms
+step:747/1555 train_time:32439ms step_avg:43.43ms
+step:748/1555 train_time:32498ms step_avg:43.45ms
+step:749/1555 train_time:32561ms step_avg:43.47ms
+step:750/1555 train_time:32620ms step_avg:43.49ms
+step:750/1555 val_loss:3.8720 train_time:32669ms step_avg:43.56ms
+step:751/1555 train_time:32691ms step_avg:43.53ms
+step:752/1555 train_time:32748ms step_avg:43.55ms
+step:753/1555 train_time:32815ms step_avg:43.58ms
+step:754/1555 train_time:32879ms step_avg:43.61ms
+step:755/1555 train_time:32941ms step_avg:43.63ms
+step:756/1555 train_time:33000ms step_avg:43.65ms
+step:757/1555 train_time:33063ms step_avg:43.68ms
+step:758/1555 train_time:33124ms step_avg:43.70ms
+step:759/1555 train_time:33186ms step_avg:43.72ms
+step:760/1555 train_time:33244ms step_avg:43.74ms
+step:761/1555 train_time:33307ms step_avg:43.77ms
+step:762/1555 train_time:33366ms step_avg:43.79ms
+step:763/1555 train_time:33429ms step_avg:43.81ms
+step:764/1555 train_time:33488ms step_avg:43.83ms
+step:765/1555 train_time:33551ms step_avg:43.86ms
+step:766/1555 train_time:33610ms step_avg:43.88ms
+step:767/1555 train_time:33674ms step_avg:43.90ms
+step:768/1555 train_time:33735ms step_avg:43.93ms
+step:769/1555 train_time:33799ms step_avg:43.95ms
+step:770/1555 train_time:33861ms step_avg:43.98ms
+step:771/1555 train_time:33924ms step_avg:44.00ms
+step:772/1555 train_time:33983ms step_avg:44.02ms
+step:773/1555 train_time:34046ms step_avg:44.04ms
+step:774/1555 train_time:34105ms step_avg:44.06ms
+step:775/1555 train_time:34169ms step_avg:44.09ms
+step:776/1555 train_time:34228ms step_avg:44.11ms
+step:777/1555 train_time:34291ms step_avg:44.13ms
+step:778/1555 train_time:34350ms step_avg:44.15ms
+step:779/1555 train_time:34413ms step_avg:44.18ms
+step:780/1555 train_time:34472ms step_avg:44.19ms
+step:781/1555 train_time:34535ms step_avg:44.22ms
+step:782/1555 train_time:34594ms step_avg:44.24ms
+step:783/1555 train_time:34658ms step_avg:44.26ms
+step:784/1555 train_time:34716ms step_avg:44.28ms
+step:785/1555 train_time:34781ms step_avg:44.31ms
+step:786/1555 train_time:34840ms step_avg:44.33ms
+step:787/1555 train_time:34904ms step_avg:44.35ms
+step:788/1555 train_time:34964ms step_avg:44.37ms
+step:789/1555 train_time:35027ms step_avg:44.39ms
+step:790/1555 train_time:35086ms step_avg:44.41ms
+step:791/1555 train_time:35149ms step_avg:44.44ms
+step:792/1555 train_time:35208ms step_avg:44.45ms
+step:793/1555 train_time:35271ms step_avg:44.48ms
+step:794/1555 train_time:35330ms step_avg:44.50ms
+step:795/1555 train_time:35394ms step_avg:44.52ms
+step:796/1555 train_time:35453ms step_avg:44.54ms
+step:797/1555 train_time:35516ms step_avg:44.56ms
+step:798/1555 train_time:35575ms step_avg:44.58ms
+step:799/1555 train_time:35638ms step_avg:44.60ms
+step:800/1555 train_time:35697ms step_avg:44.62ms
+step:801/1555 train_time:35761ms step_avg:44.65ms
+step:802/1555 train_time:35821ms step_avg:44.66ms
+step:803/1555 train_time:35885ms step_avg:44.69ms
+step:804/1555 train_time:35944ms step_avg:44.71ms
+step:805/1555 train_time:36008ms step_avg:44.73ms
+step:806/1555 train_time:36066ms step_avg:44.75ms
+step:807/1555 train_time:36130ms step_avg:44.77ms
+step:808/1555 train_time:36188ms step_avg:44.79ms
+step:809/1555 train_time:36251ms step_avg:44.81ms
+step:810/1555 train_time:36311ms step_avg:44.83ms
+step:811/1555 train_time:36375ms step_avg:44.85ms
+step:812/1555 train_time:36434ms step_avg:44.87ms
+step:813/1555 train_time:36496ms step_avg:44.89ms
+step:814/1555 train_time:36556ms step_avg:44.91ms
+step:815/1555 train_time:36619ms step_avg:44.93ms
+step:816/1555 train_time:36678ms step_avg:44.95ms
+step:817/1555 train_time:36741ms step_avg:44.97ms
+step:818/1555 train_time:36801ms step_avg:44.99ms
+step:819/1555 train_time:36864ms step_avg:45.01ms
+step:820/1555 train_time:36925ms step_avg:45.03ms
+step:821/1555 train_time:36989ms step_avg:45.05ms
+step:822/1555 train_time:37048ms step_avg:45.07ms
+step:823/1555 train_time:37111ms step_avg:45.09ms
+step:824/1555 train_time:37170ms step_avg:45.11ms
+step:825/1555 train_time:37234ms step_avg:45.13ms
+step:826/1555 train_time:37293ms step_avg:45.15ms
+step:827/1555 train_time:37356ms step_avg:45.17ms
+step:828/1555 train_time:37415ms step_avg:45.19ms
+step:829/1555 train_time:37478ms step_avg:45.21ms
+step:830/1555 train_time:37537ms step_avg:45.23ms
+step:831/1555 train_time:37600ms step_avg:45.25ms
+step:832/1555 train_time:37660ms step_avg:45.26ms
+step:833/1555 train_time:37723ms step_avg:45.29ms
+step:834/1555 train_time:37783ms step_avg:45.30ms
+step:835/1555 train_time:37846ms step_avg:45.32ms
+step:836/1555 train_time:37905ms step_avg:45.34ms
+step:837/1555 train_time:37968ms step_avg:45.36ms
+step:838/1555 train_time:38029ms step_avg:45.38ms
+step:839/1555 train_time:38094ms step_avg:45.40ms
+step:840/1555 train_time:38152ms step_avg:45.42ms
+step:841/1555 train_time:38216ms step_avg:45.44ms
+step:842/1555 train_time:38275ms step_avg:45.46ms
+step:843/1555 train_time:38338ms step_avg:45.48ms
+step:844/1555 train_time:38396ms step_avg:45.49ms
+step:845/1555 train_time:38460ms step_avg:45.51ms
+step:846/1555 train_time:38519ms step_avg:45.53ms
+step:847/1555 train_time:38582ms step_avg:45.55ms
+step:848/1555 train_time:38641ms step_avg:45.57ms
+step:849/1555 train_time:38704ms step_avg:45.59ms
+step:850/1555 train_time:38763ms step_avg:45.60ms
+step:851/1555 train_time:38827ms step_avg:45.63ms
+step:852/1555 train_time:38886ms step_avg:45.64ms
+step:853/1555 train_time:38951ms step_avg:45.66ms
+step:854/1555 train_time:39009ms step_avg:45.68ms
+step:855/1555 train_time:39072ms step_avg:45.70ms
+step:856/1555 train_time:39132ms step_avg:45.71ms
+step:857/1555 train_time:39195ms step_avg:45.74ms
+step:858/1555 train_time:39254ms step_avg:45.75ms
+step:859/1555 train_time:39318ms step_avg:45.77ms
+step:860/1555 train_time:39377ms step_avg:45.79ms
+step:861/1555 train_time:39441ms step_avg:45.81ms
+step:862/1555 train_time:39500ms step_avg:45.82ms
+step:863/1555 train_time:39563ms step_avg:45.84ms
+step:864/1555 train_time:39622ms step_avg:45.86ms
+step:865/1555 train_time:39685ms step_avg:45.88ms
+step:866/1555 train_time:39744ms step_avg:45.89ms
+step:867/1555 train_time:39808ms step_avg:45.91ms
+step:868/1555 train_time:39869ms step_avg:45.93ms
+step:869/1555 train_time:39931ms step_avg:45.95ms
+step:870/1555 train_time:39989ms step_avg:45.96ms
+step:871/1555 train_time:40053ms step_avg:45.98ms
+step:872/1555 train_time:40112ms step_avg:46.00ms
+step:873/1555 train_time:40175ms step_avg:46.02ms
+step:874/1555 train_time:40235ms step_avg:46.04ms
+step:875/1555 train_time:40298ms step_avg:46.06ms
+step:876/1555 train_time:40357ms step_avg:46.07ms
+step:877/1555 train_time:40421ms step_avg:46.09ms
+step:878/1555 train_time:40481ms step_avg:46.11ms
+step:879/1555 train_time:40544ms step_avg:46.13ms
+step:880/1555 train_time:40603ms step_avg:46.14ms
+step:881/1555 train_time:40666ms step_avg:46.16ms
+step:882/1555 train_time:40728ms step_avg:46.18ms
+step:883/1555 train_time:40793ms step_avg:46.20ms
+step:884/1555 train_time:40852ms step_avg:46.21ms
+step:885/1555 train_time:40914ms step_avg:46.23ms
+step:886/1555 train_time:40972ms step_avg:46.24ms
+step:887/1555 train_time:41035ms step_avg:46.26ms
+step:888/1555 train_time:41094ms step_avg:46.28ms
+step:889/1555 train_time:41157ms step_avg:46.30ms
+step:890/1555 train_time:41216ms step_avg:46.31ms
+step:891/1555 train_time:41279ms step_avg:46.33ms
+step:892/1555 train_time:41339ms step_avg:46.34ms
+step:893/1555 train_time:41403ms step_avg:46.36ms
+step:894/1555 train_time:41462ms step_avg:46.38ms
+step:895/1555 train_time:41527ms step_avg:46.40ms
+step:896/1555 train_time:41587ms step_avg:46.41ms
+step:897/1555 train_time:41649ms step_avg:46.43ms
+step:898/1555 train_time:41708ms step_avg:46.45ms
+step:899/1555 train_time:41771ms step_avg:46.46ms
+step:900/1555 train_time:41831ms step_avg:46.48ms
+step:901/1555 train_time:41894ms step_avg:46.50ms
+step:902/1555 train_time:41953ms step_avg:46.51ms
+step:903/1555 train_time:42016ms step_avg:46.53ms
+step:904/1555 train_time:42076ms step_avg:46.54ms
+step:905/1555 train_time:42139ms step_avg:46.56ms
+step:906/1555 train_time:42198ms step_avg:46.58ms
+step:907/1555 train_time:42261ms step_avg:46.59ms
+step:908/1555 train_time:42320ms step_avg:46.61ms
+step:909/1555 train_time:42384ms step_avg:46.63ms
+step:910/1555 train_time:42444ms step_avg:46.64ms
+step:911/1555 train_time:42508ms step_avg:46.66ms
+step:912/1555 train_time:42567ms step_avg:46.67ms
+step:913/1555 train_time:42630ms step_avg:46.69ms
+step:914/1555 train_time:42689ms step_avg:46.71ms
+step:915/1555 train_time:42752ms step_avg:46.72ms
+step:916/1555 train_time:42811ms step_avg:46.74ms
+step:917/1555 train_time:42874ms step_avg:46.76ms
+step:918/1555 train_time:42934ms step_avg:46.77ms
+step:919/1555 train_time:42997ms step_avg:46.79ms
+step:920/1555 train_time:43057ms step_avg:46.80ms
+step:921/1555 train_time:43120ms step_avg:46.82ms
+step:922/1555 train_time:43180ms step_avg:46.83ms
+step:923/1555 train_time:43243ms step_avg:46.85ms
+step:924/1555 train_time:43302ms step_avg:46.86ms
+step:925/1555 train_time:43366ms step_avg:46.88ms
+step:926/1555 train_time:43426ms step_avg:46.90ms
+step:927/1555 train_time:43490ms step_avg:46.92ms
+step:928/1555 train_time:43550ms step_avg:46.93ms
+step:929/1555 train_time:43612ms step_avg:46.95ms
+step:930/1555 train_time:43672ms step_avg:46.96ms
+step:931/1555 train_time:43735ms step_avg:46.98ms
+step:932/1555 train_time:43793ms step_avg:46.99ms
+step:933/1555 train_time:43856ms step_avg:47.01ms
+step:934/1555 train_time:43915ms step_avg:47.02ms
+step:935/1555 train_time:43979ms step_avg:47.04ms
+step:936/1555 train_time:44038ms step_avg:47.05ms
+step:937/1555 train_time:44101ms step_avg:47.07ms
+step:938/1555 train_time:44160ms step_avg:47.08ms
+step:939/1555 train_time:44223ms step_avg:47.10ms
+step:940/1555 train_time:44282ms step_avg:47.11ms
+step:941/1555 train_time:44346ms step_avg:47.13ms
+step:942/1555 train_time:44405ms step_avg:47.14ms
+step:943/1555 train_time:44469ms step_avg:47.16ms
+step:944/1555 train_time:44529ms step_avg:47.17ms
+step:945/1555 train_time:44593ms step_avg:47.19ms
+step:946/1555 train_time:44652ms step_avg:47.20ms
+step:947/1555 train_time:44715ms step_avg:47.22ms
+step:948/1555 train_time:44776ms step_avg:47.23ms
+step:949/1555 train_time:44838ms step_avg:47.25ms
+step:950/1555 train_time:44897ms step_avg:47.26ms
+step:951/1555 train_time:44960ms step_avg:47.28ms
+step:952/1555 train_time:45020ms step_avg:47.29ms
+step:953/1555 train_time:45083ms step_avg:47.31ms
+step:954/1555 train_time:45142ms step_avg:47.32ms
+step:955/1555 train_time:45205ms step_avg:47.34ms
+step:956/1555 train_time:45264ms step_avg:47.35ms
+step:957/1555 train_time:45328ms step_avg:47.36ms
+step:958/1555 train_time:45386ms step_avg:47.38ms
+step:959/1555 train_time:45450ms step_avg:47.39ms
+step:960/1555 train_time:45509ms step_avg:47.41ms
+step:961/1555 train_time:45572ms step_avg:47.42ms
+step:962/1555 train_time:45633ms step_avg:47.44ms
+step:963/1555 train_time:45696ms step_avg:47.45ms
+step:964/1555 train_time:45755ms step_avg:47.46ms
+step:965/1555 train_time:45818ms step_avg:47.48ms
+step:966/1555 train_time:45877ms step_avg:47.49ms
+step:967/1555 train_time:45940ms step_avg:47.51ms
+step:968/1555 train_time:46000ms step_avg:47.52ms
+step:969/1555 train_time:46063ms step_avg:47.54ms
+step:970/1555 train_time:46122ms step_avg:47.55ms
+step:971/1555 train_time:46186ms step_avg:47.57ms
+step:972/1555 train_time:46245ms step_avg:47.58ms
+step:973/1555 train_time:46308ms step_avg:47.59ms
+step:974/1555 train_time:46367ms step_avg:47.60ms
+step:975/1555 train_time:46430ms step_avg:47.62ms
+step:976/1555 train_time:46489ms step_avg:47.63ms
+step:977/1555 train_time:46553ms step_avg:47.65ms
+step:978/1555 train_time:46612ms step_avg:47.66ms
+step:979/1555 train_time:46677ms step_avg:47.68ms
+step:980/1555 train_time:46736ms step_avg:47.69ms
+step:981/1555 train_time:46799ms step_avg:47.70ms
+step:982/1555 train_time:46858ms step_avg:47.72ms
+step:983/1555 train_time:46921ms step_avg:47.73ms
+step:984/1555 train_time:46981ms step_avg:47.74ms
+step:985/1555 train_time:47044ms step_avg:47.76ms
+step:986/1555 train_time:47103ms step_avg:47.77ms
+step:987/1555 train_time:47167ms step_avg:47.79ms
+step:988/1555 train_time:47227ms step_avg:47.80ms
+step:989/1555 train_time:47290ms step_avg:47.82ms
+step:990/1555 train_time:47349ms step_avg:47.83ms
+step:991/1555 train_time:47412ms step_avg:47.84ms
+step:992/1555 train_time:47472ms step_avg:47.85ms
+step:993/1555 train_time:47535ms step_avg:47.87ms
+step:994/1555 train_time:47594ms step_avg:47.88ms
+step:995/1555 train_time:47657ms step_avg:47.90ms
+step:996/1555 train_time:47718ms step_avg:47.91ms
+step:997/1555 train_time:47780ms step_avg:47.92ms
+step:998/1555 train_time:47839ms step_avg:47.93ms
+step:999/1555 train_time:47902ms step_avg:47.95ms
+step:1000/1555 train_time:47962ms step_avg:47.96ms
+step:1000/1555 val_loss:3.5716 train_time:48010ms step_avg:48.01ms
+step:1001/1555 train_time:48033ms step_avg:47.98ms
+step:1002/1555 train_time:48087ms step_avg:47.99ms
+step:1003/1555 train_time:48153ms step_avg:48.01ms
+step:1004/1555 train_time:48216ms step_avg:48.02ms
+step:1005/1555 train_time:48278ms step_avg:48.04ms
+step:1006/1555 train_time:48337ms step_avg:48.05ms
+step:1007/1555 train_time:48399ms step_avg:48.06ms
+step:1008/1555 train_time:48459ms step_avg:48.07ms
+step:1009/1555 train_time:48522ms step_avg:48.09ms
+step:1010/1555 train_time:48580ms step_avg:48.10ms
+step:1011/1555 train_time:48654ms step_avg:48.12ms
+step:1012/1555 train_time:48735ms step_avg:48.16ms
+step:1013/1555 train_time:48827ms step_avg:48.20ms
+step:1014/1555 train_time:48912ms step_avg:48.24ms
+step:1015/1555 train_time:48999ms step_avg:48.28ms
+step:1016/1555 train_time:49086ms step_avg:48.31ms
+step:1017/1555 train_time:49178ms step_avg:48.36ms
+step:1018/1555 train_time:49263ms step_avg:48.39ms
+step:1019/1555 train_time:49353ms step_avg:48.43ms
+step:1020/1555 train_time:49438ms step_avg:48.47ms
+step:1021/1555 train_time:49529ms step_avg:48.51ms
+step:1022/1555 train_time:49614ms step_avg:48.55ms
+step:1023/1555 train_time:49704ms step_avg:48.59ms
+step:1024/1555 train_time:49788ms step_avg:48.62ms
+step:1025/1555 train_time:49877ms step_avg:48.66ms
+step:1026/1555 train_time:49962ms step_avg:48.70ms
+step:1027/1555 train_time:50053ms step_avg:48.74ms
+step:1028/1555 train_time:50141ms step_avg:48.77ms
+step:1029/1555 train_time:50231ms step_avg:48.82ms
+step:1030/1555 train_time:50319ms step_avg:48.85ms
+step:1031/1555 train_time:50407ms step_avg:48.89ms
+step:1032/1555 train_time:50493ms step_avg:48.93ms
+step:1033/1555 train_time:50581ms step_avg:48.96ms
+step:1034/1555 train_time:50666ms step_avg:49.00ms
+step:1035/1555 train_time:50755ms step_avg:49.04ms
+step:1036/1555 train_time:50841ms step_avg:49.07ms
+step:1037/1555 train_time:50930ms step_avg:49.11ms
+step:1038/1555 train_time:51017ms step_avg:49.15ms
+step:1039/1555 train_time:51106ms step_avg:49.19ms
+step:1040/1555 train_time:51193ms step_avg:49.22ms
+step:1041/1555 train_time:51284ms step_avg:49.26ms
+step:1042/1555 train_time:51371ms step_avg:49.30ms
+step:1043/1555 train_time:51459ms step_avg:49.34ms
+step:1044/1555 train_time:51544ms step_avg:49.37ms
+step:1045/1555 train_time:51636ms step_avg:49.41ms
+step:1046/1555 train_time:51720ms step_avg:49.45ms
+step:1047/1555 train_time:51809ms step_avg:49.48ms
+step:1048/1555 train_time:51894ms step_avg:49.52ms
+step:1049/1555 train_time:51984ms step_avg:49.56ms
+step:1050/1555 train_time:52070ms step_avg:49.59ms
+step:1051/1555 train_time:52162ms step_avg:49.63ms
+step:1052/1555 train_time:52247ms step_avg:49.66ms
+step:1053/1555 train_time:52335ms step_avg:49.70ms
+step:1054/1555 train_time:52423ms step_avg:49.74ms
+step:1055/1555 train_time:52511ms step_avg:49.77ms
+step:1056/1555 train_time:52599ms step_avg:49.81ms
+step:1057/1555 train_time:52686ms step_avg:49.84ms
+step:1058/1555 train_time:52771ms step_avg:49.88ms
+step:1059/1555 train_time:52859ms step_avg:49.91ms
+step:1060/1555 train_time:52947ms step_avg:49.95ms
+step:1061/1555 train_time:53036ms step_avg:49.99ms
+step:1062/1555 train_time:53122ms step_avg:50.02ms
+step:1063/1555 train_time:53212ms step_avg:50.06ms
+step:1064/1555 train_time:53300ms step_avg:50.09ms
+step:1065/1555 train_time:53388ms step_avg:50.13ms
+step:1066/1555 train_time:53476ms step_avg:50.16ms
+step:1067/1555 train_time:53564ms step_avg:50.20ms
+step:1068/1555 train_time:53651ms step_avg:50.24ms
+step:1069/1555 train_time:53740ms step_avg:50.27ms
+step:1070/1555 train_time:53825ms step_avg:50.30ms
+step:1071/1555 train_time:53915ms step_avg:50.34ms
+step:1072/1555 train_time:54001ms step_avg:50.37ms
+step:1073/1555 train_time:54091ms step_avg:50.41ms
+step:1074/1555 train_time:54177ms step_avg:50.44ms
+step:1075/1555 train_time:54267ms step_avg:50.48ms
+step:1076/1555 train_time:54355ms step_avg:50.52ms
+step:1077/1555 train_time:54443ms step_avg:50.55ms
+step:1078/1555 train_time:54529ms step_avg:50.58ms
+step:1079/1555 train_time:54620ms step_avg:50.62ms
+step:1080/1555 train_time:54704ms step_avg:50.65ms
+step:1081/1555 train_time:54793ms step_avg:50.69ms
+step:1082/1555 train_time:54880ms step_avg:50.72ms
+step:1083/1555 train_time:54969ms step_avg:50.76ms
+step:1084/1555 train_time:55058ms step_avg:50.79ms
+step:1085/1555 train_time:55146ms step_avg:50.83ms
+step:1086/1555 train_time:55232ms step_avg:50.86ms
+step:1087/1555 train_time:55322ms step_avg:50.89ms
+step:1088/1555 train_time:55406ms step_avg:50.93ms
+step:1089/1555 train_time:55495ms step_avg:50.96ms
+step:1090/1555 train_time:55582ms step_avg:50.99ms
+step:1091/1555 train_time:55673ms step_avg:51.03ms
+step:1092/1555 train_time:55758ms step_avg:51.06ms
+step:1093/1555 train_time:55848ms step_avg:51.10ms
+step:1094/1555 train_time:55933ms step_avg:51.13ms
+step:1095/1555 train_time:56022ms step_avg:51.16ms
+step:1096/1555 train_time:56108ms step_avg:51.19ms
+step:1097/1555 train_time:56199ms step_avg:51.23ms
+step:1098/1555 train_time:56284ms step_avg:51.26ms
+step:1099/1555 train_time:56373ms step_avg:51.29ms
+step:1100/1555 train_time:56461ms step_avg:51.33ms
+step:1101/1555 train_time:56549ms step_avg:51.36ms
+step:1102/1555 train_time:56634ms step_avg:51.39ms
+step:1103/1555 train_time:56724ms step_avg:51.43ms
+step:1104/1555 train_time:56808ms step_avg:51.46ms
+step:1105/1555 train_time:56897ms step_avg:51.49ms
+step:1106/1555 train_time:56983ms step_avg:51.52ms
+step:1107/1555 train_time:57074ms step_avg:51.56ms
+step:1108/1555 train_time:57159ms step_avg:51.59ms
+step:1109/1555 train_time:57248ms step_avg:51.62ms
+step:1110/1555 train_time:57334ms step_avg:51.65ms
+step:1111/1555 train_time:57424ms step_avg:51.69ms
+step:1112/1555 train_time:57509ms step_avg:51.72ms
+step:1113/1555 train_time:57601ms step_avg:51.75ms
+step:1114/1555 train_time:57686ms step_avg:51.78ms
+step:1115/1555 train_time:57775ms step_avg:51.82ms
+step:1116/1555 train_time:57861ms step_avg:51.85ms
+step:1117/1555 train_time:57950ms step_avg:51.88ms
+step:1118/1555 train_time:58036ms step_avg:51.91ms
+step:1119/1555 train_time:58125ms step_avg:51.94ms
+step:1120/1555 train_time:58212ms step_avg:51.97ms
+step:1121/1555 train_time:58301ms step_avg:52.01ms
+step:1122/1555 train_time:58387ms step_avg:52.04ms
+step:1123/1555 train_time:58476ms step_avg:52.07ms
+step:1124/1555 train_time:58564ms step_avg:52.10ms
+step:1125/1555 train_time:58652ms step_avg:52.14ms
+step:1126/1555 train_time:58738ms step_avg:52.16ms
+step:1127/1555 train_time:58827ms step_avg:52.20ms
+step:1128/1555 train_time:58914ms step_avg:52.23ms
+step:1129/1555 train_time:59003ms step_avg:52.26ms
+step:1130/1555 train_time:59088ms step_avg:52.29ms
+step:1131/1555 train_time:59179ms step_avg:52.32ms
+step:1132/1555 train_time:59266ms step_avg:52.36ms
+step:1133/1555 train_time:59354ms step_avg:52.39ms
+step:1134/1555 train_time:59439ms step_avg:52.42ms
+step:1135/1555 train_time:59529ms step_avg:52.45ms
+step:1136/1555 train_time:59617ms step_avg:52.48ms
+step:1137/1555 train_time:59705ms step_avg:52.51ms
+step:1138/1555 train_time:59791ms step_avg:52.54ms
+step:1139/1555 train_time:59886ms step_avg:52.58ms
+step:1140/1555 train_time:59970ms step_avg:52.60ms
+step:1141/1555 train_time:60058ms step_avg:52.64ms
+step:1142/1555 train_time:60143ms step_avg:52.66ms
+step:1143/1555 train_time:60232ms step_avg:52.70ms
+step:1144/1555 train_time:60322ms step_avg:52.73ms
+step:1145/1555 train_time:60408ms step_avg:52.76ms
+step:1146/1555 train_time:60494ms step_avg:52.79ms
+step:1147/1555 train_time:60583ms step_avg:52.82ms
+step:1148/1555 train_time:60669ms step_avg:52.85ms
+step:1149/1555 train_time:60758ms step_avg:52.88ms
+step:1150/1555 train_time:60843ms step_avg:52.91ms
+step:1151/1555 train_time:60934ms step_avg:52.94ms
+step:1152/1555 train_time:61019ms step_avg:52.97ms
+step:1153/1555 train_time:61110ms step_avg:53.00ms
+step:1154/1555 train_time:61196ms step_avg:53.03ms
+step:1155/1555 train_time:61286ms step_avg:53.06ms
+step:1156/1555 train_time:61374ms step_avg:53.09ms
+step:1157/1555 train_time:61462ms step_avg:53.12ms
+step:1158/1555 train_time:61548ms step_avg:53.15ms
+step:1159/1555 train_time:61637ms step_avg:53.18ms
+step:1160/1555 train_time:61722ms step_avg:53.21ms
+step:1161/1555 train_time:61812ms step_avg:53.24ms
+step:1162/1555 train_time:61898ms step_avg:53.27ms
+step:1163/1555 train_time:61987ms step_avg:53.30ms
+step:1164/1555 train_time:62072ms step_avg:53.33ms
+step:1165/1555 train_time:62163ms step_avg:53.36ms
+step:1166/1555 train_time:62248ms step_avg:53.39ms
+step:1167/1555 train_time:62338ms step_avg:53.42ms
+step:1168/1555 train_time:62424ms step_avg:53.44ms
+step:1169/1555 train_time:62513ms step_avg:53.48ms
+step:1170/1555 train_time:62602ms step_avg:53.51ms
+step:1171/1555 train_time:62688ms step_avg:53.53ms
+step:1172/1555 train_time:62776ms step_avg:53.56ms
+step:1173/1555 train_time:62866ms step_avg:53.59ms
+step:1174/1555 train_time:62949ms step_avg:53.62ms
+step:1175/1555 train_time:63038ms step_avg:53.65ms
+step:1176/1555 train_time:63125ms step_avg:53.68ms
+step:1177/1555 train_time:63214ms step_avg:53.71ms
+step:1178/1555 train_time:63300ms step_avg:53.74ms
+step:1179/1555 train_time:63391ms step_avg:53.77ms
+step:1180/1555 train_time:63477ms step_avg:53.79ms
+step:1181/1555 train_time:63566ms step_avg:53.82ms
+step:1182/1555 train_time:63651ms step_avg:53.85ms
+step:1183/1555 train_time:63741ms step_avg:53.88ms
+step:1184/1555 train_time:63828ms step_avg:53.91ms
+step:1185/1555 train_time:63916ms step_avg:53.94ms
+step:1186/1555 train_time:64002ms step_avg:53.96ms
+step:1187/1555 train_time:64091ms step_avg:53.99ms
+step:1188/1555 train_time:64180ms step_avg:54.02ms
+step:1189/1555 train_time:64268ms step_avg:54.05ms
+step:1190/1555 train_time:64354ms step_avg:54.08ms
+step:1191/1555 train_time:64445ms step_avg:54.11ms
+step:1192/1555 train_time:64530ms step_avg:54.14ms
+step:1193/1555 train_time:64619ms step_avg:54.16ms
+step:1194/1555 train_time:64705ms step_avg:54.19ms
+step:1195/1555 train_time:64794ms step_avg:54.22ms
+step:1196/1555 train_time:64880ms step_avg:54.25ms
+step:1197/1555 train_time:64970ms step_avg:54.28ms
+step:1198/1555 train_time:65056ms step_avg:54.30ms
+step:1199/1555 train_time:65147ms step_avg:54.33ms
+step:1200/1555 train_time:65234ms step_avg:54.36ms
+step:1201/1555 train_time:65322ms step_avg:54.39ms
+step:1202/1555 train_time:65411ms step_avg:54.42ms
+step:1203/1555 train_time:65499ms step_avg:54.45ms
+step:1204/1555 train_time:65585ms step_avg:54.47ms
+step:1205/1555 train_time:65674ms step_avg:54.50ms
+step:1206/1555 train_time:65761ms step_avg:54.53ms
+step:1207/1555 train_time:65849ms step_avg:54.56ms
+step:1208/1555 train_time:65935ms step_avg:54.58ms
+step:1209/1555 train_time:66024ms step_avg:54.61ms
+step:1210/1555 train_time:66110ms step_avg:54.64ms
+step:1211/1555 train_time:66200ms step_avg:54.67ms
+step:1212/1555 train_time:66286ms step_avg:54.69ms
+step:1213/1555 train_time:66375ms step_avg:54.72ms
+step:1214/1555 train_time:66461ms step_avg:54.75ms
+step:1215/1555 train_time:66550ms step_avg:54.77ms
+step:1216/1555 train_time:66636ms step_avg:54.80ms
+step:1217/1555 train_time:66725ms step_avg:54.83ms
+step:1218/1555 train_time:66813ms step_avg:54.85ms
+step:1219/1555 train_time:66902ms step_avg:54.88ms
+step:1220/1555 train_time:66987ms step_avg:54.91ms
+step:1221/1555 train_time:67077ms step_avg:54.94ms
+step:1222/1555 train_time:67163ms step_avg:54.96ms
+step:1223/1555 train_time:67252ms step_avg:54.99ms
+step:1224/1555 train_time:67339ms step_avg:55.02ms
+step:1225/1555 train_time:67430ms step_avg:55.04ms
+step:1226/1555 train_time:67514ms step_avg:55.07ms
+step:1227/1555 train_time:67605ms step_avg:55.10ms
+step:1228/1555 train_time:67689ms step_avg:55.12ms
+step:1229/1555 train_time:67779ms step_avg:55.15ms
+step:1230/1555 train_time:67864ms step_avg:55.17ms
+step:1231/1555 train_time:67954ms step_avg:55.20ms
+step:1232/1555 train_time:68041ms step_avg:55.23ms
+step:1233/1555 train_time:68128ms step_avg:55.25ms
+step:1234/1555 train_time:68215ms step_avg:55.28ms
+step:1235/1555 train_time:68305ms step_avg:55.31ms
+step:1236/1555 train_time:68390ms step_avg:55.33ms
+step:1237/1555 train_time:68481ms step_avg:55.36ms
+step:1238/1555 train_time:68567ms step_avg:55.39ms
+step:1239/1555 train_time:68658ms step_avg:55.41ms
+step:1240/1555 train_time:68743ms step_avg:55.44ms
+step:1241/1555 train_time:68832ms step_avg:55.46ms
+step:1242/1555 train_time:68919ms step_avg:55.49ms
+step:1243/1555 train_time:69008ms step_avg:55.52ms
+step:1244/1555 train_time:69094ms step_avg:55.54ms
+step:1245/1555 train_time:69185ms step_avg:55.57ms
+step:1246/1555 train_time:69270ms step_avg:55.59ms
+step:1247/1555 train_time:69358ms step_avg:55.62ms
+step:1248/1555 train_time:69444ms step_avg:55.64ms
+step:1249/1555 train_time:69534ms step_avg:55.67ms
+step:1250/1555 train_time:69619ms step_avg:55.69ms
+step:1250/1555 val_loss:3.3980 train_time:69694ms step_avg:55.75ms
+step:1251/1555 train_time:69715ms step_avg:55.73ms
+step:1252/1555 train_time:69799ms step_avg:55.75ms
+step:1253/1555 train_time:69897ms step_avg:55.78ms
+step:1254/1555 train_time:69983ms step_avg:55.81ms
+step:1255/1555 train_time:70072ms step_avg:55.83ms
+step:1256/1555 train_time:70160ms step_avg:55.86ms
+step:1257/1555 train_time:70247ms step_avg:55.88ms
+step:1258/1555 train_time:70334ms step_avg:55.91ms
+step:1259/1555 train_time:70421ms step_avg:55.93ms
+step:1260/1555 train_time:70505ms step_avg:55.96ms
+step:1261/1555 train_time:70594ms step_avg:55.98ms
+step:1262/1555 train_time:70680ms step_avg:56.01ms
+step:1263/1555 train_time:70774ms step_avg:56.04ms
+step:1264/1555 train_time:70859ms step_avg:56.06ms
+step:1265/1555 train_time:70951ms step_avg:56.09ms
+step:1266/1555 train_time:71037ms step_avg:56.11ms
+step:1267/1555 train_time:71126ms step_avg:56.14ms
+step:1268/1555 train_time:71212ms step_avg:56.16ms
+step:1269/1555 train_time:71301ms step_avg:56.19ms
+step:1270/1555 train_time:71386ms step_avg:56.21ms
+step:1271/1555 train_time:71475ms step_avg:56.24ms
+step:1272/1555 train_time:71560ms step_avg:56.26ms
+step:1273/1555 train_time:71649ms step_avg:56.28ms
+step:1274/1555 train_time:71737ms step_avg:56.31ms
+step:1275/1555 train_time:71828ms step_avg:56.34ms
+step:1276/1555 train_time:71914ms step_avg:56.36ms
+step:1277/1555 train_time:72006ms step_avg:56.39ms
+step:1278/1555 train_time:72091ms step_avg:56.41ms
+step:1279/1555 train_time:72181ms step_avg:56.44ms
+step:1280/1555 train_time:72267ms step_avg:56.46ms
+step:1281/1555 train_time:72354ms step_avg:56.48ms
+step:1282/1555 train_time:72441ms step_avg:56.51ms
+step:1283/1555 train_time:72531ms step_avg:56.53ms
+step:1284/1555 train_time:72616ms step_avg:56.55ms
+step:1285/1555 train_time:72707ms step_avg:56.58ms
+step:1286/1555 train_time:72792ms step_avg:56.60ms
+step:1287/1555 train_time:72883ms step_avg:56.63ms
+step:1288/1555 train_time:72971ms step_avg:56.65ms
+step:1289/1555 train_time:73061ms step_avg:56.68ms
+step:1290/1555 train_time:73148ms step_avg:56.70ms
+step:1291/1555 train_time:73235ms step_avg:56.73ms
+step:1292/1555 train_time:73321ms step_avg:56.75ms
+step:1293/1555 train_time:73410ms step_avg:56.78ms
+step:1294/1555 train_time:73496ms step_avg:56.80ms
+step:1295/1555 train_time:73586ms step_avg:56.82ms
+step:1296/1555 train_time:73670ms step_avg:56.84ms
+step:1297/1555 train_time:73760ms step_avg:56.87ms
+step:1298/1555 train_time:73846ms step_avg:56.89ms
+step:1299/1555 train_time:73935ms step_avg:56.92ms
+step:1300/1555 train_time:74022ms step_avg:56.94ms
+step:1301/1555 train_time:74111ms step_avg:56.96ms
+step:1302/1555 train_time:74199ms step_avg:56.99ms
+step:1303/1555 train_time:74287ms step_avg:57.01ms
+step:1304/1555 train_time:74374ms step_avg:57.04ms
+step:1305/1555 train_time:74462ms step_avg:57.06ms
+step:1306/1555 train_time:74549ms step_avg:57.08ms
+step:1307/1555 train_time:74637ms step_avg:57.11ms
+step:1308/1555 train_time:74723ms step_avg:57.13ms
+step:1309/1555 train_time:74812ms step_avg:57.15ms
+step:1310/1555 train_time:74898ms step_avg:57.17ms
+step:1311/1555 train_time:74988ms step_avg:57.20ms
+step:1312/1555 train_time:75076ms step_avg:57.22ms
+step:1313/1555 train_time:75165ms step_avg:57.25ms
+step:1314/1555 train_time:75251ms step_avg:57.27ms
+step:1315/1555 train_time:75341ms step_avg:57.29ms
+step:1316/1555 train_time:75426ms step_avg:57.31ms
+step:1317/1555 train_time:75516ms step_avg:57.34ms
+step:1318/1555 train_time:75602ms step_avg:57.36ms
+step:1319/1555 train_time:75690ms step_avg:57.38ms
+step:1320/1555 train_time:75778ms step_avg:57.41ms
+step:1321/1555 train_time:75867ms step_avg:57.43ms
+step:1322/1555 train_time:75954ms step_avg:57.45ms
+step:1323/1555 train_time:76044ms step_avg:57.48ms
+step:1324/1555 train_time:76131ms step_avg:57.50ms
+step:1325/1555 train_time:76219ms step_avg:57.52ms
+step:1326/1555 train_time:76305ms step_avg:57.55ms
+step:1327/1555 train_time:76397ms step_avg:57.57ms
+step:1328/1555 train_time:76481ms step_avg:57.59ms
+step:1329/1555 train_time:76571ms step_avg:57.62ms
+step:1330/1555 train_time:76655ms step_avg:57.64ms
+step:1331/1555 train_time:76746ms step_avg:57.66ms
+step:1332/1555 train_time:76831ms step_avg:57.68ms
+step:1333/1555 train_time:76921ms step_avg:57.71ms
+step:1334/1555 train_time:77007ms step_avg:57.73ms
+step:1335/1555 train_time:77096ms step_avg:57.75ms
+step:1336/1555 train_time:77183ms step_avg:57.77ms
+step:1337/1555 train_time:77271ms step_avg:57.79ms
+step:1338/1555 train_time:77358ms step_avg:57.82ms
+step:1339/1555 train_time:77447ms step_avg:57.84ms
+step:1340/1555 train_time:77533ms step_avg:57.86ms
+step:1341/1555 train_time:77622ms step_avg:57.88ms
+step:1342/1555 train_time:77709ms step_avg:57.91ms
+step:1343/1555 train_time:77797ms step_avg:57.93ms
+step:1344/1555 train_time:77883ms step_avg:57.95ms
+step:1345/1555 train_time:77972ms step_avg:57.97ms
+step:1346/1555 train_time:78058ms step_avg:57.99ms
+step:1347/1555 train_time:78148ms step_avg:58.02ms
+step:1348/1555 train_time:78233ms step_avg:58.04ms
+step:1349/1555 train_time:78323ms step_avg:58.06ms
+step:1350/1555 train_time:78408ms step_avg:58.08ms
+step:1351/1555 train_time:78502ms step_avg:58.11ms
+step:1352/1555 train_time:78587ms step_avg:58.13ms
+step:1353/1555 train_time:78718ms step_avg:58.18ms
+step:1354/1555 train_time:78800ms step_avg:58.20ms
+step:1355/1555 train_time:78888ms step_avg:58.22ms
+step:1356/1555 train_time:78974ms step_avg:58.24ms
+step:1357/1555 train_time:79060ms step_avg:58.26ms
+step:1358/1555 train_time:79145ms step_avg:58.28ms
+step:1359/1555 train_time:79234ms step_avg:58.30ms
+step:1360/1555 train_time:79319ms step_avg:58.32ms
+step:1361/1555 train_time:79408ms step_avg:58.35ms
+step:1362/1555 train_time:79495ms step_avg:58.37ms
+step:1363/1555 train_time:79591ms step_avg:58.39ms
+step:1364/1555 train_time:79681ms step_avg:58.42ms
+step:1365/1555 train_time:79770ms step_avg:58.44ms
+step:1366/1555 train_time:79857ms step_avg:58.46ms
+step:1367/1555 train_time:79946ms step_avg:58.48ms
+step:1368/1555 train_time:80030ms step_avg:58.50ms
+step:1369/1555 train_time:80118ms step_avg:58.52ms
+step:1370/1555 train_time:80204ms step_avg:58.54ms
+step:1371/1555 train_time:80291ms step_avg:58.56ms
+step:1372/1555 train_time:80377ms step_avg:58.58ms
+step:1373/1555 train_time:80469ms step_avg:58.61ms
+step:1374/1555 train_time:80556ms step_avg:58.63ms
+step:1375/1555 train_time:80648ms step_avg:58.65ms
+step:1376/1555 train_time:80735ms step_avg:58.67ms
+step:1377/1555 train_time:80824ms step_avg:58.70ms
+step:1378/1555 train_time:80910ms step_avg:58.72ms
+step:1379/1555 train_time:81000ms step_avg:58.74ms
+step:1380/1555 train_time:81084ms step_avg:58.76ms
+step:1381/1555 train_time:81172ms step_avg:58.78ms
+step:1382/1555 train_time:81257ms step_avg:58.80ms
+step:1383/1555 train_time:81348ms step_avg:58.82ms
+step:1384/1555 train_time:81433ms step_avg:58.84ms
+step:1385/1555 train_time:81524ms step_avg:58.86ms
+step:1386/1555 train_time:81613ms step_avg:58.88ms
+step:1387/1555 train_time:81701ms step_avg:58.91ms
+step:1388/1555 train_time:81787ms step_avg:58.92ms
+step:1389/1555 train_time:81878ms step_avg:58.95ms
+step:1390/1555 train_time:81963ms step_avg:58.97ms
+step:1391/1555 train_time:82051ms step_avg:58.99ms
+step:1392/1555 train_time:82137ms step_avg:59.01ms
+step:1393/1555 train_time:82225ms step_avg:59.03ms
+step:1394/1555 train_time:82311ms step_avg:59.05ms
+step:1395/1555 train_time:82401ms step_avg:59.07ms
+step:1396/1555 train_time:82487ms step_avg:59.09ms
+step:1397/1555 train_time:82578ms step_avg:59.11ms
+step:1398/1555 train_time:82664ms step_avg:59.13ms
+step:1399/1555 train_time:82755ms step_avg:59.15ms
+step:1400/1555 train_time:82841ms step_avg:59.17ms
+step:1401/1555 train_time:82930ms step_avg:59.19ms
+step:1402/1555 train_time:83015ms step_avg:59.21ms
+step:1403/1555 train_time:83105ms step_avg:59.23ms
+step:1404/1555 train_time:83191ms step_avg:59.25ms
+step:1405/1555 train_time:83281ms step_avg:59.27ms
+step:1406/1555 train_time:83368ms step_avg:59.29ms
+step:1407/1555 train_time:83457ms step_avg:59.32ms
+step:1408/1555 train_time:83543ms step_avg:59.33ms
+step:1409/1555 train_time:83633ms step_avg:59.36ms
+step:1410/1555 train_time:83719ms step_avg:59.38ms
+step:1411/1555 train_time:83809ms step_avg:59.40ms
+step:1412/1555 train_time:83895ms step_avg:59.42ms
+step:1413/1555 train_time:83984ms step_avg:59.44ms
+step:1414/1555 train_time:84072ms step_avg:59.46ms
+step:1415/1555 train_time:84160ms step_avg:59.48ms
+step:1416/1555 train_time:84245ms step_avg:59.50ms
+step:1417/1555 train_time:84334ms step_avg:59.52ms
+step:1418/1555 train_time:84422ms step_avg:59.54ms
+step:1419/1555 train_time:84510ms step_avg:59.56ms
+step:1420/1555 train_time:84598ms step_avg:59.58ms
+step:1421/1555 train_time:84688ms step_avg:59.60ms
+step:1422/1555 train_time:84776ms step_avg:59.62ms
+step:1423/1555 train_time:84864ms step_avg:59.64ms
+step:1424/1555 train_time:84950ms step_avg:59.66ms
+step:1425/1555 train_time:85042ms step_avg:59.68ms
+step:1426/1555 train_time:85128ms step_avg:59.70ms
+step:1427/1555 train_time:85216ms step_avg:59.72ms
+step:1428/1555 train_time:85301ms step_avg:59.73ms
+step:1429/1555 train_time:85391ms step_avg:59.76ms
+step:1430/1555 train_time:85477ms step_avg:59.77ms
+step:1431/1555 train_time:85567ms step_avg:59.80ms
+step:1432/1555 train_time:85653ms step_avg:59.81ms
+step:1433/1555 train_time:85743ms step_avg:59.83ms
+step:1434/1555 train_time:85830ms step_avg:59.85ms
+step:1435/1555 train_time:85919ms step_avg:59.87ms
+step:1436/1555 train_time:86005ms step_avg:59.89ms
+step:1437/1555 train_time:86095ms step_avg:59.91ms
+step:1438/1555 train_time:86181ms step_avg:59.93ms
+step:1439/1555 train_time:86269ms step_avg:59.95ms
+step:1440/1555 train_time:86355ms step_avg:59.97ms
+step:1441/1555 train_time:86445ms step_avg:59.99ms
+step:1442/1555 train_time:86530ms step_avg:60.01ms
+step:1443/1555 train_time:86619ms step_avg:60.03ms
+step:1444/1555 train_time:86706ms step_avg:60.05ms
+step:1445/1555 train_time:86795ms step_avg:60.07ms
+step:1446/1555 train_time:86883ms step_avg:60.08ms
+step:1447/1555 train_time:86973ms step_avg:60.11ms
+step:1448/1555 train_time:87059ms step_avg:60.12ms
+step:1449/1555 train_time:87148ms step_avg:60.14ms
+step:1450/1555 train_time:87234ms step_avg:60.16ms
+step:1451/1555 train_time:87324ms step_avg:60.18ms
+step:1452/1555 train_time:87411ms step_avg:60.20ms
+step:1453/1555 train_time:87500ms step_avg:60.22ms
+step:1454/1555 train_time:87585ms step_avg:60.24ms
+step:1455/1555 train_time:87678ms step_avg:60.26ms
+step:1456/1555 train_time:87761ms step_avg:60.28ms
+step:1457/1555 train_time:87850ms step_avg:60.30ms
+step:1458/1555 train_time:87937ms step_avg:60.31ms
+step:1459/1555 train_time:88026ms step_avg:60.33ms
+step:1460/1555 train_time:88112ms step_avg:60.35ms
+step:1461/1555 train_time:88202ms step_avg:60.37ms
+step:1462/1555 train_time:88288ms step_avg:60.39ms
+step:1463/1555 train_time:88377ms step_avg:60.41ms
+step:1464/1555 train_time:88465ms step_avg:60.43ms
+step:1465/1555 train_time:88554ms step_avg:60.45ms
+step:1466/1555 train_time:88639ms step_avg:60.46ms
+step:1467/1555 train_time:88728ms step_avg:60.48ms
+step:1468/1555 train_time:88815ms step_avg:60.50ms
+step:1469/1555 train_time:88905ms step_avg:60.52ms
+step:1470/1555 train_time:88990ms step_avg:60.54ms
+step:1471/1555 train_time:89080ms step_avg:60.56ms
+step:1472/1555 train_time:89166ms step_avg:60.57ms
+step:1473/1555 train_time:89254ms step_avg:60.59ms
+step:1474/1555 train_time:89341ms step_avg:60.61ms
+step:1475/1555 train_time:89431ms step_avg:60.63ms
+step:1476/1555 train_time:89517ms step_avg:60.65ms
+step:1477/1555 train_time:89607ms step_avg:60.67ms
+step:1478/1555 train_time:89692ms step_avg:60.69ms
+step:1479/1555 train_time:89783ms step_avg:60.71ms
+step:1480/1555 train_time:89869ms step_avg:60.72ms
+step:1481/1555 train_time:89959ms step_avg:60.74ms
+step:1482/1555 train_time:90045ms step_avg:60.76ms
+step:1483/1555 train_time:90135ms step_avg:60.78ms
+step:1484/1555 train_time:90219ms step_avg:60.79ms
+step:1485/1555 train_time:90310ms step_avg:60.81ms
+step:1486/1555 train_time:90396ms step_avg:60.83ms
+step:1487/1555 train_time:90485ms step_avg:60.85ms
+step:1488/1555 train_time:90570ms step_avg:60.87ms
+step:1489/1555 train_time:90662ms step_avg:60.89ms
+step:1490/1555 train_time:90747ms step_avg:60.90ms
+step:1491/1555 train_time:90837ms step_avg:60.92ms
+step:1492/1555 train_time:90923ms step_avg:60.94ms
+step:1493/1555 train_time:91013ms step_avg:60.96ms
+step:1494/1555 train_time:91099ms step_avg:60.98ms
+step:1495/1555 train_time:91189ms step_avg:61.00ms
+step:1496/1555 train_time:91276ms step_avg:61.01ms
+step:1497/1555 train_time:91366ms step_avg:61.03ms
+step:1498/1555 train_time:91451ms step_avg:61.05ms
+step:1499/1555 train_time:91540ms step_avg:61.07ms
+step:1500/1555 train_time:91628ms step_avg:61.09ms
+step:1500/1555 val_loss:3.2950 train_time:91701ms step_avg:61.13ms
+step:1501/1555 train_time:91722ms step_avg:61.11ms
+step:1502/1555 train_time:91807ms step_avg:61.12ms
+step:1503/1555 train_time:91904ms step_avg:61.15ms
+step:1504/1555 train_time:91991ms step_avg:61.16ms
+step:1505/1555 train_time:92081ms step_avg:61.18ms
+step:1506/1555 train_time:92167ms step_avg:61.20ms
+step:1507/1555 train_time:92255ms step_avg:61.22ms
+step:1508/1555 train_time:92339ms step_avg:61.23ms
+step:1509/1555 train_time:92426ms step_avg:61.25ms
+step:1510/1555 train_time:92511ms step_avg:61.27ms
+step:1511/1555 train_time:92602ms step_avg:61.29ms
+step:1512/1555 train_time:92689ms step_avg:61.30ms
+step:1513/1555 train_time:92781ms step_avg:61.32ms
+step:1514/1555 train_time:92868ms step_avg:61.34ms
+step:1515/1555 train_time:92960ms step_avg:61.36ms
+step:1516/1555 train_time:93054ms step_avg:61.38ms
+step:1517/1555 train_time:93143ms step_avg:61.40ms
+step:1518/1555 train_time:93227ms step_avg:61.41ms
+step:1519/1555 train_time:93317ms step_avg:61.43ms
+step:1520/1555 train_time:93402ms step_avg:61.45ms
+step:1521/1555 train_time:93490ms step_avg:61.47ms
+step:1522/1555 train_time:93576ms step_avg:61.48ms
+step:1523/1555 train_time:93666ms step_avg:61.50ms
+step:1524/1555 train_time:93752ms step_avg:61.52ms
+step:1525/1555 train_time:93844ms step_avg:61.54ms
+step:1526/1555 train_time:93930ms step_avg:61.55ms
+step:1527/1555 train_time:94020ms step_avg:61.57ms
+step:1528/1555 train_time:94106ms step_avg:61.59ms
+step:1529/1555 train_time:94198ms step_avg:61.61ms
+step:1530/1555 train_time:94282ms step_avg:61.62ms
+step:1531/1555 train_time:94371ms step_avg:61.64ms
+step:1532/1555 train_time:94458ms step_avg:61.66ms
+step:1533/1555 train_time:94545ms step_avg:61.67ms
+step:1534/1555 train_time:94631ms step_avg:61.69ms
+step:1535/1555 train_time:94721ms step_avg:61.71ms
+step:1536/1555 train_time:94809ms step_avg:61.72ms
+step:1537/1555 train_time:94899ms step_avg:61.74ms
+step:1538/1555 train_time:94989ms step_avg:61.76ms
+step:1539/1555 train_time:95077ms step_avg:61.78ms
+step:1540/1555 train_time:95163ms step_avg:61.79ms
+step:1541/1555 train_time:95252ms step_avg:61.81ms
+step:1542/1555 train_time:95338ms step_avg:61.83ms
+step:1543/1555 train_time:95429ms step_avg:61.85ms
+step:1544/1555 train_time:95515ms step_avg:61.86ms
+step:1545/1555 train_time:95603ms step_avg:61.88ms
+step:1546/1555 train_time:95689ms step_avg:61.89ms
+step:1547/1555 train_time:95780ms step_avg:61.91ms
+step:1548/1555 train_time:95866ms step_avg:61.93ms
+step:1549/1555 train_time:95957ms step_avg:61.95ms
+step:1550/1555 train_time:96043ms step_avg:61.96ms
+step:1551/1555 train_time:96132ms step_avg:61.98ms
+step:1552/1555 train_time:96219ms step_avg:62.00ms
+step:1553/1555 train_time:96308ms step_avg:62.01ms
+step:1554/1555 train_time:96393ms step_avg:62.03ms
+step:1555/1555 train_time:96483ms step_avg:62.05ms

--- a/records/track_1_short/2026-01-30_MimeticValueOutput/runs/793d3ace-0a1d-434b-84dd-bdaa59c4799b.txt
+++ b/records/track_1_short/2026-01-30_MimeticValueOutput/runs/793d3ace-0a1d-434b-84dd-bdaa59c4799b.txt
@@ -1,0 +1,4133 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# Mimetic V-O Initialization (Trockman & Kolter, ICML 2023)
+# Initialize V and O such that V @ O^T ≈ -βI (negative identity-like)
+# This enables attention to make meaningful contributions from step 1
+
+def mimetic_vo_init(attn_bank, model_dim=768, num_heads=6, head_dim=128, beta=0.1, noise_std=0.01):
+    """
+    Initialize attention bank with mimetic structure for V and O.
+    Q and K use standard uniform init, V and O use identity-like structure.
+
+    Args:
+        attn_bank: Tensor of shape (num_layers, 4*model_dim, hdim)
+        model_dim: Model dimension (768)
+        num_heads: Number of attention heads (6)
+        head_dim: Dimension per head (128)
+        beta: Scale for identity structure (0.1 recommended with attn_scale=0.1)
+        noise_std: Standard deviation of noise for symmetry breaking
+    """
+    num_layers = attn_bank.shape[0]
+    dim = model_dim
+    sqrt_beta = beta ** 0.5
+
+    # Standard init for Q and K (existing behavior)
+    attn_std = model_dim ** -0.5
+    attn_bound = (3 ** 0.5) * attn_std
+
+    with torch.no_grad():
+        # Q and K: uniform init (first 2*dim rows)
+        attn_bank[:, :2*dim, :].uniform_(-attn_bound, attn_bound)
+
+        # V and O: mimetic identity structure
+        for layer_idx in range(num_layers):
+            W_V = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+            W_O = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+
+            # Create per-head identity blocks
+            for h in range(num_heads):
+                start, end = h * head_dim, (h + 1) * head_dim
+                eye = torch.eye(head_dim, dtype=attn_bank.dtype, device=attn_bank.device)
+                W_V[start:end, start:end] = sqrt_beta * eye
+                W_O[start:end, start:end] = -sqrt_beta * eye
+
+            # Add noise for symmetry breaking
+            W_V += noise_std * torch.randn_like(W_V)
+            W_O += noise_std * torch.randn_like(W_O)
+
+            # Store in attn_bank: V is rows [2*dim:3*dim], O is rows [3*dim:4*dim]
+            attn_bank[layer_idx, 2*dim:3*dim, :] = W_V
+            attn_bank[layer_idx, 3*dim:4*dim, :] = W_O
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # MLP uses 0.5 * dim^-0.5
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank with MIMETIC V-O initialization
+            # Q and K: uniform init, V and O: identity-like structure for faster convergence
+            mimetic_vo_init(
+                self.attn_bank,
+                model_dim=model_dim,
+                num_heads=num_heads,
+                head_dim=head_dim,
+                beta=0.05,       # Scale for V@O^T ≈ -βI (tuned down from 0.1)
+                noise_std=0.01   # Symmetry breaking noise
+            )
+            # Init MLP bank (c_fc uniform, c_proj zero)
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 234 structure on token value embeddings by @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1515  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.11.14 (main, Oct 21 2025, 18:31:21) [GCC 11.2.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Fri Jan 30 18:33:04 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          Off |   00000000:19:00.0 Off |                    0 |
+| N/A   34C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          Off |   00000000:3B:00.0 Off |                    0 |
+| N/A   27C    P0            121W /  700W |    1568MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          Off |   00000000:4C:00.0 Off |                    0 |
+| N/A   24C    P0            117W /  700W |   50215MiB /  81559MiB |    100%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          Off |   00000000:5D:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |   50215MiB /  81559MiB |    100%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          Off |   00000000:9B:00.0 Off |                    0 |
+| N/A   33C    P0            115W /  700W |    1760MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          Off |   00000000:BB:00.0 Off |                    0 |
+| N/A   25C    P0            114W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          Off |   00000000:CB:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          Off |   00000000:DB:00.0 Off |                    0 |
+| N/A   25C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1358795      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    1   N/A  N/A   1358796      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    2   N/A  N/A   1354190      C   ...miniconda3/envs/nanogpt/bin/python3      48688MiB |
+|    2   N/A  N/A   1358797      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    3   N/A  N/A   1354191      C   ...miniconda3/envs/nanogpt/bin/python3      48688MiB |
+|    3   N/A  N/A   1358798      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    4   N/A  N/A   1358799      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    5   N/A  N/A   1358800      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    6   N/A  N/A   1358801      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    7   N/A  N/A   1358802      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 504, 505, 506, 1009, 1010, 1011, 1514, 1515, 1516] for warmup
+Resetting Model
+step:0/1555 val_loss:10.8341 train_time:0ms step_avg:0.03ms
+step:1/1555 train_time:107ms step_avg:106.53ms
+step:2/1555 train_time:126ms step_avg:63.17ms
+step:3/1555 train_time:144ms step_avg:47.89ms
+step:4/1555 train_time:177ms step_avg:44.34ms
+step:5/1555 train_time:208ms step_avg:41.55ms
+step:6/1555 train_time:246ms step_avg:40.96ms
+step:7/1555 train_time:277ms step_avg:39.58ms
+step:8/1555 train_time:315ms step_avg:39.43ms
+step:9/1555 train_time:347ms step_avg:38.52ms
+step:10/1555 train_time:385ms step_avg:38.47ms
+step:11/1555 train_time:416ms step_avg:37.83ms
+step:12/1555 train_time:455ms step_avg:37.90ms
+step:13/1555 train_time:486ms step_avg:37.40ms
+step:14/1555 train_time:524ms step_avg:37.45ms
+step:15/1555 train_time:556ms step_avg:37.04ms
+step:16/1555 train_time:594ms step_avg:37.11ms
+step:17/1555 train_time:625ms step_avg:36.77ms
+step:18/1555 train_time:663ms step_avg:36.85ms
+step:19/1555 train_time:695ms step_avg:36.56ms
+step:20/1555 train_time:733ms step_avg:36.66ms
+step:21/1555 train_time:765ms step_avg:36.42ms
+step:22/1555 train_time:803ms step_avg:36.51ms
+step:23/1555 train_time:834ms step_avg:36.28ms
+step:24/1555 train_time:873ms step_avg:36.38ms
+step:25/1555 train_time:905ms step_avg:36.18ms
+step:26/1555 train_time:943ms step_avg:36.26ms
+step:27/1555 train_time:974ms step_avg:36.09ms
+step:28/1555 train_time:1013ms step_avg:36.17ms
+step:29/1555 train_time:1044ms step_avg:36.01ms
+step:30/1555 train_time:1082ms step_avg:36.07ms
+step:31/1555 train_time:1114ms step_avg:35.93ms
+step:32/1555 train_time:1152ms step_avg:36.01ms
+step:33/1555 train_time:1184ms step_avg:35.88ms
+step:34/1555 train_time:1222ms step_avg:35.95ms
+step:35/1555 train_time:1254ms step_avg:35.83ms
+step:36/1555 train_time:1293ms step_avg:35.90ms
+step:37/1555 train_time:1324ms step_avg:35.78ms
+step:38/1555 train_time:1362ms step_avg:35.84ms
+step:39/1555 train_time:1393ms step_avg:35.73ms
+step:40/1555 train_time:1432ms step_avg:35.79ms
+step:41/1555 train_time:1463ms step_avg:35.69ms
+step:42/1555 train_time:1501ms step_avg:35.74ms
+step:43/1555 train_time:1532ms step_avg:35.64ms
+step:44/1555 train_time:1571ms step_avg:35.71ms
+step:45/1555 train_time:1602ms step_avg:35.61ms
+step:46/1555 train_time:1641ms step_avg:35.67ms
+step:47/1555 train_time:1672ms step_avg:35.58ms
+step:48/1555 train_time:1711ms step_avg:35.64ms
+step:49/1555 train_time:1742ms step_avg:35.55ms
+step:50/1555 train_time:1780ms step_avg:35.61ms
+step:51/1555 train_time:1812ms step_avg:35.53ms
+step:52/1555 train_time:1850ms step_avg:35.58ms
+step:53/1555 train_time:1882ms step_avg:35.51ms
+step:54/1555 train_time:1920ms step_avg:35.56ms
+step:55/1555 train_time:1951ms step_avg:35.48ms
+step:56/1555 train_time:1990ms step_avg:35.53ms
+step:57/1555 train_time:2021ms step_avg:35.46ms
+step:58/1555 train_time:2060ms step_avg:35.51ms
+step:59/1555 train_time:2091ms step_avg:35.44ms
+step:60/1555 train_time:2129ms step_avg:35.49ms
+step:61/1555 train_time:2161ms step_avg:35.42ms
+step:62/1555 train_time:2199ms step_avg:35.47ms
+step:63/1555 train_time:2231ms step_avg:35.41ms
+step:64/1555 train_time:2269ms step_avg:35.45ms
+step:65/1555 train_time:2300ms step_avg:35.39ms
+step:66/1555 train_time:2339ms step_avg:35.43ms
+step:67/1555 train_time:2370ms step_avg:35.38ms
+step:68/1555 train_time:2410ms step_avg:35.44ms
+step:69/1555 train_time:2441ms step_avg:35.38ms
+step:70/1555 train_time:2480ms step_avg:35.42ms
+step:71/1555 train_time:2511ms step_avg:35.37ms
+step:72/1555 train_time:2550ms step_avg:35.41ms
+step:73/1555 train_time:2581ms step_avg:35.36ms
+step:74/1555 train_time:2619ms step_avg:35.40ms
+step:75/1555 train_time:2650ms step_avg:35.34ms
+step:76/1555 train_time:2689ms step_avg:35.39ms
+step:77/1555 train_time:2721ms step_avg:35.34ms
+step:78/1555 train_time:2759ms step_avg:35.37ms
+step:79/1555 train_time:2790ms step_avg:35.32ms
+step:80/1555 train_time:2829ms step_avg:35.36ms
+step:81/1555 train_time:2860ms step_avg:35.31ms
+step:82/1555 train_time:2898ms step_avg:35.34ms
+step:83/1555 train_time:2929ms step_avg:35.29ms
+step:84/1555 train_time:2968ms step_avg:35.33ms
+step:85/1555 train_time:2999ms step_avg:35.28ms
+step:86/1555 train_time:3037ms step_avg:35.31ms
+step:87/1555 train_time:3068ms step_avg:35.27ms
+step:88/1555 train_time:3106ms step_avg:35.30ms
+step:89/1555 train_time:3138ms step_avg:35.26ms
+step:90/1555 train_time:3176ms step_avg:35.29ms
+step:91/1555 train_time:3207ms step_avg:35.24ms
+step:92/1555 train_time:3245ms step_avg:35.28ms
+step:93/1555 train_time:3277ms step_avg:35.23ms
+step:94/1555 train_time:3315ms step_avg:35.26ms
+step:95/1555 train_time:3346ms step_avg:35.22ms
+step:96/1555 train_time:3385ms step_avg:35.26ms
+step:97/1555 train_time:3415ms step_avg:35.21ms
+step:98/1555 train_time:3454ms step_avg:35.24ms
+step:99/1555 train_time:3485ms step_avg:35.20ms
+step:100/1555 train_time:3523ms step_avg:35.23ms
+step:101/1555 train_time:3554ms step_avg:35.19ms
+step:102/1555 train_time:3593ms step_avg:35.22ms
+step:103/1555 train_time:3624ms step_avg:35.18ms
+step:104/1555 train_time:3662ms step_avg:35.21ms
+step:105/1555 train_time:3693ms step_avg:35.18ms
+step:106/1555 train_time:3732ms step_avg:35.20ms
+step:107/1555 train_time:3763ms step_avg:35.17ms
+step:108/1555 train_time:3801ms step_avg:35.20ms
+step:109/1555 train_time:3833ms step_avg:35.16ms
+step:110/1555 train_time:3871ms step_avg:35.19ms
+step:111/1555 train_time:3902ms step_avg:35.16ms
+step:112/1555 train_time:3940ms step_avg:35.18ms
+step:113/1555 train_time:3972ms step_avg:35.15ms
+step:114/1555 train_time:4010ms step_avg:35.18ms
+step:115/1555 train_time:4041ms step_avg:35.14ms
+step:116/1555 train_time:4079ms step_avg:35.17ms
+step:117/1555 train_time:4111ms step_avg:35.14ms
+step:118/1555 train_time:4150ms step_avg:35.17ms
+step:119/1555 train_time:4181ms step_avg:35.13ms
+step:120/1555 train_time:4219ms step_avg:35.16ms
+step:121/1555 train_time:4251ms step_avg:35.13ms
+step:122/1555 train_time:4289ms step_avg:35.16ms
+step:123/1555 train_time:4321ms step_avg:35.13ms
+step:124/1555 train_time:4359ms step_avg:35.15ms
+step:125/1555 train_time:4390ms step_avg:35.12ms
+step:126/1555 train_time:4429ms step_avg:35.15ms
+step:127/1555 train_time:4460ms step_avg:35.12ms
+step:128/1555 train_time:4498ms step_avg:35.14ms
+step:129/1555 train_time:4530ms step_avg:35.12ms
+step:130/1555 train_time:4569ms step_avg:35.14ms
+step:131/1555 train_time:4600ms step_avg:35.11ms
+step:132/1555 train_time:4638ms step_avg:35.14ms
+step:133/1555 train_time:4669ms step_avg:35.11ms
+step:134/1555 train_time:4708ms step_avg:35.13ms
+step:135/1555 train_time:4739ms step_avg:35.10ms
+step:136/1555 train_time:4777ms step_avg:35.13ms
+step:137/1555 train_time:4808ms step_avg:35.10ms
+step:138/1555 train_time:4847ms step_avg:35.12ms
+step:139/1555 train_time:4878ms step_avg:35.09ms
+step:140/1555 train_time:4916ms step_avg:35.11ms
+step:141/1555 train_time:4947ms step_avg:35.09ms
+step:142/1555 train_time:4986ms step_avg:35.11ms
+step:143/1555 train_time:5016ms step_avg:35.08ms
+step:144/1555 train_time:5055ms step_avg:35.10ms
+step:145/1555 train_time:5086ms step_avg:35.07ms
+step:146/1555 train_time:5124ms step_avg:35.09ms
+step:147/1555 train_time:5155ms step_avg:35.07ms
+step:148/1555 train_time:5193ms step_avg:35.09ms
+step:149/1555 train_time:5224ms step_avg:35.06ms
+step:150/1555 train_time:5262ms step_avg:35.08ms
+step:151/1555 train_time:5294ms step_avg:35.06ms
+step:152/1555 train_time:5332ms step_avg:35.08ms
+step:153/1555 train_time:5363ms step_avg:35.05ms
+step:154/1555 train_time:5401ms step_avg:35.07ms
+step:155/1555 train_time:5432ms step_avg:35.05ms
+step:156/1555 train_time:5470ms step_avg:35.07ms
+step:157/1555 train_time:5502ms step_avg:35.04ms
+step:158/1555 train_time:5540ms step_avg:35.06ms
+step:159/1555 train_time:5571ms step_avg:35.04ms
+step:160/1555 train_time:5609ms step_avg:35.06ms
+step:161/1555 train_time:5640ms step_avg:35.03ms
+step:162/1555 train_time:5679ms step_avg:35.05ms
+step:163/1555 train_time:5710ms step_avg:35.03ms
+step:164/1555 train_time:5748ms step_avg:35.05ms
+step:165/1555 train_time:5780ms step_avg:35.03ms
+step:166/1555 train_time:5818ms step_avg:35.05ms
+step:167/1555 train_time:5850ms step_avg:35.03ms
+step:168/1555 train_time:5888ms step_avg:35.05ms
+step:169/1555 train_time:5919ms step_avg:35.03ms
+step:170/1555 train_time:5957ms step_avg:35.04ms
+step:171/1555 train_time:5989ms step_avg:35.02ms
+step:172/1555 train_time:6027ms step_avg:35.04ms
+step:173/1555 train_time:6059ms step_avg:35.02ms
+step:174/1555 train_time:6097ms step_avg:35.04ms
+step:175/1555 train_time:6128ms step_avg:35.02ms
+step:176/1555 train_time:6166ms step_avg:35.03ms
+step:177/1555 train_time:6197ms step_avg:35.01ms
+step:178/1555 train_time:6235ms step_avg:35.03ms
+step:179/1555 train_time:6267ms step_avg:35.01ms
+step:180/1555 train_time:6305ms step_avg:35.03ms
+step:181/1555 train_time:6336ms step_avg:35.01ms
+step:182/1555 train_time:6374ms step_avg:35.02ms
+step:183/1555 train_time:6405ms step_avg:35.00ms
+step:184/1555 train_time:6443ms step_avg:35.02ms
+step:185/1555 train_time:6474ms step_avg:35.00ms
+step:186/1555 train_time:6513ms step_avg:35.01ms
+step:187/1555 train_time:6544ms step_avg:34.99ms
+step:188/1555 train_time:6582ms step_avg:35.01ms
+step:189/1555 train_time:6613ms step_avg:34.99ms
+step:190/1555 train_time:6651ms step_avg:35.01ms
+step:191/1555 train_time:6683ms step_avg:34.99ms
+step:192/1555 train_time:6721ms step_avg:35.00ms
+step:193/1555 train_time:6753ms step_avg:34.99ms
+step:194/1555 train_time:6791ms step_avg:35.00ms
+step:195/1555 train_time:6822ms step_avg:34.98ms
+step:196/1555 train_time:6860ms step_avg:35.00ms
+step:197/1555 train_time:6892ms step_avg:34.98ms
+step:198/1555 train_time:6930ms step_avg:35.00ms
+step:199/1555 train_time:6962ms step_avg:34.98ms
+step:200/1555 train_time:7000ms step_avg:35.00ms
+step:201/1555 train_time:7031ms step_avg:34.98ms
+step:202/1555 train_time:7069ms step_avg:35.00ms
+step:203/1555 train_time:7100ms step_avg:34.98ms
+step:204/1555 train_time:7138ms step_avg:34.99ms
+step:205/1555 train_time:7169ms step_avg:34.97ms
+step:206/1555 train_time:7208ms step_avg:34.99ms
+step:207/1555 train_time:7239ms step_avg:34.97ms
+step:208/1555 train_time:7277ms step_avg:34.99ms
+step:209/1555 train_time:7309ms step_avg:34.97ms
+step:210/1555 train_time:7347ms step_avg:34.98ms
+step:211/1555 train_time:7379ms step_avg:34.97ms
+step:212/1555 train_time:7417ms step_avg:34.98ms
+step:213/1555 train_time:7448ms step_avg:34.97ms
+step:214/1555 train_time:7486ms step_avg:34.98ms
+step:215/1555 train_time:7517ms step_avg:34.96ms
+step:216/1555 train_time:7555ms step_avg:34.98ms
+step:217/1555 train_time:7586ms step_avg:34.96ms
+step:218/1555 train_time:7625ms step_avg:34.98ms
+step:219/1555 train_time:7656ms step_avg:34.96ms
+step:220/1555 train_time:7694ms step_avg:34.97ms
+step:221/1555 train_time:7725ms step_avg:34.95ms
+step:222/1555 train_time:7763ms step_avg:34.97ms
+step:223/1555 train_time:7794ms step_avg:34.95ms
+step:224/1555 train_time:7832ms step_avg:34.97ms
+step:225/1555 train_time:7863ms step_avg:34.95ms
+step:226/1555 train_time:7901ms step_avg:34.96ms
+step:227/1555 train_time:7932ms step_avg:34.94ms
+step:228/1555 train_time:7971ms step_avg:34.96ms
+step:229/1555 train_time:8002ms step_avg:34.94ms
+step:230/1555 train_time:8040ms step_avg:34.96ms
+step:231/1555 train_time:8071ms step_avg:34.94ms
+step:232/1555 train_time:8110ms step_avg:34.96ms
+step:233/1555 train_time:8141ms step_avg:34.94ms
+step:234/1555 train_time:8179ms step_avg:34.95ms
+step:235/1555 train_time:8210ms step_avg:34.94ms
+step:236/1555 train_time:8249ms step_avg:34.95ms
+step:237/1555 train_time:8280ms step_avg:34.94ms
+step:238/1555 train_time:8318ms step_avg:34.95ms
+step:239/1555 train_time:8349ms step_avg:34.93ms
+step:240/1555 train_time:8387ms step_avg:34.95ms
+step:241/1555 train_time:8418ms step_avg:34.93ms
+step:242/1555 train_time:8456ms step_avg:34.94ms
+step:243/1555 train_time:8487ms step_avg:34.93ms
+step:244/1555 train_time:8525ms step_avg:34.94ms
+step:245/1555 train_time:8557ms step_avg:34.93ms
+step:246/1555 train_time:8595ms step_avg:34.94ms
+step:247/1555 train_time:8626ms step_avg:34.92ms
+step:248/1555 train_time:8664ms step_avg:34.94ms
+step:249/1555 train_time:8695ms step_avg:34.92ms
+step:250/1555 train_time:8733ms step_avg:34.93ms
+step:250/1555 val_loss:4.5771 train_time:8782ms step_avg:35.13ms
+step:251/1555 train_time:8801ms step_avg:35.07ms
+step:252/1555 train_time:8819ms step_avg:35.00ms
+step:253/1555 train_time:8836ms step_avg:34.93ms
+step:254/1555 train_time:8875ms step_avg:34.94ms
+step:255/1555 train_time:8908ms step_avg:34.93ms
+step:256/1555 train_time:8947ms step_avg:34.95ms
+step:257/1555 train_time:8980ms step_avg:34.94ms
+step:258/1555 train_time:9019ms step_avg:34.96ms
+step:259/1555 train_time:9050ms step_avg:34.94ms
+step:260/1555 train_time:9088ms step_avg:34.95ms
+step:261/1555 train_time:9119ms step_avg:34.94ms
+step:262/1555 train_time:9158ms step_avg:34.95ms
+step:263/1555 train_time:9189ms step_avg:34.94ms
+step:264/1555 train_time:9227ms step_avg:34.95ms
+step:265/1555 train_time:9258ms step_avg:34.94ms
+step:266/1555 train_time:9296ms step_avg:34.95ms
+step:267/1555 train_time:9327ms step_avg:34.93ms
+step:268/1555 train_time:9366ms step_avg:34.95ms
+step:269/1555 train_time:9397ms step_avg:34.93ms
+step:270/1555 train_time:9435ms step_avg:34.94ms
+step:271/1555 train_time:9466ms step_avg:34.93ms
+step:272/1555 train_time:9505ms step_avg:34.94ms
+step:273/1555 train_time:9536ms step_avg:34.93ms
+step:274/1555 train_time:9574ms step_avg:34.94ms
+step:275/1555 train_time:9605ms step_avg:34.93ms
+step:276/1555 train_time:9644ms step_avg:34.94ms
+step:277/1555 train_time:9675ms step_avg:34.93ms
+step:278/1555 train_time:9713ms step_avg:34.94ms
+step:279/1555 train_time:9744ms step_avg:34.93ms
+step:280/1555 train_time:9783ms step_avg:34.94ms
+step:281/1555 train_time:9814ms step_avg:34.92ms
+step:282/1555 train_time:9852ms step_avg:34.94ms
+step:283/1555 train_time:9883ms step_avg:34.92ms
+step:284/1555 train_time:9921ms step_avg:34.93ms
+step:285/1555 train_time:9952ms step_avg:34.92ms
+step:286/1555 train_time:9990ms step_avg:34.93ms
+step:287/1555 train_time:10022ms step_avg:34.92ms
+step:288/1555 train_time:10060ms step_avg:34.93ms
+step:289/1555 train_time:10091ms step_avg:34.92ms
+step:290/1555 train_time:10129ms step_avg:34.93ms
+step:291/1555 train_time:10160ms step_avg:34.91ms
+step:292/1555 train_time:10198ms step_avg:34.93ms
+step:293/1555 train_time:10229ms step_avg:34.91ms
+step:294/1555 train_time:10267ms step_avg:34.92ms
+step:295/1555 train_time:10299ms step_avg:34.91ms
+step:296/1555 train_time:10337ms step_avg:34.92ms
+step:297/1555 train_time:10368ms step_avg:34.91ms
+step:298/1555 train_time:10406ms step_avg:34.92ms
+step:299/1555 train_time:10437ms step_avg:34.91ms
+step:300/1555 train_time:10475ms step_avg:34.92ms
+step:301/1555 train_time:10507ms step_avg:34.91ms
+step:302/1555 train_time:10545ms step_avg:34.92ms
+step:303/1555 train_time:10576ms step_avg:34.90ms
+step:304/1555 train_time:10614ms step_avg:34.91ms
+step:305/1555 train_time:10645ms step_avg:34.90ms
+step:306/1555 train_time:10684ms step_avg:34.91ms
+step:307/1555 train_time:10715ms step_avg:34.90ms
+step:308/1555 train_time:10753ms step_avg:34.91ms
+step:309/1555 train_time:10784ms step_avg:34.90ms
+step:310/1555 train_time:10822ms step_avg:34.91ms
+step:311/1555 train_time:10853ms step_avg:34.90ms
+step:312/1555 train_time:10891ms step_avg:34.91ms
+step:313/1555 train_time:10922ms step_avg:34.90ms
+step:314/1555 train_time:10961ms step_avg:34.91ms
+step:315/1555 train_time:10992ms step_avg:34.89ms
+step:316/1555 train_time:11030ms step_avg:34.90ms
+step:317/1555 train_time:11061ms step_avg:34.89ms
+step:318/1555 train_time:11100ms step_avg:34.91ms
+step:319/1555 train_time:11130ms step_avg:34.89ms
+step:320/1555 train_time:11168ms step_avg:34.90ms
+step:321/1555 train_time:11199ms step_avg:34.89ms
+step:322/1555 train_time:11237ms step_avg:34.90ms
+step:323/1555 train_time:11269ms step_avg:34.89ms
+step:324/1555 train_time:11307ms step_avg:34.90ms
+step:325/1555 train_time:11338ms step_avg:34.89ms
+step:326/1555 train_time:11376ms step_avg:34.90ms
+step:327/1555 train_time:11407ms step_avg:34.88ms
+step:328/1555 train_time:11446ms step_avg:34.90ms
+step:329/1555 train_time:11477ms step_avg:34.88ms
+step:330/1555 train_time:11515ms step_avg:34.89ms
+step:331/1555 train_time:11546ms step_avg:34.88ms
+step:332/1555 train_time:11584ms step_avg:34.89ms
+step:333/1555 train_time:11616ms step_avg:34.88ms
+step:334/1555 train_time:11653ms step_avg:34.89ms
+step:335/1555 train_time:11685ms step_avg:34.88ms
+step:336/1555 train_time:11723ms step_avg:34.89ms
+step:337/1555 train_time:11754ms step_avg:34.88ms
+step:338/1555 train_time:11792ms step_avg:34.89ms
+step:339/1555 train_time:11823ms step_avg:34.88ms
+step:340/1555 train_time:11862ms step_avg:34.89ms
+step:341/1555 train_time:11893ms step_avg:34.88ms
+step:342/1555 train_time:11931ms step_avg:34.89ms
+step:343/1555 train_time:11963ms step_avg:34.88ms
+step:344/1555 train_time:12001ms step_avg:34.89ms
+step:345/1555 train_time:12032ms step_avg:34.88ms
+step:346/1555 train_time:12070ms step_avg:34.88ms
+step:347/1555 train_time:12102ms step_avg:34.87ms
+step:348/1555 train_time:12140ms step_avg:34.88ms
+step:349/1555 train_time:12171ms step_avg:34.87ms
+step:350/1555 train_time:12209ms step_avg:34.88ms
+step:351/1555 train_time:12240ms step_avg:34.87ms
+step:352/1555 train_time:12278ms step_avg:34.88ms
+step:353/1555 train_time:12309ms step_avg:34.87ms
+step:354/1555 train_time:12347ms step_avg:34.88ms
+step:355/1555 train_time:12378ms step_avg:34.87ms
+step:356/1555 train_time:12416ms step_avg:34.88ms
+step:357/1555 train_time:12447ms step_avg:34.87ms
+step:358/1555 train_time:12486ms step_avg:34.88ms
+step:359/1555 train_time:12517ms step_avg:34.87ms
+step:360/1555 train_time:12555ms step_avg:34.87ms
+step:361/1555 train_time:12586ms step_avg:34.86ms
+step:362/1555 train_time:12624ms step_avg:34.87ms
+step:363/1555 train_time:12655ms step_avg:34.86ms
+step:364/1555 train_time:12693ms step_avg:34.87ms
+step:365/1555 train_time:12725ms step_avg:34.86ms
+step:366/1555 train_time:12763ms step_avg:34.87ms
+step:367/1555 train_time:12794ms step_avg:34.86ms
+step:368/1555 train_time:12832ms step_avg:34.87ms
+step:369/1555 train_time:12864ms step_avg:34.86ms
+step:370/1555 train_time:12902ms step_avg:34.87ms
+step:371/1555 train_time:12933ms step_avg:34.86ms
+step:372/1555 train_time:12971ms step_avg:34.87ms
+step:373/1555 train_time:13002ms step_avg:34.86ms
+step:374/1555 train_time:13041ms step_avg:34.87ms
+step:375/1555 train_time:13071ms step_avg:34.86ms
+step:376/1555 train_time:13110ms step_avg:34.87ms
+step:377/1555 train_time:13141ms step_avg:34.86ms
+step:378/1555 train_time:13179ms step_avg:34.86ms
+step:379/1555 train_time:13210ms step_avg:34.85ms
+step:380/1555 train_time:13248ms step_avg:34.86ms
+step:381/1555 train_time:13279ms step_avg:34.85ms
+step:382/1555 train_time:13317ms step_avg:34.86ms
+step:383/1555 train_time:13348ms step_avg:34.85ms
+step:384/1555 train_time:13387ms step_avg:34.86ms
+step:385/1555 train_time:13418ms step_avg:34.85ms
+step:386/1555 train_time:13456ms step_avg:34.86ms
+step:387/1555 train_time:13488ms step_avg:34.85ms
+step:388/1555 train_time:13526ms step_avg:34.86ms
+step:389/1555 train_time:13557ms step_avg:34.85ms
+step:390/1555 train_time:13595ms step_avg:34.86ms
+step:391/1555 train_time:13626ms step_avg:34.85ms
+step:392/1555 train_time:13665ms step_avg:34.86ms
+step:393/1555 train_time:13696ms step_avg:34.85ms
+step:394/1555 train_time:13734ms step_avg:34.86ms
+step:395/1555 train_time:13765ms step_avg:34.85ms
+step:396/1555 train_time:13804ms step_avg:34.86ms
+step:397/1555 train_time:13835ms step_avg:34.85ms
+step:398/1555 train_time:13873ms step_avg:34.86ms
+step:399/1555 train_time:13904ms step_avg:34.85ms
+step:400/1555 train_time:13942ms step_avg:34.85ms
+step:401/1555 train_time:13973ms step_avg:34.85ms
+step:402/1555 train_time:14011ms step_avg:34.85ms
+step:403/1555 train_time:14043ms step_avg:34.85ms
+step:404/1555 train_time:14081ms step_avg:34.85ms
+step:405/1555 train_time:14112ms step_avg:34.84ms
+step:406/1555 train_time:14150ms step_avg:34.85ms
+step:407/1555 train_time:14181ms step_avg:34.84ms
+step:408/1555 train_time:14219ms step_avg:34.85ms
+step:409/1555 train_time:14251ms step_avg:34.84ms
+step:410/1555 train_time:14289ms step_avg:34.85ms
+step:411/1555 train_time:14320ms step_avg:34.84ms
+step:412/1555 train_time:14358ms step_avg:34.85ms
+step:413/1555 train_time:14389ms step_avg:34.84ms
+step:414/1555 train_time:14427ms step_avg:34.85ms
+step:415/1555 train_time:14459ms step_avg:34.84ms
+step:416/1555 train_time:14497ms step_avg:34.85ms
+step:417/1555 train_time:14528ms step_avg:34.84ms
+step:418/1555 train_time:14566ms step_avg:34.85ms
+step:419/1555 train_time:14597ms step_avg:34.84ms
+step:420/1555 train_time:14635ms step_avg:34.85ms
+step:421/1555 train_time:14667ms step_avg:34.84ms
+step:422/1555 train_time:14705ms step_avg:34.85ms
+step:423/1555 train_time:14736ms step_avg:34.84ms
+step:424/1555 train_time:14775ms step_avg:34.85ms
+step:425/1555 train_time:14806ms step_avg:34.84ms
+step:426/1555 train_time:14844ms step_avg:34.85ms
+step:427/1555 train_time:14876ms step_avg:34.84ms
+step:428/1555 train_time:14914ms step_avg:34.84ms
+step:429/1555 train_time:14945ms step_avg:34.84ms
+step:430/1555 train_time:14983ms step_avg:34.84ms
+step:431/1555 train_time:15014ms step_avg:34.84ms
+step:432/1555 train_time:15052ms step_avg:34.84ms
+step:433/1555 train_time:15084ms step_avg:34.84ms
+step:434/1555 train_time:15122ms step_avg:34.84ms
+step:435/1555 train_time:15153ms step_avg:34.83ms
+step:436/1555 train_time:15191ms step_avg:34.84ms
+step:437/1555 train_time:15222ms step_avg:34.83ms
+step:438/1555 train_time:15260ms step_avg:34.84ms
+step:439/1555 train_time:15292ms step_avg:34.83ms
+step:440/1555 train_time:15330ms step_avg:34.84ms
+step:441/1555 train_time:15361ms step_avg:34.83ms
+step:442/1555 train_time:15399ms step_avg:34.84ms
+step:443/1555 train_time:15430ms step_avg:34.83ms
+step:444/1555 train_time:15468ms step_avg:34.84ms
+step:445/1555 train_time:15500ms step_avg:34.83ms
+step:446/1555 train_time:15538ms step_avg:34.84ms
+step:447/1555 train_time:15569ms step_avg:34.83ms
+step:448/1555 train_time:15607ms step_avg:34.84ms
+step:449/1555 train_time:15638ms step_avg:34.83ms
+step:450/1555 train_time:15676ms step_avg:34.84ms
+step:451/1555 train_time:15707ms step_avg:34.83ms
+step:452/1555 train_time:15745ms step_avg:34.83ms
+step:453/1555 train_time:15777ms step_avg:34.83ms
+step:454/1555 train_time:15815ms step_avg:34.83ms
+step:455/1555 train_time:15846ms step_avg:34.83ms
+step:456/1555 train_time:15884ms step_avg:34.83ms
+step:457/1555 train_time:15916ms step_avg:34.83ms
+step:458/1555 train_time:15953ms step_avg:34.83ms
+step:459/1555 train_time:15985ms step_avg:34.82ms
+step:460/1555 train_time:16023ms step_avg:34.83ms
+step:461/1555 train_time:16054ms step_avg:34.82ms
+step:462/1555 train_time:16092ms step_avg:34.83ms
+step:463/1555 train_time:16124ms step_avg:34.82ms
+step:464/1555 train_time:16162ms step_avg:34.83ms
+step:465/1555 train_time:16193ms step_avg:34.82ms
+step:466/1555 train_time:16231ms step_avg:34.83ms
+step:467/1555 train_time:16262ms step_avg:34.82ms
+step:468/1555 train_time:16300ms step_avg:34.83ms
+step:469/1555 train_time:16331ms step_avg:34.82ms
+step:470/1555 train_time:16369ms step_avg:34.83ms
+step:471/1555 train_time:16401ms step_avg:34.82ms
+step:472/1555 train_time:16438ms step_avg:34.83ms
+step:473/1555 train_time:16470ms step_avg:34.82ms
+step:474/1555 train_time:16508ms step_avg:34.83ms
+step:475/1555 train_time:16539ms step_avg:34.82ms
+step:476/1555 train_time:16577ms step_avg:34.83ms
+step:477/1555 train_time:16608ms step_avg:34.82ms
+step:478/1555 train_time:16646ms step_avg:34.83ms
+step:479/1555 train_time:16678ms step_avg:34.82ms
+step:480/1555 train_time:16716ms step_avg:34.82ms
+step:481/1555 train_time:16747ms step_avg:34.82ms
+step:482/1555 train_time:16785ms step_avg:34.82ms
+step:483/1555 train_time:16817ms step_avg:34.82ms
+step:484/1555 train_time:16855ms step_avg:34.82ms
+step:485/1555 train_time:16886ms step_avg:34.82ms
+step:486/1555 train_time:16924ms step_avg:34.82ms
+step:487/1555 train_time:16955ms step_avg:34.82ms
+step:488/1555 train_time:16993ms step_avg:34.82ms
+step:489/1555 train_time:17024ms step_avg:34.81ms
+step:490/1555 train_time:17062ms step_avg:34.82ms
+step:491/1555 train_time:17094ms step_avg:34.81ms
+step:492/1555 train_time:17132ms step_avg:34.82ms
+step:493/1555 train_time:17163ms step_avg:34.81ms
+step:494/1555 train_time:17202ms step_avg:34.82ms
+step:495/1555 train_time:17233ms step_avg:34.81ms
+step:496/1555 train_time:17271ms step_avg:34.82ms
+step:497/1555 train_time:17302ms step_avg:34.81ms
+step:498/1555 train_time:17340ms step_avg:34.82ms
+step:499/1555 train_time:17371ms step_avg:34.81ms
+step:500/1555 train_time:17409ms step_avg:34.82ms
+step:500/1555 val_loss:4.2308 train_time:17458ms step_avg:34.92ms
+step:501/1555 train_time:17478ms step_avg:34.89ms
+step:502/1555 train_time:17496ms step_avg:34.85ms
+step:503/1555 train_time:17511ms step_avg:34.81ms
+step:504/1555 train_time:17551ms step_avg:34.82ms
+step:505/1555 train_time:17582ms step_avg:34.82ms
+step:506/1555 train_time:17658ms step_avg:34.90ms
+step:507/1555 train_time:17719ms step_avg:34.95ms
+step:508/1555 train_time:17778ms step_avg:35.00ms
+step:509/1555 train_time:17842ms step_avg:35.05ms
+step:510/1555 train_time:17901ms step_avg:35.10ms
+step:511/1555 train_time:17963ms step_avg:35.15ms
+step:512/1555 train_time:18021ms step_avg:35.20ms
+step:513/1555 train_time:18085ms step_avg:35.25ms
+step:514/1555 train_time:18143ms step_avg:35.30ms
+step:515/1555 train_time:18205ms step_avg:35.35ms
+step:516/1555 train_time:18263ms step_avg:35.39ms
+step:517/1555 train_time:18327ms step_avg:35.45ms
+step:518/1555 train_time:18387ms step_avg:35.50ms
+step:519/1555 train_time:18452ms step_avg:35.55ms
+step:520/1555 train_time:18512ms step_avg:35.60ms
+step:521/1555 train_time:18578ms step_avg:35.66ms
+step:522/1555 train_time:18637ms step_avg:35.70ms
+step:523/1555 train_time:18700ms step_avg:35.76ms
+step:524/1555 train_time:18759ms step_avg:35.80ms
+step:525/1555 train_time:18825ms step_avg:35.86ms
+step:526/1555 train_time:18882ms step_avg:35.90ms
+step:527/1555 train_time:18944ms step_avg:35.95ms
+step:528/1555 train_time:19003ms step_avg:35.99ms
+step:529/1555 train_time:19066ms step_avg:36.04ms
+step:530/1555 train_time:19125ms step_avg:36.09ms
+step:531/1555 train_time:19188ms step_avg:36.14ms
+step:532/1555 train_time:19247ms step_avg:36.18ms
+step:533/1555 train_time:19311ms step_avg:36.23ms
+step:534/1555 train_time:19370ms step_avg:36.27ms
+step:535/1555 train_time:19434ms step_avg:36.32ms
+step:536/1555 train_time:19493ms step_avg:36.37ms
+step:537/1555 train_time:19558ms step_avg:36.42ms
+step:538/1555 train_time:19616ms step_avg:36.46ms
+step:539/1555 train_time:19680ms step_avg:36.51ms
+step:540/1555 train_time:19739ms step_avg:36.55ms
+step:541/1555 train_time:19803ms step_avg:36.61ms
+step:542/1555 train_time:19863ms step_avg:36.65ms
+step:543/1555 train_time:19925ms step_avg:36.69ms
+step:544/1555 train_time:19984ms step_avg:36.74ms
+step:545/1555 train_time:20047ms step_avg:36.78ms
+step:546/1555 train_time:20106ms step_avg:36.82ms
+step:547/1555 train_time:20170ms step_avg:36.87ms
+step:548/1555 train_time:20228ms step_avg:36.91ms
+step:549/1555 train_time:20291ms step_avg:36.96ms
+step:550/1555 train_time:20350ms step_avg:37.00ms
+step:551/1555 train_time:20413ms step_avg:37.05ms
+step:552/1555 train_time:20473ms step_avg:37.09ms
+step:553/1555 train_time:20536ms step_avg:37.14ms
+step:554/1555 train_time:20596ms step_avg:37.18ms
+step:555/1555 train_time:20660ms step_avg:37.22ms
+step:556/1555 train_time:20719ms step_avg:37.26ms
+step:557/1555 train_time:20784ms step_avg:37.31ms
+step:558/1555 train_time:20842ms step_avg:37.35ms
+step:559/1555 train_time:20905ms step_avg:37.40ms
+step:560/1555 train_time:20965ms step_avg:37.44ms
+step:561/1555 train_time:21030ms step_avg:37.49ms
+step:562/1555 train_time:21087ms step_avg:37.52ms
+step:563/1555 train_time:21150ms step_avg:37.57ms
+step:564/1555 train_time:21209ms step_avg:37.60ms
+step:565/1555 train_time:21272ms step_avg:37.65ms
+step:566/1555 train_time:21339ms step_avg:37.70ms
+step:567/1555 train_time:21398ms step_avg:37.74ms
+step:568/1555 train_time:21455ms step_avg:37.77ms
+step:569/1555 train_time:21518ms step_avg:37.82ms
+step:570/1555 train_time:21576ms step_avg:37.85ms
+step:571/1555 train_time:21640ms step_avg:37.90ms
+step:572/1555 train_time:21699ms step_avg:37.94ms
+step:573/1555 train_time:21763ms step_avg:37.98ms
+step:574/1555 train_time:21823ms step_avg:38.02ms
+step:575/1555 train_time:21887ms step_avg:38.06ms
+step:576/1555 train_time:21948ms step_avg:38.10ms
+step:577/1555 train_time:22010ms step_avg:38.15ms
+step:578/1555 train_time:22069ms step_avg:38.18ms
+step:579/1555 train_time:22132ms step_avg:38.23ms
+step:580/1555 train_time:22191ms step_avg:38.26ms
+step:581/1555 train_time:22255ms step_avg:38.31ms
+step:582/1555 train_time:22314ms step_avg:38.34ms
+step:583/1555 train_time:22377ms step_avg:38.38ms
+step:584/1555 train_time:22436ms step_avg:38.42ms
+step:585/1555 train_time:22500ms step_avg:38.46ms
+step:586/1555 train_time:22559ms step_avg:38.50ms
+step:587/1555 train_time:22624ms step_avg:38.54ms
+step:588/1555 train_time:22682ms step_avg:38.57ms
+step:589/1555 train_time:22746ms step_avg:38.62ms
+step:590/1555 train_time:22805ms step_avg:38.65ms
+step:591/1555 train_time:22869ms step_avg:38.70ms
+step:592/1555 train_time:22930ms step_avg:38.73ms
+step:593/1555 train_time:22992ms step_avg:38.77ms
+step:594/1555 train_time:23051ms step_avg:38.81ms
+step:595/1555 train_time:23114ms step_avg:38.85ms
+step:596/1555 train_time:23173ms step_avg:38.88ms
+step:597/1555 train_time:23237ms step_avg:38.92ms
+step:598/1555 train_time:23297ms step_avg:38.96ms
+step:599/1555 train_time:23360ms step_avg:39.00ms
+step:600/1555 train_time:23418ms step_avg:39.03ms
+step:601/1555 train_time:23481ms step_avg:39.07ms
+step:602/1555 train_time:23540ms step_avg:39.10ms
+step:603/1555 train_time:23604ms step_avg:39.14ms
+step:604/1555 train_time:23664ms step_avg:39.18ms
+step:605/1555 train_time:23728ms step_avg:39.22ms
+step:606/1555 train_time:23787ms step_avg:39.25ms
+step:607/1555 train_time:23850ms step_avg:39.29ms
+step:608/1555 train_time:23910ms step_avg:39.33ms
+step:609/1555 train_time:23973ms step_avg:39.37ms
+step:610/1555 train_time:24034ms step_avg:39.40ms
+step:611/1555 train_time:24097ms step_avg:39.44ms
+step:612/1555 train_time:24157ms step_avg:39.47ms
+step:613/1555 train_time:24219ms step_avg:39.51ms
+step:614/1555 train_time:24278ms step_avg:39.54ms
+step:615/1555 train_time:24343ms step_avg:39.58ms
+step:616/1555 train_time:24401ms step_avg:39.61ms
+step:617/1555 train_time:24464ms step_avg:39.65ms
+step:618/1555 train_time:24523ms step_avg:39.68ms
+step:619/1555 train_time:24586ms step_avg:39.72ms
+step:620/1555 train_time:24647ms step_avg:39.75ms
+step:621/1555 train_time:24710ms step_avg:39.79ms
+step:622/1555 train_time:24769ms step_avg:39.82ms
+step:623/1555 train_time:24832ms step_avg:39.86ms
+step:624/1555 train_time:24891ms step_avg:39.89ms
+step:625/1555 train_time:24954ms step_avg:39.93ms
+step:626/1555 train_time:25014ms step_avg:39.96ms
+step:627/1555 train_time:25079ms step_avg:40.00ms
+step:628/1555 train_time:25137ms step_avg:40.03ms
+step:629/1555 train_time:25201ms step_avg:40.07ms
+step:630/1555 train_time:25260ms step_avg:40.09ms
+step:631/1555 train_time:25323ms step_avg:40.13ms
+step:632/1555 train_time:25382ms step_avg:40.16ms
+step:633/1555 train_time:25445ms step_avg:40.20ms
+step:634/1555 train_time:25505ms step_avg:40.23ms
+step:635/1555 train_time:25567ms step_avg:40.26ms
+step:636/1555 train_time:25626ms step_avg:40.29ms
+step:637/1555 train_time:25690ms step_avg:40.33ms
+step:638/1555 train_time:25749ms step_avg:40.36ms
+step:639/1555 train_time:25812ms step_avg:40.39ms
+step:640/1555 train_time:25871ms step_avg:40.42ms
+step:641/1555 train_time:25935ms step_avg:40.46ms
+step:642/1555 train_time:25994ms step_avg:40.49ms
+step:643/1555 train_time:26058ms step_avg:40.53ms
+step:644/1555 train_time:26117ms step_avg:40.55ms
+step:645/1555 train_time:26181ms step_avg:40.59ms
+step:646/1555 train_time:26242ms step_avg:40.62ms
+step:647/1555 train_time:26304ms step_avg:40.66ms
+step:648/1555 train_time:26363ms step_avg:40.68ms
+step:649/1555 train_time:26426ms step_avg:40.72ms
+step:650/1555 train_time:26485ms step_avg:40.75ms
+step:651/1555 train_time:26548ms step_avg:40.78ms
+step:652/1555 train_time:26607ms step_avg:40.81ms
+step:653/1555 train_time:26671ms step_avg:40.84ms
+step:654/1555 train_time:26729ms step_avg:40.87ms
+step:655/1555 train_time:26792ms step_avg:40.90ms
+step:656/1555 train_time:26852ms step_avg:40.93ms
+step:657/1555 train_time:26915ms step_avg:40.97ms
+step:658/1555 train_time:26974ms step_avg:40.99ms
+step:659/1555 train_time:27038ms step_avg:41.03ms
+step:660/1555 train_time:27098ms step_avg:41.06ms
+step:661/1555 train_time:27161ms step_avg:41.09ms
+step:662/1555 train_time:27221ms step_avg:41.12ms
+step:663/1555 train_time:27284ms step_avg:41.15ms
+step:664/1555 train_time:27343ms step_avg:41.18ms
+step:665/1555 train_time:27407ms step_avg:41.21ms
+step:666/1555 train_time:27466ms step_avg:41.24ms
+step:667/1555 train_time:27530ms step_avg:41.27ms
+step:668/1555 train_time:27588ms step_avg:41.30ms
+step:669/1555 train_time:27651ms step_avg:41.33ms
+step:670/1555 train_time:27711ms step_avg:41.36ms
+step:671/1555 train_time:27774ms step_avg:41.39ms
+step:672/1555 train_time:27833ms step_avg:41.42ms
+step:673/1555 train_time:27896ms step_avg:41.45ms
+step:674/1555 train_time:27958ms step_avg:41.48ms
+step:675/1555 train_time:28020ms step_avg:41.51ms
+step:676/1555 train_time:28080ms step_avg:41.54ms
+step:677/1555 train_time:28143ms step_avg:41.57ms
+step:678/1555 train_time:28202ms step_avg:41.60ms
+step:679/1555 train_time:28265ms step_avg:41.63ms
+step:680/1555 train_time:28325ms step_avg:41.65ms
+step:681/1555 train_time:28390ms step_avg:41.69ms
+step:682/1555 train_time:28448ms step_avg:41.71ms
+step:683/1555 train_time:28511ms step_avg:41.74ms
+step:684/1555 train_time:28570ms step_avg:41.77ms
+step:685/1555 train_time:28633ms step_avg:41.80ms
+step:686/1555 train_time:28692ms step_avg:41.83ms
+step:687/1555 train_time:28756ms step_avg:41.86ms
+step:688/1555 train_time:28815ms step_avg:41.88ms
+step:689/1555 train_time:28878ms step_avg:41.91ms
+step:690/1555 train_time:28937ms step_avg:41.94ms
+step:691/1555 train_time:29001ms step_avg:41.97ms
+step:692/1555 train_time:29061ms step_avg:42.00ms
+step:693/1555 train_time:29124ms step_avg:42.03ms
+step:694/1555 train_time:29183ms step_avg:42.05ms
+step:695/1555 train_time:29247ms step_avg:42.08ms
+step:696/1555 train_time:29306ms step_avg:42.11ms
+step:697/1555 train_time:29369ms step_avg:42.14ms
+step:698/1555 train_time:29428ms step_avg:42.16ms
+step:699/1555 train_time:29491ms step_avg:42.19ms
+step:700/1555 train_time:29551ms step_avg:42.22ms
+step:701/1555 train_time:29615ms step_avg:42.25ms
+step:702/1555 train_time:29674ms step_avg:42.27ms
+step:703/1555 train_time:29737ms step_avg:42.30ms
+step:704/1555 train_time:29796ms step_avg:42.32ms
+step:705/1555 train_time:29859ms step_avg:42.35ms
+step:706/1555 train_time:29918ms step_avg:42.38ms
+step:707/1555 train_time:29981ms step_avg:42.41ms
+step:708/1555 train_time:30040ms step_avg:42.43ms
+step:709/1555 train_time:30104ms step_avg:42.46ms
+step:710/1555 train_time:30164ms step_avg:42.48ms
+step:711/1555 train_time:30226ms step_avg:42.51ms
+step:712/1555 train_time:30286ms step_avg:42.54ms
+step:713/1555 train_time:30349ms step_avg:42.56ms
+step:714/1555 train_time:30408ms step_avg:42.59ms
+step:715/1555 train_time:30472ms step_avg:42.62ms
+step:716/1555 train_time:30531ms step_avg:42.64ms
+step:717/1555 train_time:30594ms step_avg:42.67ms
+step:718/1555 train_time:30655ms step_avg:42.69ms
+step:719/1555 train_time:30717ms step_avg:42.72ms
+step:720/1555 train_time:30776ms step_avg:42.74ms
+step:721/1555 train_time:30839ms step_avg:42.77ms
+step:722/1555 train_time:30899ms step_avg:42.80ms
+step:723/1555 train_time:30962ms step_avg:42.82ms
+step:724/1555 train_time:31021ms step_avg:42.85ms
+step:725/1555 train_time:31085ms step_avg:42.88ms
+step:726/1555 train_time:31144ms step_avg:42.90ms
+step:727/1555 train_time:31208ms step_avg:42.93ms
+step:728/1555 train_time:31266ms step_avg:42.95ms
+step:729/1555 train_time:31329ms step_avg:42.98ms
+step:730/1555 train_time:31388ms step_avg:43.00ms
+step:731/1555 train_time:31452ms step_avg:43.03ms
+step:732/1555 train_time:31511ms step_avg:43.05ms
+step:733/1555 train_time:31574ms step_avg:43.08ms
+step:734/1555 train_time:31634ms step_avg:43.10ms
+step:735/1555 train_time:31698ms step_avg:43.13ms
+step:736/1555 train_time:31757ms step_avg:43.15ms
+step:737/1555 train_time:31820ms step_avg:43.18ms
+step:738/1555 train_time:31879ms step_avg:43.20ms
+step:739/1555 train_time:31942ms step_avg:43.22ms
+step:740/1555 train_time:32002ms step_avg:43.25ms
+step:741/1555 train_time:32065ms step_avg:43.27ms
+step:742/1555 train_time:32125ms step_avg:43.30ms
+step:743/1555 train_time:32190ms step_avg:43.32ms
+step:744/1555 train_time:32248ms step_avg:43.34ms
+step:745/1555 train_time:32312ms step_avg:43.37ms
+step:746/1555 train_time:32371ms step_avg:43.39ms
+step:747/1555 train_time:32434ms step_avg:43.42ms
+step:748/1555 train_time:32493ms step_avg:43.44ms
+step:749/1555 train_time:32557ms step_avg:43.47ms
+step:750/1555 train_time:32616ms step_avg:43.49ms
+step:750/1555 val_loss:3.8714 train_time:32665ms step_avg:43.55ms
+step:751/1555 train_time:32684ms step_avg:43.52ms
+step:752/1555 train_time:32743ms step_avg:43.54ms
+step:753/1555 train_time:32810ms step_avg:43.57ms
+step:754/1555 train_time:32872ms step_avg:43.60ms
+step:755/1555 train_time:32936ms step_avg:43.62ms
+step:756/1555 train_time:32995ms step_avg:43.64ms
+step:757/1555 train_time:33058ms step_avg:43.67ms
+step:758/1555 train_time:33116ms step_avg:43.69ms
+step:759/1555 train_time:33179ms step_avg:43.71ms
+step:760/1555 train_time:33239ms step_avg:43.74ms
+step:761/1555 train_time:33302ms step_avg:43.76ms
+step:762/1555 train_time:33361ms step_avg:43.78ms
+step:763/1555 train_time:33424ms step_avg:43.81ms
+step:764/1555 train_time:33484ms step_avg:43.83ms
+step:765/1555 train_time:33545ms step_avg:43.85ms
+step:766/1555 train_time:33604ms step_avg:43.87ms
+step:767/1555 train_time:33669ms step_avg:43.90ms
+step:768/1555 train_time:33729ms step_avg:43.92ms
+step:769/1555 train_time:33793ms step_avg:43.94ms
+step:770/1555 train_time:33854ms step_avg:43.97ms
+step:771/1555 train_time:33918ms step_avg:43.99ms
+step:772/1555 train_time:33977ms step_avg:44.01ms
+step:773/1555 train_time:34040ms step_avg:44.04ms
+step:774/1555 train_time:34098ms step_avg:44.05ms
+step:775/1555 train_time:34161ms step_avg:44.08ms
+step:776/1555 train_time:34221ms step_avg:44.10ms
+step:777/1555 train_time:34284ms step_avg:44.12ms
+step:778/1555 train_time:34344ms step_avg:44.14ms
+step:779/1555 train_time:34407ms step_avg:44.17ms
+step:780/1555 train_time:34467ms step_avg:44.19ms
+step:781/1555 train_time:34529ms step_avg:44.21ms
+step:782/1555 train_time:34588ms step_avg:44.23ms
+step:783/1555 train_time:34652ms step_avg:44.25ms
+step:784/1555 train_time:34711ms step_avg:44.27ms
+step:785/1555 train_time:34775ms step_avg:44.30ms
+step:786/1555 train_time:34835ms step_avg:44.32ms
+step:787/1555 train_time:34899ms step_avg:44.34ms
+step:788/1555 train_time:34959ms step_avg:44.36ms
+step:789/1555 train_time:35023ms step_avg:44.39ms
+step:790/1555 train_time:35082ms step_avg:44.41ms
+step:791/1555 train_time:35145ms step_avg:44.43ms
+step:792/1555 train_time:35204ms step_avg:44.45ms
+step:793/1555 train_time:35267ms step_avg:44.47ms
+step:794/1555 train_time:35327ms step_avg:44.49ms
+step:795/1555 train_time:35390ms step_avg:44.52ms
+step:796/1555 train_time:35448ms step_avg:44.53ms
+step:797/1555 train_time:35511ms step_avg:44.56ms
+step:798/1555 train_time:35570ms step_avg:44.57ms
+step:799/1555 train_time:35633ms step_avg:44.60ms
+step:800/1555 train_time:35693ms step_avg:44.62ms
+step:801/1555 train_time:35756ms step_avg:44.64ms
+step:802/1555 train_time:35816ms step_avg:44.66ms
+step:803/1555 train_time:35880ms step_avg:44.68ms
+step:804/1555 train_time:35939ms step_avg:44.70ms
+step:805/1555 train_time:36003ms step_avg:44.72ms
+step:806/1555 train_time:36062ms step_avg:44.74ms
+step:807/1555 train_time:36126ms step_avg:44.77ms
+step:808/1555 train_time:36184ms step_avg:44.78ms
+step:809/1555 train_time:36247ms step_avg:44.80ms
+step:810/1555 train_time:36308ms step_avg:44.82ms
+step:811/1555 train_time:36370ms step_avg:44.85ms
+step:812/1555 train_time:36429ms step_avg:44.86ms
+step:813/1555 train_time:36492ms step_avg:44.89ms
+step:814/1555 train_time:36551ms step_avg:44.90ms
+step:815/1555 train_time:36615ms step_avg:44.93ms
+step:816/1555 train_time:36674ms step_avg:44.94ms
+step:817/1555 train_time:36737ms step_avg:44.97ms
+step:818/1555 train_time:36797ms step_avg:44.98ms
+step:819/1555 train_time:36861ms step_avg:45.01ms
+step:820/1555 train_time:36922ms step_avg:45.03ms
+step:821/1555 train_time:36983ms step_avg:45.05ms
+step:822/1555 train_time:37042ms step_avg:45.06ms
+step:823/1555 train_time:37106ms step_avg:45.09ms
+step:824/1555 train_time:37165ms step_avg:45.10ms
+step:825/1555 train_time:37229ms step_avg:45.13ms
+step:826/1555 train_time:37287ms step_avg:45.14ms
+step:827/1555 train_time:37350ms step_avg:45.16ms
+step:828/1555 train_time:37410ms step_avg:45.18ms
+step:829/1555 train_time:37473ms step_avg:45.20ms
+step:830/1555 train_time:37533ms step_avg:45.22ms
+step:831/1555 train_time:37595ms step_avg:45.24ms
+step:832/1555 train_time:37654ms step_avg:45.26ms
+step:833/1555 train_time:37717ms step_avg:45.28ms
+step:834/1555 train_time:37776ms step_avg:45.30ms
+step:835/1555 train_time:37840ms step_avg:45.32ms
+step:836/1555 train_time:37900ms step_avg:45.33ms
+step:837/1555 train_time:37963ms step_avg:45.36ms
+step:838/1555 train_time:38023ms step_avg:45.37ms
+step:839/1555 train_time:38087ms step_avg:45.40ms
+step:840/1555 train_time:38146ms step_avg:45.41ms
+step:841/1555 train_time:38210ms step_avg:45.43ms
+step:842/1555 train_time:38269ms step_avg:45.45ms
+step:843/1555 train_time:38332ms step_avg:45.47ms
+step:844/1555 train_time:38391ms step_avg:45.49ms
+step:845/1555 train_time:38455ms step_avg:45.51ms
+step:846/1555 train_time:38514ms step_avg:45.52ms
+step:847/1555 train_time:38577ms step_avg:45.55ms
+step:848/1555 train_time:38636ms step_avg:45.56ms
+step:849/1555 train_time:38700ms step_avg:45.58ms
+step:850/1555 train_time:38759ms step_avg:45.60ms
+step:851/1555 train_time:38823ms step_avg:45.62ms
+step:852/1555 train_time:38882ms step_avg:45.64ms
+step:853/1555 train_time:38945ms step_avg:45.66ms
+step:854/1555 train_time:39004ms step_avg:45.67ms
+step:855/1555 train_time:39068ms step_avg:45.69ms
+step:856/1555 train_time:39127ms step_avg:45.71ms
+step:857/1555 train_time:39190ms step_avg:45.73ms
+step:858/1555 train_time:39249ms step_avg:45.75ms
+step:859/1555 train_time:39313ms step_avg:45.77ms
+step:860/1555 train_time:39372ms step_avg:45.78ms
+step:861/1555 train_time:39435ms step_avg:45.80ms
+step:862/1555 train_time:39494ms step_avg:45.82ms
+step:863/1555 train_time:39557ms step_avg:45.84ms
+step:864/1555 train_time:39616ms step_avg:45.85ms
+step:865/1555 train_time:39680ms step_avg:45.87ms
+step:866/1555 train_time:39740ms step_avg:45.89ms
+step:867/1555 train_time:39803ms step_avg:45.91ms
+step:868/1555 train_time:39863ms step_avg:45.93ms
+step:869/1555 train_time:39927ms step_avg:45.95ms
+step:870/1555 train_time:39986ms step_avg:45.96ms
+step:871/1555 train_time:40049ms step_avg:45.98ms
+step:872/1555 train_time:40108ms step_avg:46.00ms
+step:873/1555 train_time:40173ms step_avg:46.02ms
+step:874/1555 train_time:40232ms step_avg:46.03ms
+step:875/1555 train_time:40295ms step_avg:46.05ms
+step:876/1555 train_time:40354ms step_avg:46.07ms
+step:877/1555 train_time:40418ms step_avg:46.09ms
+step:878/1555 train_time:40477ms step_avg:46.10ms
+step:879/1555 train_time:40540ms step_avg:46.12ms
+step:880/1555 train_time:40599ms step_avg:46.14ms
+step:881/1555 train_time:40663ms step_avg:46.16ms
+step:882/1555 train_time:40722ms step_avg:46.17ms
+step:883/1555 train_time:40789ms step_avg:46.19ms
+step:884/1555 train_time:40848ms step_avg:46.21ms
+step:885/1555 train_time:40911ms step_avg:46.23ms
+step:886/1555 train_time:40969ms step_avg:46.24ms
+step:887/1555 train_time:41032ms step_avg:46.26ms
+step:888/1555 train_time:41091ms step_avg:46.27ms
+step:889/1555 train_time:41155ms step_avg:46.29ms
+step:890/1555 train_time:41214ms step_avg:46.31ms
+step:891/1555 train_time:41277ms step_avg:46.33ms
+step:892/1555 train_time:41337ms step_avg:46.34ms
+step:893/1555 train_time:41400ms step_avg:46.36ms
+step:894/1555 train_time:41459ms step_avg:46.37ms
+step:895/1555 train_time:41522ms step_avg:46.39ms
+step:896/1555 train_time:41582ms step_avg:46.41ms
+step:897/1555 train_time:41646ms step_avg:46.43ms
+step:898/1555 train_time:41704ms step_avg:46.44ms
+step:899/1555 train_time:41768ms step_avg:46.46ms
+step:900/1555 train_time:41826ms step_avg:46.47ms
+step:901/1555 train_time:41890ms step_avg:46.49ms
+step:902/1555 train_time:41950ms step_avg:46.51ms
+step:903/1555 train_time:42013ms step_avg:46.53ms
+step:904/1555 train_time:42072ms step_avg:46.54ms
+step:905/1555 train_time:42136ms step_avg:46.56ms
+step:906/1555 train_time:42195ms step_avg:46.57ms
+step:907/1555 train_time:42258ms step_avg:46.59ms
+step:908/1555 train_time:42317ms step_avg:46.60ms
+step:909/1555 train_time:42382ms step_avg:46.63ms
+step:910/1555 train_time:42441ms step_avg:46.64ms
+step:911/1555 train_time:42505ms step_avg:46.66ms
+step:912/1555 train_time:42564ms step_avg:46.67ms
+step:913/1555 train_time:42627ms step_avg:46.69ms
+step:914/1555 train_time:42686ms step_avg:46.70ms
+step:915/1555 train_time:42749ms step_avg:46.72ms
+step:916/1555 train_time:42808ms step_avg:46.73ms
+step:917/1555 train_time:42872ms step_avg:46.75ms
+step:918/1555 train_time:42931ms step_avg:46.77ms
+step:919/1555 train_time:42994ms step_avg:46.78ms
+step:920/1555 train_time:43054ms step_avg:46.80ms
+step:921/1555 train_time:43119ms step_avg:46.82ms
+step:922/1555 train_time:43177ms step_avg:46.83ms
+step:923/1555 train_time:43240ms step_avg:46.85ms
+step:924/1555 train_time:43300ms step_avg:46.86ms
+step:925/1555 train_time:43364ms step_avg:46.88ms
+step:926/1555 train_time:43423ms step_avg:46.89ms
+step:927/1555 train_time:43486ms step_avg:46.91ms
+step:928/1555 train_time:43545ms step_avg:46.92ms
+step:929/1555 train_time:43608ms step_avg:46.94ms
+step:930/1555 train_time:43667ms step_avg:46.95ms
+step:931/1555 train_time:43730ms step_avg:46.97ms
+step:932/1555 train_time:43790ms step_avg:46.99ms
+step:933/1555 train_time:43853ms step_avg:47.00ms
+step:934/1555 train_time:43912ms step_avg:47.02ms
+step:935/1555 train_time:43975ms step_avg:47.03ms
+step:936/1555 train_time:44034ms step_avg:47.04ms
+step:937/1555 train_time:44098ms step_avg:47.06ms
+step:938/1555 train_time:44157ms step_avg:47.08ms
+step:939/1555 train_time:44220ms step_avg:47.09ms
+step:940/1555 train_time:44280ms step_avg:47.11ms
+step:941/1555 train_time:44343ms step_avg:47.12ms
+step:942/1555 train_time:44403ms step_avg:47.14ms
+step:943/1555 train_time:44466ms step_avg:47.15ms
+step:944/1555 train_time:44526ms step_avg:47.17ms
+step:945/1555 train_time:44589ms step_avg:47.18ms
+step:946/1555 train_time:44648ms step_avg:47.20ms
+step:947/1555 train_time:44712ms step_avg:47.21ms
+step:948/1555 train_time:44772ms step_avg:47.23ms
+step:949/1555 train_time:44836ms step_avg:47.25ms
+step:950/1555 train_time:44895ms step_avg:47.26ms
+step:951/1555 train_time:44958ms step_avg:47.27ms
+step:952/1555 train_time:45017ms step_avg:47.29ms
+step:953/1555 train_time:45080ms step_avg:47.30ms
+step:954/1555 train_time:45139ms step_avg:47.32ms
+step:955/1555 train_time:45202ms step_avg:47.33ms
+step:956/1555 train_time:45263ms step_avg:47.35ms
+step:957/1555 train_time:45325ms step_avg:47.36ms
+step:958/1555 train_time:45384ms step_avg:47.37ms
+step:959/1555 train_time:45448ms step_avg:47.39ms
+step:960/1555 train_time:45507ms step_avg:47.40ms
+step:961/1555 train_time:45570ms step_avg:47.42ms
+step:962/1555 train_time:45630ms step_avg:47.43ms
+step:963/1555 train_time:45693ms step_avg:47.45ms
+step:964/1555 train_time:45753ms step_avg:47.46ms
+step:965/1555 train_time:45815ms step_avg:47.48ms
+step:966/1555 train_time:45875ms step_avg:47.49ms
+step:967/1555 train_time:45938ms step_avg:47.51ms
+step:968/1555 train_time:45997ms step_avg:47.52ms
+step:969/1555 train_time:46061ms step_avg:47.53ms
+step:970/1555 train_time:46121ms step_avg:47.55ms
+step:971/1555 train_time:46184ms step_avg:47.56ms
+step:972/1555 train_time:46243ms step_avg:47.57ms
+step:973/1555 train_time:46306ms step_avg:47.59ms
+step:974/1555 train_time:46366ms step_avg:47.60ms
+step:975/1555 train_time:46429ms step_avg:47.62ms
+step:976/1555 train_time:46489ms step_avg:47.63ms
+step:977/1555 train_time:46552ms step_avg:47.65ms
+step:978/1555 train_time:46611ms step_avg:47.66ms
+step:979/1555 train_time:46674ms step_avg:47.67ms
+step:980/1555 train_time:46733ms step_avg:47.69ms
+step:981/1555 train_time:46795ms step_avg:47.70ms
+step:982/1555 train_time:46855ms step_avg:47.71ms
+step:983/1555 train_time:46919ms step_avg:47.73ms
+step:984/1555 train_time:46978ms step_avg:47.74ms
+step:985/1555 train_time:47043ms step_avg:47.76ms
+step:986/1555 train_time:47101ms step_avg:47.77ms
+step:987/1555 train_time:47164ms step_avg:47.79ms
+step:988/1555 train_time:47223ms step_avg:47.80ms
+step:989/1555 train_time:47286ms step_avg:47.81ms
+step:990/1555 train_time:47345ms step_avg:47.82ms
+step:991/1555 train_time:47410ms step_avg:47.84ms
+step:992/1555 train_time:47469ms step_avg:47.85ms
+step:993/1555 train_time:47532ms step_avg:47.87ms
+step:994/1555 train_time:47591ms step_avg:47.88ms
+step:995/1555 train_time:47654ms step_avg:47.89ms
+step:996/1555 train_time:47713ms step_avg:47.90ms
+step:997/1555 train_time:47777ms step_avg:47.92ms
+step:998/1555 train_time:47836ms step_avg:47.93ms
+step:999/1555 train_time:47900ms step_avg:47.95ms
+step:1000/1555 train_time:47959ms step_avg:47.96ms
+step:1000/1555 val_loss:3.5681 train_time:48007ms step_avg:48.01ms
+step:1001/1555 train_time:48025ms step_avg:47.98ms
+step:1002/1555 train_time:48084ms step_avg:47.99ms
+step:1003/1555 train_time:48154ms step_avg:48.01ms
+step:1004/1555 train_time:48214ms step_avg:48.02ms
+step:1005/1555 train_time:48277ms step_avg:48.04ms
+step:1006/1555 train_time:48336ms step_avg:48.05ms
+step:1007/1555 train_time:48399ms step_avg:48.06ms
+step:1008/1555 train_time:48458ms step_avg:48.07ms
+step:1009/1555 train_time:48521ms step_avg:48.09ms
+step:1010/1555 train_time:48579ms step_avg:48.10ms
+step:1011/1555 train_time:48654ms step_avg:48.12ms
+step:1012/1555 train_time:48734ms step_avg:48.16ms
+step:1013/1555 train_time:48827ms step_avg:48.20ms
+step:1014/1555 train_time:48908ms step_avg:48.23ms
+step:1015/1555 train_time:48998ms step_avg:48.27ms
+step:1016/1555 train_time:49085ms step_avg:48.31ms
+step:1017/1555 train_time:49176ms step_avg:48.35ms
+step:1018/1555 train_time:49263ms step_avg:48.39ms
+step:1019/1555 train_time:49353ms step_avg:48.43ms
+step:1020/1555 train_time:49439ms step_avg:48.47ms
+step:1021/1555 train_time:49529ms step_avg:48.51ms
+step:1022/1555 train_time:49614ms step_avg:48.55ms
+step:1023/1555 train_time:49702ms step_avg:48.58ms
+step:1024/1555 train_time:49787ms step_avg:48.62ms
+step:1025/1555 train_time:49877ms step_avg:48.66ms
+step:1026/1555 train_time:49961ms step_avg:48.69ms
+step:1027/1555 train_time:50050ms step_avg:48.73ms
+step:1028/1555 train_time:50137ms step_avg:48.77ms
+step:1029/1555 train_time:50228ms step_avg:48.81ms
+step:1030/1555 train_time:50314ms step_avg:48.85ms
+step:1031/1555 train_time:50404ms step_avg:48.89ms
+step:1032/1555 train_time:50490ms step_avg:48.92ms
+step:1033/1555 train_time:50579ms step_avg:48.96ms
+step:1034/1555 train_time:50664ms step_avg:49.00ms
+step:1035/1555 train_time:50753ms step_avg:49.04ms
+step:1036/1555 train_time:50838ms step_avg:49.07ms
+step:1037/1555 train_time:50927ms step_avg:49.11ms
+step:1038/1555 train_time:51013ms step_avg:49.15ms
+step:1039/1555 train_time:51104ms step_avg:49.19ms
+step:1040/1555 train_time:51190ms step_avg:49.22ms
+step:1041/1555 train_time:51281ms step_avg:49.26ms
+step:1042/1555 train_time:51367ms step_avg:49.30ms
+step:1043/1555 train_time:51457ms step_avg:49.34ms
+step:1044/1555 train_time:51545ms step_avg:49.37ms
+step:1045/1555 train_time:51632ms step_avg:49.41ms
+step:1046/1555 train_time:51718ms step_avg:49.44ms
+step:1047/1555 train_time:51807ms step_avg:49.48ms
+step:1048/1555 train_time:51893ms step_avg:49.52ms
+step:1049/1555 train_time:51982ms step_avg:49.55ms
+step:1050/1555 train_time:52068ms step_avg:49.59ms
+step:1051/1555 train_time:52158ms step_avg:49.63ms
+step:1052/1555 train_time:52243ms step_avg:49.66ms
+step:1053/1555 train_time:52334ms step_avg:49.70ms
+step:1054/1555 train_time:52421ms step_avg:49.74ms
+step:1055/1555 train_time:52513ms step_avg:49.78ms
+step:1056/1555 train_time:52596ms step_avg:49.81ms
+step:1057/1555 train_time:52685ms step_avg:49.84ms
+step:1058/1555 train_time:52772ms step_avg:49.88ms
+step:1059/1555 train_time:52860ms step_avg:49.92ms
+step:1060/1555 train_time:52946ms step_avg:49.95ms
+step:1061/1555 train_time:53035ms step_avg:49.99ms
+step:1062/1555 train_time:53122ms step_avg:50.02ms
+step:1063/1555 train_time:53211ms step_avg:50.06ms
+step:1064/1555 train_time:53298ms step_avg:50.09ms
+step:1065/1555 train_time:53388ms step_avg:50.13ms
+step:1066/1555 train_time:53474ms step_avg:50.16ms
+step:1067/1555 train_time:53564ms step_avg:50.20ms
+step:1068/1555 train_time:53649ms step_avg:50.23ms
+step:1069/1555 train_time:53739ms step_avg:50.27ms
+step:1070/1555 train_time:53824ms step_avg:50.30ms
+step:1071/1555 train_time:53914ms step_avg:50.34ms
+step:1072/1555 train_time:54000ms step_avg:50.37ms
+step:1073/1555 train_time:54091ms step_avg:50.41ms
+step:1074/1555 train_time:54176ms step_avg:50.44ms
+step:1075/1555 train_time:54268ms step_avg:50.48ms
+step:1076/1555 train_time:54353ms step_avg:50.51ms
+step:1077/1555 train_time:54442ms step_avg:50.55ms
+step:1078/1555 train_time:54530ms step_avg:50.58ms
+step:1079/1555 train_time:54618ms step_avg:50.62ms
+step:1080/1555 train_time:54703ms step_avg:50.65ms
+step:1081/1555 train_time:54792ms step_avg:50.69ms
+step:1082/1555 train_time:54878ms step_avg:50.72ms
+step:1083/1555 train_time:54968ms step_avg:50.76ms
+step:1084/1555 train_time:55053ms step_avg:50.79ms
+step:1085/1555 train_time:55143ms step_avg:50.82ms
+step:1086/1555 train_time:55230ms step_avg:50.86ms
+step:1087/1555 train_time:55319ms step_avg:50.89ms
+step:1088/1555 train_time:55404ms step_avg:50.92ms
+step:1089/1555 train_time:55494ms step_avg:50.96ms
+step:1090/1555 train_time:55582ms step_avg:50.99ms
+step:1091/1555 train_time:55670ms step_avg:51.03ms
+step:1092/1555 train_time:55755ms step_avg:51.06ms
+step:1093/1555 train_time:55845ms step_avg:51.09ms
+step:1094/1555 train_time:55931ms step_avg:51.13ms
+step:1095/1555 train_time:56019ms step_avg:51.16ms
+step:1096/1555 train_time:56105ms step_avg:51.19ms
+step:1097/1555 train_time:56195ms step_avg:51.23ms
+step:1098/1555 train_time:56282ms step_avg:51.26ms
+step:1099/1555 train_time:56372ms step_avg:51.29ms
+step:1100/1555 train_time:56456ms step_avg:51.32ms
+step:1101/1555 train_time:56546ms step_avg:51.36ms
+step:1102/1555 train_time:56631ms step_avg:51.39ms
+step:1103/1555 train_time:56723ms step_avg:51.43ms
+step:1104/1555 train_time:56808ms step_avg:51.46ms
+step:1105/1555 train_time:56897ms step_avg:51.49ms
+step:1106/1555 train_time:56982ms step_avg:51.52ms
+step:1107/1555 train_time:57071ms step_avg:51.55ms
+step:1108/1555 train_time:57156ms step_avg:51.59ms
+step:1109/1555 train_time:57248ms step_avg:51.62ms
+step:1110/1555 train_time:57333ms step_avg:51.65ms
+step:1111/1555 train_time:57424ms step_avg:51.69ms
+step:1112/1555 train_time:57511ms step_avg:51.72ms
+step:1113/1555 train_time:57602ms step_avg:51.75ms
+step:1114/1555 train_time:57686ms step_avg:51.78ms
+step:1115/1555 train_time:57777ms step_avg:51.82ms
+step:1116/1555 train_time:57861ms step_avg:51.85ms
+step:1117/1555 train_time:57953ms step_avg:51.88ms
+step:1118/1555 train_time:58038ms step_avg:51.91ms
+step:1119/1555 train_time:58126ms step_avg:51.94ms
+step:1120/1555 train_time:58211ms step_avg:51.97ms
+step:1121/1555 train_time:58302ms step_avg:52.01ms
+step:1122/1555 train_time:58388ms step_avg:52.04ms
+step:1123/1555 train_time:58477ms step_avg:52.07ms
+step:1124/1555 train_time:58563ms step_avg:52.10ms
+step:1125/1555 train_time:58652ms step_avg:52.14ms
+step:1126/1555 train_time:58738ms step_avg:52.17ms
+step:1127/1555 train_time:58828ms step_avg:52.20ms
+step:1128/1555 train_time:58913ms step_avg:52.23ms
+step:1129/1555 train_time:59005ms step_avg:52.26ms
+step:1130/1555 train_time:59089ms step_avg:52.29ms
+step:1131/1555 train_time:59179ms step_avg:52.32ms
+step:1132/1555 train_time:59265ms step_avg:52.35ms
+step:1133/1555 train_time:59354ms step_avg:52.39ms
+step:1134/1555 train_time:59439ms step_avg:52.42ms
+step:1135/1555 train_time:59530ms step_avg:52.45ms
+step:1136/1555 train_time:59615ms step_avg:52.48ms
+step:1137/1555 train_time:59706ms step_avg:52.51ms
+step:1138/1555 train_time:59791ms step_avg:52.54ms
+step:1139/1555 train_time:59884ms step_avg:52.58ms
+step:1140/1555 train_time:59967ms step_avg:52.60ms
+step:1141/1555 train_time:60056ms step_avg:52.63ms
+step:1142/1555 train_time:60141ms step_avg:52.66ms
+step:1143/1555 train_time:60230ms step_avg:52.69ms
+step:1144/1555 train_time:60317ms step_avg:52.72ms
+step:1145/1555 train_time:60406ms step_avg:52.76ms
+step:1146/1555 train_time:60494ms step_avg:52.79ms
+step:1147/1555 train_time:60581ms step_avg:52.82ms
+step:1148/1555 train_time:60669ms step_avg:52.85ms
+step:1149/1555 train_time:60756ms step_avg:52.88ms
+step:1150/1555 train_time:60841ms step_avg:52.91ms
+step:1151/1555 train_time:60931ms step_avg:52.94ms
+step:1152/1555 train_time:61016ms step_avg:52.97ms
+step:1153/1555 train_time:61106ms step_avg:53.00ms
+step:1154/1555 train_time:61191ms step_avg:53.03ms
+step:1155/1555 train_time:61280ms step_avg:53.06ms
+step:1156/1555 train_time:61366ms step_avg:53.08ms
+step:1157/1555 train_time:61455ms step_avg:53.12ms
+step:1158/1555 train_time:61541ms step_avg:53.14ms
+step:1159/1555 train_time:61630ms step_avg:53.18ms
+step:1160/1555 train_time:61717ms step_avg:53.20ms
+step:1161/1555 train_time:61806ms step_avg:53.24ms
+step:1162/1555 train_time:61891ms step_avg:53.26ms
+step:1163/1555 train_time:61980ms step_avg:53.29ms
+step:1164/1555 train_time:62067ms step_avg:53.32ms
+step:1165/1555 train_time:62155ms step_avg:53.35ms
+step:1166/1555 train_time:62241ms step_avg:53.38ms
+step:1167/1555 train_time:62330ms step_avg:53.41ms
+step:1168/1555 train_time:62417ms step_avg:53.44ms
+step:1169/1555 train_time:62506ms step_avg:53.47ms
+step:1170/1555 train_time:62592ms step_avg:53.50ms
+step:1171/1555 train_time:62683ms step_avg:53.53ms
+step:1172/1555 train_time:62769ms step_avg:53.56ms
+step:1173/1555 train_time:62858ms step_avg:53.59ms
+step:1174/1555 train_time:62945ms step_avg:53.62ms
+step:1175/1555 train_time:63033ms step_avg:53.64ms
+step:1176/1555 train_time:63120ms step_avg:53.67ms
+step:1177/1555 train_time:63209ms step_avg:53.70ms
+step:1178/1555 train_time:63296ms step_avg:53.73ms
+step:1179/1555 train_time:63385ms step_avg:53.76ms
+step:1180/1555 train_time:63470ms step_avg:53.79ms
+step:1181/1555 train_time:63560ms step_avg:53.82ms
+step:1182/1555 train_time:63646ms step_avg:53.85ms
+step:1183/1555 train_time:63735ms step_avg:53.88ms
+step:1184/1555 train_time:63820ms step_avg:53.90ms
+step:1185/1555 train_time:63910ms step_avg:53.93ms
+step:1186/1555 train_time:63995ms step_avg:53.96ms
+step:1187/1555 train_time:64085ms step_avg:53.99ms
+step:1188/1555 train_time:64170ms step_avg:54.02ms
+step:1189/1555 train_time:64260ms step_avg:54.05ms
+step:1190/1555 train_time:64347ms step_avg:54.07ms
+step:1191/1555 train_time:64436ms step_avg:54.10ms
+step:1192/1555 train_time:64521ms step_avg:54.13ms
+step:1193/1555 train_time:64611ms step_avg:54.16ms
+step:1194/1555 train_time:64698ms step_avg:54.19ms
+step:1195/1555 train_time:64787ms step_avg:54.22ms
+step:1196/1555 train_time:64873ms step_avg:54.24ms
+step:1197/1555 train_time:64964ms step_avg:54.27ms
+step:1198/1555 train_time:65050ms step_avg:54.30ms
+step:1199/1555 train_time:65140ms step_avg:54.33ms
+step:1200/1555 train_time:65226ms step_avg:54.36ms
+step:1201/1555 train_time:65316ms step_avg:54.38ms
+step:1202/1555 train_time:65402ms step_avg:54.41ms
+step:1203/1555 train_time:65491ms step_avg:54.44ms
+step:1204/1555 train_time:65580ms step_avg:54.47ms
+step:1205/1555 train_time:65667ms step_avg:54.50ms
+step:1206/1555 train_time:65755ms step_avg:54.52ms
+step:1207/1555 train_time:65842ms step_avg:54.55ms
+step:1208/1555 train_time:65927ms step_avg:54.58ms
+step:1209/1555 train_time:66017ms step_avg:54.60ms
+step:1210/1555 train_time:66102ms step_avg:54.63ms
+step:1211/1555 train_time:66192ms step_avg:54.66ms
+step:1212/1555 train_time:66279ms step_avg:54.69ms
+step:1213/1555 train_time:66368ms step_avg:54.71ms
+step:1214/1555 train_time:66454ms step_avg:54.74ms
+step:1215/1555 train_time:66544ms step_avg:54.77ms
+step:1216/1555 train_time:66629ms step_avg:54.79ms
+step:1217/1555 train_time:66719ms step_avg:54.82ms
+step:1218/1555 train_time:66804ms step_avg:54.85ms
+step:1219/1555 train_time:66893ms step_avg:54.88ms
+step:1220/1555 train_time:66980ms step_avg:54.90ms
+step:1221/1555 train_time:67069ms step_avg:54.93ms
+step:1222/1555 train_time:67154ms step_avg:54.95ms
+step:1223/1555 train_time:67245ms step_avg:54.98ms
+step:1224/1555 train_time:67331ms step_avg:55.01ms
+step:1225/1555 train_time:67419ms step_avg:55.04ms
+step:1226/1555 train_time:67505ms step_avg:55.06ms
+step:1227/1555 train_time:67597ms step_avg:55.09ms
+step:1228/1555 train_time:67682ms step_avg:55.12ms
+step:1229/1555 train_time:67771ms step_avg:55.14ms
+step:1230/1555 train_time:67857ms step_avg:55.17ms
+step:1231/1555 train_time:67947ms step_avg:55.20ms
+step:1232/1555 train_time:68032ms step_avg:55.22ms
+step:1233/1555 train_time:68121ms step_avg:55.25ms
+step:1234/1555 train_time:68207ms step_avg:55.27ms
+step:1235/1555 train_time:68298ms step_avg:55.30ms
+step:1236/1555 train_time:68383ms step_avg:55.33ms
+step:1237/1555 train_time:68473ms step_avg:55.35ms
+step:1238/1555 train_time:68558ms step_avg:55.38ms
+step:1239/1555 train_time:68649ms step_avg:55.41ms
+step:1240/1555 train_time:68733ms step_avg:55.43ms
+step:1241/1555 train_time:68827ms step_avg:55.46ms
+step:1242/1555 train_time:68910ms step_avg:55.48ms
+step:1243/1555 train_time:68999ms step_avg:55.51ms
+step:1244/1555 train_time:69084ms step_avg:55.53ms
+step:1245/1555 train_time:69175ms step_avg:55.56ms
+step:1246/1555 train_time:69261ms step_avg:55.59ms
+step:1247/1555 train_time:69350ms step_avg:55.61ms
+step:1248/1555 train_time:69435ms step_avg:55.64ms
+step:1249/1555 train_time:69526ms step_avg:55.66ms
+step:1250/1555 train_time:69611ms step_avg:55.69ms
+step:1250/1555 val_loss:3.3974 train_time:69687ms step_avg:55.75ms
+step:1251/1555 train_time:69711ms step_avg:55.72ms
+step:1252/1555 train_time:69801ms step_avg:55.75ms
+step:1253/1555 train_time:69892ms step_avg:55.78ms
+step:1254/1555 train_time:69977ms step_avg:55.80ms
+step:1255/1555 train_time:70067ms step_avg:55.83ms
+step:1256/1555 train_time:70150ms step_avg:55.85ms
+step:1257/1555 train_time:70238ms step_avg:55.88ms
+step:1258/1555 train_time:70323ms step_avg:55.90ms
+step:1259/1555 train_time:70413ms step_avg:55.93ms
+step:1260/1555 train_time:70499ms step_avg:55.95ms
+step:1261/1555 train_time:70586ms step_avg:55.98ms
+step:1262/1555 train_time:70674ms step_avg:56.00ms
+step:1263/1555 train_time:70767ms step_avg:56.03ms
+step:1264/1555 train_time:70855ms step_avg:56.06ms
+step:1265/1555 train_time:70944ms step_avg:56.08ms
+step:1266/1555 train_time:71030ms step_avg:56.11ms
+step:1267/1555 train_time:71121ms step_avg:56.13ms
+step:1268/1555 train_time:71204ms step_avg:56.15ms
+step:1269/1555 train_time:71294ms step_avg:56.18ms
+step:1270/1555 train_time:71381ms step_avg:56.21ms
+step:1271/1555 train_time:71468ms step_avg:56.23ms
+step:1272/1555 train_time:71552ms step_avg:56.25ms
+step:1273/1555 train_time:71643ms step_avg:56.28ms
+step:1274/1555 train_time:71729ms step_avg:56.30ms
+step:1275/1555 train_time:71821ms step_avg:56.33ms
+step:1276/1555 train_time:71908ms step_avg:56.35ms
+step:1277/1555 train_time:71999ms step_avg:56.38ms
+step:1278/1555 train_time:72084ms step_avg:56.40ms
+step:1279/1555 train_time:72173ms step_avg:56.43ms
+step:1280/1555 train_time:72258ms step_avg:56.45ms
+step:1281/1555 train_time:72346ms step_avg:56.48ms
+step:1282/1555 train_time:72433ms step_avg:56.50ms
+step:1283/1555 train_time:72520ms step_avg:56.52ms
+step:1284/1555 train_time:72606ms step_avg:56.55ms
+step:1285/1555 train_time:72698ms step_avg:56.57ms
+step:1286/1555 train_time:72784ms step_avg:56.60ms
+step:1287/1555 train_time:72874ms step_avg:56.62ms
+step:1288/1555 train_time:72960ms step_avg:56.65ms
+step:1289/1555 train_time:73051ms step_avg:56.67ms
+step:1290/1555 train_time:73136ms step_avg:56.69ms
+step:1291/1555 train_time:73224ms step_avg:56.72ms
+step:1292/1555 train_time:73309ms step_avg:56.74ms
+step:1293/1555 train_time:73398ms step_avg:56.77ms
+step:1294/1555 train_time:73484ms step_avg:56.79ms
+step:1295/1555 train_time:73573ms step_avg:56.81ms
+step:1296/1555 train_time:73660ms step_avg:56.84ms
+step:1297/1555 train_time:73750ms step_avg:56.86ms
+step:1298/1555 train_time:73836ms step_avg:56.88ms
+step:1299/1555 train_time:73926ms step_avg:56.91ms
+step:1300/1555 train_time:74014ms step_avg:56.93ms
+step:1301/1555 train_time:74103ms step_avg:56.96ms
+step:1302/1555 train_time:74189ms step_avg:56.98ms
+step:1303/1555 train_time:74282ms step_avg:57.01ms
+step:1304/1555 train_time:74364ms step_avg:57.03ms
+step:1305/1555 train_time:74453ms step_avg:57.05ms
+step:1306/1555 train_time:74539ms step_avg:57.07ms
+step:1307/1555 train_time:74629ms step_avg:57.10ms
+step:1308/1555 train_time:74715ms step_avg:57.12ms
+step:1309/1555 train_time:74805ms step_avg:57.15ms
+step:1310/1555 train_time:74891ms step_avg:57.17ms
+step:1311/1555 train_time:74980ms step_avg:57.19ms
+step:1312/1555 train_time:75066ms step_avg:57.21ms
+step:1313/1555 train_time:75157ms step_avg:57.24ms
+step:1314/1555 train_time:75241ms step_avg:57.26ms
+step:1315/1555 train_time:75331ms step_avg:57.29ms
+step:1316/1555 train_time:75418ms step_avg:57.31ms
+step:1317/1555 train_time:75506ms step_avg:57.33ms
+step:1318/1555 train_time:75592ms step_avg:57.35ms
+step:1319/1555 train_time:75682ms step_avg:57.38ms
+step:1320/1555 train_time:75769ms step_avg:57.40ms
+step:1321/1555 train_time:75858ms step_avg:57.42ms
+step:1322/1555 train_time:75945ms step_avg:57.45ms
+step:1323/1555 train_time:76035ms step_avg:57.47ms
+step:1324/1555 train_time:76121ms step_avg:57.49ms
+step:1325/1555 train_time:76210ms step_avg:57.52ms
+step:1326/1555 train_time:76296ms step_avg:57.54ms
+step:1327/1555 train_time:76385ms step_avg:57.56ms
+step:1328/1555 train_time:76471ms step_avg:57.58ms
+step:1329/1555 train_time:76562ms step_avg:57.61ms
+step:1330/1555 train_time:76647ms step_avg:57.63ms
+step:1331/1555 train_time:76738ms step_avg:57.65ms
+step:1332/1555 train_time:76823ms step_avg:57.68ms
+step:1333/1555 train_time:76915ms step_avg:57.70ms
+step:1334/1555 train_time:76999ms step_avg:57.72ms
+step:1335/1555 train_time:77091ms step_avg:57.75ms
+step:1336/1555 train_time:77177ms step_avg:57.77ms
+step:1337/1555 train_time:77265ms step_avg:57.79ms
+step:1338/1555 train_time:77350ms step_avg:57.81ms
+step:1339/1555 train_time:77440ms step_avg:57.83ms
+step:1340/1555 train_time:77525ms step_avg:57.85ms
+step:1341/1555 train_time:77615ms step_avg:57.88ms
+step:1342/1555 train_time:77700ms step_avg:57.90ms
+step:1343/1555 train_time:77789ms step_avg:57.92ms
+step:1344/1555 train_time:77875ms step_avg:57.94ms
+step:1345/1555 train_time:77966ms step_avg:57.97ms
+step:1346/1555 train_time:78051ms step_avg:57.99ms
+step:1347/1555 train_time:78141ms step_avg:58.01ms
+step:1348/1555 train_time:78226ms step_avg:58.03ms
+step:1349/1555 train_time:78316ms step_avg:58.06ms
+step:1350/1555 train_time:78402ms step_avg:58.08ms
+step:1351/1555 train_time:78495ms step_avg:58.10ms
+step:1352/1555 train_time:78581ms step_avg:58.12ms
+step:1353/1555 train_time:78669ms step_avg:58.14ms
+step:1354/1555 train_time:78755ms step_avg:58.17ms
+step:1355/1555 train_time:78844ms step_avg:58.19ms
+step:1356/1555 train_time:78931ms step_avg:58.21ms
+step:1357/1555 train_time:79020ms step_avg:58.23ms
+step:1358/1555 train_time:79106ms step_avg:58.25ms
+step:1359/1555 train_time:79197ms step_avg:58.28ms
+step:1360/1555 train_time:79282ms step_avg:58.30ms
+step:1361/1555 train_time:79372ms step_avg:58.32ms
+step:1362/1555 train_time:79457ms step_avg:58.34ms
+step:1363/1555 train_time:79547ms step_avg:58.36ms
+step:1364/1555 train_time:79634ms step_avg:58.38ms
+step:1365/1555 train_time:79724ms step_avg:58.41ms
+step:1366/1555 train_time:79809ms step_avg:58.43ms
+step:1367/1555 train_time:79900ms step_avg:58.45ms
+step:1368/1555 train_time:79985ms step_avg:58.47ms
+step:1369/1555 train_time:80074ms step_avg:58.49ms
+step:1370/1555 train_time:80160ms step_avg:58.51ms
+step:1371/1555 train_time:80250ms step_avg:58.53ms
+step:1372/1555 train_time:80335ms step_avg:58.55ms
+step:1373/1555 train_time:80425ms step_avg:58.58ms
+step:1374/1555 train_time:80510ms step_avg:58.60ms
+step:1375/1555 train_time:80601ms step_avg:58.62ms
+step:1376/1555 train_time:80686ms step_avg:58.64ms
+step:1377/1555 train_time:80777ms step_avg:58.66ms
+step:1378/1555 train_time:80863ms step_avg:58.68ms
+step:1379/1555 train_time:80951ms step_avg:58.70ms
+step:1380/1555 train_time:81037ms step_avg:58.72ms
+step:1381/1555 train_time:81127ms step_avg:58.74ms
+step:1382/1555 train_time:81213ms step_avg:58.76ms
+step:1383/1555 train_time:81304ms step_avg:58.79ms
+step:1384/1555 train_time:81389ms step_avg:58.81ms
+step:1385/1555 train_time:81478ms step_avg:58.83ms
+step:1386/1555 train_time:81565ms step_avg:58.85ms
+step:1387/1555 train_time:81653ms step_avg:58.87ms
+step:1388/1555 train_time:81739ms step_avg:58.89ms
+step:1389/1555 train_time:81830ms step_avg:58.91ms
+step:1390/1555 train_time:81916ms step_avg:58.93ms
+step:1391/1555 train_time:82006ms step_avg:58.95ms
+step:1392/1555 train_time:82092ms step_avg:58.97ms
+step:1393/1555 train_time:82182ms step_avg:59.00ms
+step:1394/1555 train_time:82268ms step_avg:59.02ms
+step:1395/1555 train_time:82358ms step_avg:59.04ms
+step:1396/1555 train_time:82445ms step_avg:59.06ms
+step:1397/1555 train_time:82534ms step_avg:59.08ms
+step:1398/1555 train_time:82619ms step_avg:59.10ms
+step:1399/1555 train_time:82709ms step_avg:59.12ms
+step:1400/1555 train_time:82794ms step_avg:59.14ms
+step:1401/1555 train_time:82884ms step_avg:59.16ms
+step:1402/1555 train_time:82969ms step_avg:59.18ms
+step:1403/1555 train_time:83059ms step_avg:59.20ms
+step:1404/1555 train_time:83145ms step_avg:59.22ms
+step:1405/1555 train_time:83236ms step_avg:59.24ms
+step:1406/1555 train_time:83321ms step_avg:59.26ms
+step:1407/1555 train_time:83413ms step_avg:59.28ms
+step:1408/1555 train_time:83497ms step_avg:59.30ms
+step:1409/1555 train_time:83586ms step_avg:59.32ms
+step:1410/1555 train_time:83672ms step_avg:59.34ms
+step:1411/1555 train_time:83761ms step_avg:59.36ms
+step:1412/1555 train_time:83847ms step_avg:59.38ms
+step:1413/1555 train_time:83937ms step_avg:59.40ms
+step:1414/1555 train_time:84022ms step_avg:59.42ms
+step:1415/1555 train_time:84113ms step_avg:59.44ms
+step:1416/1555 train_time:84198ms step_avg:59.46ms
+step:1417/1555 train_time:84287ms step_avg:59.48ms
+step:1418/1555 train_time:84373ms step_avg:59.50ms
+step:1419/1555 train_time:84462ms step_avg:59.52ms
+step:1420/1555 train_time:84549ms step_avg:59.54ms
+step:1421/1555 train_time:84638ms step_avg:59.56ms
+step:1422/1555 train_time:84724ms step_avg:59.58ms
+step:1423/1555 train_time:84816ms step_avg:59.60ms
+step:1424/1555 train_time:84900ms step_avg:59.62ms
+step:1425/1555 train_time:84991ms step_avg:59.64ms
+step:1426/1555 train_time:85077ms step_avg:59.66ms
+step:1427/1555 train_time:85166ms step_avg:59.68ms
+step:1428/1555 train_time:85253ms step_avg:59.70ms
+step:1429/1555 train_time:85343ms step_avg:59.72ms
+step:1430/1555 train_time:85428ms step_avg:59.74ms
+step:1431/1555 train_time:85518ms step_avg:59.76ms
+step:1432/1555 train_time:85605ms step_avg:59.78ms
+step:1433/1555 train_time:85694ms step_avg:59.80ms
+step:1434/1555 train_time:85779ms step_avg:59.82ms
+step:1435/1555 train_time:85869ms step_avg:59.84ms
+step:1436/1555 train_time:85954ms step_avg:59.86ms
+step:1437/1555 train_time:86044ms step_avg:59.88ms
+step:1438/1555 train_time:86130ms step_avg:59.90ms
+step:1439/1555 train_time:86220ms step_avg:59.92ms
+step:1440/1555 train_time:86306ms step_avg:59.93ms
+step:1441/1555 train_time:86395ms step_avg:59.95ms
+step:1442/1555 train_time:86482ms step_avg:59.97ms
+step:1443/1555 train_time:86570ms step_avg:59.99ms
+step:1444/1555 train_time:86656ms step_avg:60.01ms
+step:1445/1555 train_time:86746ms step_avg:60.03ms
+step:1446/1555 train_time:86832ms step_avg:60.05ms
+step:1447/1555 train_time:86923ms step_avg:60.07ms
+step:1448/1555 train_time:87008ms step_avg:60.09ms
+step:1449/1555 train_time:87097ms step_avg:60.11ms
+step:1450/1555 train_time:87183ms step_avg:60.13ms
+step:1451/1555 train_time:87272ms step_avg:60.15ms
+step:1452/1555 train_time:87358ms step_avg:60.16ms
+step:1453/1555 train_time:87449ms step_avg:60.19ms
+step:1454/1555 train_time:87535ms step_avg:60.20ms
+step:1455/1555 train_time:87624ms step_avg:60.22ms
+step:1456/1555 train_time:87709ms step_avg:60.24ms
+step:1457/1555 train_time:87800ms step_avg:60.26ms
+step:1458/1555 train_time:87889ms step_avg:60.28ms
+step:1459/1555 train_time:87976ms step_avg:60.30ms
+step:1460/1555 train_time:88061ms step_avg:60.32ms
+step:1461/1555 train_time:88151ms step_avg:60.34ms
+step:1462/1555 train_time:88240ms step_avg:60.36ms
+step:1463/1555 train_time:88326ms step_avg:60.37ms
+step:1464/1555 train_time:88412ms step_avg:60.39ms
+step:1465/1555 train_time:88502ms step_avg:60.41ms
+step:1466/1555 train_time:88588ms step_avg:60.43ms
+step:1467/1555 train_time:88677ms step_avg:60.45ms
+step:1468/1555 train_time:88763ms step_avg:60.47ms
+step:1469/1555 train_time:88853ms step_avg:60.49ms
+step:1470/1555 train_time:88938ms step_avg:60.50ms
+step:1471/1555 train_time:89027ms step_avg:60.52ms
+step:1472/1555 train_time:89114ms step_avg:60.54ms
+step:1473/1555 train_time:89203ms step_avg:60.56ms
+step:1474/1555 train_time:89290ms step_avg:60.58ms
+step:1475/1555 train_time:89380ms step_avg:60.60ms
+step:1476/1555 train_time:89465ms step_avg:60.61ms
+step:1477/1555 train_time:89554ms step_avg:60.63ms
+step:1478/1555 train_time:89641ms step_avg:60.65ms
+step:1479/1555 train_time:89731ms step_avg:60.67ms
+step:1480/1555 train_time:89818ms step_avg:60.69ms
+step:1481/1555 train_time:89907ms step_avg:60.71ms
+step:1482/1555 train_time:89993ms step_avg:60.72ms
+step:1483/1555 train_time:90083ms step_avg:60.74ms
+step:1484/1555 train_time:90169ms step_avg:60.76ms
+step:1485/1555 train_time:90258ms step_avg:60.78ms
+step:1486/1555 train_time:90344ms step_avg:60.80ms
+step:1487/1555 train_time:90434ms step_avg:60.82ms
+step:1488/1555 train_time:90520ms step_avg:60.83ms
+step:1489/1555 train_time:90609ms step_avg:60.85ms
+step:1490/1555 train_time:90695ms step_avg:60.87ms
+step:1491/1555 train_time:90785ms step_avg:60.89ms
+step:1492/1555 train_time:90871ms step_avg:60.91ms
+step:1493/1555 train_time:90960ms step_avg:60.92ms
+step:1494/1555 train_time:91046ms step_avg:60.94ms
+step:1495/1555 train_time:91135ms step_avg:60.96ms
+step:1496/1555 train_time:91221ms step_avg:60.98ms
+step:1497/1555 train_time:91310ms step_avg:61.00ms
+step:1498/1555 train_time:91396ms step_avg:61.01ms
+step:1499/1555 train_time:91486ms step_avg:61.03ms
+step:1500/1555 train_time:91572ms step_avg:61.05ms
+step:1500/1555 val_loss:3.2939 train_time:91647ms step_avg:61.10ms
+step:1501/1555 train_time:91665ms step_avg:61.07ms
+step:1502/1555 train_time:91753ms step_avg:61.09ms
+step:1503/1555 train_time:91849ms step_avg:61.11ms
+step:1504/1555 train_time:91933ms step_avg:61.13ms
+step:1505/1555 train_time:92022ms step_avg:61.14ms
+step:1506/1555 train_time:92107ms step_avg:61.16ms
+step:1507/1555 train_time:92196ms step_avg:61.18ms
+step:1508/1555 train_time:92280ms step_avg:61.19ms
+step:1509/1555 train_time:92369ms step_avg:61.21ms
+step:1510/1555 train_time:92454ms step_avg:61.23ms
+step:1511/1555 train_time:92543ms step_avg:61.25ms
+step:1512/1555 train_time:92631ms step_avg:61.26ms
+step:1513/1555 train_time:92723ms step_avg:61.28ms
+step:1514/1555 train_time:92811ms step_avg:61.30ms
+step:1515/1555 train_time:92902ms step_avg:61.32ms
+step:1516/1555 train_time:92996ms step_avg:61.34ms
+step:1517/1555 train_time:93083ms step_avg:61.36ms
+step:1518/1555 train_time:93168ms step_avg:61.38ms
+step:1519/1555 train_time:93257ms step_avg:61.39ms
+step:1520/1555 train_time:93342ms step_avg:61.41ms
+step:1521/1555 train_time:93431ms step_avg:61.43ms
+step:1522/1555 train_time:93517ms step_avg:61.44ms
+step:1523/1555 train_time:93606ms step_avg:61.46ms
+step:1524/1555 train_time:93693ms step_avg:61.48ms
+step:1525/1555 train_time:93784ms step_avg:61.50ms
+step:1526/1555 train_time:93871ms step_avg:61.51ms
+step:1527/1555 train_time:93961ms step_avg:61.53ms
+step:1528/1555 train_time:94047ms step_avg:61.55ms
+step:1529/1555 train_time:94137ms step_avg:61.57ms
+step:1530/1555 train_time:94223ms step_avg:61.58ms
+step:1531/1555 train_time:94312ms step_avg:61.60ms
+step:1532/1555 train_time:94397ms step_avg:61.62ms
+step:1533/1555 train_time:94486ms step_avg:61.63ms
+step:1534/1555 train_time:94571ms step_avg:61.65ms
+step:1535/1555 train_time:94663ms step_avg:61.67ms
+step:1536/1555 train_time:94749ms step_avg:61.69ms
+step:1537/1555 train_time:94840ms step_avg:61.70ms
+step:1538/1555 train_time:94927ms step_avg:61.72ms
+step:1539/1555 train_time:95018ms step_avg:61.74ms
+step:1540/1555 train_time:95104ms step_avg:61.76ms
+step:1541/1555 train_time:95194ms step_avg:61.77ms
+step:1542/1555 train_time:95279ms step_avg:61.79ms
+step:1543/1555 train_time:95368ms step_avg:61.81ms
+step:1544/1555 train_time:95453ms step_avg:61.82ms
+step:1545/1555 train_time:95543ms step_avg:61.84ms
+step:1546/1555 train_time:95629ms step_avg:61.86ms
+step:1547/1555 train_time:95720ms step_avg:61.87ms
+step:1548/1555 train_time:95807ms step_avg:61.89ms
+step:1549/1555 train_time:95897ms step_avg:61.91ms
+step:1550/1555 train_time:95985ms step_avg:61.93ms
+step:1551/1555 train_time:96074ms step_avg:61.94ms
+step:1552/1555 train_time:96160ms step_avg:61.96ms
+step:1553/1555 train_time:96249ms step_avg:61.98ms
+step:1554/1555 train_time:96335ms step_avg:61.99ms
+step:1555/1555 train_time:96424ms step_avg:62.01ms
+step:1555/1555 val_loss:3.2775 train_time:96493ms step_avg:62.05ms
+peak memory allocated: 31016 MiB reserved: 47018 MiB

--- a/records/track_1_short/2026-01-30_MimeticValueOutput/runs/81ccb409-be20-4f75-a1e7-11438938a06b.txt
+++ b/records/track_1_short/2026-01-30_MimeticValueOutput/runs/81ccb409-be20-4f75-a1e7-11438938a06b.txt
@@ -1,0 +1,4131 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# Mimetic V-O Initialization (Trockman & Kolter, ICML 2023)
+# Initialize V and O such that V @ O^T ≈ -βI (negative identity-like)
+# This enables attention to make meaningful contributions from step 1
+
+def mimetic_vo_init(attn_bank, model_dim=768, num_heads=6, head_dim=128, beta=0.1, noise_std=0.01):
+    """
+    Initialize attention bank with mimetic structure for V and O.
+    Q and K use standard uniform init, V and O use identity-like structure.
+
+    Args:
+        attn_bank: Tensor of shape (num_layers, 4*model_dim, hdim)
+        model_dim: Model dimension (768)
+        num_heads: Number of attention heads (6)
+        head_dim: Dimension per head (128)
+        beta: Scale for identity structure (0.1 recommended with attn_scale=0.1)
+        noise_std: Standard deviation of noise for symmetry breaking
+    """
+    num_layers = attn_bank.shape[0]
+    dim = model_dim
+    sqrt_beta = beta ** 0.5
+
+    # Standard init for Q and K (existing behavior)
+    attn_std = model_dim ** -0.5
+    attn_bound = (3 ** 0.5) * attn_std
+
+    with torch.no_grad():
+        # Q and K: uniform init (first 2*dim rows)
+        attn_bank[:, :2*dim, :].uniform_(-attn_bound, attn_bound)
+
+        # V and O: mimetic identity structure
+        for layer_idx in range(num_layers):
+            W_V = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+            W_O = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+
+            # Create per-head identity blocks
+            for h in range(num_heads):
+                start, end = h * head_dim, (h + 1) * head_dim
+                eye = torch.eye(head_dim, dtype=attn_bank.dtype, device=attn_bank.device)
+                W_V[start:end, start:end] = sqrt_beta * eye
+                W_O[start:end, start:end] = -sqrt_beta * eye
+
+            # Add noise for symmetry breaking
+            W_V += noise_std * torch.randn_like(W_V)
+            W_O += noise_std * torch.randn_like(W_O)
+
+            # Store in attn_bank: V is rows [2*dim:3*dim], O is rows [3*dim:4*dim]
+            attn_bank[layer_idx, 2*dim:3*dim, :] = W_V
+            attn_bank[layer_idx, 3*dim:4*dim, :] = W_O
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # MLP uses 0.5 * dim^-0.5
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank with MIMETIC V-O initialization
+            # Q and K: uniform init, V and O: identity-like structure for faster convergence
+            mimetic_vo_init(
+                self.attn_bank,
+                model_dim=model_dim,
+                num_heads=num_heads,
+                head_dim=head_dim,
+                beta=0.05,       # Scale for V@O^T ≈ -βI (tuned down from 0.1)
+                noise_std=0.01   # Symmetry breaking noise
+            )
+            # Init MLP bank (c_fc uniform, c_proj zero)
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 234 structure on token value embeddings by @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1515  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.11.14 (main, Oct 21 2025, 18:31:21) [GCC 11.2.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Fri Jan 30 18:47:24 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          Off |   00000000:19:00.0 Off |                    0 |
+| N/A   29C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          Off |   00000000:3B:00.0 Off |                    0 |
+| N/A   25C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          Off |   00000000:4C:00.0 Off |                    0 |
+| N/A   22C    P0            114W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          Off |   00000000:5D:00.0 Off |                    0 |
+| N/A   28C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          Off |   00000000:9B:00.0 Off |                    0 |
+| N/A   28C    P0            113W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          Off |   00000000:BB:00.0 Off |                    0 |
+| N/A   23C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          Off |   00000000:CB:00.0 Off |                    0 |
+| N/A   26C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          Off |   00000000:DB:00.0 Off |                    0 |
+| N/A   23C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1376595      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    1   N/A  N/A   1376596      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    2   N/A  N/A   1376597      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    3   N/A  N/A   1376598      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    4   N/A  N/A   1376599      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    5   N/A  N/A   1376600      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    6   N/A  N/A   1376601      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    7   N/A  N/A   1376602      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 504, 505, 506, 1009, 1010, 1011, 1514, 1515, 1516] for warmup
+Resetting Model
+step:0/1555 val_loss:10.8316 train_time:0ms step_avg:0.03ms
+step:1/1555 train_time:76ms step_avg:75.76ms
+step:2/1555 train_time:97ms step_avg:48.42ms
+step:3/1555 train_time:167ms step_avg:55.62ms
+step:4/1555 train_time:206ms step_avg:51.61ms
+step:5/1555 train_time:237ms step_avg:47.49ms
+step:6/1555 train_time:276ms step_avg:45.98ms
+step:7/1555 train_time:307ms step_avg:43.87ms
+step:8/1555 train_time:348ms step_avg:43.50ms
+step:9/1555 train_time:377ms step_avg:41.84ms
+step:10/1555 train_time:415ms step_avg:41.51ms
+step:11/1555 train_time:448ms step_avg:40.69ms
+step:12/1555 train_time:485ms step_avg:40.44ms
+step:13/1555 train_time:517ms step_avg:39.75ms
+step:14/1555 train_time:556ms step_avg:39.69ms
+step:15/1555 train_time:587ms step_avg:39.13ms
+step:16/1555 train_time:625ms step_avg:39.06ms
+step:17/1555 train_time:657ms step_avg:38.63ms
+step:18/1555 train_time:695ms step_avg:38.61ms
+step:19/1555 train_time:726ms step_avg:38.23ms
+step:20/1555 train_time:764ms step_avg:38.22ms
+step:21/1555 train_time:796ms step_avg:37.92ms
+step:22/1555 train_time:835ms step_avg:37.96ms
+step:23/1555 train_time:867ms step_avg:37.68ms
+step:24/1555 train_time:905ms step_avg:37.70ms
+step:25/1555 train_time:936ms step_avg:37.45ms
+step:26/1555 train_time:975ms step_avg:37.49ms
+step:27/1555 train_time:1006ms step_avg:37.26ms
+step:28/1555 train_time:1044ms step_avg:37.30ms
+step:29/1555 train_time:1075ms step_avg:37.08ms
+step:30/1555 train_time:1114ms step_avg:37.14ms
+step:31/1555 train_time:1146ms step_avg:36.96ms
+step:32/1555 train_time:1184ms step_avg:36.99ms
+step:33/1555 train_time:1215ms step_avg:36.83ms
+step:34/1555 train_time:1254ms step_avg:36.89ms
+step:35/1555 train_time:1286ms step_avg:36.73ms
+step:36/1555 train_time:1324ms step_avg:36.77ms
+step:37/1555 train_time:1355ms step_avg:36.63ms
+step:38/1555 train_time:1394ms step_avg:36.69ms
+step:39/1555 train_time:1426ms step_avg:36.56ms
+step:40/1555 train_time:1464ms step_avg:36.59ms
+step:41/1555 train_time:1495ms step_avg:36.47ms
+step:42/1555 train_time:1534ms step_avg:36.52ms
+step:43/1555 train_time:1565ms step_avg:36.40ms
+step:44/1555 train_time:1603ms step_avg:36.44ms
+step:45/1555 train_time:1635ms step_avg:36.33ms
+step:46/1555 train_time:1673ms step_avg:36.37ms
+step:47/1555 train_time:1705ms step_avg:36.27ms
+step:48/1555 train_time:1743ms step_avg:36.31ms
+step:49/1555 train_time:1774ms step_avg:36.21ms
+step:50/1555 train_time:1812ms step_avg:36.25ms
+step:51/1555 train_time:1844ms step_avg:36.15ms
+step:52/1555 train_time:1882ms step_avg:36.19ms
+step:53/1555 train_time:1913ms step_avg:36.10ms
+step:54/1555 train_time:1952ms step_avg:36.14ms
+step:55/1555 train_time:1983ms step_avg:36.06ms
+step:56/1555 train_time:2021ms step_avg:36.09ms
+step:57/1555 train_time:2052ms step_avg:36.01ms
+step:58/1555 train_time:2091ms step_avg:36.04ms
+step:59/1555 train_time:2122ms step_avg:35.97ms
+step:60/1555 train_time:2160ms step_avg:36.01ms
+step:61/1555 train_time:2192ms step_avg:35.93ms
+step:62/1555 train_time:2230ms step_avg:35.97ms
+step:63/1555 train_time:2261ms step_avg:35.90ms
+step:64/1555 train_time:2299ms step_avg:35.93ms
+step:65/1555 train_time:2331ms step_avg:35.86ms
+step:66/1555 train_time:2369ms step_avg:35.89ms
+step:67/1555 train_time:2400ms step_avg:35.82ms
+step:68/1555 train_time:2438ms step_avg:35.86ms
+step:69/1555 train_time:2470ms step_avg:35.80ms
+step:70/1555 train_time:2509ms step_avg:35.84ms
+step:71/1555 train_time:2540ms step_avg:35.78ms
+step:72/1555 train_time:2578ms step_avg:35.81ms
+step:73/1555 train_time:2610ms step_avg:35.75ms
+step:74/1555 train_time:2648ms step_avg:35.78ms
+step:75/1555 train_time:2679ms step_avg:35.72ms
+step:76/1555 train_time:2718ms step_avg:35.76ms
+step:77/1555 train_time:2749ms step_avg:35.70ms
+step:78/1555 train_time:2787ms step_avg:35.73ms
+step:79/1555 train_time:2818ms step_avg:35.67ms
+step:80/1555 train_time:2856ms step_avg:35.71ms
+step:81/1555 train_time:2888ms step_avg:35.65ms
+step:82/1555 train_time:2926ms step_avg:35.68ms
+step:83/1555 train_time:2957ms step_avg:35.63ms
+step:84/1555 train_time:2995ms step_avg:35.66ms
+step:85/1555 train_time:3026ms step_avg:35.60ms
+step:86/1555 train_time:3064ms step_avg:35.63ms
+step:87/1555 train_time:3096ms step_avg:35.59ms
+step:88/1555 train_time:3134ms step_avg:35.62ms
+step:89/1555 train_time:3166ms step_avg:35.57ms
+step:90/1555 train_time:3204ms step_avg:35.60ms
+step:91/1555 train_time:3235ms step_avg:35.55ms
+step:92/1555 train_time:3273ms step_avg:35.58ms
+step:93/1555 train_time:3304ms step_avg:35.53ms
+step:94/1555 train_time:3342ms step_avg:35.56ms
+step:95/1555 train_time:3373ms step_avg:35.51ms
+step:96/1555 train_time:3412ms step_avg:35.54ms
+step:97/1555 train_time:3443ms step_avg:35.50ms
+step:98/1555 train_time:3481ms step_avg:35.52ms
+step:99/1555 train_time:3513ms step_avg:35.48ms
+step:100/1555 train_time:3551ms step_avg:35.51ms
+step:101/1555 train_time:3582ms step_avg:35.47ms
+step:102/1555 train_time:3620ms step_avg:35.49ms
+step:103/1555 train_time:3652ms step_avg:35.45ms
+step:104/1555 train_time:3690ms step_avg:35.48ms
+step:105/1555 train_time:3722ms step_avg:35.44ms
+step:106/1555 train_time:3760ms step_avg:35.47ms
+step:107/1555 train_time:3791ms step_avg:35.43ms
+step:108/1555 train_time:3829ms step_avg:35.46ms
+step:109/1555 train_time:3861ms step_avg:35.42ms
+step:110/1555 train_time:3899ms step_avg:35.45ms
+step:111/1555 train_time:3930ms step_avg:35.41ms
+step:112/1555 train_time:3969ms step_avg:35.43ms
+step:113/1555 train_time:4000ms step_avg:35.40ms
+step:114/1555 train_time:4038ms step_avg:35.42ms
+step:115/1555 train_time:4069ms step_avg:35.39ms
+step:116/1555 train_time:4107ms step_avg:35.41ms
+step:117/1555 train_time:4139ms step_avg:35.37ms
+step:118/1555 train_time:4177ms step_avg:35.40ms
+step:119/1555 train_time:4208ms step_avg:35.36ms
+step:120/1555 train_time:4246ms step_avg:35.39ms
+step:121/1555 train_time:4278ms step_avg:35.35ms
+step:122/1555 train_time:4316ms step_avg:35.38ms
+step:123/1555 train_time:4347ms step_avg:35.34ms
+step:124/1555 train_time:4385ms step_avg:35.36ms
+step:125/1555 train_time:4417ms step_avg:35.33ms
+step:126/1555 train_time:4455ms step_avg:35.36ms
+step:127/1555 train_time:4486ms step_avg:35.33ms
+step:128/1555 train_time:4524ms step_avg:35.35ms
+step:129/1555 train_time:4556ms step_avg:35.32ms
+step:130/1555 train_time:4594ms step_avg:35.34ms
+step:131/1555 train_time:4625ms step_avg:35.31ms
+step:132/1555 train_time:4663ms step_avg:35.33ms
+step:133/1555 train_time:4695ms step_avg:35.30ms
+step:134/1555 train_time:4733ms step_avg:35.32ms
+step:135/1555 train_time:4764ms step_avg:35.29ms
+step:136/1555 train_time:4802ms step_avg:35.31ms
+step:137/1555 train_time:4834ms step_avg:35.28ms
+step:138/1555 train_time:4872ms step_avg:35.30ms
+step:139/1555 train_time:4903ms step_avg:35.28ms
+step:140/1555 train_time:4942ms step_avg:35.30ms
+step:141/1555 train_time:4973ms step_avg:35.27ms
+step:142/1555 train_time:5012ms step_avg:35.29ms
+step:143/1555 train_time:5043ms step_avg:35.27ms
+step:144/1555 train_time:5081ms step_avg:35.28ms
+step:145/1555 train_time:5112ms step_avg:35.26ms
+step:146/1555 train_time:5151ms step_avg:35.28ms
+step:147/1555 train_time:5182ms step_avg:35.25ms
+step:148/1555 train_time:5220ms step_avg:35.27ms
+step:149/1555 train_time:5251ms step_avg:35.24ms
+step:150/1555 train_time:5289ms step_avg:35.26ms
+step:151/1555 train_time:5321ms step_avg:35.24ms
+step:152/1555 train_time:5359ms step_avg:35.25ms
+step:153/1555 train_time:5390ms step_avg:35.23ms
+step:154/1555 train_time:5429ms step_avg:35.25ms
+step:155/1555 train_time:5460ms step_avg:35.23ms
+step:156/1555 train_time:5498ms step_avg:35.24ms
+step:157/1555 train_time:5529ms step_avg:35.22ms
+step:158/1555 train_time:5567ms step_avg:35.24ms
+step:159/1555 train_time:5598ms step_avg:35.21ms
+step:160/1555 train_time:5637ms step_avg:35.23ms
+step:161/1555 train_time:5668ms step_avg:35.20ms
+step:162/1555 train_time:5706ms step_avg:35.22ms
+step:163/1555 train_time:5737ms step_avg:35.20ms
+step:164/1555 train_time:5775ms step_avg:35.21ms
+step:165/1555 train_time:5806ms step_avg:35.19ms
+step:166/1555 train_time:5844ms step_avg:35.21ms
+step:167/1555 train_time:5876ms step_avg:35.18ms
+step:168/1555 train_time:5914ms step_avg:35.20ms
+step:169/1555 train_time:5945ms step_avg:35.18ms
+step:170/1555 train_time:5984ms step_avg:35.20ms
+step:171/1555 train_time:6015ms step_avg:35.18ms
+step:172/1555 train_time:6053ms step_avg:35.19ms
+step:173/1555 train_time:6085ms step_avg:35.17ms
+step:174/1555 train_time:6122ms step_avg:35.19ms
+step:175/1555 train_time:6154ms step_avg:35.17ms
+step:176/1555 train_time:6192ms step_avg:35.18ms
+step:177/1555 train_time:6223ms step_avg:35.16ms
+step:178/1555 train_time:6261ms step_avg:35.18ms
+step:179/1555 train_time:6293ms step_avg:35.15ms
+step:180/1555 train_time:6331ms step_avg:35.17ms
+step:181/1555 train_time:6362ms step_avg:35.15ms
+step:182/1555 train_time:6400ms step_avg:35.17ms
+step:183/1555 train_time:6432ms step_avg:35.15ms
+step:184/1555 train_time:6470ms step_avg:35.16ms
+step:185/1555 train_time:6501ms step_avg:35.14ms
+step:186/1555 train_time:6539ms step_avg:35.16ms
+step:187/1555 train_time:6571ms step_avg:35.14ms
+step:188/1555 train_time:6609ms step_avg:35.15ms
+step:189/1555 train_time:6640ms step_avg:35.13ms
+step:190/1555 train_time:6678ms step_avg:35.15ms
+step:191/1555 train_time:6710ms step_avg:35.13ms
+step:192/1555 train_time:6748ms step_avg:35.14ms
+step:193/1555 train_time:6779ms step_avg:35.12ms
+step:194/1555 train_time:6817ms step_avg:35.14ms
+step:195/1555 train_time:6848ms step_avg:35.12ms
+step:196/1555 train_time:6886ms step_avg:35.13ms
+step:197/1555 train_time:6918ms step_avg:35.11ms
+step:198/1555 train_time:6956ms step_avg:35.13ms
+step:199/1555 train_time:6987ms step_avg:35.11ms
+step:200/1555 train_time:7025ms step_avg:35.12ms
+step:201/1555 train_time:7056ms step_avg:35.11ms
+step:202/1555 train_time:7095ms step_avg:35.12ms
+step:203/1555 train_time:7126ms step_avg:35.10ms
+step:204/1555 train_time:7164ms step_avg:35.12ms
+step:205/1555 train_time:7196ms step_avg:35.10ms
+step:206/1555 train_time:7234ms step_avg:35.12ms
+step:207/1555 train_time:7265ms step_avg:35.10ms
+step:208/1555 train_time:7303ms step_avg:35.11ms
+step:209/1555 train_time:7335ms step_avg:35.10ms
+step:210/1555 train_time:7373ms step_avg:35.11ms
+step:211/1555 train_time:7405ms step_avg:35.09ms
+step:212/1555 train_time:7443ms step_avg:35.11ms
+step:213/1555 train_time:7474ms step_avg:35.09ms
+step:214/1555 train_time:7513ms step_avg:35.11ms
+step:215/1555 train_time:7544ms step_avg:35.09ms
+step:216/1555 train_time:7582ms step_avg:35.10ms
+step:217/1555 train_time:7614ms step_avg:35.09ms
+step:218/1555 train_time:7652ms step_avg:35.10ms
+step:219/1555 train_time:7684ms step_avg:35.09ms
+step:220/1555 train_time:7722ms step_avg:35.10ms
+step:221/1555 train_time:7753ms step_avg:35.08ms
+step:222/1555 train_time:7791ms step_avg:35.10ms
+step:223/1555 train_time:7823ms step_avg:35.08ms
+step:224/1555 train_time:7861ms step_avg:35.09ms
+step:225/1555 train_time:7892ms step_avg:35.07ms
+step:226/1555 train_time:7930ms step_avg:35.09ms
+step:227/1555 train_time:7962ms step_avg:35.07ms
+step:228/1555 train_time:7999ms step_avg:35.09ms
+step:229/1555 train_time:8031ms step_avg:35.07ms
+step:230/1555 train_time:8069ms step_avg:35.08ms
+step:231/1555 train_time:8100ms step_avg:35.06ms
+step:232/1555 train_time:8138ms step_avg:35.08ms
+step:233/1555 train_time:8169ms step_avg:35.06ms
+step:234/1555 train_time:8207ms step_avg:35.07ms
+step:235/1555 train_time:8238ms step_avg:35.06ms
+step:236/1555 train_time:8277ms step_avg:35.07ms
+step:237/1555 train_time:8308ms step_avg:35.05ms
+step:238/1555 train_time:8345ms step_avg:35.06ms
+step:239/1555 train_time:8377ms step_avg:35.05ms
+step:240/1555 train_time:8415ms step_avg:35.06ms
+step:241/1555 train_time:8446ms step_avg:35.04ms
+step:242/1555 train_time:8484ms step_avg:35.06ms
+step:243/1555 train_time:8515ms step_avg:35.04ms
+step:244/1555 train_time:8553ms step_avg:35.05ms
+step:245/1555 train_time:8584ms step_avg:35.04ms
+step:246/1555 train_time:8622ms step_avg:35.05ms
+step:247/1555 train_time:8654ms step_avg:35.04ms
+step:248/1555 train_time:8692ms step_avg:35.05ms
+step:249/1555 train_time:8723ms step_avg:35.03ms
+step:250/1555 train_time:8761ms step_avg:35.05ms
+step:250/1555 val_loss:4.5699 train_time:8810ms step_avg:35.24ms
+step:251/1555 train_time:8830ms step_avg:35.18ms
+step:252/1555 train_time:8848ms step_avg:35.11ms
+step:253/1555 train_time:8865ms step_avg:35.04ms
+step:254/1555 train_time:8905ms step_avg:35.06ms
+step:255/1555 train_time:8936ms step_avg:35.04ms
+step:256/1555 train_time:8975ms step_avg:35.06ms
+step:257/1555 train_time:9007ms step_avg:35.05ms
+step:258/1555 train_time:9046ms step_avg:35.06ms
+step:259/1555 train_time:9077ms step_avg:35.04ms
+step:260/1555 train_time:9115ms step_avg:35.06ms
+step:261/1555 train_time:9146ms step_avg:35.04ms
+step:262/1555 train_time:9184ms step_avg:35.05ms
+step:263/1555 train_time:9215ms step_avg:35.04ms
+step:264/1555 train_time:9253ms step_avg:35.05ms
+step:265/1555 train_time:9285ms step_avg:35.04ms
+step:266/1555 train_time:9323ms step_avg:35.05ms
+step:267/1555 train_time:9354ms step_avg:35.04ms
+step:268/1555 train_time:9392ms step_avg:35.05ms
+step:269/1555 train_time:9424ms step_avg:35.03ms
+step:270/1555 train_time:9462ms step_avg:35.05ms
+step:271/1555 train_time:9493ms step_avg:35.03ms
+step:272/1555 train_time:9531ms step_avg:35.04ms
+step:273/1555 train_time:9563ms step_avg:35.03ms
+step:274/1555 train_time:9601ms step_avg:35.04ms
+step:275/1555 train_time:9632ms step_avg:35.03ms
+step:276/1555 train_time:9670ms step_avg:35.04ms
+step:277/1555 train_time:9701ms step_avg:35.02ms
+step:278/1555 train_time:9740ms step_avg:35.04ms
+step:279/1555 train_time:9771ms step_avg:35.02ms
+step:280/1555 train_time:9809ms step_avg:35.03ms
+step:281/1555 train_time:9840ms step_avg:35.02ms
+step:282/1555 train_time:9879ms step_avg:35.03ms
+step:283/1555 train_time:9910ms step_avg:35.02ms
+step:284/1555 train_time:9948ms step_avg:35.03ms
+step:285/1555 train_time:9980ms step_avg:35.02ms
+step:286/1555 train_time:10018ms step_avg:35.03ms
+step:287/1555 train_time:10049ms step_avg:35.01ms
+step:288/1555 train_time:10088ms step_avg:35.03ms
+step:289/1555 train_time:10119ms step_avg:35.01ms
+step:290/1555 train_time:10157ms step_avg:35.02ms
+step:291/1555 train_time:10188ms step_avg:35.01ms
+step:292/1555 train_time:10226ms step_avg:35.02ms
+step:293/1555 train_time:10258ms step_avg:35.01ms
+step:294/1555 train_time:10296ms step_avg:35.02ms
+step:295/1555 train_time:10327ms step_avg:35.01ms
+step:296/1555 train_time:10365ms step_avg:35.02ms
+step:297/1555 train_time:10396ms step_avg:35.00ms
+step:298/1555 train_time:10434ms step_avg:35.01ms
+step:299/1555 train_time:10465ms step_avg:35.00ms
+step:300/1555 train_time:10503ms step_avg:35.01ms
+step:301/1555 train_time:10535ms step_avg:35.00ms
+step:302/1555 train_time:10573ms step_avg:35.01ms
+step:303/1555 train_time:10604ms step_avg:35.00ms
+step:304/1555 train_time:10642ms step_avg:35.01ms
+step:305/1555 train_time:10674ms step_avg:35.00ms
+step:306/1555 train_time:10712ms step_avg:35.01ms
+step:307/1555 train_time:10743ms step_avg:34.99ms
+step:308/1555 train_time:10781ms step_avg:35.00ms
+step:309/1555 train_time:10812ms step_avg:34.99ms
+step:310/1555 train_time:10850ms step_avg:35.00ms
+step:311/1555 train_time:10881ms step_avg:34.99ms
+step:312/1555 train_time:10919ms step_avg:35.00ms
+step:313/1555 train_time:10951ms step_avg:34.99ms
+step:314/1555 train_time:10989ms step_avg:35.00ms
+step:315/1555 train_time:11020ms step_avg:34.98ms
+step:316/1555 train_time:11060ms step_avg:35.00ms
+step:317/1555 train_time:11090ms step_avg:34.98ms
+step:318/1555 train_time:11128ms step_avg:34.99ms
+step:319/1555 train_time:11159ms step_avg:34.98ms
+step:320/1555 train_time:11197ms step_avg:34.99ms
+step:321/1555 train_time:11228ms step_avg:34.98ms
+step:322/1555 train_time:11266ms step_avg:34.99ms
+step:323/1555 train_time:11297ms step_avg:34.98ms
+step:324/1555 train_time:11335ms step_avg:34.99ms
+step:325/1555 train_time:11367ms step_avg:34.97ms
+step:326/1555 train_time:11404ms step_avg:34.98ms
+step:327/1555 train_time:11436ms step_avg:34.97ms
+step:328/1555 train_time:11474ms step_avg:34.98ms
+step:329/1555 train_time:11505ms step_avg:34.97ms
+step:330/1555 train_time:11543ms step_avg:34.98ms
+step:331/1555 train_time:11574ms step_avg:34.97ms
+step:332/1555 train_time:11612ms step_avg:34.98ms
+step:333/1555 train_time:11644ms step_avg:34.97ms
+step:334/1555 train_time:11682ms step_avg:34.98ms
+step:335/1555 train_time:11713ms step_avg:34.96ms
+step:336/1555 train_time:11751ms step_avg:34.97ms
+step:337/1555 train_time:11782ms step_avg:34.96ms
+step:338/1555 train_time:11821ms step_avg:34.97ms
+step:339/1555 train_time:11852ms step_avg:34.96ms
+step:340/1555 train_time:11890ms step_avg:34.97ms
+step:341/1555 train_time:11922ms step_avg:34.96ms
+step:342/1555 train_time:11960ms step_avg:34.97ms
+step:343/1555 train_time:11991ms step_avg:34.96ms
+step:344/1555 train_time:12029ms step_avg:34.97ms
+step:345/1555 train_time:12060ms step_avg:34.96ms
+step:346/1555 train_time:12098ms step_avg:34.97ms
+step:347/1555 train_time:12130ms step_avg:34.96ms
+step:348/1555 train_time:12168ms step_avg:34.96ms
+step:349/1555 train_time:12199ms step_avg:34.95ms
+step:350/1555 train_time:12237ms step_avg:34.96ms
+step:351/1555 train_time:12268ms step_avg:34.95ms
+step:352/1555 train_time:12306ms step_avg:34.96ms
+step:353/1555 train_time:12337ms step_avg:34.95ms
+step:354/1555 train_time:12375ms step_avg:34.96ms
+step:355/1555 train_time:12406ms step_avg:34.95ms
+step:356/1555 train_time:12444ms step_avg:34.96ms
+step:357/1555 train_time:12476ms step_avg:34.95ms
+step:358/1555 train_time:12514ms step_avg:34.96ms
+step:359/1555 train_time:12545ms step_avg:34.94ms
+step:360/1555 train_time:12583ms step_avg:34.95ms
+step:361/1555 train_time:12614ms step_avg:34.94ms
+step:362/1555 train_time:12652ms step_avg:34.95ms
+step:363/1555 train_time:12683ms step_avg:34.94ms
+step:364/1555 train_time:12722ms step_avg:34.95ms
+step:365/1555 train_time:12753ms step_avg:34.94ms
+step:366/1555 train_time:12791ms step_avg:34.95ms
+step:367/1555 train_time:12822ms step_avg:34.94ms
+step:368/1555 train_time:12860ms step_avg:34.95ms
+step:369/1555 train_time:12891ms step_avg:34.94ms
+step:370/1555 train_time:12929ms step_avg:34.94ms
+step:371/1555 train_time:12961ms step_avg:34.93ms
+step:372/1555 train_time:12999ms step_avg:34.94ms
+step:373/1555 train_time:13030ms step_avg:34.93ms
+step:374/1555 train_time:13068ms step_avg:34.94ms
+step:375/1555 train_time:13099ms step_avg:34.93ms
+step:376/1555 train_time:13138ms step_avg:34.94ms
+step:377/1555 train_time:13169ms step_avg:34.93ms
+step:378/1555 train_time:13207ms step_avg:34.94ms
+step:379/1555 train_time:13238ms step_avg:34.93ms
+step:380/1555 train_time:13277ms step_avg:34.94ms
+step:381/1555 train_time:13308ms step_avg:34.93ms
+step:382/1555 train_time:13346ms step_avg:34.94ms
+step:383/1555 train_time:13377ms step_avg:34.93ms
+step:384/1555 train_time:13416ms step_avg:34.94ms
+step:385/1555 train_time:13447ms step_avg:34.93ms
+step:386/1555 train_time:13485ms step_avg:34.93ms
+step:387/1555 train_time:13516ms step_avg:34.92ms
+step:388/1555 train_time:13554ms step_avg:34.93ms
+step:389/1555 train_time:13585ms step_avg:34.92ms
+step:390/1555 train_time:13623ms step_avg:34.93ms
+step:391/1555 train_time:13654ms step_avg:34.92ms
+step:392/1555 train_time:13692ms step_avg:34.93ms
+step:393/1555 train_time:13724ms step_avg:34.92ms
+step:394/1555 train_time:13762ms step_avg:34.93ms
+step:395/1555 train_time:13793ms step_avg:34.92ms
+step:396/1555 train_time:13831ms step_avg:34.93ms
+step:397/1555 train_time:13862ms step_avg:34.92ms
+step:398/1555 train_time:13900ms step_avg:34.92ms
+step:399/1555 train_time:13931ms step_avg:34.92ms
+step:400/1555 train_time:13969ms step_avg:34.92ms
+step:401/1555 train_time:14001ms step_avg:34.91ms
+step:402/1555 train_time:14039ms step_avg:34.92ms
+step:403/1555 train_time:14070ms step_avg:34.91ms
+step:404/1555 train_time:14108ms step_avg:34.92ms
+step:405/1555 train_time:14139ms step_avg:34.91ms
+step:406/1555 train_time:14178ms step_avg:34.92ms
+step:407/1555 train_time:14209ms step_avg:34.91ms
+step:408/1555 train_time:14247ms step_avg:34.92ms
+step:409/1555 train_time:14278ms step_avg:34.91ms
+step:410/1555 train_time:14317ms step_avg:34.92ms
+step:411/1555 train_time:14348ms step_avg:34.91ms
+step:412/1555 train_time:14386ms step_avg:34.92ms
+step:413/1555 train_time:14417ms step_avg:34.91ms
+step:414/1555 train_time:14455ms step_avg:34.92ms
+step:415/1555 train_time:14486ms step_avg:34.91ms
+step:416/1555 train_time:14525ms step_avg:34.91ms
+step:417/1555 train_time:14556ms step_avg:34.91ms
+step:418/1555 train_time:14594ms step_avg:34.91ms
+step:419/1555 train_time:14625ms step_avg:34.90ms
+step:420/1555 train_time:14664ms step_avg:34.91ms
+step:421/1555 train_time:14695ms step_avg:34.91ms
+step:422/1555 train_time:14733ms step_avg:34.91ms
+step:423/1555 train_time:14764ms step_avg:34.90ms
+step:424/1555 train_time:14802ms step_avg:34.91ms
+step:425/1555 train_time:14833ms step_avg:34.90ms
+step:426/1555 train_time:14871ms step_avg:34.91ms
+step:427/1555 train_time:14902ms step_avg:34.90ms
+step:428/1555 train_time:14940ms step_avg:34.91ms
+step:429/1555 train_time:14971ms step_avg:34.90ms
+step:430/1555 train_time:15009ms step_avg:34.91ms
+step:431/1555 train_time:15041ms step_avg:34.90ms
+step:432/1555 train_time:15079ms step_avg:34.91ms
+step:433/1555 train_time:15110ms step_avg:34.90ms
+step:434/1555 train_time:15148ms step_avg:34.90ms
+step:435/1555 train_time:15180ms step_avg:34.90ms
+step:436/1555 train_time:15218ms step_avg:34.90ms
+step:437/1555 train_time:15249ms step_avg:34.90ms
+step:438/1555 train_time:15287ms step_avg:34.90ms
+step:439/1555 train_time:15318ms step_avg:34.89ms
+step:440/1555 train_time:15357ms step_avg:34.90ms
+step:441/1555 train_time:15388ms step_avg:34.89ms
+step:442/1555 train_time:15426ms step_avg:34.90ms
+step:443/1555 train_time:15457ms step_avg:34.89ms
+step:444/1555 train_time:15495ms step_avg:34.90ms
+step:445/1555 train_time:15526ms step_avg:34.89ms
+step:446/1555 train_time:15564ms step_avg:34.90ms
+step:447/1555 train_time:15595ms step_avg:34.89ms
+step:448/1555 train_time:15633ms step_avg:34.90ms
+step:449/1555 train_time:15665ms step_avg:34.89ms
+step:450/1555 train_time:15702ms step_avg:34.89ms
+step:451/1555 train_time:15734ms step_avg:34.89ms
+step:452/1555 train_time:15771ms step_avg:34.89ms
+step:453/1555 train_time:15803ms step_avg:34.88ms
+step:454/1555 train_time:15841ms step_avg:34.89ms
+step:455/1555 train_time:15872ms step_avg:34.88ms
+step:456/1555 train_time:15910ms step_avg:34.89ms
+step:457/1555 train_time:15941ms step_avg:34.88ms
+step:458/1555 train_time:15980ms step_avg:34.89ms
+step:459/1555 train_time:16011ms step_avg:34.88ms
+step:460/1555 train_time:16049ms step_avg:34.89ms
+step:461/1555 train_time:16080ms step_avg:34.88ms
+step:462/1555 train_time:16118ms step_avg:34.89ms
+step:463/1555 train_time:16150ms step_avg:34.88ms
+step:464/1555 train_time:16188ms step_avg:34.89ms
+step:465/1555 train_time:16219ms step_avg:34.88ms
+step:466/1555 train_time:16258ms step_avg:34.89ms
+step:467/1555 train_time:16289ms step_avg:34.88ms
+step:468/1555 train_time:16327ms step_avg:34.89ms
+step:469/1555 train_time:16358ms step_avg:34.88ms
+step:470/1555 train_time:16396ms step_avg:34.89ms
+step:471/1555 train_time:16427ms step_avg:34.88ms
+step:472/1555 train_time:16465ms step_avg:34.88ms
+step:473/1555 train_time:16496ms step_avg:34.88ms
+step:474/1555 train_time:16534ms step_avg:34.88ms
+step:475/1555 train_time:16566ms step_avg:34.88ms
+step:476/1555 train_time:16604ms step_avg:34.88ms
+step:477/1555 train_time:16635ms step_avg:34.88ms
+step:478/1555 train_time:16673ms step_avg:34.88ms
+step:479/1555 train_time:16705ms step_avg:34.87ms
+step:480/1555 train_time:16744ms step_avg:34.88ms
+step:481/1555 train_time:16775ms step_avg:34.87ms
+step:482/1555 train_time:16813ms step_avg:34.88ms
+step:483/1555 train_time:16844ms step_avg:34.87ms
+step:484/1555 train_time:16882ms step_avg:34.88ms
+step:485/1555 train_time:16914ms step_avg:34.87ms
+step:486/1555 train_time:16952ms step_avg:34.88ms
+step:487/1555 train_time:16983ms step_avg:34.87ms
+step:488/1555 train_time:17021ms step_avg:34.88ms
+step:489/1555 train_time:17052ms step_avg:34.87ms
+step:490/1555 train_time:17090ms step_avg:34.88ms
+step:491/1555 train_time:17121ms step_avg:34.87ms
+step:492/1555 train_time:17159ms step_avg:34.88ms
+step:493/1555 train_time:17190ms step_avg:34.87ms
+step:494/1555 train_time:17228ms step_avg:34.88ms
+step:495/1555 train_time:17260ms step_avg:34.87ms
+step:496/1555 train_time:17298ms step_avg:34.87ms
+step:497/1555 train_time:17329ms step_avg:34.87ms
+step:498/1555 train_time:17367ms step_avg:34.87ms
+step:499/1555 train_time:17398ms step_avg:34.87ms
+step:500/1555 train_time:17436ms step_avg:34.87ms
+step:500/1555 val_loss:4.2232 train_time:17485ms step_avg:34.97ms
+step:501/1555 train_time:17502ms step_avg:34.93ms
+step:502/1555 train_time:17520ms step_avg:34.90ms
+step:503/1555 train_time:17542ms step_avg:34.87ms
+step:504/1555 train_time:17580ms step_avg:34.88ms
+step:505/1555 train_time:17613ms step_avg:34.88ms
+step:506/1555 train_time:17689ms step_avg:34.96ms
+step:507/1555 train_time:17749ms step_avg:35.01ms
+step:508/1555 train_time:17807ms step_avg:35.05ms
+step:509/1555 train_time:17870ms step_avg:35.11ms
+step:510/1555 train_time:17929ms step_avg:35.16ms
+step:511/1555 train_time:17993ms step_avg:35.21ms
+step:512/1555 train_time:18051ms step_avg:35.26ms
+step:513/1555 train_time:18114ms step_avg:35.31ms
+step:514/1555 train_time:18173ms step_avg:35.36ms
+step:515/1555 train_time:18235ms step_avg:35.41ms
+step:516/1555 train_time:18294ms step_avg:35.45ms
+step:517/1555 train_time:18357ms step_avg:35.51ms
+step:518/1555 train_time:18417ms step_avg:35.55ms
+step:519/1555 train_time:18482ms step_avg:35.61ms
+step:520/1555 train_time:18543ms step_avg:35.66ms
+step:521/1555 train_time:18608ms step_avg:35.72ms
+step:522/1555 train_time:18668ms step_avg:35.76ms
+step:523/1555 train_time:18731ms step_avg:35.81ms
+step:524/1555 train_time:18790ms step_avg:35.86ms
+step:525/1555 train_time:18855ms step_avg:35.91ms
+step:526/1555 train_time:18915ms step_avg:35.96ms
+step:527/1555 train_time:18978ms step_avg:36.01ms
+step:528/1555 train_time:19037ms step_avg:36.06ms
+step:529/1555 train_time:19101ms step_avg:36.11ms
+step:530/1555 train_time:19160ms step_avg:36.15ms
+step:531/1555 train_time:19223ms step_avg:36.20ms
+step:532/1555 train_time:19282ms step_avg:36.24ms
+step:533/1555 train_time:19346ms step_avg:36.30ms
+step:534/1555 train_time:19405ms step_avg:36.34ms
+step:535/1555 train_time:19468ms step_avg:36.39ms
+step:536/1555 train_time:19527ms step_avg:36.43ms
+step:537/1555 train_time:19592ms step_avg:36.48ms
+step:538/1555 train_time:19652ms step_avg:36.53ms
+step:539/1555 train_time:19715ms step_avg:36.58ms
+step:540/1555 train_time:19775ms step_avg:36.62ms
+step:541/1555 train_time:19839ms step_avg:36.67ms
+step:542/1555 train_time:19901ms step_avg:36.72ms
+step:543/1555 train_time:19965ms step_avg:36.77ms
+step:544/1555 train_time:20023ms step_avg:36.81ms
+step:545/1555 train_time:20086ms step_avg:36.85ms
+step:546/1555 train_time:20146ms step_avg:36.90ms
+step:547/1555 train_time:20208ms step_avg:36.94ms
+step:548/1555 train_time:20267ms step_avg:36.98ms
+step:549/1555 train_time:20331ms step_avg:37.03ms
+step:550/1555 train_time:20389ms step_avg:37.07ms
+step:551/1555 train_time:20453ms step_avg:37.12ms
+step:552/1555 train_time:20512ms step_avg:37.16ms
+step:553/1555 train_time:20578ms step_avg:37.21ms
+step:554/1555 train_time:20635ms step_avg:37.25ms
+step:555/1555 train_time:20699ms step_avg:37.29ms
+step:556/1555 train_time:20758ms step_avg:37.33ms
+step:557/1555 train_time:20821ms step_avg:37.38ms
+step:558/1555 train_time:20880ms step_avg:37.42ms
+step:559/1555 train_time:20944ms step_avg:37.47ms
+step:560/1555 train_time:21003ms step_avg:37.51ms
+step:561/1555 train_time:21066ms step_avg:37.55ms
+step:562/1555 train_time:21125ms step_avg:37.59ms
+step:563/1555 train_time:21189ms step_avg:37.64ms
+step:564/1555 train_time:21247ms step_avg:37.67ms
+step:565/1555 train_time:21310ms step_avg:37.72ms
+step:566/1555 train_time:21382ms step_avg:37.78ms
+step:567/1555 train_time:21435ms step_avg:37.80ms
+step:568/1555 train_time:21492ms step_avg:37.84ms
+step:569/1555 train_time:21555ms step_avg:37.88ms
+step:570/1555 train_time:21615ms step_avg:37.92ms
+step:571/1555 train_time:21677ms step_avg:37.96ms
+step:572/1555 train_time:21737ms step_avg:38.00ms
+step:573/1555 train_time:21801ms step_avg:38.05ms
+step:574/1555 train_time:21862ms step_avg:38.09ms
+step:575/1555 train_time:21924ms step_avg:38.13ms
+step:576/1555 train_time:21984ms step_avg:38.17ms
+step:577/1555 train_time:22047ms step_avg:38.21ms
+step:578/1555 train_time:22107ms step_avg:38.25ms
+step:579/1555 train_time:22170ms step_avg:38.29ms
+step:580/1555 train_time:22229ms step_avg:38.33ms
+step:581/1555 train_time:22292ms step_avg:38.37ms
+step:582/1555 train_time:22352ms step_avg:38.41ms
+step:583/1555 train_time:22415ms step_avg:38.45ms
+step:584/1555 train_time:22473ms step_avg:38.48ms
+step:585/1555 train_time:22537ms step_avg:38.52ms
+step:586/1555 train_time:22597ms step_avg:38.56ms
+step:587/1555 train_time:22660ms step_avg:38.60ms
+step:588/1555 train_time:22719ms step_avg:38.64ms
+step:589/1555 train_time:22783ms step_avg:38.68ms
+step:590/1555 train_time:22843ms step_avg:38.72ms
+step:591/1555 train_time:22906ms step_avg:38.76ms
+step:592/1555 train_time:22965ms step_avg:38.79ms
+step:593/1555 train_time:23028ms step_avg:38.83ms
+step:594/1555 train_time:23087ms step_avg:38.87ms
+step:595/1555 train_time:23153ms step_avg:38.91ms
+step:596/1555 train_time:23211ms step_avg:38.94ms
+step:597/1555 train_time:23274ms step_avg:38.98ms
+step:598/1555 train_time:23333ms step_avg:39.02ms
+step:599/1555 train_time:23397ms step_avg:39.06ms
+step:600/1555 train_time:23456ms step_avg:39.09ms
+step:601/1555 train_time:23520ms step_avg:39.13ms
+step:602/1555 train_time:23579ms step_avg:39.17ms
+step:603/1555 train_time:23643ms step_avg:39.21ms
+step:604/1555 train_time:23701ms step_avg:39.24ms
+step:605/1555 train_time:23764ms step_avg:39.28ms
+step:606/1555 train_time:23824ms step_avg:39.31ms
+step:607/1555 train_time:23887ms step_avg:39.35ms
+step:608/1555 train_time:23947ms step_avg:39.39ms
+step:609/1555 train_time:24010ms step_avg:39.42ms
+step:610/1555 train_time:24069ms step_avg:39.46ms
+step:611/1555 train_time:24133ms step_avg:39.50ms
+step:612/1555 train_time:24191ms step_avg:39.53ms
+step:613/1555 train_time:24255ms step_avg:39.57ms
+step:614/1555 train_time:24315ms step_avg:39.60ms
+step:615/1555 train_time:24378ms step_avg:39.64ms
+step:616/1555 train_time:24439ms step_avg:39.67ms
+step:617/1555 train_time:24501ms step_avg:39.71ms
+step:618/1555 train_time:24560ms step_avg:39.74ms
+step:619/1555 train_time:24623ms step_avg:39.78ms
+step:620/1555 train_time:24682ms step_avg:39.81ms
+step:621/1555 train_time:24747ms step_avg:39.85ms
+step:622/1555 train_time:24806ms step_avg:39.88ms
+step:623/1555 train_time:24868ms step_avg:39.92ms
+step:624/1555 train_time:24928ms step_avg:39.95ms
+step:625/1555 train_time:24991ms step_avg:39.99ms
+step:626/1555 train_time:25052ms step_avg:40.02ms
+step:627/1555 train_time:25114ms step_avg:40.05ms
+step:628/1555 train_time:25173ms step_avg:40.08ms
+step:629/1555 train_time:25236ms step_avg:40.12ms
+step:630/1555 train_time:25296ms step_avg:40.15ms
+step:631/1555 train_time:25361ms step_avg:40.19ms
+step:632/1555 train_time:25419ms step_avg:40.22ms
+step:633/1555 train_time:25483ms step_avg:40.26ms
+step:634/1555 train_time:25543ms step_avg:40.29ms
+step:635/1555 train_time:25606ms step_avg:40.32ms
+step:636/1555 train_time:25666ms step_avg:40.36ms
+step:637/1555 train_time:25728ms step_avg:40.39ms
+step:638/1555 train_time:25787ms step_avg:40.42ms
+step:639/1555 train_time:25850ms step_avg:40.45ms
+step:640/1555 train_time:25910ms step_avg:40.49ms
+step:641/1555 train_time:25973ms step_avg:40.52ms
+step:642/1555 train_time:26032ms step_avg:40.55ms
+step:643/1555 train_time:26096ms step_avg:40.58ms
+step:644/1555 train_time:26155ms step_avg:40.61ms
+step:645/1555 train_time:26220ms step_avg:40.65ms
+step:646/1555 train_time:26278ms step_avg:40.68ms
+step:647/1555 train_time:26341ms step_avg:40.71ms
+step:648/1555 train_time:26401ms step_avg:40.74ms
+step:649/1555 train_time:26463ms step_avg:40.78ms
+step:650/1555 train_time:26523ms step_avg:40.81ms
+step:651/1555 train_time:26587ms step_avg:40.84ms
+step:652/1555 train_time:26646ms step_avg:40.87ms
+step:653/1555 train_time:26709ms step_avg:40.90ms
+step:654/1555 train_time:26769ms step_avg:40.93ms
+step:655/1555 train_time:26832ms step_avg:40.97ms
+step:656/1555 train_time:26893ms step_avg:40.99ms
+step:657/1555 train_time:26956ms step_avg:41.03ms
+step:658/1555 train_time:27015ms step_avg:41.06ms
+step:659/1555 train_time:27079ms step_avg:41.09ms
+step:660/1555 train_time:27138ms step_avg:41.12ms
+step:661/1555 train_time:27202ms step_avg:41.15ms
+step:662/1555 train_time:27262ms step_avg:41.18ms
+step:663/1555 train_time:27324ms step_avg:41.21ms
+step:664/1555 train_time:27383ms step_avg:41.24ms
+step:665/1555 train_time:27447ms step_avg:41.27ms
+step:666/1555 train_time:27506ms step_avg:41.30ms
+step:667/1555 train_time:27569ms step_avg:41.33ms
+step:668/1555 train_time:27628ms step_avg:41.36ms
+step:669/1555 train_time:27691ms step_avg:41.39ms
+step:670/1555 train_time:27750ms step_avg:41.42ms
+step:671/1555 train_time:27814ms step_avg:41.45ms
+step:672/1555 train_time:27873ms step_avg:41.48ms
+step:673/1555 train_time:27938ms step_avg:41.51ms
+step:674/1555 train_time:27997ms step_avg:41.54ms
+step:675/1555 train_time:28060ms step_avg:41.57ms
+step:676/1555 train_time:28119ms step_avg:41.60ms
+step:677/1555 train_time:28183ms step_avg:41.63ms
+step:678/1555 train_time:28243ms step_avg:41.66ms
+step:679/1555 train_time:28307ms step_avg:41.69ms
+step:680/1555 train_time:28365ms step_avg:41.71ms
+step:681/1555 train_time:28428ms step_avg:41.74ms
+step:682/1555 train_time:28487ms step_avg:41.77ms
+step:683/1555 train_time:28550ms step_avg:41.80ms
+step:684/1555 train_time:28609ms step_avg:41.83ms
+step:685/1555 train_time:28674ms step_avg:41.86ms
+step:686/1555 train_time:28732ms step_avg:41.88ms
+step:687/1555 train_time:28796ms step_avg:41.92ms
+step:688/1555 train_time:28855ms step_avg:41.94ms
+step:689/1555 train_time:28919ms step_avg:41.97ms
+step:690/1555 train_time:28978ms step_avg:42.00ms
+step:691/1555 train_time:29043ms step_avg:42.03ms
+step:692/1555 train_time:29101ms step_avg:42.05ms
+step:693/1555 train_time:29163ms step_avg:42.08ms
+step:694/1555 train_time:29222ms step_avg:42.11ms
+step:695/1555 train_time:29286ms step_avg:42.14ms
+step:696/1555 train_time:29346ms step_avg:42.16ms
+step:697/1555 train_time:29408ms step_avg:42.19ms
+step:698/1555 train_time:29467ms step_avg:42.22ms
+step:699/1555 train_time:29530ms step_avg:42.25ms
+step:700/1555 train_time:29589ms step_avg:42.27ms
+step:701/1555 train_time:29652ms step_avg:42.30ms
+step:702/1555 train_time:29713ms step_avg:42.33ms
+step:703/1555 train_time:29775ms step_avg:42.35ms
+step:704/1555 train_time:29834ms step_avg:42.38ms
+step:705/1555 train_time:29897ms step_avg:42.41ms
+step:706/1555 train_time:29957ms step_avg:42.43ms
+step:707/1555 train_time:30021ms step_avg:42.46ms
+step:708/1555 train_time:30080ms step_avg:42.49ms
+step:709/1555 train_time:30145ms step_avg:42.52ms
+step:710/1555 train_time:30204ms step_avg:42.54ms
+step:711/1555 train_time:30267ms step_avg:42.57ms
+step:712/1555 train_time:30326ms step_avg:42.59ms
+step:713/1555 train_time:30389ms step_avg:42.62ms
+step:714/1555 train_time:30448ms step_avg:42.64ms
+step:715/1555 train_time:30511ms step_avg:42.67ms
+step:716/1555 train_time:30572ms step_avg:42.70ms
+step:717/1555 train_time:30634ms step_avg:42.73ms
+step:718/1555 train_time:30694ms step_avg:42.75ms
+step:719/1555 train_time:30757ms step_avg:42.78ms
+step:720/1555 train_time:30816ms step_avg:42.80ms
+step:721/1555 train_time:30880ms step_avg:42.83ms
+step:722/1555 train_time:30939ms step_avg:42.85ms
+step:723/1555 train_time:31004ms step_avg:42.88ms
+step:724/1555 train_time:31062ms step_avg:42.90ms
+step:725/1555 train_time:31125ms step_avg:42.93ms
+step:726/1555 train_time:31185ms step_avg:42.95ms
+step:727/1555 train_time:31248ms step_avg:42.98ms
+step:728/1555 train_time:31308ms step_avg:43.01ms
+step:729/1555 train_time:31372ms step_avg:43.03ms
+step:730/1555 train_time:31432ms step_avg:43.06ms
+step:731/1555 train_time:31495ms step_avg:43.08ms
+step:732/1555 train_time:31554ms step_avg:43.11ms
+step:733/1555 train_time:31618ms step_avg:43.13ms
+step:734/1555 train_time:31677ms step_avg:43.16ms
+step:735/1555 train_time:31740ms step_avg:43.18ms
+step:736/1555 train_time:31799ms step_avg:43.21ms
+step:737/1555 train_time:31864ms step_avg:43.23ms
+step:738/1555 train_time:31922ms step_avg:43.25ms
+step:739/1555 train_time:31985ms step_avg:43.28ms
+step:740/1555 train_time:32044ms step_avg:43.30ms
+step:741/1555 train_time:32107ms step_avg:43.33ms
+step:742/1555 train_time:32167ms step_avg:43.35ms
+step:743/1555 train_time:32230ms step_avg:43.38ms
+step:744/1555 train_time:32290ms step_avg:43.40ms
+step:745/1555 train_time:32352ms step_avg:43.43ms
+step:746/1555 train_time:32411ms step_avg:43.45ms
+step:747/1555 train_time:32474ms step_avg:43.47ms
+step:748/1555 train_time:32533ms step_avg:43.49ms
+step:749/1555 train_time:32596ms step_avg:43.52ms
+step:750/1555 train_time:32656ms step_avg:43.54ms
+step:750/1555 val_loss:3.8791 train_time:32705ms step_avg:43.61ms
+step:751/1555 train_time:32726ms step_avg:43.58ms
+step:752/1555 train_time:32783ms step_avg:43.59ms
+step:753/1555 train_time:32850ms step_avg:43.63ms
+step:754/1555 train_time:32910ms step_avg:43.65ms
+step:755/1555 train_time:32973ms step_avg:43.67ms
+step:756/1555 train_time:33034ms step_avg:43.70ms
+step:757/1555 train_time:33096ms step_avg:43.72ms
+step:758/1555 train_time:33156ms step_avg:43.74ms
+step:759/1555 train_time:33219ms step_avg:43.77ms
+step:760/1555 train_time:33277ms step_avg:43.79ms
+step:761/1555 train_time:33340ms step_avg:43.81ms
+step:762/1555 train_time:33399ms step_avg:43.83ms
+step:763/1555 train_time:33462ms step_avg:43.86ms
+step:764/1555 train_time:33521ms step_avg:43.88ms
+step:765/1555 train_time:33585ms step_avg:43.90ms
+step:766/1555 train_time:33644ms step_avg:43.92ms
+step:767/1555 train_time:33708ms step_avg:43.95ms
+step:768/1555 train_time:33768ms step_avg:43.97ms
+step:769/1555 train_time:33832ms step_avg:44.00ms
+step:770/1555 train_time:33892ms step_avg:44.02ms
+step:771/1555 train_time:33955ms step_avg:44.04ms
+step:772/1555 train_time:34015ms step_avg:44.06ms
+step:773/1555 train_time:34079ms step_avg:44.09ms
+step:774/1555 train_time:34137ms step_avg:44.10ms
+step:775/1555 train_time:34201ms step_avg:44.13ms
+step:776/1555 train_time:34260ms step_avg:44.15ms
+step:777/1555 train_time:34323ms step_avg:44.17ms
+step:778/1555 train_time:34382ms step_avg:44.19ms
+step:779/1555 train_time:34445ms step_avg:44.22ms
+step:780/1555 train_time:34504ms step_avg:44.24ms
+step:781/1555 train_time:34568ms step_avg:44.26ms
+step:782/1555 train_time:34627ms step_avg:44.28ms
+step:783/1555 train_time:34691ms step_avg:44.30ms
+step:784/1555 train_time:34750ms step_avg:44.32ms
+step:785/1555 train_time:34814ms step_avg:44.35ms
+step:786/1555 train_time:34873ms step_avg:44.37ms
+step:787/1555 train_time:34937ms step_avg:44.39ms
+step:788/1555 train_time:34996ms step_avg:44.41ms
+step:789/1555 train_time:35062ms step_avg:44.44ms
+step:790/1555 train_time:35120ms step_avg:44.46ms
+step:791/1555 train_time:35184ms step_avg:44.48ms
+step:792/1555 train_time:35243ms step_avg:44.50ms
+step:793/1555 train_time:35306ms step_avg:44.52ms
+step:794/1555 train_time:35365ms step_avg:44.54ms
+step:795/1555 train_time:35428ms step_avg:44.56ms
+step:796/1555 train_time:35487ms step_avg:44.58ms
+step:797/1555 train_time:35550ms step_avg:44.60ms
+step:798/1555 train_time:35610ms step_avg:44.62ms
+step:799/1555 train_time:35672ms step_avg:44.65ms
+step:800/1555 train_time:35732ms step_avg:44.66ms
+step:801/1555 train_time:35796ms step_avg:44.69ms
+step:802/1555 train_time:35855ms step_avg:44.71ms
+step:803/1555 train_time:35919ms step_avg:44.73ms
+step:804/1555 train_time:35979ms step_avg:44.75ms
+step:805/1555 train_time:36043ms step_avg:44.77ms
+step:806/1555 train_time:36104ms step_avg:44.79ms
+step:807/1555 train_time:36166ms step_avg:44.82ms
+step:808/1555 train_time:36225ms step_avg:44.83ms
+step:809/1555 train_time:36288ms step_avg:44.86ms
+step:810/1555 train_time:36349ms step_avg:44.87ms
+step:811/1555 train_time:36411ms step_avg:44.90ms
+step:812/1555 train_time:36470ms step_avg:44.91ms
+step:813/1555 train_time:36533ms step_avg:44.94ms
+step:814/1555 train_time:36592ms step_avg:44.95ms
+step:815/1555 train_time:36655ms step_avg:44.98ms
+step:816/1555 train_time:36714ms step_avg:44.99ms
+step:817/1555 train_time:36777ms step_avg:45.01ms
+step:818/1555 train_time:36837ms step_avg:45.03ms
+step:819/1555 train_time:36900ms step_avg:45.06ms
+step:820/1555 train_time:36961ms step_avg:45.07ms
+step:821/1555 train_time:37024ms step_avg:45.10ms
+step:822/1555 train_time:37084ms step_avg:45.11ms
+step:823/1555 train_time:37149ms step_avg:45.14ms
+step:824/1555 train_time:37207ms step_avg:45.15ms
+step:825/1555 train_time:37270ms step_avg:45.18ms
+step:826/1555 train_time:37330ms step_avg:45.19ms
+step:827/1555 train_time:37393ms step_avg:45.21ms
+step:828/1555 train_time:37452ms step_avg:45.23ms
+step:829/1555 train_time:37515ms step_avg:45.25ms
+step:830/1555 train_time:37574ms step_avg:45.27ms
+step:831/1555 train_time:37638ms step_avg:45.29ms
+step:832/1555 train_time:37697ms step_avg:45.31ms
+step:833/1555 train_time:37761ms step_avg:45.33ms
+step:834/1555 train_time:37820ms step_avg:45.35ms
+step:835/1555 train_time:37884ms step_avg:45.37ms
+step:836/1555 train_time:37944ms step_avg:45.39ms
+step:837/1555 train_time:38007ms step_avg:45.41ms
+step:838/1555 train_time:38066ms step_avg:45.43ms
+step:839/1555 train_time:38130ms step_avg:45.45ms
+step:840/1555 train_time:38189ms step_avg:45.46ms
+step:841/1555 train_time:38253ms step_avg:45.49ms
+step:842/1555 train_time:38311ms step_avg:45.50ms
+step:843/1555 train_time:38374ms step_avg:45.52ms
+step:844/1555 train_time:38434ms step_avg:45.54ms
+step:845/1555 train_time:38496ms step_avg:45.56ms
+step:846/1555 train_time:38555ms step_avg:45.57ms
+step:847/1555 train_time:38619ms step_avg:45.59ms
+step:848/1555 train_time:38677ms step_avg:45.61ms
+step:849/1555 train_time:38741ms step_avg:45.63ms
+step:850/1555 train_time:38801ms step_avg:45.65ms
+step:851/1555 train_time:38865ms step_avg:45.67ms
+step:852/1555 train_time:38924ms step_avg:45.69ms
+step:853/1555 train_time:38987ms step_avg:45.71ms
+step:854/1555 train_time:39046ms step_avg:45.72ms
+step:855/1555 train_time:39111ms step_avg:45.74ms
+step:856/1555 train_time:39170ms step_avg:45.76ms
+step:857/1555 train_time:39233ms step_avg:45.78ms
+step:858/1555 train_time:39292ms step_avg:45.79ms
+step:859/1555 train_time:39355ms step_avg:45.82ms
+step:860/1555 train_time:39415ms step_avg:45.83ms
+step:861/1555 train_time:39478ms step_avg:45.85ms
+step:862/1555 train_time:39537ms step_avg:45.87ms
+step:863/1555 train_time:39601ms step_avg:45.89ms
+step:864/1555 train_time:39660ms step_avg:45.90ms
+step:865/1555 train_time:39724ms step_avg:45.92ms
+step:866/1555 train_time:39783ms step_avg:45.94ms
+step:867/1555 train_time:39846ms step_avg:45.96ms
+step:868/1555 train_time:39905ms step_avg:45.97ms
+step:869/1555 train_time:39968ms step_avg:45.99ms
+step:870/1555 train_time:40028ms step_avg:46.01ms
+step:871/1555 train_time:40093ms step_avg:46.03ms
+step:872/1555 train_time:40151ms step_avg:46.05ms
+step:873/1555 train_time:40215ms step_avg:46.06ms
+step:874/1555 train_time:40274ms step_avg:46.08ms
+step:875/1555 train_time:40336ms step_avg:46.10ms
+step:876/1555 train_time:40396ms step_avg:46.11ms
+step:877/1555 train_time:40459ms step_avg:46.13ms
+step:878/1555 train_time:40518ms step_avg:46.15ms
+step:879/1555 train_time:40581ms step_avg:46.17ms
+step:880/1555 train_time:40640ms step_avg:46.18ms
+step:881/1555 train_time:40705ms step_avg:46.20ms
+step:882/1555 train_time:40763ms step_avg:46.22ms
+step:883/1555 train_time:40830ms step_avg:46.24ms
+step:884/1555 train_time:40889ms step_avg:46.25ms
+step:885/1555 train_time:40950ms step_avg:46.27ms
+step:886/1555 train_time:41009ms step_avg:46.29ms
+step:887/1555 train_time:41073ms step_avg:46.31ms
+step:888/1555 train_time:41132ms step_avg:46.32ms
+step:889/1555 train_time:41195ms step_avg:46.34ms
+step:890/1555 train_time:41254ms step_avg:46.35ms
+step:891/1555 train_time:41318ms step_avg:46.37ms
+step:892/1555 train_time:41376ms step_avg:46.39ms
+step:893/1555 train_time:41440ms step_avg:46.41ms
+step:894/1555 train_time:41499ms step_avg:46.42ms
+step:895/1555 train_time:41562ms step_avg:46.44ms
+step:896/1555 train_time:41622ms step_avg:46.45ms
+step:897/1555 train_time:41686ms step_avg:46.47ms
+step:898/1555 train_time:41745ms step_avg:46.49ms
+step:899/1555 train_time:41808ms step_avg:46.51ms
+step:900/1555 train_time:41868ms step_avg:46.52ms
+step:901/1555 train_time:41933ms step_avg:46.54ms
+step:902/1555 train_time:41991ms step_avg:46.55ms
+step:903/1555 train_time:42053ms step_avg:46.57ms
+step:904/1555 train_time:42113ms step_avg:46.59ms
+step:905/1555 train_time:42176ms step_avg:46.60ms
+step:906/1555 train_time:42236ms step_avg:46.62ms
+step:907/1555 train_time:42299ms step_avg:46.64ms
+step:908/1555 train_time:42359ms step_avg:46.65ms
+step:909/1555 train_time:42422ms step_avg:46.67ms
+step:910/1555 train_time:42482ms step_avg:46.68ms
+step:911/1555 train_time:42545ms step_avg:46.70ms
+step:912/1555 train_time:42604ms step_avg:46.72ms
+step:913/1555 train_time:42668ms step_avg:46.73ms
+step:914/1555 train_time:42728ms step_avg:46.75ms
+step:915/1555 train_time:42791ms step_avg:46.77ms
+step:916/1555 train_time:42850ms step_avg:46.78ms
+step:917/1555 train_time:42914ms step_avg:46.80ms
+step:918/1555 train_time:42973ms step_avg:46.81ms
+step:919/1555 train_time:43037ms step_avg:46.83ms
+step:920/1555 train_time:43097ms step_avg:46.84ms
+step:921/1555 train_time:43160ms step_avg:46.86ms
+step:922/1555 train_time:43219ms step_avg:46.87ms
+step:923/1555 train_time:43282ms step_avg:46.89ms
+step:924/1555 train_time:43342ms step_avg:46.91ms
+step:925/1555 train_time:43405ms step_avg:46.92ms
+step:926/1555 train_time:43464ms step_avg:46.94ms
+step:927/1555 train_time:43527ms step_avg:46.95ms
+step:928/1555 train_time:43586ms step_avg:46.97ms
+step:929/1555 train_time:43649ms step_avg:46.99ms
+step:930/1555 train_time:43709ms step_avg:47.00ms
+step:931/1555 train_time:43771ms step_avg:47.02ms
+step:932/1555 train_time:43832ms step_avg:47.03ms
+step:933/1555 train_time:43894ms step_avg:47.05ms
+step:934/1555 train_time:43953ms step_avg:47.06ms
+step:935/1555 train_time:44016ms step_avg:47.08ms
+step:936/1555 train_time:44076ms step_avg:47.09ms
+step:937/1555 train_time:44139ms step_avg:47.11ms
+step:938/1555 train_time:44198ms step_avg:47.12ms
+step:939/1555 train_time:44261ms step_avg:47.14ms
+step:940/1555 train_time:44320ms step_avg:47.15ms
+step:941/1555 train_time:44384ms step_avg:47.17ms
+step:942/1555 train_time:44443ms step_avg:47.18ms
+step:943/1555 train_time:44507ms step_avg:47.20ms
+step:944/1555 train_time:44568ms step_avg:47.21ms
+step:945/1555 train_time:44630ms step_avg:47.23ms
+step:946/1555 train_time:44689ms step_avg:47.24ms
+step:947/1555 train_time:44753ms step_avg:47.26ms
+step:948/1555 train_time:44812ms step_avg:47.27ms
+step:949/1555 train_time:44875ms step_avg:47.29ms
+step:950/1555 train_time:44934ms step_avg:47.30ms
+step:951/1555 train_time:44997ms step_avg:47.32ms
+step:952/1555 train_time:45057ms step_avg:47.33ms
+step:953/1555 train_time:45120ms step_avg:47.34ms
+step:954/1555 train_time:45179ms step_avg:47.36ms
+step:955/1555 train_time:45242ms step_avg:47.37ms
+step:956/1555 train_time:45303ms step_avg:47.39ms
+step:957/1555 train_time:45366ms step_avg:47.40ms
+step:958/1555 train_time:45425ms step_avg:47.42ms
+step:959/1555 train_time:45488ms step_avg:47.43ms
+step:960/1555 train_time:45548ms step_avg:47.45ms
+step:961/1555 train_time:45612ms step_avg:47.46ms
+step:962/1555 train_time:45671ms step_avg:47.48ms
+step:963/1555 train_time:45735ms step_avg:47.49ms
+step:964/1555 train_time:45794ms step_avg:47.50ms
+step:965/1555 train_time:45857ms step_avg:47.52ms
+step:966/1555 train_time:45916ms step_avg:47.53ms
+step:967/1555 train_time:45979ms step_avg:47.55ms
+step:968/1555 train_time:46040ms step_avg:47.56ms
+step:969/1555 train_time:46102ms step_avg:47.58ms
+step:970/1555 train_time:46161ms step_avg:47.59ms
+step:971/1555 train_time:46225ms step_avg:47.61ms
+step:972/1555 train_time:46285ms step_avg:47.62ms
+step:973/1555 train_time:46348ms step_avg:47.63ms
+step:974/1555 train_time:46407ms step_avg:47.65ms
+step:975/1555 train_time:46470ms step_avg:47.66ms
+step:976/1555 train_time:46529ms step_avg:47.67ms
+step:977/1555 train_time:46593ms step_avg:47.69ms
+step:978/1555 train_time:46653ms step_avg:47.70ms
+step:979/1555 train_time:46715ms step_avg:47.72ms
+step:980/1555 train_time:46776ms step_avg:47.73ms
+step:981/1555 train_time:46838ms step_avg:47.74ms
+step:982/1555 train_time:46897ms step_avg:47.76ms
+step:983/1555 train_time:46960ms step_avg:47.77ms
+step:984/1555 train_time:47019ms step_avg:47.78ms
+step:985/1555 train_time:47083ms step_avg:47.80ms
+step:986/1555 train_time:47143ms step_avg:47.81ms
+step:987/1555 train_time:47206ms step_avg:47.83ms
+step:988/1555 train_time:47266ms step_avg:47.84ms
+step:989/1555 train_time:47329ms step_avg:47.86ms
+step:990/1555 train_time:47388ms step_avg:47.87ms
+step:991/1555 train_time:47451ms step_avg:47.88ms
+step:992/1555 train_time:47512ms step_avg:47.90ms
+step:993/1555 train_time:47574ms step_avg:47.91ms
+step:994/1555 train_time:47633ms step_avg:47.92ms
+step:995/1555 train_time:47696ms step_avg:47.94ms
+step:996/1555 train_time:47756ms step_avg:47.95ms
+step:997/1555 train_time:47819ms step_avg:47.96ms
+step:998/1555 train_time:47878ms step_avg:47.97ms
+step:999/1555 train_time:47942ms step_avg:47.99ms
+step:1000/1555 train_time:48001ms step_avg:48.00ms
+step:1000/1555 val_loss:3.5721 train_time:48050ms step_avg:48.05ms
+step:1001/1555 train_time:48069ms step_avg:48.02ms
+step:1002/1555 train_time:48126ms step_avg:48.03ms
+step:1003/1555 train_time:48192ms step_avg:48.05ms
+step:1004/1555 train_time:48253ms step_avg:48.06ms
+step:1005/1555 train_time:48317ms step_avg:48.08ms
+step:1006/1555 train_time:48377ms step_avg:48.09ms
+step:1007/1555 train_time:48439ms step_avg:48.10ms
+step:1008/1555 train_time:48498ms step_avg:48.11ms
+step:1009/1555 train_time:48562ms step_avg:48.13ms
+step:1010/1555 train_time:48621ms step_avg:48.14ms
+step:1011/1555 train_time:48695ms step_avg:48.17ms
+step:1012/1555 train_time:48777ms step_avg:48.20ms
+step:1013/1555 train_time:48867ms step_avg:48.24ms
+step:1014/1555 train_time:48952ms step_avg:48.28ms
+step:1015/1555 train_time:49043ms step_avg:48.32ms
+step:1016/1555 train_time:49131ms step_avg:48.36ms
+step:1017/1555 train_time:49221ms step_avg:48.40ms
+step:1018/1555 train_time:49308ms step_avg:48.44ms
+step:1019/1555 train_time:49397ms step_avg:48.48ms
+step:1020/1555 train_time:49483ms step_avg:48.51ms
+step:1021/1555 train_time:49573ms step_avg:48.55ms
+step:1022/1555 train_time:49658ms step_avg:48.59ms
+step:1023/1555 train_time:49746ms step_avg:48.63ms
+step:1024/1555 train_time:49832ms step_avg:48.66ms
+step:1025/1555 train_time:49920ms step_avg:48.70ms
+step:1026/1555 train_time:50006ms step_avg:48.74ms
+step:1027/1555 train_time:50098ms step_avg:48.78ms
+step:1028/1555 train_time:50184ms step_avg:48.82ms
+step:1029/1555 train_time:50274ms step_avg:48.86ms
+step:1030/1555 train_time:50361ms step_avg:48.89ms
+step:1031/1555 train_time:50449ms step_avg:48.93ms
+step:1032/1555 train_time:50535ms step_avg:48.97ms
+step:1033/1555 train_time:50624ms step_avg:49.01ms
+step:1034/1555 train_time:50710ms step_avg:49.04ms
+step:1035/1555 train_time:50798ms step_avg:49.08ms
+step:1036/1555 train_time:50883ms step_avg:49.12ms
+step:1037/1555 train_time:50973ms step_avg:49.15ms
+step:1038/1555 train_time:51059ms step_avg:49.19ms
+step:1039/1555 train_time:51149ms step_avg:49.23ms
+step:1040/1555 train_time:51236ms step_avg:49.27ms
+step:1041/1555 train_time:51325ms step_avg:49.30ms
+step:1042/1555 train_time:51412ms step_avg:49.34ms
+step:1043/1555 train_time:51501ms step_avg:49.38ms
+step:1044/1555 train_time:51588ms step_avg:49.41ms
+step:1045/1555 train_time:51678ms step_avg:49.45ms
+step:1046/1555 train_time:51766ms step_avg:49.49ms
+step:1047/1555 train_time:51854ms step_avg:49.53ms
+step:1048/1555 train_time:51938ms step_avg:49.56ms
+step:1049/1555 train_time:52030ms step_avg:49.60ms
+step:1050/1555 train_time:52116ms step_avg:49.63ms
+step:1051/1555 train_time:52205ms step_avg:49.67ms
+step:1052/1555 train_time:52293ms step_avg:49.71ms
+step:1053/1555 train_time:52381ms step_avg:49.74ms
+step:1054/1555 train_time:52467ms step_avg:49.78ms
+step:1055/1555 train_time:52557ms step_avg:49.82ms
+step:1056/1555 train_time:52642ms step_avg:49.85ms
+step:1057/1555 train_time:52731ms step_avg:49.89ms
+step:1058/1555 train_time:52817ms step_avg:49.92ms
+step:1059/1555 train_time:52907ms step_avg:49.96ms
+step:1060/1555 train_time:52992ms step_avg:49.99ms
+step:1061/1555 train_time:53082ms step_avg:50.03ms
+step:1062/1555 train_time:53168ms step_avg:50.06ms
+step:1063/1555 train_time:53257ms step_avg:50.10ms
+step:1064/1555 train_time:53345ms step_avg:50.14ms
+step:1065/1555 train_time:53433ms step_avg:50.17ms
+step:1066/1555 train_time:53519ms step_avg:50.21ms
+step:1067/1555 train_time:53610ms step_avg:50.24ms
+step:1068/1555 train_time:53696ms step_avg:50.28ms
+step:1069/1555 train_time:53786ms step_avg:50.31ms
+step:1070/1555 train_time:53872ms step_avg:50.35ms
+step:1071/1555 train_time:53961ms step_avg:50.38ms
+step:1072/1555 train_time:54048ms step_avg:50.42ms
+step:1073/1555 train_time:54136ms step_avg:50.45ms
+step:1074/1555 train_time:54221ms step_avg:50.48ms
+step:1075/1555 train_time:54310ms step_avg:50.52ms
+step:1076/1555 train_time:54399ms step_avg:50.56ms
+step:1077/1555 train_time:54488ms step_avg:50.59ms
+step:1078/1555 train_time:54574ms step_avg:50.63ms
+step:1079/1555 train_time:54663ms step_avg:50.66ms
+step:1080/1555 train_time:54751ms step_avg:50.70ms
+step:1081/1555 train_time:54842ms step_avg:50.73ms
+step:1082/1555 train_time:54926ms step_avg:50.76ms
+step:1083/1555 train_time:55016ms step_avg:50.80ms
+step:1084/1555 train_time:55103ms step_avg:50.83ms
+step:1085/1555 train_time:55192ms step_avg:50.87ms
+step:1086/1555 train_time:55277ms step_avg:50.90ms
+step:1087/1555 train_time:55367ms step_avg:50.94ms
+step:1088/1555 train_time:55454ms step_avg:50.97ms
+step:1089/1555 train_time:55545ms step_avg:51.01ms
+step:1090/1555 train_time:55630ms step_avg:51.04ms
+step:1091/1555 train_time:55720ms step_avg:51.07ms
+step:1092/1555 train_time:55805ms step_avg:51.10ms
+step:1093/1555 train_time:55897ms step_avg:51.14ms
+step:1094/1555 train_time:55981ms step_avg:51.17ms
+step:1095/1555 train_time:56071ms step_avg:51.21ms
+step:1096/1555 train_time:56157ms step_avg:51.24ms
+step:1097/1555 train_time:56246ms step_avg:51.27ms
+step:1098/1555 train_time:56332ms step_avg:51.30ms
+step:1099/1555 train_time:56421ms step_avg:51.34ms
+step:1100/1555 train_time:56507ms step_avg:51.37ms
+step:1101/1555 train_time:56597ms step_avg:51.41ms
+step:1102/1555 train_time:56684ms step_avg:51.44ms
+step:1103/1555 train_time:56772ms step_avg:51.47ms
+step:1104/1555 train_time:56858ms step_avg:51.50ms
+step:1105/1555 train_time:56948ms step_avg:51.54ms
+step:1106/1555 train_time:57033ms step_avg:51.57ms
+step:1107/1555 train_time:57122ms step_avg:51.60ms
+step:1108/1555 train_time:57208ms step_avg:51.63ms
+step:1109/1555 train_time:57299ms step_avg:51.67ms
+step:1110/1555 train_time:57385ms step_avg:51.70ms
+step:1111/1555 train_time:57475ms step_avg:51.73ms
+step:1112/1555 train_time:57560ms step_avg:51.76ms
+step:1113/1555 train_time:57649ms step_avg:51.80ms
+step:1114/1555 train_time:57735ms step_avg:51.83ms
+step:1115/1555 train_time:57825ms step_avg:51.86ms
+step:1116/1555 train_time:57911ms step_avg:51.89ms
+step:1117/1555 train_time:58001ms step_avg:51.93ms
+step:1118/1555 train_time:58087ms step_avg:51.96ms
+step:1119/1555 train_time:58177ms step_avg:51.99ms
+step:1120/1555 train_time:58262ms step_avg:52.02ms
+step:1121/1555 train_time:58352ms step_avg:52.05ms
+step:1122/1555 train_time:58437ms step_avg:52.08ms
+step:1123/1555 train_time:58527ms step_avg:52.12ms
+step:1124/1555 train_time:58613ms step_avg:52.15ms
+step:1125/1555 train_time:58703ms step_avg:52.18ms
+step:1126/1555 train_time:58789ms step_avg:52.21ms
+step:1127/1555 train_time:58879ms step_avg:52.24ms
+step:1128/1555 train_time:58964ms step_avg:52.27ms
+step:1129/1555 train_time:59053ms step_avg:52.31ms
+step:1130/1555 train_time:59140ms step_avg:52.34ms
+step:1131/1555 train_time:59229ms step_avg:52.37ms
+step:1132/1555 train_time:59315ms step_avg:52.40ms
+step:1133/1555 train_time:59404ms step_avg:52.43ms
+step:1134/1555 train_time:59490ms step_avg:52.46ms
+step:1135/1555 train_time:59580ms step_avg:52.49ms
+step:1136/1555 train_time:59665ms step_avg:52.52ms
+step:1137/1555 train_time:59755ms step_avg:52.56ms
+step:1138/1555 train_time:59840ms step_avg:52.58ms
+step:1139/1555 train_time:59933ms step_avg:52.62ms
+step:1140/1555 train_time:60018ms step_avg:52.65ms
+step:1141/1555 train_time:60106ms step_avg:52.68ms
+step:1142/1555 train_time:60192ms step_avg:52.71ms
+step:1143/1555 train_time:60281ms step_avg:52.74ms
+step:1144/1555 train_time:60367ms step_avg:52.77ms
+step:1145/1555 train_time:60458ms step_avg:52.80ms
+step:1146/1555 train_time:60543ms step_avg:52.83ms
+step:1147/1555 train_time:60633ms step_avg:52.86ms
+step:1148/1555 train_time:60720ms step_avg:52.89ms
+step:1149/1555 train_time:60808ms step_avg:52.92ms
+step:1150/1555 train_time:60895ms step_avg:52.95ms
+step:1151/1555 train_time:60983ms step_avg:52.98ms
+step:1152/1555 train_time:61069ms step_avg:53.01ms
+step:1153/1555 train_time:61158ms step_avg:53.04ms
+step:1154/1555 train_time:61245ms step_avg:53.07ms
+step:1155/1555 train_time:61333ms step_avg:53.10ms
+step:1156/1555 train_time:61419ms step_avg:53.13ms
+step:1157/1555 train_time:61511ms step_avg:53.16ms
+step:1158/1555 train_time:61595ms step_avg:53.19ms
+step:1159/1555 train_time:61685ms step_avg:53.22ms
+step:1160/1555 train_time:61769ms step_avg:53.25ms
+step:1161/1555 train_time:61861ms step_avg:53.28ms
+step:1162/1555 train_time:61945ms step_avg:53.31ms
+step:1163/1555 train_time:62034ms step_avg:53.34ms
+step:1164/1555 train_time:62120ms step_avg:53.37ms
+step:1165/1555 train_time:62208ms step_avg:53.40ms
+step:1166/1555 train_time:62294ms step_avg:53.43ms
+step:1167/1555 train_time:62384ms step_avg:53.46ms
+step:1168/1555 train_time:62470ms step_avg:53.48ms
+step:1169/1555 train_time:62560ms step_avg:53.52ms
+step:1170/1555 train_time:62647ms step_avg:53.54ms
+step:1171/1555 train_time:62736ms step_avg:53.57ms
+step:1172/1555 train_time:62822ms step_avg:53.60ms
+step:1173/1555 train_time:62911ms step_avg:53.63ms
+step:1174/1555 train_time:62996ms step_avg:53.66ms
+step:1175/1555 train_time:63087ms step_avg:53.69ms
+step:1176/1555 train_time:63172ms step_avg:53.72ms
+step:1177/1555 train_time:63261ms step_avg:53.75ms
+step:1178/1555 train_time:63347ms step_avg:53.77ms
+step:1179/1555 train_time:63436ms step_avg:53.80ms
+step:1180/1555 train_time:63521ms step_avg:53.83ms
+step:1181/1555 train_time:63611ms step_avg:53.86ms
+step:1182/1555 train_time:63698ms step_avg:53.89ms
+step:1183/1555 train_time:63788ms step_avg:53.92ms
+step:1184/1555 train_time:63872ms step_avg:53.95ms
+step:1185/1555 train_time:63962ms step_avg:53.98ms
+step:1186/1555 train_time:64050ms step_avg:54.00ms
+step:1187/1555 train_time:64139ms step_avg:54.03ms
+step:1188/1555 train_time:64225ms step_avg:54.06ms
+step:1189/1555 train_time:64316ms step_avg:54.09ms
+step:1190/1555 train_time:64401ms step_avg:54.12ms
+step:1191/1555 train_time:64490ms step_avg:54.15ms
+step:1192/1555 train_time:64576ms step_avg:54.17ms
+step:1193/1555 train_time:64666ms step_avg:54.20ms
+step:1194/1555 train_time:64754ms step_avg:54.23ms
+step:1195/1555 train_time:64842ms step_avg:54.26ms
+step:1196/1555 train_time:64928ms step_avg:54.29ms
+step:1197/1555 train_time:65018ms step_avg:54.32ms
+step:1198/1555 train_time:65104ms step_avg:54.34ms
+step:1199/1555 train_time:65194ms step_avg:54.37ms
+step:1200/1555 train_time:65279ms step_avg:54.40ms
+step:1201/1555 train_time:65369ms step_avg:54.43ms
+step:1202/1555 train_time:65455ms step_avg:54.45ms
+step:1203/1555 train_time:65544ms step_avg:54.48ms
+step:1204/1555 train_time:65630ms step_avg:54.51ms
+step:1205/1555 train_time:65721ms step_avg:54.54ms
+step:1206/1555 train_time:65805ms step_avg:54.56ms
+step:1207/1555 train_time:65895ms step_avg:54.59ms
+step:1208/1555 train_time:65980ms step_avg:54.62ms
+step:1209/1555 train_time:66071ms step_avg:54.65ms
+step:1210/1555 train_time:66157ms step_avg:54.67ms
+step:1211/1555 train_time:66246ms step_avg:54.70ms
+step:1212/1555 train_time:66332ms step_avg:54.73ms
+step:1213/1555 train_time:66421ms step_avg:54.76ms
+step:1214/1555 train_time:66508ms step_avg:54.78ms
+step:1215/1555 train_time:66599ms step_avg:54.81ms
+step:1216/1555 train_time:66684ms step_avg:54.84ms
+step:1217/1555 train_time:66773ms step_avg:54.87ms
+step:1218/1555 train_time:66860ms step_avg:54.89ms
+step:1219/1555 train_time:66948ms step_avg:54.92ms
+step:1220/1555 train_time:67033ms step_avg:54.95ms
+step:1221/1555 train_time:67122ms step_avg:54.97ms
+step:1222/1555 train_time:67210ms step_avg:55.00ms
+step:1223/1555 train_time:67298ms step_avg:55.03ms
+step:1224/1555 train_time:67385ms step_avg:55.05ms
+step:1225/1555 train_time:67476ms step_avg:55.08ms
+step:1226/1555 train_time:67560ms step_avg:55.11ms
+step:1227/1555 train_time:67650ms step_avg:55.13ms
+step:1228/1555 train_time:67735ms step_avg:55.16ms
+step:1229/1555 train_time:67825ms step_avg:55.19ms
+step:1230/1555 train_time:67911ms step_avg:55.21ms
+step:1231/1555 train_time:68000ms step_avg:55.24ms
+step:1232/1555 train_time:68086ms step_avg:55.26ms
+step:1233/1555 train_time:68176ms step_avg:55.29ms
+step:1234/1555 train_time:68263ms step_avg:55.32ms
+step:1235/1555 train_time:68352ms step_avg:55.35ms
+step:1236/1555 train_time:68437ms step_avg:55.37ms
+step:1237/1555 train_time:68527ms step_avg:55.40ms
+step:1238/1555 train_time:68613ms step_avg:55.42ms
+step:1239/1555 train_time:68703ms step_avg:55.45ms
+step:1240/1555 train_time:68789ms step_avg:55.48ms
+step:1241/1555 train_time:68879ms step_avg:55.50ms
+step:1242/1555 train_time:68965ms step_avg:55.53ms
+step:1243/1555 train_time:69056ms step_avg:55.56ms
+step:1244/1555 train_time:69141ms step_avg:55.58ms
+step:1245/1555 train_time:69231ms step_avg:55.61ms
+step:1246/1555 train_time:69317ms step_avg:55.63ms
+step:1247/1555 train_time:69406ms step_avg:55.66ms
+step:1248/1555 train_time:69492ms step_avg:55.68ms
+step:1249/1555 train_time:69583ms step_avg:55.71ms
+step:1250/1555 train_time:69668ms step_avg:55.73ms
+step:1250/1555 val_loss:3.3981 train_time:69743ms step_avg:55.79ms
+step:1251/1555 train_time:69768ms step_avg:55.77ms
+step:1252/1555 train_time:69853ms step_avg:55.79ms
+step:1253/1555 train_time:69949ms step_avg:55.83ms
+step:1254/1555 train_time:70033ms step_avg:55.85ms
+step:1255/1555 train_time:70121ms step_avg:55.87ms
+step:1256/1555 train_time:70206ms step_avg:55.90ms
+step:1257/1555 train_time:70296ms step_avg:55.92ms
+step:1258/1555 train_time:70380ms step_avg:55.95ms
+step:1259/1555 train_time:70468ms step_avg:55.97ms
+step:1260/1555 train_time:70553ms step_avg:55.99ms
+step:1261/1555 train_time:70642ms step_avg:56.02ms
+step:1262/1555 train_time:70728ms step_avg:56.04ms
+step:1263/1555 train_time:70820ms step_avg:56.07ms
+step:1264/1555 train_time:70907ms step_avg:56.10ms
+step:1265/1555 train_time:70999ms step_avg:56.13ms
+step:1266/1555 train_time:71084ms step_avg:56.15ms
+step:1267/1555 train_time:71174ms step_avg:56.17ms
+step:1268/1555 train_time:71258ms step_avg:56.20ms
+step:1269/1555 train_time:71349ms step_avg:56.22ms
+step:1270/1555 train_time:71433ms step_avg:56.25ms
+step:1271/1555 train_time:71521ms step_avg:56.27ms
+step:1272/1555 train_time:71606ms step_avg:56.29ms
+step:1273/1555 train_time:71696ms step_avg:56.32ms
+step:1274/1555 train_time:71784ms step_avg:56.35ms
+step:1275/1555 train_time:71875ms step_avg:56.37ms
+step:1276/1555 train_time:71961ms step_avg:56.40ms
+step:1277/1555 train_time:72050ms step_avg:56.42ms
+step:1278/1555 train_time:72137ms step_avg:56.44ms
+step:1279/1555 train_time:72226ms step_avg:56.47ms
+step:1280/1555 train_time:72311ms step_avg:56.49ms
+step:1281/1555 train_time:72401ms step_avg:56.52ms
+step:1282/1555 train_time:72486ms step_avg:56.54ms
+step:1283/1555 train_time:72576ms step_avg:56.57ms
+step:1284/1555 train_time:72661ms step_avg:56.59ms
+step:1285/1555 train_time:72751ms step_avg:56.62ms
+step:1286/1555 train_time:72838ms step_avg:56.64ms
+step:1287/1555 train_time:72928ms step_avg:56.67ms
+step:1288/1555 train_time:73014ms step_avg:56.69ms
+step:1289/1555 train_time:73104ms step_avg:56.71ms
+step:1290/1555 train_time:73189ms step_avg:56.74ms
+step:1291/1555 train_time:73278ms step_avg:56.76ms
+step:1292/1555 train_time:73364ms step_avg:56.78ms
+step:1293/1555 train_time:73452ms step_avg:56.81ms
+step:1294/1555 train_time:73538ms step_avg:56.83ms
+step:1295/1555 train_time:73626ms step_avg:56.85ms
+step:1296/1555 train_time:73713ms step_avg:56.88ms
+step:1297/1555 train_time:73804ms step_avg:56.90ms
+step:1298/1555 train_time:73888ms step_avg:56.92ms
+step:1299/1555 train_time:73978ms step_avg:56.95ms
+step:1300/1555 train_time:74064ms step_avg:56.97ms
+step:1301/1555 train_time:74154ms step_avg:57.00ms
+step:1302/1555 train_time:74239ms step_avg:57.02ms
+step:1303/1555 train_time:74329ms step_avg:57.04ms
+step:1304/1555 train_time:74414ms step_avg:57.07ms
+step:1305/1555 train_time:74503ms step_avg:57.09ms
+step:1306/1555 train_time:74591ms step_avg:57.11ms
+step:1307/1555 train_time:74679ms step_avg:57.14ms
+step:1308/1555 train_time:74766ms step_avg:57.16ms
+step:1309/1555 train_time:74858ms step_avg:57.19ms
+step:1310/1555 train_time:74944ms step_avg:57.21ms
+step:1311/1555 train_time:75033ms step_avg:57.23ms
+step:1312/1555 train_time:75120ms step_avg:57.26ms
+step:1313/1555 train_time:75208ms step_avg:57.28ms
+step:1314/1555 train_time:75294ms step_avg:57.30ms
+step:1315/1555 train_time:75384ms step_avg:57.33ms
+step:1316/1555 train_time:75470ms step_avg:57.35ms
+step:1317/1555 train_time:75559ms step_avg:57.37ms
+step:1318/1555 train_time:75644ms step_avg:57.39ms
+step:1319/1555 train_time:75734ms step_avg:57.42ms
+step:1320/1555 train_time:75822ms step_avg:57.44ms
+step:1321/1555 train_time:75912ms step_avg:57.47ms
+step:1322/1555 train_time:75998ms step_avg:57.49ms
+step:1323/1555 train_time:76088ms step_avg:57.51ms
+step:1324/1555 train_time:76173ms step_avg:57.53ms
+step:1325/1555 train_time:76263ms step_avg:57.56ms
+step:1326/1555 train_time:76349ms step_avg:57.58ms
+step:1327/1555 train_time:76439ms step_avg:57.60ms
+step:1328/1555 train_time:76524ms step_avg:57.62ms
+step:1329/1555 train_time:76613ms step_avg:57.65ms
+step:1330/1555 train_time:76699ms step_avg:57.67ms
+step:1331/1555 train_time:76788ms step_avg:57.69ms
+step:1332/1555 train_time:76875ms step_avg:57.71ms
+step:1333/1555 train_time:76964ms step_avg:57.74ms
+step:1334/1555 train_time:77051ms step_avg:57.76ms
+step:1335/1555 train_time:77140ms step_avg:57.78ms
+step:1336/1555 train_time:77226ms step_avg:57.80ms
+step:1337/1555 train_time:77318ms step_avg:57.83ms
+step:1338/1555 train_time:77402ms step_avg:57.85ms
+step:1339/1555 train_time:77491ms step_avg:57.87ms
+step:1340/1555 train_time:77577ms step_avg:57.89ms
+step:1341/1555 train_time:77666ms step_avg:57.92ms
+step:1342/1555 train_time:77752ms step_avg:57.94ms
+step:1343/1555 train_time:77843ms step_avg:57.96ms
+step:1344/1555 train_time:77927ms step_avg:57.98ms
+step:1345/1555 train_time:78018ms step_avg:58.01ms
+step:1346/1555 train_time:78106ms step_avg:58.03ms
+step:1347/1555 train_time:78196ms step_avg:58.05ms
+step:1348/1555 train_time:78281ms step_avg:58.07ms
+step:1349/1555 train_time:78373ms step_avg:58.10ms
+step:1350/1555 train_time:78458ms step_avg:58.12ms
+step:1351/1555 train_time:78549ms step_avg:58.14ms
+step:1352/1555 train_time:78634ms step_avg:58.16ms
+step:1353/1555 train_time:78723ms step_avg:58.18ms
+step:1354/1555 train_time:78808ms step_avg:58.20ms
+step:1355/1555 train_time:78899ms step_avg:58.23ms
+step:1356/1555 train_time:78985ms step_avg:58.25ms
+step:1357/1555 train_time:79077ms step_avg:58.27ms
+step:1358/1555 train_time:79163ms step_avg:58.29ms
+step:1359/1555 train_time:79254ms step_avg:58.32ms
+step:1360/1555 train_time:79340ms step_avg:58.34ms
+step:1361/1555 train_time:79429ms step_avg:58.36ms
+step:1362/1555 train_time:79515ms step_avg:58.38ms
+step:1363/1555 train_time:79604ms step_avg:58.40ms
+step:1364/1555 train_time:79691ms step_avg:58.42ms
+step:1365/1555 train_time:79779ms step_avg:58.45ms
+step:1366/1555 train_time:79867ms step_avg:58.47ms
+step:1367/1555 train_time:79956ms step_avg:58.49ms
+step:1368/1555 train_time:80042ms step_avg:58.51ms
+step:1369/1555 train_time:80132ms step_avg:58.53ms
+step:1370/1555 train_time:80218ms step_avg:58.55ms
+step:1371/1555 train_time:80307ms step_avg:58.58ms
+step:1372/1555 train_time:80394ms step_avg:58.60ms
+step:1373/1555 train_time:80484ms step_avg:58.62ms
+step:1374/1555 train_time:80568ms step_avg:58.64ms
+step:1375/1555 train_time:80657ms step_avg:58.66ms
+step:1376/1555 train_time:80743ms step_avg:58.68ms
+step:1377/1555 train_time:80832ms step_avg:58.70ms
+step:1378/1555 train_time:80919ms step_avg:58.72ms
+step:1379/1555 train_time:81009ms step_avg:58.75ms
+step:1380/1555 train_time:81096ms step_avg:58.77ms
+step:1381/1555 train_time:81185ms step_avg:58.79ms
+step:1382/1555 train_time:81272ms step_avg:58.81ms
+step:1383/1555 train_time:81361ms step_avg:58.83ms
+step:1384/1555 train_time:81449ms step_avg:58.85ms
+step:1385/1555 train_time:81538ms step_avg:58.87ms
+step:1386/1555 train_time:81625ms step_avg:58.89ms
+step:1387/1555 train_time:81712ms step_avg:58.91ms
+step:1388/1555 train_time:81799ms step_avg:58.93ms
+step:1389/1555 train_time:81889ms step_avg:58.96ms
+step:1390/1555 train_time:81975ms step_avg:58.97ms
+step:1391/1555 train_time:82064ms step_avg:59.00ms
+step:1392/1555 train_time:82150ms step_avg:59.02ms
+step:1393/1555 train_time:82240ms step_avg:59.04ms
+step:1394/1555 train_time:82325ms step_avg:59.06ms
+step:1395/1555 train_time:82415ms step_avg:59.08ms
+step:1396/1555 train_time:82501ms step_avg:59.10ms
+step:1397/1555 train_time:82591ms step_avg:59.12ms
+step:1398/1555 train_time:82677ms step_avg:59.14ms
+step:1399/1555 train_time:82765ms step_avg:59.16ms
+step:1400/1555 train_time:82851ms step_avg:59.18ms
+step:1401/1555 train_time:82940ms step_avg:59.20ms
+step:1402/1555 train_time:83026ms step_avg:59.22ms
+step:1403/1555 train_time:83116ms step_avg:59.24ms
+step:1404/1555 train_time:83202ms step_avg:59.26ms
+step:1405/1555 train_time:83292ms step_avg:59.28ms
+step:1406/1555 train_time:83378ms step_avg:59.30ms
+step:1407/1555 train_time:83468ms step_avg:59.32ms
+step:1408/1555 train_time:83554ms step_avg:59.34ms
+step:1409/1555 train_time:83643ms step_avg:59.36ms
+step:1410/1555 train_time:83728ms step_avg:59.38ms
+step:1411/1555 train_time:83819ms step_avg:59.40ms
+step:1412/1555 train_time:83903ms step_avg:59.42ms
+step:1413/1555 train_time:83992ms step_avg:59.44ms
+step:1414/1555 train_time:84078ms step_avg:59.46ms
+step:1415/1555 train_time:84168ms step_avg:59.48ms
+step:1416/1555 train_time:84253ms step_avg:59.50ms
+step:1417/1555 train_time:84343ms step_avg:59.52ms
+step:1418/1555 train_time:84429ms step_avg:59.54ms
+step:1419/1555 train_time:84519ms step_avg:59.56ms
+step:1420/1555 train_time:84605ms step_avg:59.58ms
+step:1421/1555 train_time:84695ms step_avg:59.60ms
+step:1422/1555 train_time:84780ms step_avg:59.62ms
+step:1423/1555 train_time:84872ms step_avg:59.64ms
+step:1424/1555 train_time:84956ms step_avg:59.66ms
+step:1425/1555 train_time:85047ms step_avg:59.68ms
+step:1426/1555 train_time:85132ms step_avg:59.70ms
+step:1427/1555 train_time:85222ms step_avg:59.72ms
+step:1428/1555 train_time:85309ms step_avg:59.74ms
+step:1429/1555 train_time:85398ms step_avg:59.76ms
+step:1430/1555 train_time:85483ms step_avg:59.78ms
+step:1431/1555 train_time:85573ms step_avg:59.80ms
+step:1432/1555 train_time:85659ms step_avg:59.82ms
+step:1433/1555 train_time:85748ms step_avg:59.84ms
+step:1434/1555 train_time:85834ms step_avg:59.86ms
+step:1435/1555 train_time:85923ms step_avg:59.88ms
+step:1436/1555 train_time:86008ms step_avg:59.89ms
+step:1437/1555 train_time:86099ms step_avg:59.92ms
+step:1438/1555 train_time:86185ms step_avg:59.93ms
+step:1439/1555 train_time:86274ms step_avg:59.95ms
+step:1440/1555 train_time:86360ms step_avg:59.97ms
+step:1441/1555 train_time:86449ms step_avg:59.99ms
+step:1442/1555 train_time:86535ms step_avg:60.01ms
+step:1443/1555 train_time:86626ms step_avg:60.03ms
+step:1444/1555 train_time:86711ms step_avg:60.05ms
+step:1445/1555 train_time:86800ms step_avg:60.07ms
+step:1446/1555 train_time:86887ms step_avg:60.09ms
+step:1447/1555 train_time:86977ms step_avg:60.11ms
+step:1448/1555 train_time:87062ms step_avg:60.13ms
+step:1449/1555 train_time:87152ms step_avg:60.15ms
+step:1450/1555 train_time:87238ms step_avg:60.16ms
+step:1451/1555 train_time:87327ms step_avg:60.18ms
+step:1452/1555 train_time:87413ms step_avg:60.20ms
+step:1453/1555 train_time:87502ms step_avg:60.22ms
+step:1454/1555 train_time:87588ms step_avg:60.24ms
+step:1455/1555 train_time:87679ms step_avg:60.26ms
+step:1456/1555 train_time:87764ms step_avg:60.28ms
+step:1457/1555 train_time:87855ms step_avg:60.30ms
+step:1458/1555 train_time:87940ms step_avg:60.32ms
+step:1459/1555 train_time:88030ms step_avg:60.34ms
+step:1460/1555 train_time:88116ms step_avg:60.35ms
+step:1461/1555 train_time:88206ms step_avg:60.37ms
+step:1462/1555 train_time:88291ms step_avg:60.39ms
+step:1463/1555 train_time:88380ms step_avg:60.41ms
+step:1464/1555 train_time:88466ms step_avg:60.43ms
+step:1465/1555 train_time:88556ms step_avg:60.45ms
+step:1466/1555 train_time:88643ms step_avg:60.47ms
+step:1467/1555 train_time:88730ms step_avg:60.48ms
+step:1468/1555 train_time:88816ms step_avg:60.50ms
+step:1469/1555 train_time:88905ms step_avg:60.52ms
+step:1470/1555 train_time:88992ms step_avg:60.54ms
+step:1471/1555 train_time:89082ms step_avg:60.56ms
+step:1472/1555 train_time:89169ms step_avg:60.58ms
+step:1473/1555 train_time:89258ms step_avg:60.60ms
+step:1474/1555 train_time:89344ms step_avg:60.61ms
+step:1475/1555 train_time:89433ms step_avg:60.63ms
+step:1476/1555 train_time:89520ms step_avg:60.65ms
+step:1477/1555 train_time:89608ms step_avg:60.67ms
+step:1478/1555 train_time:89693ms step_avg:60.69ms
+step:1479/1555 train_time:89783ms step_avg:60.71ms
+step:1480/1555 train_time:89869ms step_avg:60.72ms
+step:1481/1555 train_time:89959ms step_avg:60.74ms
+step:1482/1555 train_time:90045ms step_avg:60.76ms
+step:1483/1555 train_time:90134ms step_avg:60.78ms
+step:1484/1555 train_time:90220ms step_avg:60.80ms
+step:1485/1555 train_time:90310ms step_avg:60.82ms
+step:1486/1555 train_time:90395ms step_avg:60.83ms
+step:1487/1555 train_time:90487ms step_avg:60.85ms
+step:1488/1555 train_time:90572ms step_avg:60.87ms
+step:1489/1555 train_time:90662ms step_avg:60.89ms
+step:1490/1555 train_time:90747ms step_avg:60.90ms
+step:1491/1555 train_time:90840ms step_avg:60.93ms
+step:1492/1555 train_time:90924ms step_avg:60.94ms
+step:1493/1555 train_time:91013ms step_avg:60.96ms
+step:1494/1555 train_time:91099ms step_avg:60.98ms
+step:1495/1555 train_time:91188ms step_avg:61.00ms
+step:1496/1555 train_time:91275ms step_avg:61.01ms
+step:1497/1555 train_time:91364ms step_avg:61.03ms
+step:1498/1555 train_time:91452ms step_avg:61.05ms
+step:1499/1555 train_time:91540ms step_avg:61.07ms
+step:1500/1555 train_time:91626ms step_avg:61.08ms
+step:1500/1555 val_loss:3.2945 train_time:91701ms step_avg:61.13ms
+step:1501/1555 train_time:91721ms step_avg:61.11ms
+step:1502/1555 train_time:91810ms step_avg:61.13ms
+step:1503/1555 train_time:91901ms step_avg:61.14ms
+step:1504/1555 train_time:91988ms step_avg:61.16ms
+step:1505/1555 train_time:92076ms step_avg:61.18ms
+step:1506/1555 train_time:92161ms step_avg:61.20ms
+step:1507/1555 train_time:92250ms step_avg:61.21ms
+step:1508/1555 train_time:92335ms step_avg:61.23ms
+step:1509/1555 train_time:92423ms step_avg:61.25ms
+step:1510/1555 train_time:92508ms step_avg:61.26ms
+step:1511/1555 train_time:92597ms step_avg:61.28ms
+step:1512/1555 train_time:92682ms step_avg:61.30ms
+step:1513/1555 train_time:92774ms step_avg:61.32ms
+step:1514/1555 train_time:92861ms step_avg:61.34ms
+step:1515/1555 train_time:92953ms step_avg:61.36ms
+step:1516/1555 train_time:93047ms step_avg:61.38ms
+step:1517/1555 train_time:93136ms step_avg:61.39ms
+step:1518/1555 train_time:93222ms step_avg:61.41ms
+step:1519/1555 train_time:93310ms step_avg:61.43ms
+step:1520/1555 train_time:93395ms step_avg:61.44ms
+step:1521/1555 train_time:93484ms step_avg:61.46ms
+step:1522/1555 train_time:93569ms step_avg:61.48ms
+step:1523/1555 train_time:93660ms step_avg:61.50ms
+step:1524/1555 train_time:93747ms step_avg:61.51ms
+step:1525/1555 train_time:93839ms step_avg:61.53ms
+step:1526/1555 train_time:93926ms step_avg:61.55ms
+step:1527/1555 train_time:94016ms step_avg:61.57ms
+step:1528/1555 train_time:94104ms step_avg:61.59ms
+step:1529/1555 train_time:94197ms step_avg:61.61ms
+step:1530/1555 train_time:94281ms step_avg:61.62ms
+step:1531/1555 train_time:94371ms step_avg:61.64ms
+step:1532/1555 train_time:94456ms step_avg:61.66ms
+step:1533/1555 train_time:94546ms step_avg:61.67ms
+step:1534/1555 train_time:94630ms step_avg:61.69ms
+step:1535/1555 train_time:94721ms step_avg:61.71ms
+step:1536/1555 train_time:94808ms step_avg:61.72ms
+step:1537/1555 train_time:94898ms step_avg:61.74ms
+step:1538/1555 train_time:94985ms step_avg:61.76ms
+step:1539/1555 train_time:95076ms step_avg:61.78ms
+step:1540/1555 train_time:95162ms step_avg:61.79ms
+step:1541/1555 train_time:95253ms step_avg:61.81ms
+step:1542/1555 train_time:95338ms step_avg:61.83ms
+step:1543/1555 train_time:95428ms step_avg:61.85ms
+step:1544/1555 train_time:95513ms step_avg:61.86ms
+step:1545/1555 train_time:95602ms step_avg:61.88ms
+step:1546/1555 train_time:95688ms step_avg:61.89ms
+step:1547/1555 train_time:95778ms step_avg:61.91ms
+step:1548/1555 train_time:95864ms step_avg:61.93ms
+step:1549/1555 train_time:95956ms step_avg:61.95ms
+step:1550/1555 train_time:96042ms step_avg:61.96ms
+step:1551/1555 train_time:96132ms step_avg:61.98ms
+step:1552/1555 train_time:96218ms step_avg:62.00ms
+step:1553/1555 train_time:96307ms step_avg:62.01ms
+step:1554/1555 train_time:96393ms step_avg:62.03ms
+step:1555/1555 train_time:96483ms step_avg:62.05ms
+step:1555/1555 val_loss:3.2778 train_time:96552ms step_avg:62.09ms
+peak memory allocated: 31016 MiB reserved: 47018 MiB

--- a/records/track_1_short/2026-01-30_MimeticValueOutput/runs/822b483a-6991-4c5d-aea3-ce1d026ec9b7.txt
+++ b/records/track_1_short/2026-01-30_MimeticValueOutput/runs/822b483a-6991-4c5d-aea3-ce1d026ec9b7.txt
@@ -1,0 +1,4131 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# Mimetic V-O Initialization (Trockman & Kolter, ICML 2023)
+# Initialize V and O such that V @ O^T ≈ -βI (negative identity-like)
+# This enables attention to make meaningful contributions from step 1
+
+def mimetic_vo_init(attn_bank, model_dim=768, num_heads=6, head_dim=128, beta=0.1, noise_std=0.01):
+    """
+    Initialize attention bank with mimetic structure for V and O.
+    Q and K use standard uniform init, V and O use identity-like structure.
+
+    Args:
+        attn_bank: Tensor of shape (num_layers, 4*model_dim, hdim)
+        model_dim: Model dimension (768)
+        num_heads: Number of attention heads (6)
+        head_dim: Dimension per head (128)
+        beta: Scale for identity structure (0.1 recommended with attn_scale=0.1)
+        noise_std: Standard deviation of noise for symmetry breaking
+    """
+    num_layers = attn_bank.shape[0]
+    dim = model_dim
+    sqrt_beta = beta ** 0.5
+
+    # Standard init for Q and K (existing behavior)
+    attn_std = model_dim ** -0.5
+    attn_bound = (3 ** 0.5) * attn_std
+
+    with torch.no_grad():
+        # Q and K: uniform init (first 2*dim rows)
+        attn_bank[:, :2*dim, :].uniform_(-attn_bound, attn_bound)
+
+        # V and O: mimetic identity structure
+        for layer_idx in range(num_layers):
+            W_V = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+            W_O = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+
+            # Create per-head identity blocks
+            for h in range(num_heads):
+                start, end = h * head_dim, (h + 1) * head_dim
+                eye = torch.eye(head_dim, dtype=attn_bank.dtype, device=attn_bank.device)
+                W_V[start:end, start:end] = sqrt_beta * eye
+                W_O[start:end, start:end] = -sqrt_beta * eye
+
+            # Add noise for symmetry breaking
+            W_V += noise_std * torch.randn_like(W_V)
+            W_O += noise_std * torch.randn_like(W_O)
+
+            # Store in attn_bank: V is rows [2*dim:3*dim], O is rows [3*dim:4*dim]
+            attn_bank[layer_idx, 2*dim:3*dim, :] = W_V
+            attn_bank[layer_idx, 3*dim:4*dim, :] = W_O
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # MLP uses 0.5 * dim^-0.5
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank with MIMETIC V-O initialization
+            # Q and K: uniform init, V and O: identity-like structure for faster convergence
+            mimetic_vo_init(
+                self.attn_bank,
+                model_dim=model_dim,
+                num_heads=num_heads,
+                head_dim=head_dim,
+                beta=0.05,       # Scale for V@O^T ≈ -βI (tuned down from 0.1)
+                noise_std=0.01   # Symmetry breaking noise
+            )
+            # Init MLP bank (c_fc uniform, c_proj zero)
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 234 structure on token value embeddings by @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1515  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.11.14 (main, Oct 21 2025, 18:31:21) [GCC 11.2.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Fri Jan 30 18:50:45 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          Off |   00000000:19:00.0 Off |                    0 |
+| N/A   35C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          Off |   00000000:3B:00.0 Off |                    0 |
+| N/A   28C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          Off |   00000000:4C:00.0 Off |                    0 |
+| N/A   25C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          Off |   00000000:5D:00.0 Off |                    0 |
+| N/A   33C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          Off |   00000000:9B:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          Off |   00000000:BB:00.0 Off |                    0 |
+| N/A   25C    P0            114W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          Off |   00000000:CB:00.0 Off |                    0 |
+| N/A   32C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          Off |   00000000:DB:00.0 Off |                    0 |
+| N/A   26C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1381190      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    1   N/A  N/A   1381191      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    2   N/A  N/A   1381192      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    3   N/A  N/A   1381193      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    4   N/A  N/A   1381194      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    5   N/A  N/A   1381195      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    6   N/A  N/A   1381196      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    7   N/A  N/A   1381197      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 504, 505, 506, 1009, 1010, 1011, 1514, 1515, 1516] for warmup
+Resetting Model
+step:0/1555 val_loss:10.8337 train_time:0ms step_avg:0.03ms
+step:1/1555 train_time:92ms step_avg:92.35ms
+step:2/1555 train_time:114ms step_avg:57.09ms
+step:3/1555 train_time:144ms step_avg:48.00ms
+step:4/1555 train_time:182ms step_avg:45.60ms
+step:5/1555 train_time:213ms step_avg:42.68ms
+step:6/1555 train_time:252ms step_avg:41.98ms
+step:7/1555 train_time:283ms step_avg:40.47ms
+step:8/1555 train_time:322ms step_avg:40.19ms
+step:9/1555 train_time:353ms step_avg:39.25ms
+step:10/1555 train_time:392ms step_avg:39.17ms
+step:11/1555 train_time:423ms step_avg:38.45ms
+step:12/1555 train_time:461ms step_avg:38.42ms
+step:13/1555 train_time:493ms step_avg:37.90ms
+step:14/1555 train_time:531ms step_avg:37.96ms
+step:15/1555 train_time:563ms step_avg:37.52ms
+step:16/1555 train_time:601ms step_avg:37.55ms
+step:17/1555 train_time:633ms step_avg:37.21ms
+step:18/1555 train_time:672ms step_avg:37.31ms
+step:19/1555 train_time:704ms step_avg:37.03ms
+step:20/1555 train_time:742ms step_avg:37.10ms
+step:21/1555 train_time:773ms step_avg:36.82ms
+step:22/1555 train_time:812ms step_avg:36.91ms
+step:23/1555 train_time:844ms step_avg:36.67ms
+step:24/1555 train_time:882ms step_avg:36.75ms
+step:25/1555 train_time:913ms step_avg:36.52ms
+step:26/1555 train_time:952ms step_avg:36.60ms
+step:27/1555 train_time:983ms step_avg:36.40ms
+step:28/1555 train_time:1021ms step_avg:36.47ms
+step:29/1555 train_time:1053ms step_avg:36.30ms
+step:30/1555 train_time:1091ms step_avg:36.38ms
+step:31/1555 train_time:1123ms step_avg:36.23ms
+step:32/1555 train_time:1161ms step_avg:36.29ms
+step:33/1555 train_time:1193ms step_avg:36.15ms
+step:34/1555 train_time:1231ms step_avg:36.22ms
+step:35/1555 train_time:1263ms step_avg:36.09ms
+step:36/1555 train_time:1301ms step_avg:36.15ms
+step:37/1555 train_time:1333ms step_avg:36.02ms
+step:38/1555 train_time:1371ms step_avg:36.09ms
+step:39/1555 train_time:1403ms step_avg:35.97ms
+step:40/1555 train_time:1441ms step_avg:36.01ms
+step:41/1555 train_time:1472ms step_avg:35.91ms
+step:42/1555 train_time:1510ms step_avg:35.96ms
+step:43/1555 train_time:1542ms step_avg:35.86ms
+step:44/1555 train_time:1580ms step_avg:35.91ms
+step:45/1555 train_time:1612ms step_avg:35.82ms
+step:46/1555 train_time:1650ms step_avg:35.88ms
+step:47/1555 train_time:1682ms step_avg:35.79ms
+step:48/1555 train_time:1720ms step_avg:35.84ms
+step:49/1555 train_time:1751ms step_avg:35.74ms
+step:50/1555 train_time:1790ms step_avg:35.79ms
+step:51/1555 train_time:1821ms step_avg:35.70ms
+step:52/1555 train_time:1859ms step_avg:35.75ms
+step:53/1555 train_time:1890ms step_avg:35.67ms
+step:54/1555 train_time:1929ms step_avg:35.72ms
+step:55/1555 train_time:1960ms step_avg:35.64ms
+step:56/1555 train_time:1999ms step_avg:35.69ms
+step:57/1555 train_time:2030ms step_avg:35.61ms
+step:58/1555 train_time:2068ms step_avg:35.66ms
+step:59/1555 train_time:2100ms step_avg:35.59ms
+step:60/1555 train_time:2138ms step_avg:35.64ms
+step:61/1555 train_time:2169ms step_avg:35.56ms
+step:62/1555 train_time:2208ms step_avg:35.60ms
+step:63/1555 train_time:2239ms step_avg:35.54ms
+step:64/1555 train_time:2277ms step_avg:35.58ms
+step:65/1555 train_time:2308ms step_avg:35.52ms
+step:66/1555 train_time:2346ms step_avg:35.55ms
+step:67/1555 train_time:2378ms step_avg:35.49ms
+step:68/1555 train_time:2416ms step_avg:35.53ms
+step:69/1555 train_time:2447ms step_avg:35.47ms
+step:70/1555 train_time:2485ms step_avg:35.51ms
+step:71/1555 train_time:2517ms step_avg:35.45ms
+step:72/1555 train_time:2555ms step_avg:35.49ms
+step:73/1555 train_time:2587ms step_avg:35.44ms
+step:74/1555 train_time:2625ms step_avg:35.47ms
+step:75/1555 train_time:2656ms step_avg:35.42ms
+step:76/1555 train_time:2694ms step_avg:35.45ms
+step:77/1555 train_time:2726ms step_avg:35.40ms
+step:78/1555 train_time:2764ms step_avg:35.43ms
+step:79/1555 train_time:2795ms step_avg:35.38ms
+step:80/1555 train_time:2834ms step_avg:35.42ms
+step:81/1555 train_time:2865ms step_avg:35.37ms
+step:82/1555 train_time:2903ms step_avg:35.40ms
+step:83/1555 train_time:2934ms step_avg:35.36ms
+step:84/1555 train_time:2973ms step_avg:35.39ms
+step:85/1555 train_time:3004ms step_avg:35.34ms
+step:86/1555 train_time:3042ms step_avg:35.38ms
+step:87/1555 train_time:3074ms step_avg:35.33ms
+step:88/1555 train_time:3112ms step_avg:35.36ms
+step:89/1555 train_time:3143ms step_avg:35.32ms
+step:90/1555 train_time:3181ms step_avg:35.35ms
+step:91/1555 train_time:3213ms step_avg:35.30ms
+step:92/1555 train_time:3251ms step_avg:35.33ms
+step:93/1555 train_time:3282ms step_avg:35.29ms
+step:94/1555 train_time:3320ms step_avg:35.32ms
+step:95/1555 train_time:3351ms step_avg:35.28ms
+step:96/1555 train_time:3390ms step_avg:35.31ms
+step:97/1555 train_time:3421ms step_avg:35.27ms
+step:98/1555 train_time:3459ms step_avg:35.30ms
+step:99/1555 train_time:3490ms step_avg:35.26ms
+step:100/1555 train_time:3529ms step_avg:35.29ms
+step:101/1555 train_time:3560ms step_avg:35.24ms
+step:102/1555 train_time:3598ms step_avg:35.28ms
+step:103/1555 train_time:3629ms step_avg:35.24ms
+step:104/1555 train_time:3668ms step_avg:35.26ms
+step:105/1555 train_time:3699ms step_avg:35.23ms
+step:106/1555 train_time:3737ms step_avg:35.26ms
+step:107/1555 train_time:3769ms step_avg:35.22ms
+step:108/1555 train_time:3807ms step_avg:35.25ms
+step:109/1555 train_time:3838ms step_avg:35.21ms
+step:110/1555 train_time:3876ms step_avg:35.24ms
+step:111/1555 train_time:3908ms step_avg:35.21ms
+step:112/1555 train_time:3946ms step_avg:35.23ms
+step:113/1555 train_time:3977ms step_avg:35.20ms
+step:114/1555 train_time:4016ms step_avg:35.23ms
+step:115/1555 train_time:4047ms step_avg:35.19ms
+step:116/1555 train_time:4085ms step_avg:35.21ms
+step:117/1555 train_time:4116ms step_avg:35.18ms
+step:118/1555 train_time:4154ms step_avg:35.21ms
+step:119/1555 train_time:4186ms step_avg:35.17ms
+step:120/1555 train_time:4223ms step_avg:35.20ms
+step:121/1555 train_time:4256ms step_avg:35.17ms
+step:122/1555 train_time:4294ms step_avg:35.20ms
+step:123/1555 train_time:4325ms step_avg:35.17ms
+step:124/1555 train_time:4364ms step_avg:35.19ms
+step:125/1555 train_time:4395ms step_avg:35.16ms
+step:126/1555 train_time:4434ms step_avg:35.19ms
+step:127/1555 train_time:4465ms step_avg:35.16ms
+step:128/1555 train_time:4503ms step_avg:35.18ms
+step:129/1555 train_time:4535ms step_avg:35.15ms
+step:130/1555 train_time:4573ms step_avg:35.18ms
+step:131/1555 train_time:4604ms step_avg:35.15ms
+step:132/1555 train_time:4642ms step_avg:35.17ms
+step:133/1555 train_time:4674ms step_avg:35.14ms
+step:134/1555 train_time:4713ms step_avg:35.17ms
+step:135/1555 train_time:4744ms step_avg:35.14ms
+step:136/1555 train_time:4782ms step_avg:35.16ms
+step:137/1555 train_time:4813ms step_avg:35.13ms
+step:138/1555 train_time:4852ms step_avg:35.16ms
+step:139/1555 train_time:4883ms step_avg:35.13ms
+step:140/1555 train_time:4921ms step_avg:35.15ms
+step:141/1555 train_time:4952ms step_avg:35.12ms
+step:142/1555 train_time:4990ms step_avg:35.14ms
+step:143/1555 train_time:5022ms step_avg:35.12ms
+step:144/1555 train_time:5060ms step_avg:35.14ms
+step:145/1555 train_time:5091ms step_avg:35.11ms
+step:146/1555 train_time:5129ms step_avg:35.13ms
+step:147/1555 train_time:5160ms step_avg:35.10ms
+step:148/1555 train_time:5198ms step_avg:35.12ms
+step:149/1555 train_time:5230ms step_avg:35.10ms
+step:150/1555 train_time:5268ms step_avg:35.12ms
+step:151/1555 train_time:5299ms step_avg:35.09ms
+step:152/1555 train_time:5337ms step_avg:35.11ms
+step:153/1555 train_time:5369ms step_avg:35.09ms
+step:154/1555 train_time:5407ms step_avg:35.11ms
+step:155/1555 train_time:5438ms step_avg:35.08ms
+step:156/1555 train_time:5476ms step_avg:35.10ms
+step:157/1555 train_time:5507ms step_avg:35.08ms
+step:158/1555 train_time:5545ms step_avg:35.10ms
+step:159/1555 train_time:5577ms step_avg:35.07ms
+step:160/1555 train_time:5615ms step_avg:35.09ms
+step:161/1555 train_time:5646ms step_avg:35.07ms
+step:162/1555 train_time:5684ms step_avg:35.09ms
+step:163/1555 train_time:5716ms step_avg:35.07ms
+step:164/1555 train_time:5755ms step_avg:35.09ms
+step:165/1555 train_time:5786ms step_avg:35.07ms
+step:166/1555 train_time:5824ms step_avg:35.08ms
+step:167/1555 train_time:5855ms step_avg:35.06ms
+step:168/1555 train_time:5894ms step_avg:35.08ms
+step:169/1555 train_time:5925ms step_avg:35.06ms
+step:170/1555 train_time:5963ms step_avg:35.08ms
+step:171/1555 train_time:5994ms step_avg:35.05ms
+step:172/1555 train_time:6033ms step_avg:35.07ms
+step:173/1555 train_time:6064ms step_avg:35.05ms
+step:174/1555 train_time:6102ms step_avg:35.07ms
+step:175/1555 train_time:6133ms step_avg:35.05ms
+step:176/1555 train_time:6171ms step_avg:35.06ms
+step:177/1555 train_time:6202ms step_avg:35.04ms
+step:178/1555 train_time:6241ms step_avg:35.06ms
+step:179/1555 train_time:6272ms step_avg:35.04ms
+step:180/1555 train_time:6310ms step_avg:35.06ms
+step:181/1555 train_time:6342ms step_avg:35.04ms
+step:182/1555 train_time:6380ms step_avg:35.06ms
+step:183/1555 train_time:6411ms step_avg:35.04ms
+step:184/1555 train_time:6450ms step_avg:35.05ms
+step:185/1555 train_time:6481ms step_avg:35.03ms
+step:186/1555 train_time:6519ms step_avg:35.05ms
+step:187/1555 train_time:6550ms step_avg:35.03ms
+step:188/1555 train_time:6588ms step_avg:35.05ms
+step:189/1555 train_time:6620ms step_avg:35.03ms
+step:190/1555 train_time:6658ms step_avg:35.04ms
+step:191/1555 train_time:6689ms step_avg:35.02ms
+step:192/1555 train_time:6727ms step_avg:35.04ms
+step:193/1555 train_time:6758ms step_avg:35.02ms
+step:194/1555 train_time:6796ms step_avg:35.03ms
+step:195/1555 train_time:6828ms step_avg:35.02ms
+step:196/1555 train_time:6866ms step_avg:35.03ms
+step:197/1555 train_time:6897ms step_avg:35.01ms
+step:198/1555 train_time:6936ms step_avg:35.03ms
+step:199/1555 train_time:6967ms step_avg:35.01ms
+step:200/1555 train_time:7005ms step_avg:35.03ms
+step:201/1555 train_time:7037ms step_avg:35.01ms
+step:202/1555 train_time:7075ms step_avg:35.02ms
+step:203/1555 train_time:7106ms step_avg:35.00ms
+step:204/1555 train_time:7144ms step_avg:35.02ms
+step:205/1555 train_time:7175ms step_avg:35.00ms
+step:206/1555 train_time:7214ms step_avg:35.02ms
+step:207/1555 train_time:7245ms step_avg:35.00ms
+step:208/1555 train_time:7283ms step_avg:35.01ms
+step:209/1555 train_time:7314ms step_avg:35.00ms
+step:210/1555 train_time:7352ms step_avg:35.01ms
+step:211/1555 train_time:7384ms step_avg:34.99ms
+step:212/1555 train_time:7422ms step_avg:35.01ms
+step:213/1555 train_time:7453ms step_avg:34.99ms
+step:214/1555 train_time:7491ms step_avg:35.01ms
+step:215/1555 train_time:7523ms step_avg:34.99ms
+step:216/1555 train_time:7561ms step_avg:35.00ms
+step:217/1555 train_time:7592ms step_avg:34.99ms
+step:218/1555 train_time:7630ms step_avg:35.00ms
+step:219/1555 train_time:7662ms step_avg:34.98ms
+step:220/1555 train_time:7700ms step_avg:35.00ms
+step:221/1555 train_time:7731ms step_avg:34.98ms
+step:222/1555 train_time:7769ms step_avg:35.00ms
+step:223/1555 train_time:7801ms step_avg:34.98ms
+step:224/1555 train_time:7839ms step_avg:34.99ms
+step:225/1555 train_time:7870ms step_avg:34.98ms
+step:226/1555 train_time:7909ms step_avg:34.99ms
+step:227/1555 train_time:7940ms step_avg:34.98ms
+step:228/1555 train_time:7978ms step_avg:34.99ms
+step:229/1555 train_time:8009ms step_avg:34.97ms
+step:230/1555 train_time:8047ms step_avg:34.99ms
+step:231/1555 train_time:8078ms step_avg:34.97ms
+step:232/1555 train_time:8116ms step_avg:34.98ms
+step:233/1555 train_time:8148ms step_avg:34.97ms
+step:234/1555 train_time:8186ms step_avg:34.98ms
+step:235/1555 train_time:8217ms step_avg:34.96ms
+step:236/1555 train_time:8255ms step_avg:34.98ms
+step:237/1555 train_time:8286ms step_avg:34.96ms
+step:238/1555 train_time:8324ms step_avg:34.97ms
+step:239/1555 train_time:8355ms step_avg:34.96ms
+step:240/1555 train_time:8393ms step_avg:34.97ms
+step:241/1555 train_time:8425ms step_avg:34.96ms
+step:242/1555 train_time:8462ms step_avg:34.97ms
+step:243/1555 train_time:8494ms step_avg:34.95ms
+step:244/1555 train_time:8532ms step_avg:34.97ms
+step:245/1555 train_time:8564ms step_avg:34.95ms
+step:246/1555 train_time:8602ms step_avg:34.97ms
+step:247/1555 train_time:8633ms step_avg:34.95ms
+step:248/1555 train_time:8672ms step_avg:34.97ms
+step:249/1555 train_time:8703ms step_avg:34.95ms
+step:250/1555 train_time:8741ms step_avg:34.96ms
+step:250/1555 val_loss:4.5622 train_time:8790ms step_avg:35.16ms
+step:251/1555 train_time:8807ms step_avg:35.09ms
+step:252/1555 train_time:8824ms step_avg:35.02ms
+step:253/1555 train_time:8845ms step_avg:34.96ms
+step:254/1555 train_time:8884ms step_avg:34.98ms
+step:255/1555 train_time:8919ms step_avg:34.98ms
+step:256/1555 train_time:8959ms step_avg:35.00ms
+step:257/1555 train_time:8992ms step_avg:34.99ms
+step:258/1555 train_time:9030ms step_avg:35.00ms
+step:259/1555 train_time:9061ms step_avg:34.99ms
+step:260/1555 train_time:9099ms step_avg:35.00ms
+step:261/1555 train_time:9130ms step_avg:34.98ms
+step:262/1555 train_time:9168ms step_avg:34.99ms
+step:263/1555 train_time:9200ms step_avg:34.98ms
+step:264/1555 train_time:9238ms step_avg:34.99ms
+step:265/1555 train_time:9269ms step_avg:34.98ms
+step:266/1555 train_time:9307ms step_avg:34.99ms
+step:267/1555 train_time:9338ms step_avg:34.97ms
+step:268/1555 train_time:9377ms step_avg:34.99ms
+step:269/1555 train_time:9407ms step_avg:34.97ms
+step:270/1555 train_time:9445ms step_avg:34.98ms
+step:271/1555 train_time:9477ms step_avg:34.97ms
+step:272/1555 train_time:9515ms step_avg:34.98ms
+step:273/1555 train_time:9546ms step_avg:34.97ms
+step:274/1555 train_time:9584ms step_avg:34.98ms
+step:275/1555 train_time:9616ms step_avg:34.97ms
+step:276/1555 train_time:9654ms step_avg:34.98ms
+step:277/1555 train_time:9686ms step_avg:34.97ms
+step:278/1555 train_time:9723ms step_avg:34.98ms
+step:279/1555 train_time:9755ms step_avg:34.96ms
+step:280/1555 train_time:9793ms step_avg:34.98ms
+step:281/1555 train_time:9824ms step_avg:34.96ms
+step:282/1555 train_time:9862ms step_avg:34.97ms
+step:283/1555 train_time:9894ms step_avg:34.96ms
+step:284/1555 train_time:9932ms step_avg:34.97ms
+step:285/1555 train_time:9963ms step_avg:34.96ms
+step:286/1555 train_time:10001ms step_avg:34.97ms
+step:287/1555 train_time:10032ms step_avg:34.96ms
+step:288/1555 train_time:10071ms step_avg:34.97ms
+step:289/1555 train_time:10102ms step_avg:34.96ms
+step:290/1555 train_time:10140ms step_avg:34.97ms
+step:291/1555 train_time:10172ms step_avg:34.95ms
+step:292/1555 train_time:10209ms step_avg:34.96ms
+step:293/1555 train_time:10241ms step_avg:34.95ms
+step:294/1555 train_time:10279ms step_avg:34.96ms
+step:295/1555 train_time:10310ms step_avg:34.95ms
+step:296/1555 train_time:10349ms step_avg:34.96ms
+step:297/1555 train_time:10380ms step_avg:34.95ms
+step:298/1555 train_time:10418ms step_avg:34.96ms
+step:299/1555 train_time:10449ms step_avg:34.95ms
+step:300/1555 train_time:10487ms step_avg:34.96ms
+step:301/1555 train_time:10519ms step_avg:34.95ms
+step:302/1555 train_time:10557ms step_avg:34.96ms
+step:303/1555 train_time:10588ms step_avg:34.94ms
+step:304/1555 train_time:10626ms step_avg:34.95ms
+step:305/1555 train_time:10657ms step_avg:34.94ms
+step:306/1555 train_time:10695ms step_avg:34.95ms
+step:307/1555 train_time:10726ms step_avg:34.94ms
+step:308/1555 train_time:10764ms step_avg:34.95ms
+step:309/1555 train_time:10796ms step_avg:34.94ms
+step:310/1555 train_time:10834ms step_avg:34.95ms
+step:311/1555 train_time:10865ms step_avg:34.94ms
+step:312/1555 train_time:10903ms step_avg:34.95ms
+step:313/1555 train_time:10934ms step_avg:34.93ms
+step:314/1555 train_time:10973ms step_avg:34.95ms
+step:315/1555 train_time:11004ms step_avg:34.93ms
+step:316/1555 train_time:11042ms step_avg:34.94ms
+step:317/1555 train_time:11073ms step_avg:34.93ms
+step:318/1555 train_time:11111ms step_avg:34.94ms
+step:319/1555 train_time:11143ms step_avg:34.93ms
+step:320/1555 train_time:11181ms step_avg:34.94ms
+step:321/1555 train_time:11212ms step_avg:34.93ms
+step:322/1555 train_time:11250ms step_avg:34.94ms
+step:323/1555 train_time:11282ms step_avg:34.93ms
+step:324/1555 train_time:11320ms step_avg:34.94ms
+step:325/1555 train_time:11351ms step_avg:34.93ms
+step:326/1555 train_time:11390ms step_avg:34.94ms
+step:327/1555 train_time:11421ms step_avg:34.93ms
+step:328/1555 train_time:11459ms step_avg:34.94ms
+step:329/1555 train_time:11490ms step_avg:34.92ms
+step:330/1555 train_time:11529ms step_avg:34.93ms
+step:331/1555 train_time:11560ms step_avg:34.92ms
+step:332/1555 train_time:11598ms step_avg:34.93ms
+step:333/1555 train_time:11629ms step_avg:34.92ms
+step:334/1555 train_time:11667ms step_avg:34.93ms
+step:335/1555 train_time:11698ms step_avg:34.92ms
+step:336/1555 train_time:11736ms step_avg:34.93ms
+step:337/1555 train_time:11768ms step_avg:34.92ms
+step:338/1555 train_time:11805ms step_avg:34.93ms
+step:339/1555 train_time:11837ms step_avg:34.92ms
+step:340/1555 train_time:11875ms step_avg:34.93ms
+step:341/1555 train_time:11906ms step_avg:34.92ms
+step:342/1555 train_time:11944ms step_avg:34.92ms
+step:343/1555 train_time:11975ms step_avg:34.91ms
+step:344/1555 train_time:12013ms step_avg:34.92ms
+step:345/1555 train_time:12045ms step_avg:34.91ms
+step:346/1555 train_time:12083ms step_avg:34.92ms
+step:347/1555 train_time:12114ms step_avg:34.91ms
+step:348/1555 train_time:12153ms step_avg:34.92ms
+step:349/1555 train_time:12184ms step_avg:34.91ms
+step:350/1555 train_time:12222ms step_avg:34.92ms
+step:351/1555 train_time:12253ms step_avg:34.91ms
+step:352/1555 train_time:12291ms step_avg:34.92ms
+step:353/1555 train_time:12323ms step_avg:34.91ms
+step:354/1555 train_time:12361ms step_avg:34.92ms
+step:355/1555 train_time:12394ms step_avg:34.91ms
+step:356/1555 train_time:12431ms step_avg:34.92ms
+step:357/1555 train_time:12462ms step_avg:34.91ms
+step:358/1555 train_time:12500ms step_avg:34.92ms
+step:359/1555 train_time:12532ms step_avg:34.91ms
+step:360/1555 train_time:12570ms step_avg:34.92ms
+step:361/1555 train_time:12601ms step_avg:34.91ms
+step:362/1555 train_time:12639ms step_avg:34.92ms
+step:363/1555 train_time:12671ms step_avg:34.91ms
+step:364/1555 train_time:12709ms step_avg:34.91ms
+step:365/1555 train_time:12740ms step_avg:34.90ms
+step:366/1555 train_time:12778ms step_avg:34.91ms
+step:367/1555 train_time:12810ms step_avg:34.90ms
+step:368/1555 train_time:12847ms step_avg:34.91ms
+step:369/1555 train_time:12879ms step_avg:34.90ms
+step:370/1555 train_time:12917ms step_avg:34.91ms
+step:371/1555 train_time:12948ms step_avg:34.90ms
+step:372/1555 train_time:12986ms step_avg:34.91ms
+step:373/1555 train_time:13017ms step_avg:34.90ms
+step:374/1555 train_time:13056ms step_avg:34.91ms
+step:375/1555 train_time:13087ms step_avg:34.90ms
+step:376/1555 train_time:13125ms step_avg:34.91ms
+step:377/1555 train_time:13156ms step_avg:34.90ms
+step:378/1555 train_time:13194ms step_avg:34.91ms
+step:379/1555 train_time:13225ms step_avg:34.90ms
+step:380/1555 train_time:13263ms step_avg:34.90ms
+step:381/1555 train_time:13295ms step_avg:34.89ms
+step:382/1555 train_time:13333ms step_avg:34.90ms
+step:383/1555 train_time:13364ms step_avg:34.89ms
+step:384/1555 train_time:13403ms step_avg:34.90ms
+step:385/1555 train_time:13434ms step_avg:34.89ms
+step:386/1555 train_time:13472ms step_avg:34.90ms
+step:387/1555 train_time:13503ms step_avg:34.89ms
+step:388/1555 train_time:13541ms step_avg:34.90ms
+step:389/1555 train_time:13572ms step_avg:34.89ms
+step:390/1555 train_time:13611ms step_avg:34.90ms
+step:391/1555 train_time:13642ms step_avg:34.89ms
+step:392/1555 train_time:13680ms step_avg:34.90ms
+step:393/1555 train_time:13711ms step_avg:34.89ms
+step:394/1555 train_time:13749ms step_avg:34.90ms
+step:395/1555 train_time:13781ms step_avg:34.89ms
+step:396/1555 train_time:13819ms step_avg:34.90ms
+step:397/1555 train_time:13850ms step_avg:34.89ms
+step:398/1555 train_time:13887ms step_avg:34.89ms
+step:399/1555 train_time:13919ms step_avg:34.88ms
+step:400/1555 train_time:13957ms step_avg:34.89ms
+step:401/1555 train_time:13988ms step_avg:34.88ms
+step:402/1555 train_time:14026ms step_avg:34.89ms
+step:403/1555 train_time:14057ms step_avg:34.88ms
+step:404/1555 train_time:14095ms step_avg:34.89ms
+step:405/1555 train_time:14127ms step_avg:34.88ms
+step:406/1555 train_time:14165ms step_avg:34.89ms
+step:407/1555 train_time:14196ms step_avg:34.88ms
+step:408/1555 train_time:14234ms step_avg:34.89ms
+step:409/1555 train_time:14265ms step_avg:34.88ms
+step:410/1555 train_time:14303ms step_avg:34.89ms
+step:411/1555 train_time:14335ms step_avg:34.88ms
+step:412/1555 train_time:14373ms step_avg:34.89ms
+step:413/1555 train_time:14404ms step_avg:34.88ms
+step:414/1555 train_time:14442ms step_avg:34.88ms
+step:415/1555 train_time:14473ms step_avg:34.88ms
+step:416/1555 train_time:14513ms step_avg:34.89ms
+step:417/1555 train_time:14543ms step_avg:34.87ms
+step:418/1555 train_time:14581ms step_avg:34.88ms
+step:419/1555 train_time:14612ms step_avg:34.87ms
+step:420/1555 train_time:14651ms step_avg:34.88ms
+step:421/1555 train_time:14682ms step_avg:34.87ms
+step:422/1555 train_time:14720ms step_avg:34.88ms
+step:423/1555 train_time:14751ms step_avg:34.87ms
+step:424/1555 train_time:14789ms step_avg:34.88ms
+step:425/1555 train_time:14820ms step_avg:34.87ms
+step:426/1555 train_time:14858ms step_avg:34.88ms
+step:427/1555 train_time:14890ms step_avg:34.87ms
+step:428/1555 train_time:14927ms step_avg:34.88ms
+step:429/1555 train_time:14959ms step_avg:34.87ms
+step:430/1555 train_time:14997ms step_avg:34.88ms
+step:431/1555 train_time:15028ms step_avg:34.87ms
+step:432/1555 train_time:15066ms step_avg:34.88ms
+step:433/1555 train_time:15097ms step_avg:34.87ms
+step:434/1555 train_time:15136ms step_avg:34.87ms
+step:435/1555 train_time:15167ms step_avg:34.87ms
+step:436/1555 train_time:15205ms step_avg:34.87ms
+step:437/1555 train_time:15236ms step_avg:34.86ms
+step:438/1555 train_time:15274ms step_avg:34.87ms
+step:439/1555 train_time:15305ms step_avg:34.86ms
+step:440/1555 train_time:15343ms step_avg:34.87ms
+step:441/1555 train_time:15375ms step_avg:34.86ms
+step:442/1555 train_time:15413ms step_avg:34.87ms
+step:443/1555 train_time:15445ms step_avg:34.86ms
+step:444/1555 train_time:15482ms step_avg:34.87ms
+step:445/1555 train_time:15514ms step_avg:34.86ms
+step:446/1555 train_time:15552ms step_avg:34.87ms
+step:447/1555 train_time:15584ms step_avg:34.86ms
+step:448/1555 train_time:15622ms step_avg:34.87ms
+step:449/1555 train_time:15653ms step_avg:34.86ms
+step:450/1555 train_time:15691ms step_avg:34.87ms
+step:451/1555 train_time:15723ms step_avg:34.86ms
+step:452/1555 train_time:15761ms step_avg:34.87ms
+step:453/1555 train_time:15792ms step_avg:34.86ms
+step:454/1555 train_time:15829ms step_avg:34.87ms
+step:455/1555 train_time:15861ms step_avg:34.86ms
+step:456/1555 train_time:15899ms step_avg:34.87ms
+step:457/1555 train_time:15930ms step_avg:34.86ms
+step:458/1555 train_time:15968ms step_avg:34.86ms
+step:459/1555 train_time:15999ms step_avg:34.86ms
+step:460/1555 train_time:16037ms step_avg:34.86ms
+step:461/1555 train_time:16068ms step_avg:34.86ms
+step:462/1555 train_time:16106ms step_avg:34.86ms
+step:463/1555 train_time:16138ms step_avg:34.85ms
+step:464/1555 train_time:16176ms step_avg:34.86ms
+step:465/1555 train_time:16207ms step_avg:34.85ms
+step:466/1555 train_time:16245ms step_avg:34.86ms
+step:467/1555 train_time:16276ms step_avg:34.85ms
+step:468/1555 train_time:16315ms step_avg:34.86ms
+step:469/1555 train_time:16346ms step_avg:34.85ms
+step:470/1555 train_time:16384ms step_avg:34.86ms
+step:471/1555 train_time:16415ms step_avg:34.85ms
+step:472/1555 train_time:16453ms step_avg:34.86ms
+step:473/1555 train_time:16484ms step_avg:34.85ms
+step:474/1555 train_time:16522ms step_avg:34.86ms
+step:475/1555 train_time:16553ms step_avg:34.85ms
+step:476/1555 train_time:16592ms step_avg:34.86ms
+step:477/1555 train_time:16623ms step_avg:34.85ms
+step:478/1555 train_time:16661ms step_avg:34.86ms
+step:479/1555 train_time:16692ms step_avg:34.85ms
+step:480/1555 train_time:16731ms step_avg:34.86ms
+step:481/1555 train_time:16762ms step_avg:34.85ms
+step:482/1555 train_time:16800ms step_avg:34.85ms
+step:483/1555 train_time:16831ms step_avg:34.85ms
+step:484/1555 train_time:16869ms step_avg:34.85ms
+step:485/1555 train_time:16900ms step_avg:34.84ms
+step:486/1555 train_time:16938ms step_avg:34.85ms
+step:487/1555 train_time:16969ms step_avg:34.84ms
+step:488/1555 train_time:17007ms step_avg:34.85ms
+step:489/1555 train_time:17039ms step_avg:34.84ms
+step:490/1555 train_time:17076ms step_avg:34.85ms
+step:491/1555 train_time:17108ms step_avg:34.84ms
+step:492/1555 train_time:17146ms step_avg:34.85ms
+step:493/1555 train_time:17177ms step_avg:34.84ms
+step:494/1555 train_time:17215ms step_avg:34.85ms
+step:495/1555 train_time:17246ms step_avg:34.84ms
+step:496/1555 train_time:17284ms step_avg:34.85ms
+step:497/1555 train_time:17315ms step_avg:34.84ms
+step:498/1555 train_time:17353ms step_avg:34.85ms
+step:499/1555 train_time:17384ms step_avg:34.84ms
+step:500/1555 train_time:17422ms step_avg:34.84ms
+step:500/1555 val_loss:4.2253 train_time:17471ms step_avg:34.94ms
+step:501/1555 train_time:17490ms step_avg:34.91ms
+step:502/1555 train_time:17508ms step_avg:34.88ms
+step:503/1555 train_time:17526ms step_avg:34.84ms
+step:504/1555 train_time:17565ms step_avg:34.85ms
+step:505/1555 train_time:17599ms step_avg:34.85ms
+step:506/1555 train_time:17677ms step_avg:34.94ms
+step:507/1555 train_time:17737ms step_avg:34.98ms
+step:508/1555 train_time:17796ms step_avg:35.03ms
+step:509/1555 train_time:17861ms step_avg:35.09ms
+step:510/1555 train_time:17919ms step_avg:35.13ms
+step:511/1555 train_time:17981ms step_avg:35.19ms
+step:512/1555 train_time:18039ms step_avg:35.23ms
+step:513/1555 train_time:18102ms step_avg:35.29ms
+step:514/1555 train_time:18160ms step_avg:35.33ms
+step:515/1555 train_time:18222ms step_avg:35.38ms
+step:516/1555 train_time:18284ms step_avg:35.43ms
+step:517/1555 train_time:18343ms step_avg:35.48ms
+step:518/1555 train_time:18403ms step_avg:35.53ms
+step:519/1555 train_time:18469ms step_avg:35.59ms
+step:520/1555 train_time:18528ms step_avg:35.63ms
+step:521/1555 train_time:18592ms step_avg:35.69ms
+step:522/1555 train_time:18652ms step_avg:35.73ms
+step:523/1555 train_time:18718ms step_avg:35.79ms
+step:524/1555 train_time:18776ms step_avg:35.83ms
+step:525/1555 train_time:18839ms step_avg:35.88ms
+step:526/1555 train_time:18899ms step_avg:35.93ms
+step:527/1555 train_time:18962ms step_avg:35.98ms
+step:528/1555 train_time:19021ms step_avg:36.02ms
+step:529/1555 train_time:19083ms step_avg:36.07ms
+step:530/1555 train_time:19143ms step_avg:36.12ms
+step:531/1555 train_time:19205ms step_avg:36.17ms
+step:532/1555 train_time:19263ms step_avg:36.21ms
+step:533/1555 train_time:19326ms step_avg:36.26ms
+step:534/1555 train_time:19387ms step_avg:36.30ms
+step:535/1555 train_time:19449ms step_avg:36.35ms
+step:536/1555 train_time:19508ms step_avg:36.40ms
+step:537/1555 train_time:19572ms step_avg:36.45ms
+step:538/1555 train_time:19632ms step_avg:36.49ms
+step:539/1555 train_time:19696ms step_avg:36.54ms
+step:540/1555 train_time:19756ms step_avg:36.58ms
+step:541/1555 train_time:19820ms step_avg:36.64ms
+step:542/1555 train_time:19880ms step_avg:36.68ms
+step:543/1555 train_time:19943ms step_avg:36.73ms
+step:544/1555 train_time:20002ms step_avg:36.77ms
+step:545/1555 train_time:20065ms step_avg:36.82ms
+step:546/1555 train_time:20127ms step_avg:36.86ms
+step:547/1555 train_time:20188ms step_avg:36.91ms
+step:548/1555 train_time:20247ms step_avg:36.95ms
+step:549/1555 train_time:20310ms step_avg:36.99ms
+step:550/1555 train_time:20370ms step_avg:37.04ms
+step:551/1555 train_time:20432ms step_avg:37.08ms
+step:552/1555 train_time:20492ms step_avg:37.12ms
+step:553/1555 train_time:20555ms step_avg:37.17ms
+step:554/1555 train_time:20615ms step_avg:37.21ms
+step:555/1555 train_time:20680ms step_avg:37.26ms
+step:556/1555 train_time:20738ms step_avg:37.30ms
+step:557/1555 train_time:20801ms step_avg:37.34ms
+step:558/1555 train_time:20861ms step_avg:37.38ms
+step:559/1555 train_time:20925ms step_avg:37.43ms
+step:560/1555 train_time:20983ms step_avg:37.47ms
+step:561/1555 train_time:21046ms step_avg:37.52ms
+step:562/1555 train_time:21107ms step_avg:37.56ms
+step:563/1555 train_time:21169ms step_avg:37.60ms
+step:564/1555 train_time:21229ms step_avg:37.64ms
+step:565/1555 train_time:21292ms step_avg:37.68ms
+step:566/1555 train_time:21353ms step_avg:37.73ms
+step:567/1555 train_time:21418ms step_avg:37.77ms
+step:568/1555 train_time:21476ms step_avg:37.81ms
+step:569/1555 train_time:21538ms step_avg:37.85ms
+step:570/1555 train_time:21597ms step_avg:37.89ms
+step:571/1555 train_time:21660ms step_avg:37.93ms
+step:572/1555 train_time:21719ms step_avg:37.97ms
+step:573/1555 train_time:21783ms step_avg:38.02ms
+step:574/1555 train_time:21842ms step_avg:38.05ms
+step:575/1555 train_time:21906ms step_avg:38.10ms
+step:576/1555 train_time:21966ms step_avg:38.14ms
+step:577/1555 train_time:22029ms step_avg:38.18ms
+step:578/1555 train_time:22090ms step_avg:38.22ms
+step:579/1555 train_time:22153ms step_avg:38.26ms
+step:580/1555 train_time:22213ms step_avg:38.30ms
+step:581/1555 train_time:22276ms step_avg:38.34ms
+step:582/1555 train_time:22336ms step_avg:38.38ms
+step:583/1555 train_time:22400ms step_avg:38.42ms
+step:584/1555 train_time:22459ms step_avg:38.46ms
+step:585/1555 train_time:22522ms step_avg:38.50ms
+step:586/1555 train_time:22581ms step_avg:38.53ms
+step:587/1555 train_time:22645ms step_avg:38.58ms
+step:588/1555 train_time:22703ms step_avg:38.61ms
+step:589/1555 train_time:22766ms step_avg:38.65ms
+step:590/1555 train_time:22825ms step_avg:38.69ms
+step:591/1555 train_time:22888ms step_avg:38.73ms
+step:592/1555 train_time:22948ms step_avg:38.76ms
+step:593/1555 train_time:23011ms step_avg:38.80ms
+step:594/1555 train_time:23070ms step_avg:38.84ms
+step:595/1555 train_time:23133ms step_avg:38.88ms
+step:596/1555 train_time:23193ms step_avg:38.91ms
+step:597/1555 train_time:23259ms step_avg:38.96ms
+step:598/1555 train_time:23317ms step_avg:38.99ms
+step:599/1555 train_time:23380ms step_avg:39.03ms
+step:600/1555 train_time:23439ms step_avg:39.07ms
+step:601/1555 train_time:23503ms step_avg:39.11ms
+step:602/1555 train_time:23563ms step_avg:39.14ms
+step:603/1555 train_time:23625ms step_avg:39.18ms
+step:604/1555 train_time:23684ms step_avg:39.21ms
+step:605/1555 train_time:23747ms step_avg:39.25ms
+step:606/1555 train_time:23806ms step_avg:39.28ms
+step:607/1555 train_time:23870ms step_avg:39.32ms
+step:608/1555 train_time:23928ms step_avg:39.36ms
+step:609/1555 train_time:23991ms step_avg:39.39ms
+step:610/1555 train_time:24050ms step_avg:39.43ms
+step:611/1555 train_time:24114ms step_avg:39.47ms
+step:612/1555 train_time:24173ms step_avg:39.50ms
+step:613/1555 train_time:24237ms step_avg:39.54ms
+step:614/1555 train_time:24297ms step_avg:39.57ms
+step:615/1555 train_time:24360ms step_avg:39.61ms
+step:616/1555 train_time:24420ms step_avg:39.64ms
+step:617/1555 train_time:24483ms step_avg:39.68ms
+step:618/1555 train_time:24543ms step_avg:39.71ms
+step:619/1555 train_time:24605ms step_avg:39.75ms
+step:620/1555 train_time:24665ms step_avg:39.78ms
+step:621/1555 train_time:24728ms step_avg:39.82ms
+step:622/1555 train_time:24787ms step_avg:39.85ms
+step:623/1555 train_time:24850ms step_avg:39.89ms
+step:624/1555 train_time:24911ms step_avg:39.92ms
+step:625/1555 train_time:24973ms step_avg:39.96ms
+step:626/1555 train_time:25032ms step_avg:39.99ms
+step:627/1555 train_time:25095ms step_avg:40.02ms
+step:628/1555 train_time:25154ms step_avg:40.05ms
+step:629/1555 train_time:25219ms step_avg:40.09ms
+step:630/1555 train_time:25278ms step_avg:40.12ms
+step:631/1555 train_time:25341ms step_avg:40.16ms
+step:632/1555 train_time:25401ms step_avg:40.19ms
+step:633/1555 train_time:25464ms step_avg:40.23ms
+step:634/1555 train_time:25524ms step_avg:40.26ms
+step:635/1555 train_time:25588ms step_avg:40.30ms
+step:636/1555 train_time:25646ms step_avg:40.32ms
+step:637/1555 train_time:25709ms step_avg:40.36ms
+step:638/1555 train_time:25769ms step_avg:40.39ms
+step:639/1555 train_time:25832ms step_avg:40.43ms
+step:640/1555 train_time:25891ms step_avg:40.46ms
+step:641/1555 train_time:25956ms step_avg:40.49ms
+step:642/1555 train_time:26015ms step_avg:40.52ms
+step:643/1555 train_time:26078ms step_avg:40.56ms
+step:644/1555 train_time:26137ms step_avg:40.59ms
+step:645/1555 train_time:26201ms step_avg:40.62ms
+step:646/1555 train_time:26260ms step_avg:40.65ms
+step:647/1555 train_time:26324ms step_avg:40.69ms
+step:648/1555 train_time:26383ms step_avg:40.71ms
+step:649/1555 train_time:26446ms step_avg:40.75ms
+step:650/1555 train_time:26505ms step_avg:40.78ms
+step:651/1555 train_time:26569ms step_avg:40.81ms
+step:652/1555 train_time:26628ms step_avg:40.84ms
+step:653/1555 train_time:26693ms step_avg:40.88ms
+step:654/1555 train_time:26750ms step_avg:40.90ms
+step:655/1555 train_time:26814ms step_avg:40.94ms
+step:656/1555 train_time:26873ms step_avg:40.96ms
+step:657/1555 train_time:26936ms step_avg:41.00ms
+step:658/1555 train_time:26996ms step_avg:41.03ms
+step:659/1555 train_time:27059ms step_avg:41.06ms
+step:660/1555 train_time:27118ms step_avg:41.09ms
+step:661/1555 train_time:27182ms step_avg:41.12ms
+step:662/1555 train_time:27241ms step_avg:41.15ms
+step:663/1555 train_time:27305ms step_avg:41.18ms
+step:664/1555 train_time:27366ms step_avg:41.21ms
+step:665/1555 train_time:27428ms step_avg:41.25ms
+step:666/1555 train_time:27487ms step_avg:41.27ms
+step:667/1555 train_time:27550ms step_avg:41.31ms
+step:668/1555 train_time:27609ms step_avg:41.33ms
+step:669/1555 train_time:27673ms step_avg:41.36ms
+step:670/1555 train_time:27732ms step_avg:41.39ms
+step:671/1555 train_time:27796ms step_avg:41.42ms
+step:672/1555 train_time:27854ms step_avg:41.45ms
+step:673/1555 train_time:27917ms step_avg:41.48ms
+step:674/1555 train_time:27976ms step_avg:41.51ms
+step:675/1555 train_time:28040ms step_avg:41.54ms
+step:676/1555 train_time:28100ms step_avg:41.57ms
+step:677/1555 train_time:28163ms step_avg:41.60ms
+step:678/1555 train_time:28224ms step_avg:41.63ms
+step:679/1555 train_time:28287ms step_avg:41.66ms
+step:680/1555 train_time:28346ms step_avg:41.69ms
+step:681/1555 train_time:28411ms step_avg:41.72ms
+step:682/1555 train_time:28470ms step_avg:41.74ms
+step:683/1555 train_time:28533ms step_avg:41.78ms
+step:684/1555 train_time:28592ms step_avg:41.80ms
+step:685/1555 train_time:28656ms step_avg:41.83ms
+step:686/1555 train_time:28715ms step_avg:41.86ms
+step:687/1555 train_time:28778ms step_avg:41.89ms
+step:688/1555 train_time:28837ms step_avg:41.91ms
+step:689/1555 train_time:28900ms step_avg:41.94ms
+step:690/1555 train_time:28959ms step_avg:41.97ms
+step:691/1555 train_time:29022ms step_avg:42.00ms
+step:692/1555 train_time:29083ms step_avg:42.03ms
+step:693/1555 train_time:29145ms step_avg:42.06ms
+step:694/1555 train_time:29204ms step_avg:42.08ms
+step:695/1555 train_time:29267ms step_avg:42.11ms
+step:696/1555 train_time:29326ms step_avg:42.14ms
+step:697/1555 train_time:29389ms step_avg:42.17ms
+step:698/1555 train_time:29448ms step_avg:42.19ms
+step:699/1555 train_time:29513ms step_avg:42.22ms
+step:700/1555 train_time:29572ms step_avg:42.25ms
+step:701/1555 train_time:29636ms step_avg:42.28ms
+step:702/1555 train_time:29694ms step_avg:42.30ms
+step:703/1555 train_time:29758ms step_avg:42.33ms
+step:704/1555 train_time:29817ms step_avg:42.35ms
+step:705/1555 train_time:29880ms step_avg:42.38ms
+step:706/1555 train_time:29940ms step_avg:42.41ms
+step:707/1555 train_time:30003ms step_avg:42.44ms
+step:708/1555 train_time:30062ms step_avg:42.46ms
+step:709/1555 train_time:30125ms step_avg:42.49ms
+step:710/1555 train_time:30184ms step_avg:42.51ms
+step:711/1555 train_time:30248ms step_avg:42.54ms
+step:712/1555 train_time:30307ms step_avg:42.57ms
+step:713/1555 train_time:30372ms step_avg:42.60ms
+step:714/1555 train_time:30430ms step_avg:42.62ms
+step:715/1555 train_time:30494ms step_avg:42.65ms
+step:716/1555 train_time:30553ms step_avg:42.67ms
+step:717/1555 train_time:30617ms step_avg:42.70ms
+step:718/1555 train_time:30676ms step_avg:42.72ms
+step:719/1555 train_time:30740ms step_avg:42.75ms
+step:720/1555 train_time:30800ms step_avg:42.78ms
+step:721/1555 train_time:30862ms step_avg:42.80ms
+step:722/1555 train_time:30921ms step_avg:42.83ms
+step:723/1555 train_time:30983ms step_avg:42.85ms
+step:724/1555 train_time:31043ms step_avg:42.88ms
+step:725/1555 train_time:31105ms step_avg:42.90ms
+step:726/1555 train_time:31165ms step_avg:42.93ms
+step:727/1555 train_time:31229ms step_avg:42.96ms
+step:728/1555 train_time:31287ms step_avg:42.98ms
+step:729/1555 train_time:31350ms step_avg:43.00ms
+step:730/1555 train_time:31410ms step_avg:43.03ms
+step:731/1555 train_time:31472ms step_avg:43.05ms
+step:732/1555 train_time:31532ms step_avg:43.08ms
+step:733/1555 train_time:31595ms step_avg:43.10ms
+step:734/1555 train_time:31656ms step_avg:43.13ms
+step:735/1555 train_time:31720ms step_avg:43.16ms
+step:736/1555 train_time:31779ms step_avg:43.18ms
+step:737/1555 train_time:31843ms step_avg:43.21ms
+step:738/1555 train_time:31902ms step_avg:43.23ms
+step:739/1555 train_time:31964ms step_avg:43.25ms
+step:740/1555 train_time:32024ms step_avg:43.28ms
+step:741/1555 train_time:32087ms step_avg:43.30ms
+step:742/1555 train_time:32146ms step_avg:43.32ms
+step:743/1555 train_time:32211ms step_avg:43.35ms
+step:744/1555 train_time:32270ms step_avg:43.37ms
+step:745/1555 train_time:32333ms step_avg:43.40ms
+step:746/1555 train_time:32393ms step_avg:43.42ms
+step:747/1555 train_time:32456ms step_avg:43.45ms
+step:748/1555 train_time:32515ms step_avg:43.47ms
+step:749/1555 train_time:32580ms step_avg:43.50ms
+step:750/1555 train_time:32639ms step_avg:43.52ms
+step:750/1555 val_loss:3.8692 train_time:32687ms step_avg:43.58ms
+step:751/1555 train_time:32705ms step_avg:43.55ms
+step:752/1555 train_time:32767ms step_avg:43.57ms
+step:753/1555 train_time:32832ms step_avg:43.60ms
+step:754/1555 train_time:32893ms step_avg:43.62ms
+step:755/1555 train_time:32957ms step_avg:43.65ms
+step:756/1555 train_time:33017ms step_avg:43.67ms
+step:757/1555 train_time:33080ms step_avg:43.70ms
+step:758/1555 train_time:33139ms step_avg:43.72ms
+step:759/1555 train_time:33203ms step_avg:43.75ms
+step:760/1555 train_time:33261ms step_avg:43.76ms
+step:761/1555 train_time:33325ms step_avg:43.79ms
+step:762/1555 train_time:33384ms step_avg:43.81ms
+step:763/1555 train_time:33447ms step_avg:43.84ms
+step:764/1555 train_time:33505ms step_avg:43.85ms
+step:765/1555 train_time:33569ms step_avg:43.88ms
+step:766/1555 train_time:33627ms step_avg:43.90ms
+step:767/1555 train_time:33692ms step_avg:43.93ms
+step:768/1555 train_time:33751ms step_avg:43.95ms
+step:769/1555 train_time:33816ms step_avg:43.97ms
+step:770/1555 train_time:33875ms step_avg:43.99ms
+step:771/1555 train_time:33941ms step_avg:44.02ms
+step:772/1555 train_time:33999ms step_avg:44.04ms
+step:773/1555 train_time:34062ms step_avg:44.06ms
+step:774/1555 train_time:34121ms step_avg:44.08ms
+step:775/1555 train_time:34185ms step_avg:44.11ms
+step:776/1555 train_time:34244ms step_avg:44.13ms
+step:777/1555 train_time:34307ms step_avg:44.15ms
+step:778/1555 train_time:34367ms step_avg:44.17ms
+step:779/1555 train_time:34429ms step_avg:44.20ms
+step:780/1555 train_time:34488ms step_avg:44.22ms
+step:781/1555 train_time:34550ms step_avg:44.24ms
+step:782/1555 train_time:34609ms step_avg:44.26ms
+step:783/1555 train_time:34673ms step_avg:44.28ms
+step:784/1555 train_time:34732ms step_avg:44.30ms
+step:785/1555 train_time:34796ms step_avg:44.33ms
+step:786/1555 train_time:34856ms step_avg:44.35ms
+step:787/1555 train_time:34920ms step_avg:44.37ms
+step:788/1555 train_time:34979ms step_avg:44.39ms
+step:789/1555 train_time:35043ms step_avg:44.41ms
+step:790/1555 train_time:35103ms step_avg:44.43ms
+step:791/1555 train_time:35165ms step_avg:44.46ms
+step:792/1555 train_time:35226ms step_avg:44.48ms
+step:793/1555 train_time:35288ms step_avg:44.50ms
+step:794/1555 train_time:35347ms step_avg:44.52ms
+step:795/1555 train_time:35410ms step_avg:44.54ms
+step:796/1555 train_time:35468ms step_avg:44.56ms
+step:797/1555 train_time:35533ms step_avg:44.58ms
+step:798/1555 train_time:35591ms step_avg:44.60ms
+step:799/1555 train_time:35654ms step_avg:44.62ms
+step:800/1555 train_time:35712ms step_avg:44.64ms
+step:801/1555 train_time:35776ms step_avg:44.66ms
+step:802/1555 train_time:35836ms step_avg:44.68ms
+step:803/1555 train_time:35898ms step_avg:44.71ms
+step:804/1555 train_time:35958ms step_avg:44.72ms
+step:805/1555 train_time:36023ms step_avg:44.75ms
+step:806/1555 train_time:36082ms step_avg:44.77ms
+step:807/1555 train_time:36146ms step_avg:44.79ms
+step:808/1555 train_time:36205ms step_avg:44.81ms
+step:809/1555 train_time:36269ms step_avg:44.83ms
+step:810/1555 train_time:36329ms step_avg:44.85ms
+step:811/1555 train_time:36391ms step_avg:44.87ms
+step:812/1555 train_time:36450ms step_avg:44.89ms
+step:813/1555 train_time:36514ms step_avg:44.91ms
+step:814/1555 train_time:36572ms step_avg:44.93ms
+step:815/1555 train_time:36636ms step_avg:44.95ms
+step:816/1555 train_time:36696ms step_avg:44.97ms
+step:817/1555 train_time:36759ms step_avg:44.99ms
+step:818/1555 train_time:36819ms step_avg:45.01ms
+step:819/1555 train_time:36883ms step_avg:45.03ms
+step:820/1555 train_time:36941ms step_avg:45.05ms
+step:821/1555 train_time:37005ms step_avg:45.07ms
+step:822/1555 train_time:37063ms step_avg:45.09ms
+step:823/1555 train_time:37127ms step_avg:45.11ms
+step:824/1555 train_time:37188ms step_avg:45.13ms
+step:825/1555 train_time:37250ms step_avg:45.15ms
+step:826/1555 train_time:37310ms step_avg:45.17ms
+step:827/1555 train_time:37373ms step_avg:45.19ms
+step:828/1555 train_time:37433ms step_avg:45.21ms
+step:829/1555 train_time:37497ms step_avg:45.23ms
+step:830/1555 train_time:37556ms step_avg:45.25ms
+step:831/1555 train_time:37620ms step_avg:45.27ms
+step:832/1555 train_time:37679ms step_avg:45.29ms
+step:833/1555 train_time:37743ms step_avg:45.31ms
+step:834/1555 train_time:37802ms step_avg:45.33ms
+step:835/1555 train_time:37866ms step_avg:45.35ms
+step:836/1555 train_time:37925ms step_avg:45.36ms
+step:837/1555 train_time:37988ms step_avg:45.39ms
+step:838/1555 train_time:38049ms step_avg:45.40ms
+step:839/1555 train_time:38112ms step_avg:45.43ms
+step:840/1555 train_time:38171ms step_avg:45.44ms
+step:841/1555 train_time:38236ms step_avg:45.46ms
+step:842/1555 train_time:38295ms step_avg:45.48ms
+step:843/1555 train_time:38359ms step_avg:45.50ms
+step:844/1555 train_time:38420ms step_avg:45.52ms
+step:845/1555 train_time:38482ms step_avg:45.54ms
+step:846/1555 train_time:38541ms step_avg:45.56ms
+step:847/1555 train_time:38605ms step_avg:45.58ms
+step:848/1555 train_time:38664ms step_avg:45.59ms
+step:849/1555 train_time:38728ms step_avg:45.62ms
+step:850/1555 train_time:38787ms step_avg:45.63ms
+step:851/1555 train_time:38852ms step_avg:45.65ms
+step:852/1555 train_time:38911ms step_avg:45.67ms
+step:853/1555 train_time:38973ms step_avg:45.69ms
+step:854/1555 train_time:39034ms step_avg:45.71ms
+step:855/1555 train_time:39097ms step_avg:45.73ms
+step:856/1555 train_time:39156ms step_avg:45.74ms
+step:857/1555 train_time:39219ms step_avg:45.76ms
+step:858/1555 train_time:39279ms step_avg:45.78ms
+step:859/1555 train_time:39343ms step_avg:45.80ms
+step:860/1555 train_time:39402ms step_avg:45.82ms
+step:861/1555 train_time:39467ms step_avg:45.84ms
+step:862/1555 train_time:39525ms step_avg:45.85ms
+step:863/1555 train_time:39588ms step_avg:45.87ms
+step:864/1555 train_time:39647ms step_avg:45.89ms
+step:865/1555 train_time:39711ms step_avg:45.91ms
+step:866/1555 train_time:39769ms step_avg:45.92ms
+step:867/1555 train_time:39832ms step_avg:45.94ms
+step:868/1555 train_time:39891ms step_avg:45.96ms
+step:869/1555 train_time:39954ms step_avg:45.98ms
+step:870/1555 train_time:40013ms step_avg:45.99ms
+step:871/1555 train_time:40076ms step_avg:46.01ms
+step:872/1555 train_time:40136ms step_avg:46.03ms
+step:873/1555 train_time:40199ms step_avg:46.05ms
+step:874/1555 train_time:40259ms step_avg:46.06ms
+step:875/1555 train_time:40324ms step_avg:46.08ms
+step:876/1555 train_time:40385ms step_avg:46.10ms
+step:877/1555 train_time:40447ms step_avg:46.12ms
+step:878/1555 train_time:40506ms step_avg:46.13ms
+step:879/1555 train_time:40569ms step_avg:46.15ms
+step:880/1555 train_time:40630ms step_avg:46.17ms
+step:881/1555 train_time:40692ms step_avg:46.19ms
+step:882/1555 train_time:40751ms step_avg:46.20ms
+step:883/1555 train_time:40818ms step_avg:46.23ms
+step:884/1555 train_time:40877ms step_avg:46.24ms
+step:885/1555 train_time:40938ms step_avg:46.26ms
+step:886/1555 train_time:40996ms step_avg:46.27ms
+step:887/1555 train_time:41060ms step_avg:46.29ms
+step:888/1555 train_time:41121ms step_avg:46.31ms
+step:889/1555 train_time:41183ms step_avg:46.33ms
+step:890/1555 train_time:41242ms step_avg:46.34ms
+step:891/1555 train_time:41305ms step_avg:46.36ms
+step:892/1555 train_time:41365ms step_avg:46.37ms
+step:893/1555 train_time:41428ms step_avg:46.39ms
+step:894/1555 train_time:41488ms step_avg:46.41ms
+step:895/1555 train_time:41551ms step_avg:46.43ms
+step:896/1555 train_time:41612ms step_avg:46.44ms
+step:897/1555 train_time:41673ms step_avg:46.46ms
+step:898/1555 train_time:41733ms step_avg:46.47ms
+step:899/1555 train_time:41796ms step_avg:46.49ms
+step:900/1555 train_time:41856ms step_avg:46.51ms
+step:901/1555 train_time:41918ms step_avg:46.52ms
+step:902/1555 train_time:41978ms step_avg:46.54ms
+step:903/1555 train_time:42042ms step_avg:46.56ms
+step:904/1555 train_time:42102ms step_avg:46.57ms
+step:905/1555 train_time:42166ms step_avg:46.59ms
+step:906/1555 train_time:42225ms step_avg:46.61ms
+step:907/1555 train_time:42288ms step_avg:46.62ms
+step:908/1555 train_time:42348ms step_avg:46.64ms
+step:909/1555 train_time:42410ms step_avg:46.66ms
+step:910/1555 train_time:42470ms step_avg:46.67ms
+step:911/1555 train_time:42533ms step_avg:46.69ms
+step:912/1555 train_time:42592ms step_avg:46.70ms
+step:913/1555 train_time:42657ms step_avg:46.72ms
+step:914/1555 train_time:42716ms step_avg:46.74ms
+step:915/1555 train_time:42779ms step_avg:46.75ms
+step:916/1555 train_time:42838ms step_avg:46.77ms
+step:917/1555 train_time:42902ms step_avg:46.78ms
+step:918/1555 train_time:42963ms step_avg:46.80ms
+step:919/1555 train_time:43025ms step_avg:46.82ms
+step:920/1555 train_time:43084ms step_avg:46.83ms
+step:921/1555 train_time:43147ms step_avg:46.85ms
+step:922/1555 train_time:43207ms step_avg:46.86ms
+step:923/1555 train_time:43271ms step_avg:46.88ms
+step:924/1555 train_time:43329ms step_avg:46.89ms
+step:925/1555 train_time:43392ms step_avg:46.91ms
+step:926/1555 train_time:43452ms step_avg:46.92ms
+step:927/1555 train_time:43515ms step_avg:46.94ms
+step:928/1555 train_time:43576ms step_avg:46.96ms
+step:929/1555 train_time:43638ms step_avg:46.97ms
+step:930/1555 train_time:43697ms step_avg:46.99ms
+step:931/1555 train_time:43761ms step_avg:47.00ms
+step:932/1555 train_time:43822ms step_avg:47.02ms
+step:933/1555 train_time:43884ms step_avg:47.04ms
+step:934/1555 train_time:43943ms step_avg:47.05ms
+step:935/1555 train_time:44007ms step_avg:47.07ms
+step:936/1555 train_time:44066ms step_avg:47.08ms
+step:937/1555 train_time:44130ms step_avg:47.10ms
+step:938/1555 train_time:44189ms step_avg:47.11ms
+step:939/1555 train_time:44252ms step_avg:47.13ms
+step:940/1555 train_time:44311ms step_avg:47.14ms
+step:941/1555 train_time:44375ms step_avg:47.16ms
+step:942/1555 train_time:44436ms step_avg:47.17ms
+step:943/1555 train_time:44498ms step_avg:47.19ms
+step:944/1555 train_time:44557ms step_avg:47.20ms
+step:945/1555 train_time:44622ms step_avg:47.22ms
+step:946/1555 train_time:44681ms step_avg:47.23ms
+step:947/1555 train_time:44745ms step_avg:47.25ms
+step:948/1555 train_time:44803ms step_avg:47.26ms
+step:949/1555 train_time:44867ms step_avg:47.28ms
+step:950/1555 train_time:44926ms step_avg:47.29ms
+step:951/1555 train_time:44989ms step_avg:47.31ms
+step:952/1555 train_time:45049ms step_avg:47.32ms
+step:953/1555 train_time:45111ms step_avg:47.34ms
+step:954/1555 train_time:45171ms step_avg:47.35ms
+step:955/1555 train_time:45234ms step_avg:47.37ms
+step:956/1555 train_time:45293ms step_avg:47.38ms
+step:957/1555 train_time:45358ms step_avg:47.40ms
+step:958/1555 train_time:45416ms step_avg:47.41ms
+step:959/1555 train_time:45480ms step_avg:47.42ms
+step:960/1555 train_time:45540ms step_avg:47.44ms
+step:961/1555 train_time:45603ms step_avg:47.45ms
+step:962/1555 train_time:45662ms step_avg:47.47ms
+step:963/1555 train_time:45727ms step_avg:47.48ms
+step:964/1555 train_time:45785ms step_avg:47.50ms
+step:965/1555 train_time:45849ms step_avg:47.51ms
+step:966/1555 train_time:45908ms step_avg:47.52ms
+step:967/1555 train_time:45972ms step_avg:47.54ms
+step:968/1555 train_time:46031ms step_avg:47.55ms
+step:969/1555 train_time:46094ms step_avg:47.57ms
+step:970/1555 train_time:46153ms step_avg:47.58ms
+step:971/1555 train_time:46216ms step_avg:47.60ms
+step:972/1555 train_time:46276ms step_avg:47.61ms
+step:973/1555 train_time:46340ms step_avg:47.63ms
+step:974/1555 train_time:46400ms step_avg:47.64ms
+step:975/1555 train_time:46465ms step_avg:47.66ms
+step:976/1555 train_time:46523ms step_avg:47.67ms
+step:977/1555 train_time:46586ms step_avg:47.68ms
+step:978/1555 train_time:46645ms step_avg:47.69ms
+step:979/1555 train_time:46709ms step_avg:47.71ms
+step:980/1555 train_time:46769ms step_avg:47.72ms
+step:981/1555 train_time:46832ms step_avg:47.74ms
+step:982/1555 train_time:46890ms step_avg:47.75ms
+step:983/1555 train_time:46953ms step_avg:47.76ms
+step:984/1555 train_time:47012ms step_avg:47.78ms
+step:985/1555 train_time:47076ms step_avg:47.79ms
+step:986/1555 train_time:47135ms step_avg:47.80ms
+step:987/1555 train_time:47197ms step_avg:47.82ms
+step:988/1555 train_time:47256ms step_avg:47.83ms
+step:989/1555 train_time:47319ms step_avg:47.85ms
+step:990/1555 train_time:47379ms step_avg:47.86ms
+step:991/1555 train_time:47442ms step_avg:47.87ms
+step:992/1555 train_time:47504ms step_avg:47.89ms
+step:993/1555 train_time:47566ms step_avg:47.90ms
+step:994/1555 train_time:47625ms step_avg:47.91ms
+step:995/1555 train_time:47689ms step_avg:47.93ms
+step:996/1555 train_time:47748ms step_avg:47.94ms
+step:997/1555 train_time:47811ms step_avg:47.96ms
+step:998/1555 train_time:47872ms step_avg:47.97ms
+step:999/1555 train_time:47935ms step_avg:47.98ms
+step:1000/1555 train_time:47994ms step_avg:47.99ms
+step:1000/1555 val_loss:3.5712 train_time:48044ms step_avg:48.04ms
+step:1001/1555 train_time:48062ms step_avg:48.01ms
+step:1002/1555 train_time:48122ms step_avg:48.03ms
+step:1003/1555 train_time:48187ms step_avg:48.04ms
+step:1004/1555 train_time:48249ms step_avg:48.06ms
+step:1005/1555 train_time:48313ms step_avg:48.07ms
+step:1006/1555 train_time:48372ms step_avg:48.08ms
+step:1007/1555 train_time:48435ms step_avg:48.10ms
+step:1008/1555 train_time:48494ms step_avg:48.11ms
+step:1009/1555 train_time:48557ms step_avg:48.12ms
+step:1010/1555 train_time:48615ms step_avg:48.13ms
+step:1011/1555 train_time:48689ms step_avg:48.16ms
+step:1012/1555 train_time:48773ms step_avg:48.20ms
+step:1013/1555 train_time:48862ms step_avg:48.24ms
+step:1014/1555 train_time:48948ms step_avg:48.27ms
+step:1015/1555 train_time:49036ms step_avg:48.31ms
+step:1016/1555 train_time:49123ms step_avg:48.35ms
+step:1017/1555 train_time:49216ms step_avg:48.39ms
+step:1018/1555 train_time:49302ms step_avg:48.43ms
+step:1019/1555 train_time:49391ms step_avg:48.47ms
+step:1020/1555 train_time:49479ms step_avg:48.51ms
+step:1021/1555 train_time:49566ms step_avg:48.55ms
+step:1022/1555 train_time:49651ms step_avg:48.58ms
+step:1023/1555 train_time:49740ms step_avg:48.62ms
+step:1024/1555 train_time:49825ms step_avg:48.66ms
+step:1025/1555 train_time:49915ms step_avg:48.70ms
+step:1026/1555 train_time:50000ms step_avg:48.73ms
+step:1027/1555 train_time:50090ms step_avg:48.77ms
+step:1028/1555 train_time:50176ms step_avg:48.81ms
+step:1029/1555 train_time:50267ms step_avg:48.85ms
+step:1030/1555 train_time:50356ms step_avg:48.89ms
+step:1031/1555 train_time:50443ms step_avg:48.93ms
+step:1032/1555 train_time:50529ms step_avg:48.96ms
+step:1033/1555 train_time:50618ms step_avg:49.00ms
+step:1034/1555 train_time:50703ms step_avg:49.04ms
+step:1035/1555 train_time:50794ms step_avg:49.08ms
+step:1036/1555 train_time:50878ms step_avg:49.11ms
+step:1037/1555 train_time:50968ms step_avg:49.15ms
+step:1038/1555 train_time:51053ms step_avg:49.18ms
+step:1039/1555 train_time:51144ms step_avg:49.22ms
+step:1040/1555 train_time:51232ms step_avg:49.26ms
+step:1041/1555 train_time:51321ms step_avg:49.30ms
+step:1042/1555 train_time:51408ms step_avg:49.34ms
+step:1043/1555 train_time:51496ms step_avg:49.37ms
+step:1044/1555 train_time:51581ms step_avg:49.41ms
+step:1045/1555 train_time:51671ms step_avg:49.45ms
+step:1046/1555 train_time:51756ms step_avg:49.48ms
+step:1047/1555 train_time:51845ms step_avg:49.52ms
+step:1048/1555 train_time:51931ms step_avg:49.55ms
+step:1049/1555 train_time:52020ms step_avg:49.59ms
+step:1050/1555 train_time:52107ms step_avg:49.63ms
+step:1051/1555 train_time:52200ms step_avg:49.67ms
+step:1052/1555 train_time:52285ms step_avg:49.70ms
+step:1053/1555 train_time:52375ms step_avg:49.74ms
+step:1054/1555 train_time:52461ms step_avg:49.77ms
+step:1055/1555 train_time:52550ms step_avg:49.81ms
+step:1056/1555 train_time:52635ms step_avg:49.84ms
+step:1057/1555 train_time:52724ms step_avg:49.88ms
+step:1058/1555 train_time:52810ms step_avg:49.92ms
+step:1059/1555 train_time:52899ms step_avg:49.95ms
+step:1060/1555 train_time:52985ms step_avg:49.99ms
+step:1061/1555 train_time:53076ms step_avg:50.02ms
+step:1062/1555 train_time:53164ms step_avg:50.06ms
+step:1063/1555 train_time:53254ms step_avg:50.10ms
+step:1064/1555 train_time:53339ms step_avg:50.13ms
+step:1065/1555 train_time:53431ms step_avg:50.17ms
+step:1066/1555 train_time:53516ms step_avg:50.20ms
+step:1067/1555 train_time:53605ms step_avg:50.24ms
+step:1068/1555 train_time:53691ms step_avg:50.27ms
+step:1069/1555 train_time:53780ms step_avg:50.31ms
+step:1070/1555 train_time:53865ms step_avg:50.34ms
+step:1071/1555 train_time:53955ms step_avg:50.38ms
+step:1072/1555 train_time:54041ms step_avg:50.41ms
+step:1073/1555 train_time:54132ms step_avg:50.45ms
+step:1074/1555 train_time:54218ms step_avg:50.48ms
+step:1075/1555 train_time:54309ms step_avg:50.52ms
+step:1076/1555 train_time:54394ms step_avg:50.55ms
+step:1077/1555 train_time:54482ms step_avg:50.59ms
+step:1078/1555 train_time:54568ms step_avg:50.62ms
+step:1079/1555 train_time:54657ms step_avg:50.66ms
+step:1080/1555 train_time:54742ms step_avg:50.69ms
+step:1081/1555 train_time:54831ms step_avg:50.72ms
+step:1082/1555 train_time:54916ms step_avg:50.75ms
+step:1083/1555 train_time:55005ms step_avg:50.79ms
+step:1084/1555 train_time:55094ms step_avg:50.82ms
+step:1085/1555 train_time:55182ms step_avg:50.86ms
+step:1086/1555 train_time:55268ms step_avg:50.89ms
+step:1087/1555 train_time:55358ms step_avg:50.93ms
+step:1088/1555 train_time:55444ms step_avg:50.96ms
+step:1089/1555 train_time:55534ms step_avg:51.00ms
+step:1090/1555 train_time:55620ms step_avg:51.03ms
+step:1091/1555 train_time:55711ms step_avg:51.06ms
+step:1092/1555 train_time:55795ms step_avg:51.09ms
+step:1093/1555 train_time:55885ms step_avg:51.13ms
+step:1094/1555 train_time:55971ms step_avg:51.16ms
+step:1095/1555 train_time:56061ms step_avg:51.20ms
+step:1096/1555 train_time:56147ms step_avg:51.23ms
+step:1097/1555 train_time:56236ms step_avg:51.26ms
+step:1098/1555 train_time:56323ms step_avg:51.30ms
+step:1099/1555 train_time:56412ms step_avg:51.33ms
+step:1100/1555 train_time:56498ms step_avg:51.36ms
+step:1101/1555 train_time:56587ms step_avg:51.40ms
+step:1102/1555 train_time:56673ms step_avg:51.43ms
+step:1103/1555 train_time:56762ms step_avg:51.46ms
+step:1104/1555 train_time:56848ms step_avg:51.49ms
+step:1105/1555 train_time:56938ms step_avg:51.53ms
+step:1106/1555 train_time:57023ms step_avg:51.56ms
+step:1107/1555 train_time:57113ms step_avg:51.59ms
+step:1108/1555 train_time:57200ms step_avg:51.62ms
+step:1109/1555 train_time:57290ms step_avg:51.66ms
+step:1110/1555 train_time:57376ms step_avg:51.69ms
+step:1111/1555 train_time:57467ms step_avg:51.73ms
+step:1112/1555 train_time:57552ms step_avg:51.76ms
+step:1113/1555 train_time:57641ms step_avg:51.79ms
+step:1114/1555 train_time:57726ms step_avg:51.82ms
+step:1115/1555 train_time:57816ms step_avg:51.85ms
+step:1116/1555 train_time:57901ms step_avg:51.88ms
+step:1117/1555 train_time:57991ms step_avg:51.92ms
+step:1118/1555 train_time:58078ms step_avg:51.95ms
+step:1119/1555 train_time:58167ms step_avg:51.98ms
+step:1120/1555 train_time:58253ms step_avg:52.01ms
+step:1121/1555 train_time:58342ms step_avg:52.04ms
+step:1122/1555 train_time:58428ms step_avg:52.07ms
+step:1123/1555 train_time:58518ms step_avg:52.11ms
+step:1124/1555 train_time:58604ms step_avg:52.14ms
+step:1125/1555 train_time:58694ms step_avg:52.17ms
+step:1126/1555 train_time:58778ms step_avg:52.20ms
+step:1127/1555 train_time:58868ms step_avg:52.23ms
+step:1128/1555 train_time:58953ms step_avg:52.26ms
+step:1129/1555 train_time:59043ms step_avg:52.30ms
+step:1130/1555 train_time:59129ms step_avg:52.33ms
+step:1131/1555 train_time:59222ms step_avg:52.36ms
+step:1132/1555 train_time:59305ms step_avg:52.39ms
+step:1133/1555 train_time:59394ms step_avg:52.42ms
+step:1134/1555 train_time:59481ms step_avg:52.45ms
+step:1135/1555 train_time:59570ms step_avg:52.48ms
+step:1136/1555 train_time:59656ms step_avg:52.51ms
+step:1137/1555 train_time:59744ms step_avg:52.55ms
+step:1138/1555 train_time:59830ms step_avg:52.57ms
+step:1139/1555 train_time:59924ms step_avg:52.61ms
+step:1140/1555 train_time:60008ms step_avg:52.64ms
+step:1141/1555 train_time:60098ms step_avg:52.67ms
+step:1142/1555 train_time:60183ms step_avg:52.70ms
+step:1143/1555 train_time:60273ms step_avg:52.73ms
+step:1144/1555 train_time:60358ms step_avg:52.76ms
+step:1145/1555 train_time:60447ms step_avg:52.79ms
+step:1146/1555 train_time:60533ms step_avg:52.82ms
+step:1147/1555 train_time:60623ms step_avg:52.85ms
+step:1148/1555 train_time:60709ms step_avg:52.88ms
+step:1149/1555 train_time:60798ms step_avg:52.91ms
+step:1150/1555 train_time:60883ms step_avg:52.94ms
+step:1151/1555 train_time:60975ms step_avg:52.98ms
+step:1152/1555 train_time:61059ms step_avg:53.00ms
+step:1153/1555 train_time:61148ms step_avg:53.03ms
+step:1154/1555 train_time:61235ms step_avg:53.06ms
+step:1155/1555 train_time:61324ms step_avg:53.09ms
+step:1156/1555 train_time:61411ms step_avg:53.12ms
+step:1157/1555 train_time:61500ms step_avg:53.16ms
+step:1158/1555 train_time:61587ms step_avg:53.18ms
+step:1159/1555 train_time:61676ms step_avg:53.21ms
+step:1160/1555 train_time:61761ms step_avg:53.24ms
+step:1161/1555 train_time:61850ms step_avg:53.27ms
+step:1162/1555 train_time:61936ms step_avg:53.30ms
+step:1163/1555 train_time:62025ms step_avg:53.33ms
+step:1164/1555 train_time:62111ms step_avg:53.36ms
+step:1165/1555 train_time:62201ms step_avg:53.39ms
+step:1166/1555 train_time:62288ms step_avg:53.42ms
+step:1167/1555 train_time:62378ms step_avg:53.45ms
+step:1168/1555 train_time:62463ms step_avg:53.48ms
+step:1169/1555 train_time:62553ms step_avg:53.51ms
+step:1170/1555 train_time:62639ms step_avg:53.54ms
+step:1171/1555 train_time:62728ms step_avg:53.57ms
+step:1172/1555 train_time:62814ms step_avg:53.60ms
+step:1173/1555 train_time:62903ms step_avg:53.63ms
+step:1174/1555 train_time:62990ms step_avg:53.65ms
+step:1175/1555 train_time:63078ms step_avg:53.68ms
+step:1176/1555 train_time:63164ms step_avg:53.71ms
+step:1177/1555 train_time:63253ms step_avg:53.74ms
+step:1178/1555 train_time:63339ms step_avg:53.77ms
+step:1179/1555 train_time:63429ms step_avg:53.80ms
+step:1180/1555 train_time:63515ms step_avg:53.83ms
+step:1181/1555 train_time:63605ms step_avg:53.86ms
+step:1182/1555 train_time:63692ms step_avg:53.89ms
+step:1183/1555 train_time:63781ms step_avg:53.91ms
+step:1184/1555 train_time:63866ms step_avg:53.94ms
+step:1185/1555 train_time:63956ms step_avg:53.97ms
+step:1186/1555 train_time:64042ms step_avg:54.00ms
+step:1187/1555 train_time:64132ms step_avg:54.03ms
+step:1188/1555 train_time:64217ms step_avg:54.06ms
+step:1189/1555 train_time:64308ms step_avg:54.09ms
+step:1190/1555 train_time:64395ms step_avg:54.11ms
+step:1191/1555 train_time:64484ms step_avg:54.14ms
+step:1192/1555 train_time:64570ms step_avg:54.17ms
+step:1193/1555 train_time:64659ms step_avg:54.20ms
+step:1194/1555 train_time:64746ms step_avg:54.23ms
+step:1195/1555 train_time:64835ms step_avg:54.26ms
+step:1196/1555 train_time:64920ms step_avg:54.28ms
+step:1197/1555 train_time:65010ms step_avg:54.31ms
+step:1198/1555 train_time:65097ms step_avg:54.34ms
+step:1199/1555 train_time:65185ms step_avg:54.37ms
+step:1200/1555 train_time:65271ms step_avg:54.39ms
+step:1201/1555 train_time:65361ms step_avg:54.42ms
+step:1202/1555 train_time:65451ms step_avg:54.45ms
+step:1203/1555 train_time:65537ms step_avg:54.48ms
+step:1204/1555 train_time:65623ms step_avg:54.50ms
+step:1205/1555 train_time:65713ms step_avg:54.53ms
+step:1206/1555 train_time:65797ms step_avg:54.56ms
+step:1207/1555 train_time:65889ms step_avg:54.59ms
+step:1208/1555 train_time:65974ms step_avg:54.61ms
+step:1209/1555 train_time:66063ms step_avg:54.64ms
+step:1210/1555 train_time:66149ms step_avg:54.67ms
+step:1211/1555 train_time:66239ms step_avg:54.70ms
+step:1212/1555 train_time:66325ms step_avg:54.72ms
+step:1213/1555 train_time:66415ms step_avg:54.75ms
+step:1214/1555 train_time:66499ms step_avg:54.78ms
+step:1215/1555 train_time:66590ms step_avg:54.81ms
+step:1216/1555 train_time:66678ms step_avg:54.83ms
+step:1217/1555 train_time:66765ms step_avg:54.86ms
+step:1218/1555 train_time:66851ms step_avg:54.89ms
+step:1219/1555 train_time:66941ms step_avg:54.92ms
+step:1220/1555 train_time:67025ms step_avg:54.94ms
+step:1221/1555 train_time:67115ms step_avg:54.97ms
+step:1222/1555 train_time:67200ms step_avg:54.99ms
+step:1223/1555 train_time:67290ms step_avg:55.02ms
+step:1224/1555 train_time:67376ms step_avg:55.05ms
+step:1225/1555 train_time:67466ms step_avg:55.07ms
+step:1226/1555 train_time:67552ms step_avg:55.10ms
+step:1227/1555 train_time:67642ms step_avg:55.13ms
+step:1228/1555 train_time:67727ms step_avg:55.15ms
+step:1229/1555 train_time:67817ms step_avg:55.18ms
+step:1230/1555 train_time:67902ms step_avg:55.20ms
+step:1231/1555 train_time:67992ms step_avg:55.23ms
+step:1232/1555 train_time:68077ms step_avg:55.26ms
+step:1233/1555 train_time:68168ms step_avg:55.29ms
+step:1234/1555 train_time:68253ms step_avg:55.31ms
+step:1235/1555 train_time:68343ms step_avg:55.34ms
+step:1236/1555 train_time:68429ms step_avg:55.36ms
+step:1237/1555 train_time:68520ms step_avg:55.39ms
+step:1238/1555 train_time:68607ms step_avg:55.42ms
+step:1239/1555 train_time:68695ms step_avg:55.44ms
+step:1240/1555 train_time:68782ms step_avg:55.47ms
+step:1241/1555 train_time:68871ms step_avg:55.50ms
+step:1242/1555 train_time:68959ms step_avg:55.52ms
+step:1243/1555 train_time:69046ms step_avg:55.55ms
+step:1244/1555 train_time:69132ms step_avg:55.57ms
+step:1245/1555 train_time:69221ms step_avg:55.60ms
+step:1246/1555 train_time:69311ms step_avg:55.63ms
+step:1247/1555 train_time:69398ms step_avg:55.65ms
+step:1248/1555 train_time:69483ms step_avg:55.68ms
+step:1249/1555 train_time:69573ms step_avg:55.70ms
+step:1250/1555 train_time:69659ms step_avg:55.73ms
+step:1250/1555 val_loss:3.3970 train_time:69733ms step_avg:55.79ms
+step:1251/1555 train_time:69753ms step_avg:55.76ms
+step:1252/1555 train_time:69844ms step_avg:55.79ms
+step:1253/1555 train_time:69941ms step_avg:55.82ms
+step:1254/1555 train_time:70027ms step_avg:55.84ms
+step:1255/1555 train_time:70114ms step_avg:55.87ms
+step:1256/1555 train_time:70199ms step_avg:55.89ms
+step:1257/1555 train_time:70286ms step_avg:55.92ms
+step:1258/1555 train_time:70372ms step_avg:55.94ms
+step:1259/1555 train_time:70459ms step_avg:55.96ms
+step:1260/1555 train_time:70544ms step_avg:55.99ms
+step:1261/1555 train_time:70633ms step_avg:56.01ms
+step:1262/1555 train_time:70723ms step_avg:56.04ms
+step:1263/1555 train_time:70812ms step_avg:56.07ms
+step:1264/1555 train_time:70901ms step_avg:56.09ms
+step:1265/1555 train_time:70992ms step_avg:56.12ms
+step:1266/1555 train_time:71079ms step_avg:56.14ms
+step:1267/1555 train_time:71170ms step_avg:56.17ms
+step:1268/1555 train_time:71253ms step_avg:56.19ms
+step:1269/1555 train_time:71341ms step_avg:56.22ms
+step:1270/1555 train_time:71427ms step_avg:56.24ms
+step:1271/1555 train_time:71515ms step_avg:56.27ms
+step:1272/1555 train_time:71601ms step_avg:56.29ms
+step:1273/1555 train_time:71690ms step_avg:56.32ms
+step:1274/1555 train_time:71776ms step_avg:56.34ms
+step:1275/1555 train_time:71867ms step_avg:56.37ms
+step:1276/1555 train_time:71955ms step_avg:56.39ms
+step:1277/1555 train_time:72046ms step_avg:56.42ms
+step:1278/1555 train_time:72132ms step_avg:56.44ms
+step:1279/1555 train_time:72222ms step_avg:56.47ms
+step:1280/1555 train_time:72307ms step_avg:56.49ms
+step:1281/1555 train_time:72396ms step_avg:56.52ms
+step:1282/1555 train_time:72481ms step_avg:56.54ms
+step:1283/1555 train_time:72570ms step_avg:56.56ms
+step:1284/1555 train_time:72657ms step_avg:56.59ms
+step:1285/1555 train_time:72746ms step_avg:56.61ms
+step:1286/1555 train_time:72833ms step_avg:56.63ms
+step:1287/1555 train_time:72926ms step_avg:56.66ms
+step:1288/1555 train_time:73011ms step_avg:56.69ms
+step:1289/1555 train_time:73101ms step_avg:56.71ms
+step:1290/1555 train_time:73187ms step_avg:56.73ms
+step:1291/1555 train_time:73276ms step_avg:56.76ms
+step:1292/1555 train_time:73364ms step_avg:56.78ms
+step:1293/1555 train_time:73450ms step_avg:56.81ms
+step:1294/1555 train_time:73535ms step_avg:56.83ms
+step:1295/1555 train_time:73625ms step_avg:56.85ms
+step:1296/1555 train_time:73710ms step_avg:56.87ms
+step:1297/1555 train_time:73800ms step_avg:56.90ms
+step:1298/1555 train_time:73887ms step_avg:56.92ms
+step:1299/1555 train_time:73976ms step_avg:56.95ms
+step:1300/1555 train_time:74062ms step_avg:56.97ms
+step:1301/1555 train_time:74152ms step_avg:57.00ms
+step:1302/1555 train_time:74238ms step_avg:57.02ms
+step:1303/1555 train_time:74327ms step_avg:57.04ms
+step:1304/1555 train_time:74413ms step_avg:57.07ms
+step:1305/1555 train_time:74502ms step_avg:57.09ms
+step:1306/1555 train_time:74587ms step_avg:57.11ms
+step:1307/1555 train_time:74679ms step_avg:57.14ms
+step:1308/1555 train_time:74765ms step_avg:57.16ms
+step:1309/1555 train_time:74855ms step_avg:57.18ms
+step:1310/1555 train_time:74942ms step_avg:57.21ms
+step:1311/1555 train_time:75031ms step_avg:57.23ms
+step:1312/1555 train_time:75118ms step_avg:57.25ms
+step:1313/1555 train_time:75208ms step_avg:57.28ms
+step:1314/1555 train_time:75294ms step_avg:57.30ms
+step:1315/1555 train_time:75383ms step_avg:57.33ms
+step:1316/1555 train_time:75468ms step_avg:57.35ms
+step:1317/1555 train_time:75559ms step_avg:57.37ms
+step:1318/1555 train_time:75643ms step_avg:57.39ms
+step:1319/1555 train_time:75731ms step_avg:57.42ms
+step:1320/1555 train_time:75819ms step_avg:57.44ms
+step:1321/1555 train_time:75908ms step_avg:57.46ms
+step:1322/1555 train_time:75994ms step_avg:57.48ms
+step:1323/1555 train_time:76087ms step_avg:57.51ms
+step:1324/1555 train_time:76170ms step_avg:57.53ms
+step:1325/1555 train_time:76260ms step_avg:57.55ms
+step:1326/1555 train_time:76345ms step_avg:57.58ms
+step:1327/1555 train_time:76435ms step_avg:57.60ms
+step:1328/1555 train_time:76521ms step_avg:57.62ms
+step:1329/1555 train_time:76610ms step_avg:57.64ms
+step:1330/1555 train_time:76697ms step_avg:57.67ms
+step:1331/1555 train_time:76786ms step_avg:57.69ms
+step:1332/1555 train_time:76873ms step_avg:57.71ms
+step:1333/1555 train_time:76962ms step_avg:57.74ms
+step:1334/1555 train_time:77049ms step_avg:57.76ms
+step:1335/1555 train_time:77138ms step_avg:57.78ms
+step:1336/1555 train_time:77223ms step_avg:57.80ms
+step:1337/1555 train_time:77314ms step_avg:57.83ms
+step:1338/1555 train_time:77399ms step_avg:57.85ms
+step:1339/1555 train_time:77489ms step_avg:57.87ms
+step:1340/1555 train_time:77574ms step_avg:57.89ms
+step:1341/1555 train_time:77665ms step_avg:57.92ms
+step:1342/1555 train_time:77749ms step_avg:57.94ms
+step:1343/1555 train_time:77840ms step_avg:57.96ms
+step:1344/1555 train_time:77926ms step_avg:57.98ms
+step:1345/1555 train_time:78017ms step_avg:58.00ms
+step:1346/1555 train_time:78102ms step_avg:58.03ms
+step:1347/1555 train_time:78192ms step_avg:58.05ms
+step:1348/1555 train_time:78278ms step_avg:58.07ms
+step:1349/1555 train_time:78370ms step_avg:58.09ms
+step:1350/1555 train_time:78453ms step_avg:58.11ms
+step:1351/1555 train_time:78546ms step_avg:58.14ms
+step:1352/1555 train_time:78631ms step_avg:58.16ms
+step:1353/1555 train_time:78720ms step_avg:58.18ms
+step:1354/1555 train_time:78805ms step_avg:58.20ms
+step:1355/1555 train_time:78898ms step_avg:58.23ms
+step:1356/1555 train_time:78982ms step_avg:58.25ms
+step:1357/1555 train_time:79072ms step_avg:58.27ms
+step:1358/1555 train_time:79159ms step_avg:58.29ms
+step:1359/1555 train_time:79249ms step_avg:58.31ms
+step:1360/1555 train_time:79335ms step_avg:58.33ms
+step:1361/1555 train_time:79425ms step_avg:58.36ms
+step:1362/1555 train_time:79509ms step_avg:58.38ms
+step:1363/1555 train_time:79598ms step_avg:58.40ms
+step:1364/1555 train_time:79684ms step_avg:58.42ms
+step:1365/1555 train_time:79775ms step_avg:58.44ms
+step:1366/1555 train_time:79860ms step_avg:58.46ms
+step:1367/1555 train_time:79951ms step_avg:58.49ms
+step:1368/1555 train_time:80036ms step_avg:58.51ms
+step:1369/1555 train_time:80126ms step_avg:58.53ms
+step:1370/1555 train_time:80213ms step_avg:58.55ms
+step:1371/1555 train_time:80301ms step_avg:58.57ms
+step:1372/1555 train_time:80387ms step_avg:58.59ms
+step:1373/1555 train_time:80477ms step_avg:58.61ms
+step:1374/1555 train_time:80562ms step_avg:58.63ms
+step:1375/1555 train_time:80651ms step_avg:58.66ms
+step:1376/1555 train_time:80739ms step_avg:58.68ms
+step:1377/1555 train_time:80828ms step_avg:58.70ms
+step:1378/1555 train_time:80917ms step_avg:58.72ms
+step:1379/1555 train_time:81004ms step_avg:58.74ms
+step:1380/1555 train_time:81089ms step_avg:58.76ms
+step:1381/1555 train_time:81178ms step_avg:58.78ms
+step:1382/1555 train_time:81268ms step_avg:58.80ms
+step:1383/1555 train_time:81354ms step_avg:58.82ms
+step:1384/1555 train_time:81440ms step_avg:58.84ms
+step:1385/1555 train_time:81530ms step_avg:58.87ms
+step:1386/1555 train_time:81616ms step_avg:58.89ms
+step:1387/1555 train_time:81706ms step_avg:58.91ms
+step:1388/1555 train_time:81791ms step_avg:58.93ms
+step:1389/1555 train_time:81881ms step_avg:58.95ms
+step:1390/1555 train_time:81966ms step_avg:58.97ms
+step:1391/1555 train_time:82056ms step_avg:58.99ms
+step:1392/1555 train_time:82141ms step_avg:59.01ms
+step:1393/1555 train_time:82231ms step_avg:59.03ms
+step:1394/1555 train_time:82317ms step_avg:59.05ms
+step:1395/1555 train_time:82409ms step_avg:59.07ms
+step:1396/1555 train_time:82493ms step_avg:59.09ms
+step:1397/1555 train_time:82585ms step_avg:59.12ms
+step:1398/1555 train_time:82670ms step_avg:59.13ms
+step:1399/1555 train_time:82759ms step_avg:59.16ms
+step:1400/1555 train_time:82845ms step_avg:59.17ms
+step:1401/1555 train_time:82934ms step_avg:59.20ms
+step:1402/1555 train_time:83020ms step_avg:59.22ms
+step:1403/1555 train_time:83110ms step_avg:59.24ms
+step:1404/1555 train_time:83195ms step_avg:59.26ms
+step:1405/1555 train_time:83285ms step_avg:59.28ms
+step:1406/1555 train_time:83370ms step_avg:59.30ms
+step:1407/1555 train_time:83460ms step_avg:59.32ms
+step:1408/1555 train_time:83546ms step_avg:59.34ms
+step:1409/1555 train_time:83635ms step_avg:59.36ms
+step:1410/1555 train_time:83721ms step_avg:59.38ms
+step:1411/1555 train_time:83810ms step_avg:59.40ms
+step:1412/1555 train_time:83896ms step_avg:59.42ms
+step:1413/1555 train_time:83986ms step_avg:59.44ms
+step:1414/1555 train_time:84072ms step_avg:59.46ms
+step:1415/1555 train_time:84162ms step_avg:59.48ms
+step:1416/1555 train_time:84247ms step_avg:59.50ms
+step:1417/1555 train_time:84336ms step_avg:59.52ms
+step:1418/1555 train_time:84422ms step_avg:59.54ms
+step:1419/1555 train_time:84512ms step_avg:59.56ms
+step:1420/1555 train_time:84600ms step_avg:59.58ms
+step:1421/1555 train_time:84688ms step_avg:59.60ms
+step:1422/1555 train_time:84774ms step_avg:59.62ms
+step:1423/1555 train_time:84864ms step_avg:59.64ms
+step:1424/1555 train_time:84949ms step_avg:59.66ms
+step:1425/1555 train_time:85041ms step_avg:59.68ms
+step:1426/1555 train_time:85125ms step_avg:59.70ms
+step:1427/1555 train_time:85214ms step_avg:59.72ms
+step:1428/1555 train_time:85301ms step_avg:59.73ms
+step:1429/1555 train_time:85391ms step_avg:59.76ms
+step:1430/1555 train_time:85478ms step_avg:59.77ms
+step:1431/1555 train_time:85568ms step_avg:59.80ms
+step:1432/1555 train_time:85653ms step_avg:59.81ms
+step:1433/1555 train_time:85743ms step_avg:59.83ms
+step:1434/1555 train_time:85828ms step_avg:59.85ms
+step:1435/1555 train_time:85918ms step_avg:59.87ms
+step:1436/1555 train_time:86006ms step_avg:59.89ms
+step:1437/1555 train_time:86092ms step_avg:59.91ms
+step:1438/1555 train_time:86178ms step_avg:59.93ms
+step:1439/1555 train_time:86268ms step_avg:59.95ms
+step:1440/1555 train_time:86353ms step_avg:59.97ms
+step:1441/1555 train_time:86443ms step_avg:59.99ms
+step:1442/1555 train_time:86529ms step_avg:60.01ms
+step:1443/1555 train_time:86619ms step_avg:60.03ms
+step:1444/1555 train_time:86705ms step_avg:60.04ms
+step:1445/1555 train_time:86795ms step_avg:60.07ms
+step:1446/1555 train_time:86881ms step_avg:60.08ms
+step:1447/1555 train_time:86972ms step_avg:60.11ms
+step:1448/1555 train_time:87058ms step_avg:60.12ms
+step:1449/1555 train_time:87147ms step_avg:60.14ms
+step:1450/1555 train_time:87232ms step_avg:60.16ms
+step:1451/1555 train_time:87322ms step_avg:60.18ms
+step:1452/1555 train_time:87408ms step_avg:60.20ms
+step:1453/1555 train_time:87499ms step_avg:60.22ms
+step:1454/1555 train_time:87584ms step_avg:60.24ms
+step:1455/1555 train_time:87673ms step_avg:60.26ms
+step:1456/1555 train_time:87758ms step_avg:60.27ms
+step:1457/1555 train_time:87848ms step_avg:60.29ms
+step:1458/1555 train_time:87934ms step_avg:60.31ms
+step:1459/1555 train_time:88024ms step_avg:60.33ms
+step:1460/1555 train_time:88110ms step_avg:60.35ms
+step:1461/1555 train_time:88199ms step_avg:60.37ms
+step:1462/1555 train_time:88284ms step_avg:60.39ms
+step:1463/1555 train_time:88374ms step_avg:60.41ms
+step:1464/1555 train_time:88460ms step_avg:60.42ms
+step:1465/1555 train_time:88549ms step_avg:60.44ms
+step:1466/1555 train_time:88635ms step_avg:60.46ms
+step:1467/1555 train_time:88726ms step_avg:60.48ms
+step:1468/1555 train_time:88811ms step_avg:60.50ms
+step:1469/1555 train_time:88900ms step_avg:60.52ms
+step:1470/1555 train_time:88986ms step_avg:60.53ms
+step:1471/1555 train_time:89076ms step_avg:60.55ms
+step:1472/1555 train_time:89161ms step_avg:60.57ms
+step:1473/1555 train_time:89251ms step_avg:60.59ms
+step:1474/1555 train_time:89338ms step_avg:60.61ms
+step:1475/1555 train_time:89428ms step_avg:60.63ms
+step:1476/1555 train_time:89514ms step_avg:60.65ms
+step:1477/1555 train_time:89604ms step_avg:60.67ms
+step:1478/1555 train_time:89689ms step_avg:60.68ms
+step:1479/1555 train_time:89778ms step_avg:60.70ms
+step:1480/1555 train_time:89865ms step_avg:60.72ms
+step:1481/1555 train_time:89955ms step_avg:60.74ms
+step:1482/1555 train_time:90041ms step_avg:60.76ms
+step:1483/1555 train_time:90131ms step_avg:60.78ms
+step:1484/1555 train_time:90218ms step_avg:60.79ms
+step:1485/1555 train_time:90307ms step_avg:60.81ms
+step:1486/1555 train_time:90392ms step_avg:60.83ms
+step:1487/1555 train_time:90485ms step_avg:60.85ms
+step:1488/1555 train_time:90568ms step_avg:60.87ms
+step:1489/1555 train_time:90659ms step_avg:60.89ms
+step:1490/1555 train_time:90745ms step_avg:60.90ms
+step:1491/1555 train_time:90836ms step_avg:60.92ms
+step:1492/1555 train_time:90922ms step_avg:60.94ms
+step:1493/1555 train_time:91012ms step_avg:60.96ms
+step:1494/1555 train_time:91098ms step_avg:60.98ms
+step:1495/1555 train_time:91188ms step_avg:61.00ms
+step:1496/1555 train_time:91273ms step_avg:61.01ms
+step:1497/1555 train_time:91362ms step_avg:61.03ms
+step:1498/1555 train_time:91447ms step_avg:61.05ms
+step:1499/1555 train_time:91537ms step_avg:61.07ms
+step:1500/1555 train_time:91625ms step_avg:61.08ms
+step:1500/1555 val_loss:3.2933 train_time:91697ms step_avg:61.13ms
+step:1501/1555 train_time:91715ms step_avg:61.10ms
+step:1502/1555 train_time:91806ms step_avg:61.12ms
+step:1503/1555 train_time:91900ms step_avg:61.14ms
+step:1504/1555 train_time:91988ms step_avg:61.16ms
+step:1505/1555 train_time:92077ms step_avg:61.18ms
+step:1506/1555 train_time:92162ms step_avg:61.20ms
+step:1507/1555 train_time:92251ms step_avg:61.21ms
+step:1508/1555 train_time:92336ms step_avg:61.23ms
+step:1509/1555 train_time:92425ms step_avg:61.25ms
+step:1510/1555 train_time:92510ms step_avg:61.27ms
+step:1511/1555 train_time:92599ms step_avg:61.28ms
+step:1512/1555 train_time:92685ms step_avg:61.30ms
+step:1513/1555 train_time:92776ms step_avg:61.32ms
+step:1514/1555 train_time:92864ms step_avg:61.34ms
+step:1515/1555 train_time:92956ms step_avg:61.36ms
+step:1516/1555 train_time:93049ms step_avg:61.38ms
+step:1517/1555 train_time:93137ms step_avg:61.40ms
+step:1518/1555 train_time:93222ms step_avg:61.41ms
+step:1519/1555 train_time:93313ms step_avg:61.43ms
+step:1520/1555 train_time:93398ms step_avg:61.45ms
+step:1521/1555 train_time:93487ms step_avg:61.46ms
+step:1522/1555 train_time:93575ms step_avg:61.48ms
+step:1523/1555 train_time:93663ms step_avg:61.50ms
+step:1524/1555 train_time:93751ms step_avg:61.52ms
+step:1525/1555 train_time:93841ms step_avg:61.54ms
+step:1526/1555 train_time:93928ms step_avg:61.55ms
+step:1527/1555 train_time:94019ms step_avg:61.57ms
+step:1528/1555 train_time:94105ms step_avg:61.59ms
+step:1529/1555 train_time:94195ms step_avg:61.61ms
+step:1530/1555 train_time:94282ms step_avg:61.62ms
+step:1531/1555 train_time:94371ms step_avg:61.64ms
+step:1532/1555 train_time:94458ms step_avg:61.66ms
+step:1533/1555 train_time:94546ms step_avg:61.67ms
+step:1534/1555 train_time:94634ms step_avg:61.69ms
+step:1535/1555 train_time:94725ms step_avg:61.71ms
+step:1536/1555 train_time:94811ms step_avg:61.73ms
+step:1537/1555 train_time:94901ms step_avg:61.74ms
+step:1538/1555 train_time:94989ms step_avg:61.76ms
+step:1539/1555 train_time:95079ms step_avg:61.78ms
+step:1540/1555 train_time:95165ms step_avg:61.80ms
+step:1541/1555 train_time:95255ms step_avg:61.81ms
+step:1542/1555 train_time:95340ms step_avg:61.83ms
+step:1543/1555 train_time:95430ms step_avg:61.85ms
+step:1544/1555 train_time:95516ms step_avg:61.86ms
+step:1545/1555 train_time:95605ms step_avg:61.88ms
+step:1546/1555 train_time:95691ms step_avg:61.90ms
+step:1547/1555 train_time:95782ms step_avg:61.91ms
+step:1548/1555 train_time:95869ms step_avg:61.93ms
+step:1549/1555 train_time:95959ms step_avg:61.95ms
+step:1550/1555 train_time:96045ms step_avg:61.96ms
+step:1551/1555 train_time:96136ms step_avg:61.98ms
+step:1552/1555 train_time:96221ms step_avg:62.00ms
+step:1553/1555 train_time:96311ms step_avg:62.02ms
+step:1554/1555 train_time:96397ms step_avg:62.03ms
+step:1555/1555 train_time:96486ms step_avg:62.05ms
+step:1555/1555 val_loss:3.2772 train_time:96556ms step_avg:62.09ms
+peak memory allocated: 31016 MiB reserved: 47018 MiB

--- a/records/track_1_short/2026-01-30_MimeticValueOutput/runs/cc2467e6-e240-4f8f-a889-fbe9230db43f.txt
+++ b/records/track_1_short/2026-01-30_MimeticValueOutput/runs/cc2467e6-e240-4f8f-a889-fbe9230db43f.txt
@@ -1,0 +1,4131 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# Mimetic V-O Initialization (Trockman & Kolter, ICML 2023)
+# Initialize V and O such that V @ O^T ≈ -βI (negative identity-like)
+# This enables attention to make meaningful contributions from step 1
+
+def mimetic_vo_init(attn_bank, model_dim=768, num_heads=6, head_dim=128, beta=0.1, noise_std=0.01):
+    """
+    Initialize attention bank with mimetic structure for V and O.
+    Q and K use standard uniform init, V and O use identity-like structure.
+
+    Args:
+        attn_bank: Tensor of shape (num_layers, 4*model_dim, hdim)
+        model_dim: Model dimension (768)
+        num_heads: Number of attention heads (6)
+        head_dim: Dimension per head (128)
+        beta: Scale for identity structure (0.1 recommended with attn_scale=0.1)
+        noise_std: Standard deviation of noise for symmetry breaking
+    """
+    num_layers = attn_bank.shape[0]
+    dim = model_dim
+    sqrt_beta = beta ** 0.5
+
+    # Standard init for Q and K (existing behavior)
+    attn_std = model_dim ** -0.5
+    attn_bound = (3 ** 0.5) * attn_std
+
+    with torch.no_grad():
+        # Q and K: uniform init (first 2*dim rows)
+        attn_bank[:, :2*dim, :].uniform_(-attn_bound, attn_bound)
+
+        # V and O: mimetic identity structure
+        for layer_idx in range(num_layers):
+            W_V = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+            W_O = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+
+            # Create per-head identity blocks
+            for h in range(num_heads):
+                start, end = h * head_dim, (h + 1) * head_dim
+                eye = torch.eye(head_dim, dtype=attn_bank.dtype, device=attn_bank.device)
+                W_V[start:end, start:end] = sqrt_beta * eye
+                W_O[start:end, start:end] = -sqrt_beta * eye
+
+            # Add noise for symmetry breaking
+            W_V += noise_std * torch.randn_like(W_V)
+            W_O += noise_std * torch.randn_like(W_O)
+
+            # Store in attn_bank: V is rows [2*dim:3*dim], O is rows [3*dim:4*dim]
+            attn_bank[layer_idx, 2*dim:3*dim, :] = W_V
+            attn_bank[layer_idx, 3*dim:4*dim, :] = W_O
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # MLP uses 0.5 * dim^-0.5
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank with MIMETIC V-O initialization
+            # Q and K: uniform init, V and O: identity-like structure for faster convergence
+            mimetic_vo_init(
+                self.attn_bank,
+                model_dim=model_dim,
+                num_heads=num_heads,
+                head_dim=head_dim,
+                beta=0.05,       # Scale for V@O^T ≈ -βI (tuned down from 0.1)
+                noise_std=0.01   # Symmetry breaking noise
+            )
+            # Init MLP bank (c_fc uniform, c_proj zero)
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 234 structure on token value embeddings by @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1515  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.11.14 (main, Oct 21 2025, 18:31:21) [GCC 11.2.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Fri Jan 30 18:43:33 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          Off |   00000000:19:00.0 Off |                    0 |
+| N/A   29C    P0            121W /  700W |    1520MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          Off |   00000000:3B:00.0 Off |                    0 |
+| N/A   25C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          Off |   00000000:4C:00.0 Off |                    0 |
+| N/A   22C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          Off |   00000000:5D:00.0 Off |                    0 |
+| N/A   28C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          Off |   00000000:9B:00.0 Off |                    0 |
+| N/A   29C    P0            113W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          Off |   00000000:BB:00.0 Off |                    0 |
+| N/A   23C    P0            114W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          Off |   00000000:CB:00.0 Off |                    0 |
+| N/A   26C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          Off |   00000000:DB:00.0 Off |                    0 |
+| N/A   24C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1372028      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    1   N/A  N/A   1372029      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    2   N/A  N/A   1372030      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    3   N/A  N/A   1372031      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    4   N/A  N/A   1372032      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    5   N/A  N/A   1372033      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    6   N/A  N/A   1372034      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    7   N/A  N/A   1372035      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 504, 505, 506, 1009, 1010, 1011, 1514, 1515, 1516] for warmup
+Resetting Model
+step:0/1555 val_loss:10.8326 train_time:0ms step_avg:0.03ms
+step:1/1555 train_time:121ms step_avg:121.33ms
+step:2/1555 train_time:142ms step_avg:71.10ms
+step:3/1555 train_time:179ms step_avg:59.61ms
+step:4/1555 train_time:217ms step_avg:54.27ms
+step:5/1555 train_time:248ms step_avg:49.60ms
+step:6/1555 train_time:286ms step_avg:47.66ms
+step:7/1555 train_time:317ms step_avg:45.34ms
+step:8/1555 train_time:356ms step_avg:44.45ms
+step:9/1555 train_time:387ms step_avg:43.00ms
+step:10/1555 train_time:425ms step_avg:42.55ms
+step:11/1555 train_time:457ms step_avg:41.54ms
+step:12/1555 train_time:495ms step_avg:41.25ms
+step:13/1555 train_time:527ms step_avg:40.51ms
+step:14/1555 train_time:565ms step_avg:40.36ms
+step:15/1555 train_time:597ms step_avg:39.77ms
+step:16/1555 train_time:635ms step_avg:39.67ms
+step:17/1555 train_time:666ms step_avg:39.18ms
+step:18/1555 train_time:705ms step_avg:39.14ms
+step:19/1555 train_time:736ms step_avg:38.74ms
+step:20/1555 train_time:774ms step_avg:38.70ms
+step:21/1555 train_time:805ms step_avg:38.35ms
+step:22/1555 train_time:844ms step_avg:38.35ms
+step:23/1555 train_time:875ms step_avg:38.05ms
+step:24/1555 train_time:914ms step_avg:38.06ms
+step:25/1555 train_time:945ms step_avg:37.80ms
+step:26/1555 train_time:984ms step_avg:37.83ms
+step:27/1555 train_time:1015ms step_avg:37.60ms
+step:28/1555 train_time:1053ms step_avg:37.62ms
+step:29/1555 train_time:1085ms step_avg:37.41ms
+step:30/1555 train_time:1123ms step_avg:37.43ms
+step:31/1555 train_time:1154ms step_avg:37.24ms
+step:32/1555 train_time:1193ms step_avg:37.27ms
+step:33/1555 train_time:1224ms step_avg:37.10ms
+step:34/1555 train_time:1263ms step_avg:37.13ms
+step:35/1555 train_time:1294ms step_avg:36.97ms
+step:36/1555 train_time:1332ms step_avg:37.00ms
+step:37/1555 train_time:1364ms step_avg:36.85ms
+step:38/1555 train_time:1402ms step_avg:36.90ms
+step:39/1555 train_time:1433ms step_avg:36.76ms
+step:40/1555 train_time:1472ms step_avg:36.80ms
+step:41/1555 train_time:1503ms step_avg:36.66ms
+step:42/1555 train_time:1541ms step_avg:36.70ms
+step:43/1555 train_time:1573ms step_avg:36.57ms
+step:44/1555 train_time:1611ms step_avg:36.61ms
+step:45/1555 train_time:1642ms step_avg:36.49ms
+step:46/1555 train_time:1680ms step_avg:36.53ms
+step:47/1555 train_time:1712ms step_avg:36.42ms
+step:48/1555 train_time:1750ms step_avg:36.46ms
+step:49/1555 train_time:1782ms step_avg:36.36ms
+step:50/1555 train_time:1820ms step_avg:36.40ms
+step:51/1555 train_time:1851ms step_avg:36.30ms
+step:52/1555 train_time:1890ms step_avg:36.34ms
+step:53/1555 train_time:1921ms step_avg:36.25ms
+step:54/1555 train_time:1960ms step_avg:36.29ms
+step:55/1555 train_time:1991ms step_avg:36.20ms
+step:56/1555 train_time:2029ms step_avg:36.23ms
+step:57/1555 train_time:2060ms step_avg:36.15ms
+step:58/1555 train_time:2099ms step_avg:36.18ms
+step:59/1555 train_time:2130ms step_avg:36.10ms
+step:60/1555 train_time:2168ms step_avg:36.13ms
+step:61/1555 train_time:2199ms step_avg:36.05ms
+step:62/1555 train_time:2237ms step_avg:36.09ms
+step:63/1555 train_time:2269ms step_avg:36.01ms
+step:64/1555 train_time:2307ms step_avg:36.04ms
+step:65/1555 train_time:2338ms step_avg:35.97ms
+step:66/1555 train_time:2376ms step_avg:36.00ms
+step:67/1555 train_time:2408ms step_avg:35.94ms
+step:68/1555 train_time:2446ms step_avg:35.97ms
+step:69/1555 train_time:2478ms step_avg:35.91ms
+step:70/1555 train_time:2516ms step_avg:35.94ms
+step:71/1555 train_time:2547ms step_avg:35.87ms
+step:72/1555 train_time:2586ms step_avg:35.91ms
+step:73/1555 train_time:2617ms step_avg:35.85ms
+step:74/1555 train_time:2655ms step_avg:35.88ms
+step:75/1555 train_time:2686ms step_avg:35.82ms
+step:76/1555 train_time:2725ms step_avg:35.85ms
+step:77/1555 train_time:2756ms step_avg:35.79ms
+step:78/1555 train_time:2794ms step_avg:35.82ms
+step:79/1555 train_time:2825ms step_avg:35.76ms
+step:80/1555 train_time:2864ms step_avg:35.80ms
+step:81/1555 train_time:2895ms step_avg:35.74ms
+step:82/1555 train_time:2933ms step_avg:35.77ms
+step:83/1555 train_time:2965ms step_avg:35.72ms
+step:84/1555 train_time:3003ms step_avg:35.75ms
+step:85/1555 train_time:3034ms step_avg:35.70ms
+step:86/1555 train_time:3072ms step_avg:35.72ms
+step:87/1555 train_time:3104ms step_avg:35.67ms
+step:88/1555 train_time:3142ms step_avg:35.71ms
+step:89/1555 train_time:3173ms step_avg:35.65ms
+step:90/1555 train_time:3211ms step_avg:35.68ms
+step:91/1555 train_time:3243ms step_avg:35.64ms
+step:92/1555 train_time:3281ms step_avg:35.66ms
+step:93/1555 train_time:3312ms step_avg:35.61ms
+step:94/1555 train_time:3350ms step_avg:35.64ms
+step:95/1555 train_time:3381ms step_avg:35.59ms
+step:96/1555 train_time:3420ms step_avg:35.62ms
+step:97/1555 train_time:3451ms step_avg:35.58ms
+step:98/1555 train_time:3489ms step_avg:35.61ms
+step:99/1555 train_time:3521ms step_avg:35.56ms
+step:100/1555 train_time:3559ms step_avg:35.59ms
+step:101/1555 train_time:3590ms step_avg:35.55ms
+step:102/1555 train_time:3628ms step_avg:35.57ms
+step:103/1555 train_time:3660ms step_avg:35.53ms
+step:104/1555 train_time:3698ms step_avg:35.55ms
+step:105/1555 train_time:3729ms step_avg:35.51ms
+step:106/1555 train_time:3768ms step_avg:35.54ms
+step:107/1555 train_time:3799ms step_avg:35.50ms
+step:108/1555 train_time:3837ms step_avg:35.53ms
+step:109/1555 train_time:3868ms step_avg:35.49ms
+step:110/1555 train_time:3906ms step_avg:35.51ms
+step:111/1555 train_time:3938ms step_avg:35.47ms
+step:112/1555 train_time:3976ms step_avg:35.50ms
+step:113/1555 train_time:4007ms step_avg:35.46ms
+step:114/1555 train_time:4045ms step_avg:35.49ms
+step:115/1555 train_time:4077ms step_avg:35.45ms
+step:116/1555 train_time:4115ms step_avg:35.47ms
+step:117/1555 train_time:4146ms step_avg:35.43ms
+step:118/1555 train_time:4184ms step_avg:35.46ms
+step:119/1555 train_time:4216ms step_avg:35.43ms
+step:120/1555 train_time:4254ms step_avg:35.45ms
+step:121/1555 train_time:4285ms step_avg:35.42ms
+step:122/1555 train_time:4324ms step_avg:35.44ms
+step:123/1555 train_time:4355ms step_avg:35.41ms
+step:124/1555 train_time:4393ms step_avg:35.43ms
+step:125/1555 train_time:4424ms step_avg:35.39ms
+step:126/1555 train_time:4463ms step_avg:35.42ms
+step:127/1555 train_time:4494ms step_avg:35.38ms
+step:128/1555 train_time:4532ms step_avg:35.40ms
+step:129/1555 train_time:4563ms step_avg:35.37ms
+step:130/1555 train_time:4602ms step_avg:35.40ms
+step:131/1555 train_time:4633ms step_avg:35.36ms
+step:132/1555 train_time:4671ms step_avg:35.38ms
+step:133/1555 train_time:4702ms step_avg:35.36ms
+step:134/1555 train_time:4740ms step_avg:35.37ms
+step:135/1555 train_time:4771ms step_avg:35.34ms
+step:136/1555 train_time:4809ms step_avg:35.36ms
+step:137/1555 train_time:4841ms step_avg:35.33ms
+step:138/1555 train_time:4878ms step_avg:35.35ms
+step:139/1555 train_time:4910ms step_avg:35.32ms
+step:140/1555 train_time:4948ms step_avg:35.34ms
+step:141/1555 train_time:4979ms step_avg:35.31ms
+step:142/1555 train_time:5017ms step_avg:35.33ms
+step:143/1555 train_time:5049ms step_avg:35.31ms
+step:144/1555 train_time:5087ms step_avg:35.32ms
+step:145/1555 train_time:5118ms step_avg:35.30ms
+step:146/1555 train_time:5156ms step_avg:35.32ms
+step:147/1555 train_time:5188ms step_avg:35.29ms
+step:148/1555 train_time:5226ms step_avg:35.31ms
+step:149/1555 train_time:5257ms step_avg:35.28ms
+step:150/1555 train_time:5295ms step_avg:35.30ms
+step:151/1555 train_time:5327ms step_avg:35.28ms
+step:152/1555 train_time:5365ms step_avg:35.30ms
+step:153/1555 train_time:5396ms step_avg:35.27ms
+step:154/1555 train_time:5434ms step_avg:35.29ms
+step:155/1555 train_time:5465ms step_avg:35.26ms
+step:156/1555 train_time:5504ms step_avg:35.28ms
+step:157/1555 train_time:5535ms step_avg:35.26ms
+step:158/1555 train_time:5573ms step_avg:35.27ms
+step:159/1555 train_time:5604ms step_avg:35.25ms
+step:160/1555 train_time:5642ms step_avg:35.27ms
+step:161/1555 train_time:5674ms step_avg:35.24ms
+step:162/1555 train_time:5712ms step_avg:35.26ms
+step:163/1555 train_time:5743ms step_avg:35.23ms
+step:164/1555 train_time:5782ms step_avg:35.25ms
+step:165/1555 train_time:5813ms step_avg:35.23ms
+step:166/1555 train_time:5851ms step_avg:35.24ms
+step:167/1555 train_time:5882ms step_avg:35.22ms
+step:168/1555 train_time:5920ms step_avg:35.24ms
+step:169/1555 train_time:5951ms step_avg:35.21ms
+step:170/1555 train_time:5989ms step_avg:35.23ms
+step:171/1555 train_time:6021ms step_avg:35.21ms
+step:172/1555 train_time:6058ms step_avg:35.22ms
+step:173/1555 train_time:6090ms step_avg:35.20ms
+step:174/1555 train_time:6128ms step_avg:35.22ms
+step:175/1555 train_time:6159ms step_avg:35.20ms
+step:176/1555 train_time:6197ms step_avg:35.21ms
+step:177/1555 train_time:6228ms step_avg:35.19ms
+step:178/1555 train_time:6266ms step_avg:35.20ms
+step:179/1555 train_time:6297ms step_avg:35.18ms
+step:180/1555 train_time:6335ms step_avg:35.20ms
+step:181/1555 train_time:6367ms step_avg:35.18ms
+step:182/1555 train_time:6405ms step_avg:35.19ms
+step:183/1555 train_time:6436ms step_avg:35.17ms
+step:184/1555 train_time:6474ms step_avg:35.19ms
+step:185/1555 train_time:6505ms step_avg:35.16ms
+step:186/1555 train_time:6543ms step_avg:35.18ms
+step:187/1555 train_time:6574ms step_avg:35.16ms
+step:188/1555 train_time:6612ms step_avg:35.17ms
+step:189/1555 train_time:6644ms step_avg:35.15ms
+step:190/1555 train_time:6682ms step_avg:35.17ms
+step:191/1555 train_time:6713ms step_avg:35.15ms
+step:192/1555 train_time:6751ms step_avg:35.16ms
+step:193/1555 train_time:6783ms step_avg:35.14ms
+step:194/1555 train_time:6821ms step_avg:35.16ms
+step:195/1555 train_time:6852ms step_avg:35.14ms
+step:196/1555 train_time:6890ms step_avg:35.15ms
+step:197/1555 train_time:6921ms step_avg:35.13ms
+step:198/1555 train_time:6959ms step_avg:35.15ms
+step:199/1555 train_time:6990ms step_avg:35.13ms
+step:200/1555 train_time:7028ms step_avg:35.14ms
+step:201/1555 train_time:7060ms step_avg:35.12ms
+step:202/1555 train_time:7098ms step_avg:35.14ms
+step:203/1555 train_time:7129ms step_avg:35.12ms
+step:204/1555 train_time:7167ms step_avg:35.13ms
+step:205/1555 train_time:7198ms step_avg:35.11ms
+step:206/1555 train_time:7236ms step_avg:35.13ms
+step:207/1555 train_time:7268ms step_avg:35.11ms
+step:208/1555 train_time:7306ms step_avg:35.12ms
+step:209/1555 train_time:7337ms step_avg:35.11ms
+step:210/1555 train_time:7375ms step_avg:35.12ms
+step:211/1555 train_time:7407ms step_avg:35.10ms
+step:212/1555 train_time:7445ms step_avg:35.12ms
+step:213/1555 train_time:7476ms step_avg:35.10ms
+step:214/1555 train_time:7514ms step_avg:35.11ms
+step:215/1555 train_time:7546ms step_avg:35.10ms
+step:216/1555 train_time:7584ms step_avg:35.11ms
+step:217/1555 train_time:7615ms step_avg:35.09ms
+step:218/1555 train_time:7653ms step_avg:35.11ms
+step:219/1555 train_time:7685ms step_avg:35.09ms
+step:220/1555 train_time:7723ms step_avg:35.10ms
+step:221/1555 train_time:7754ms step_avg:35.09ms
+step:222/1555 train_time:7792ms step_avg:35.10ms
+step:223/1555 train_time:7823ms step_avg:35.08ms
+step:224/1555 train_time:7861ms step_avg:35.10ms
+step:225/1555 train_time:7893ms step_avg:35.08ms
+step:226/1555 train_time:7931ms step_avg:35.09ms
+step:227/1555 train_time:7962ms step_avg:35.07ms
+step:228/1555 train_time:8000ms step_avg:35.09ms
+step:229/1555 train_time:8031ms step_avg:35.07ms
+step:230/1555 train_time:8069ms step_avg:35.08ms
+step:231/1555 train_time:8101ms step_avg:35.07ms
+step:232/1555 train_time:8139ms step_avg:35.08ms
+step:233/1555 train_time:8170ms step_avg:35.07ms
+step:234/1555 train_time:8208ms step_avg:35.08ms
+step:235/1555 train_time:8239ms step_avg:35.06ms
+step:236/1555 train_time:8277ms step_avg:35.07ms
+step:237/1555 train_time:8309ms step_avg:35.06ms
+step:238/1555 train_time:8347ms step_avg:35.07ms
+step:239/1555 train_time:8378ms step_avg:35.05ms
+step:240/1555 train_time:8416ms step_avg:35.07ms
+step:241/1555 train_time:8447ms step_avg:35.05ms
+step:242/1555 train_time:8486ms step_avg:35.07ms
+step:243/1555 train_time:8517ms step_avg:35.05ms
+step:244/1555 train_time:8555ms step_avg:35.06ms
+step:245/1555 train_time:8586ms step_avg:35.05ms
+step:246/1555 train_time:8625ms step_avg:35.06ms
+step:247/1555 train_time:8656ms step_avg:35.05ms
+step:248/1555 train_time:8694ms step_avg:35.06ms
+step:249/1555 train_time:8726ms step_avg:35.04ms
+step:250/1555 train_time:8764ms step_avg:35.05ms
+step:250/1555 val_loss:4.5528 train_time:8812ms step_avg:35.25ms
+step:251/1555 train_time:8832ms step_avg:35.19ms
+step:252/1555 train_time:8850ms step_avg:35.12ms
+step:253/1555 train_time:8867ms step_avg:35.05ms
+step:254/1555 train_time:8906ms step_avg:35.06ms
+step:255/1555 train_time:8938ms step_avg:35.05ms
+step:256/1555 train_time:8979ms step_avg:35.07ms
+step:257/1555 train_time:9011ms step_avg:35.06ms
+step:258/1555 train_time:9050ms step_avg:35.08ms
+step:259/1555 train_time:9082ms step_avg:35.07ms
+step:260/1555 train_time:9121ms step_avg:35.08ms
+step:261/1555 train_time:9152ms step_avg:35.07ms
+step:262/1555 train_time:9191ms step_avg:35.08ms
+step:263/1555 train_time:9222ms step_avg:35.07ms
+step:264/1555 train_time:9260ms step_avg:35.08ms
+step:265/1555 train_time:9291ms step_avg:35.06ms
+step:266/1555 train_time:9330ms step_avg:35.07ms
+step:267/1555 train_time:9361ms step_avg:35.06ms
+step:268/1555 train_time:9399ms step_avg:35.07ms
+step:269/1555 train_time:9430ms step_avg:35.06ms
+step:270/1555 train_time:9469ms step_avg:35.07ms
+step:271/1555 train_time:9500ms step_avg:35.05ms
+step:272/1555 train_time:9538ms step_avg:35.07ms
+step:273/1555 train_time:9569ms step_avg:35.05ms
+step:274/1555 train_time:9607ms step_avg:35.06ms
+step:275/1555 train_time:9638ms step_avg:35.05ms
+step:276/1555 train_time:9676ms step_avg:35.06ms
+step:277/1555 train_time:9708ms step_avg:35.05ms
+step:278/1555 train_time:9746ms step_avg:35.06ms
+step:279/1555 train_time:9777ms step_avg:35.04ms
+step:280/1555 train_time:9815ms step_avg:35.05ms
+step:281/1555 train_time:9846ms step_avg:35.04ms
+step:282/1555 train_time:9884ms step_avg:35.05ms
+step:283/1555 train_time:9915ms step_avg:35.04ms
+step:284/1555 train_time:9953ms step_avg:35.05ms
+step:285/1555 train_time:9984ms step_avg:35.03ms
+step:286/1555 train_time:10022ms step_avg:35.04ms
+step:287/1555 train_time:10054ms step_avg:35.03ms
+step:288/1555 train_time:10092ms step_avg:35.04ms
+step:289/1555 train_time:10123ms step_avg:35.03ms
+step:290/1555 train_time:10161ms step_avg:35.04ms
+step:291/1555 train_time:10193ms step_avg:35.03ms
+step:292/1555 train_time:10231ms step_avg:35.04ms
+step:293/1555 train_time:10262ms step_avg:35.02ms
+step:294/1555 train_time:10300ms step_avg:35.03ms
+step:295/1555 train_time:10332ms step_avg:35.02ms
+step:296/1555 train_time:10370ms step_avg:35.03ms
+step:297/1555 train_time:10401ms step_avg:35.02ms
+step:298/1555 train_time:10439ms step_avg:35.03ms
+step:299/1555 train_time:10470ms step_avg:35.02ms
+step:300/1555 train_time:10508ms step_avg:35.03ms
+step:301/1555 train_time:10540ms step_avg:35.02ms
+step:302/1555 train_time:10578ms step_avg:35.03ms
+step:303/1555 train_time:10609ms step_avg:35.01ms
+step:304/1555 train_time:10647ms step_avg:35.02ms
+step:305/1555 train_time:10678ms step_avg:35.01ms
+step:306/1555 train_time:10716ms step_avg:35.02ms
+step:307/1555 train_time:10748ms step_avg:35.01ms
+step:308/1555 train_time:10786ms step_avg:35.02ms
+step:309/1555 train_time:10817ms step_avg:35.01ms
+step:310/1555 train_time:10855ms step_avg:35.02ms
+step:311/1555 train_time:10886ms step_avg:35.00ms
+step:312/1555 train_time:10924ms step_avg:35.01ms
+step:313/1555 train_time:10955ms step_avg:35.00ms
+step:314/1555 train_time:10994ms step_avg:35.01ms
+step:315/1555 train_time:11025ms step_avg:35.00ms
+step:316/1555 train_time:11063ms step_avg:35.01ms
+step:317/1555 train_time:11095ms step_avg:35.00ms
+step:318/1555 train_time:11133ms step_avg:35.01ms
+step:319/1555 train_time:11164ms step_avg:35.00ms
+step:320/1555 train_time:11202ms step_avg:35.01ms
+step:321/1555 train_time:11233ms step_avg:34.99ms
+step:322/1555 train_time:11272ms step_avg:35.00ms
+step:323/1555 train_time:11303ms step_avg:34.99ms
+step:324/1555 train_time:11341ms step_avg:35.00ms
+step:325/1555 train_time:11372ms step_avg:34.99ms
+step:326/1555 train_time:11411ms step_avg:35.00ms
+step:327/1555 train_time:11442ms step_avg:34.99ms
+step:328/1555 train_time:11480ms step_avg:35.00ms
+step:329/1555 train_time:11511ms step_avg:34.99ms
+step:330/1555 train_time:11549ms step_avg:35.00ms
+step:331/1555 train_time:11580ms step_avg:34.99ms
+step:332/1555 train_time:11618ms step_avg:34.99ms
+step:333/1555 train_time:11650ms step_avg:34.98ms
+step:334/1555 train_time:11688ms step_avg:34.99ms
+step:335/1555 train_time:11719ms step_avg:34.98ms
+step:336/1555 train_time:11757ms step_avg:34.99ms
+step:337/1555 train_time:11788ms step_avg:34.98ms
+step:338/1555 train_time:11826ms step_avg:34.99ms
+step:339/1555 train_time:11857ms step_avg:34.98ms
+step:340/1555 train_time:11895ms step_avg:34.99ms
+step:341/1555 train_time:11927ms step_avg:34.98ms
+step:342/1555 train_time:11965ms step_avg:34.98ms
+step:343/1555 train_time:11996ms step_avg:34.97ms
+step:344/1555 train_time:12034ms step_avg:34.98ms
+step:345/1555 train_time:12065ms step_avg:34.97ms
+step:346/1555 train_time:12103ms step_avg:34.98ms
+step:347/1555 train_time:12135ms step_avg:34.97ms
+step:348/1555 train_time:12173ms step_avg:34.98ms
+step:349/1555 train_time:12204ms step_avg:34.97ms
+step:350/1555 train_time:12242ms step_avg:34.98ms
+step:351/1555 train_time:12273ms step_avg:34.97ms
+step:352/1555 train_time:12312ms step_avg:34.98ms
+step:353/1555 train_time:12343ms step_avg:34.97ms
+step:354/1555 train_time:12381ms step_avg:34.97ms
+step:355/1555 train_time:12412ms step_avg:34.96ms
+step:356/1555 train_time:12450ms step_avg:34.97ms
+step:357/1555 train_time:12482ms step_avg:34.96ms
+step:358/1555 train_time:12519ms step_avg:34.97ms
+step:359/1555 train_time:12551ms step_avg:34.96ms
+step:360/1555 train_time:12589ms step_avg:34.97ms
+step:361/1555 train_time:12620ms step_avg:34.96ms
+step:362/1555 train_time:12658ms step_avg:34.97ms
+step:363/1555 train_time:12689ms step_avg:34.96ms
+step:364/1555 train_time:12727ms step_avg:34.97ms
+step:365/1555 train_time:12759ms step_avg:34.96ms
+step:366/1555 train_time:12797ms step_avg:34.96ms
+step:367/1555 train_time:12828ms step_avg:34.95ms
+step:368/1555 train_time:12867ms step_avg:34.96ms
+step:369/1555 train_time:12897ms step_avg:34.95ms
+step:370/1555 train_time:12935ms step_avg:34.96ms
+step:371/1555 train_time:12967ms step_avg:34.95ms
+step:372/1555 train_time:13005ms step_avg:34.96ms
+step:373/1555 train_time:13036ms step_avg:34.95ms
+step:374/1555 train_time:13074ms step_avg:34.96ms
+step:375/1555 train_time:13106ms step_avg:34.95ms
+step:376/1555 train_time:13143ms step_avg:34.96ms
+step:377/1555 train_time:13175ms step_avg:34.95ms
+step:378/1555 train_time:13213ms step_avg:34.95ms
+step:379/1555 train_time:13244ms step_avg:34.94ms
+step:380/1555 train_time:13282ms step_avg:34.95ms
+step:381/1555 train_time:13313ms step_avg:34.94ms
+step:382/1555 train_time:13352ms step_avg:34.95ms
+step:383/1555 train_time:13383ms step_avg:34.94ms
+step:384/1555 train_time:13421ms step_avg:34.95ms
+step:385/1555 train_time:13452ms step_avg:34.94ms
+step:386/1555 train_time:13491ms step_avg:34.95ms
+step:387/1555 train_time:13522ms step_avg:34.94ms
+step:388/1555 train_time:13560ms step_avg:34.95ms
+step:389/1555 train_time:13591ms step_avg:34.94ms
+step:390/1555 train_time:13630ms step_avg:34.95ms
+step:391/1555 train_time:13661ms step_avg:34.94ms
+step:392/1555 train_time:13699ms step_avg:34.95ms
+step:393/1555 train_time:13730ms step_avg:34.94ms
+step:394/1555 train_time:13768ms step_avg:34.94ms
+step:395/1555 train_time:13799ms step_avg:34.93ms
+step:396/1555 train_time:13837ms step_avg:34.94ms
+step:397/1555 train_time:13868ms step_avg:34.93ms
+step:398/1555 train_time:13906ms step_avg:34.94ms
+step:399/1555 train_time:13937ms step_avg:34.93ms
+step:400/1555 train_time:13975ms step_avg:34.94ms
+step:401/1555 train_time:14006ms step_avg:34.93ms
+step:402/1555 train_time:14044ms step_avg:34.94ms
+step:403/1555 train_time:14075ms step_avg:34.93ms
+step:404/1555 train_time:14114ms step_avg:34.93ms
+step:405/1555 train_time:14144ms step_avg:34.92ms
+step:406/1555 train_time:14182ms step_avg:34.93ms
+step:407/1555 train_time:14214ms step_avg:34.92ms
+step:408/1555 train_time:14252ms step_avg:34.93ms
+step:409/1555 train_time:14283ms step_avg:34.92ms
+step:410/1555 train_time:14321ms step_avg:34.93ms
+step:411/1555 train_time:14353ms step_avg:34.92ms
+step:412/1555 train_time:14391ms step_avg:34.93ms
+step:413/1555 train_time:14423ms step_avg:34.92ms
+step:414/1555 train_time:14460ms step_avg:34.93ms
+step:415/1555 train_time:14492ms step_avg:34.92ms
+step:416/1555 train_time:14530ms step_avg:34.93ms
+step:417/1555 train_time:14561ms step_avg:34.92ms
+step:418/1555 train_time:14599ms step_avg:34.93ms
+step:419/1555 train_time:14631ms step_avg:34.92ms
+step:420/1555 train_time:14669ms step_avg:34.93ms
+step:421/1555 train_time:14700ms step_avg:34.92ms
+step:422/1555 train_time:14738ms step_avg:34.92ms
+step:423/1555 train_time:14769ms step_avg:34.92ms
+step:424/1555 train_time:14807ms step_avg:34.92ms
+step:425/1555 train_time:14838ms step_avg:34.91ms
+step:426/1555 train_time:14876ms step_avg:34.92ms
+step:427/1555 train_time:14908ms step_avg:34.91ms
+step:428/1555 train_time:14946ms step_avg:34.92ms
+step:429/1555 train_time:14977ms step_avg:34.91ms
+step:430/1555 train_time:15015ms step_avg:34.92ms
+step:431/1555 train_time:15046ms step_avg:34.91ms
+step:432/1555 train_time:15084ms step_avg:34.92ms
+step:433/1555 train_time:15116ms step_avg:34.91ms
+step:434/1555 train_time:15153ms step_avg:34.92ms
+step:435/1555 train_time:15185ms step_avg:34.91ms
+step:436/1555 train_time:15222ms step_avg:34.91ms
+step:437/1555 train_time:15254ms step_avg:34.91ms
+step:438/1555 train_time:15292ms step_avg:34.91ms
+step:439/1555 train_time:15323ms step_avg:34.91ms
+step:440/1555 train_time:15362ms step_avg:34.91ms
+step:441/1555 train_time:15393ms step_avg:34.90ms
+step:442/1555 train_time:15431ms step_avg:34.91ms
+step:443/1555 train_time:15463ms step_avg:34.90ms
+step:444/1555 train_time:15500ms step_avg:34.91ms
+step:445/1555 train_time:15532ms step_avg:34.90ms
+step:446/1555 train_time:15570ms step_avg:34.91ms
+step:447/1555 train_time:15601ms step_avg:34.90ms
+step:448/1555 train_time:15639ms step_avg:34.91ms
+step:449/1555 train_time:15670ms step_avg:34.90ms
+step:450/1555 train_time:15708ms step_avg:34.91ms
+step:451/1555 train_time:15739ms step_avg:34.90ms
+step:452/1555 train_time:15777ms step_avg:34.90ms
+step:453/1555 train_time:15808ms step_avg:34.90ms
+step:454/1555 train_time:15846ms step_avg:34.90ms
+step:455/1555 train_time:15877ms step_avg:34.90ms
+step:456/1555 train_time:15915ms step_avg:34.90ms
+step:457/1555 train_time:15947ms step_avg:34.89ms
+step:458/1555 train_time:15984ms step_avg:34.90ms
+step:459/1555 train_time:16016ms step_avg:34.89ms
+step:460/1555 train_time:16054ms step_avg:34.90ms
+step:461/1555 train_time:16085ms step_avg:34.89ms
+step:462/1555 train_time:16123ms step_avg:34.90ms
+step:463/1555 train_time:16154ms step_avg:34.89ms
+step:464/1555 train_time:16192ms step_avg:34.90ms
+step:465/1555 train_time:16223ms step_avg:34.89ms
+step:466/1555 train_time:16261ms step_avg:34.90ms
+step:467/1555 train_time:16293ms step_avg:34.89ms
+step:468/1555 train_time:16331ms step_avg:34.90ms
+step:469/1555 train_time:16362ms step_avg:34.89ms
+step:470/1555 train_time:16400ms step_avg:34.89ms
+step:471/1555 train_time:16431ms step_avg:34.89ms
+step:472/1555 train_time:16470ms step_avg:34.89ms
+step:473/1555 train_time:16501ms step_avg:34.89ms
+step:474/1555 train_time:16539ms step_avg:34.89ms
+step:475/1555 train_time:16570ms step_avg:34.88ms
+step:476/1555 train_time:16608ms step_avg:34.89ms
+step:477/1555 train_time:16640ms step_avg:34.88ms
+step:478/1555 train_time:16678ms step_avg:34.89ms
+step:479/1555 train_time:16709ms step_avg:34.88ms
+step:480/1555 train_time:16747ms step_avg:34.89ms
+step:481/1555 train_time:16778ms step_avg:34.88ms
+step:482/1555 train_time:16816ms step_avg:34.89ms
+step:483/1555 train_time:16847ms step_avg:34.88ms
+step:484/1555 train_time:16885ms step_avg:34.89ms
+step:485/1555 train_time:16917ms step_avg:34.88ms
+step:486/1555 train_time:16955ms step_avg:34.89ms
+step:487/1555 train_time:16986ms step_avg:34.88ms
+step:488/1555 train_time:17024ms step_avg:34.89ms
+step:489/1555 train_time:17055ms step_avg:34.88ms
+step:490/1555 train_time:17093ms step_avg:34.88ms
+step:491/1555 train_time:17124ms step_avg:34.88ms
+step:492/1555 train_time:17162ms step_avg:34.88ms
+step:493/1555 train_time:17193ms step_avg:34.87ms
+step:494/1555 train_time:17231ms step_avg:34.88ms
+step:495/1555 train_time:17262ms step_avg:34.87ms
+step:496/1555 train_time:17300ms step_avg:34.88ms
+step:497/1555 train_time:17331ms step_avg:34.87ms
+step:498/1555 train_time:17369ms step_avg:34.88ms
+step:499/1555 train_time:17401ms step_avg:34.87ms
+step:500/1555 train_time:17438ms step_avg:34.88ms
+step:500/1555 val_loss:4.2253 train_time:17487ms step_avg:34.97ms
+step:501/1555 train_time:17506ms step_avg:34.94ms
+step:502/1555 train_time:17524ms step_avg:34.91ms
+step:503/1555 train_time:17541ms step_avg:34.87ms
+step:504/1555 train_time:17581ms step_avg:34.88ms
+step:505/1555 train_time:17614ms step_avg:34.88ms
+step:506/1555 train_time:17691ms step_avg:34.96ms
+step:507/1555 train_time:17752ms step_avg:35.01ms
+step:508/1555 train_time:17810ms step_avg:35.06ms
+step:509/1555 train_time:17873ms step_avg:35.11ms
+step:510/1555 train_time:17932ms step_avg:35.16ms
+step:511/1555 train_time:17994ms step_avg:35.21ms
+step:512/1555 train_time:18052ms step_avg:35.26ms
+step:513/1555 train_time:18116ms step_avg:35.31ms
+step:514/1555 train_time:18174ms step_avg:35.36ms
+step:515/1555 train_time:18236ms step_avg:35.41ms
+step:516/1555 train_time:18295ms step_avg:35.46ms
+step:517/1555 train_time:18357ms step_avg:35.51ms
+step:518/1555 train_time:18417ms step_avg:35.55ms
+step:519/1555 train_time:18481ms step_avg:35.61ms
+step:520/1555 train_time:18541ms step_avg:35.66ms
+step:521/1555 train_time:18606ms step_avg:35.71ms
+step:522/1555 train_time:18665ms step_avg:35.76ms
+step:523/1555 train_time:18729ms step_avg:35.81ms
+step:524/1555 train_time:18789ms step_avg:35.86ms
+step:525/1555 train_time:18852ms step_avg:35.91ms
+step:526/1555 train_time:18911ms step_avg:35.95ms
+step:527/1555 train_time:18973ms step_avg:36.00ms
+step:528/1555 train_time:19032ms step_avg:36.05ms
+step:529/1555 train_time:19095ms step_avg:36.10ms
+step:530/1555 train_time:19154ms step_avg:36.14ms
+step:531/1555 train_time:19217ms step_avg:36.19ms
+step:532/1555 train_time:19276ms step_avg:36.23ms
+step:533/1555 train_time:19339ms step_avg:36.28ms
+step:534/1555 train_time:19398ms step_avg:36.33ms
+step:535/1555 train_time:19461ms step_avg:36.38ms
+step:536/1555 train_time:19521ms step_avg:36.42ms
+step:537/1555 train_time:19584ms step_avg:36.47ms
+step:538/1555 train_time:19644ms step_avg:36.51ms
+step:539/1555 train_time:19707ms step_avg:36.56ms
+step:540/1555 train_time:19767ms step_avg:36.60ms
+step:541/1555 train_time:19830ms step_avg:36.66ms
+step:542/1555 train_time:19890ms step_avg:36.70ms
+step:543/1555 train_time:19954ms step_avg:36.75ms
+step:544/1555 train_time:20013ms step_avg:36.79ms
+step:545/1555 train_time:20076ms step_avg:36.84ms
+step:546/1555 train_time:20135ms step_avg:36.88ms
+step:547/1555 train_time:20197ms step_avg:36.92ms
+step:548/1555 train_time:20256ms step_avg:36.96ms
+step:549/1555 train_time:20319ms step_avg:37.01ms
+step:550/1555 train_time:20378ms step_avg:37.05ms
+step:551/1555 train_time:20441ms step_avg:37.10ms
+step:552/1555 train_time:20501ms step_avg:37.14ms
+step:553/1555 train_time:20564ms step_avg:37.19ms
+step:554/1555 train_time:20623ms step_avg:37.23ms
+step:555/1555 train_time:20687ms step_avg:37.27ms
+step:556/1555 train_time:20746ms step_avg:37.31ms
+step:557/1555 train_time:20810ms step_avg:37.36ms
+step:558/1555 train_time:20869ms step_avg:37.40ms
+step:559/1555 train_time:20933ms step_avg:37.45ms
+step:560/1555 train_time:20992ms step_avg:37.49ms
+step:561/1555 train_time:21056ms step_avg:37.53ms
+step:562/1555 train_time:21116ms step_avg:37.57ms
+step:563/1555 train_time:21179ms step_avg:37.62ms
+step:564/1555 train_time:21239ms step_avg:37.66ms
+step:565/1555 train_time:21301ms step_avg:37.70ms
+step:566/1555 train_time:21365ms step_avg:37.75ms
+step:567/1555 train_time:21427ms step_avg:37.79ms
+step:568/1555 train_time:21485ms step_avg:37.83ms
+step:569/1555 train_time:21547ms step_avg:37.87ms
+step:570/1555 train_time:21607ms step_avg:37.91ms
+step:571/1555 train_time:21670ms step_avg:37.95ms
+step:572/1555 train_time:21729ms step_avg:37.99ms
+step:573/1555 train_time:21793ms step_avg:38.03ms
+step:574/1555 train_time:21852ms step_avg:38.07ms
+step:575/1555 train_time:21915ms step_avg:38.11ms
+step:576/1555 train_time:21974ms step_avg:38.15ms
+step:577/1555 train_time:22037ms step_avg:38.19ms
+step:578/1555 train_time:22096ms step_avg:38.23ms
+step:579/1555 train_time:22159ms step_avg:38.27ms
+step:580/1555 train_time:22218ms step_avg:38.31ms
+step:581/1555 train_time:22281ms step_avg:38.35ms
+step:582/1555 train_time:22340ms step_avg:38.38ms
+step:583/1555 train_time:22403ms step_avg:38.43ms
+step:584/1555 train_time:22462ms step_avg:38.46ms
+step:585/1555 train_time:22526ms step_avg:38.51ms
+step:586/1555 train_time:22585ms step_avg:38.54ms
+step:587/1555 train_time:22649ms step_avg:38.58ms
+step:588/1555 train_time:22708ms step_avg:38.62ms
+step:589/1555 train_time:22772ms step_avg:38.66ms
+step:590/1555 train_time:22831ms step_avg:38.70ms
+step:591/1555 train_time:22895ms step_avg:38.74ms
+step:592/1555 train_time:22954ms step_avg:38.77ms
+step:593/1555 train_time:23017ms step_avg:38.81ms
+step:594/1555 train_time:23076ms step_avg:38.85ms
+step:595/1555 train_time:23139ms step_avg:38.89ms
+step:596/1555 train_time:23198ms step_avg:38.92ms
+step:597/1555 train_time:23261ms step_avg:38.96ms
+step:598/1555 train_time:23320ms step_avg:39.00ms
+step:599/1555 train_time:23384ms step_avg:39.04ms
+step:600/1555 train_time:23443ms step_avg:39.07ms
+step:601/1555 train_time:23506ms step_avg:39.11ms
+step:602/1555 train_time:23565ms step_avg:39.15ms
+step:603/1555 train_time:23630ms step_avg:39.19ms
+step:604/1555 train_time:23689ms step_avg:39.22ms
+step:605/1555 train_time:23752ms step_avg:39.26ms
+step:606/1555 train_time:23811ms step_avg:39.29ms
+step:607/1555 train_time:23875ms step_avg:39.33ms
+step:608/1555 train_time:23935ms step_avg:39.37ms
+step:609/1555 train_time:23998ms step_avg:39.41ms
+step:610/1555 train_time:24057ms step_avg:39.44ms
+step:611/1555 train_time:24120ms step_avg:39.48ms
+step:612/1555 train_time:24179ms step_avg:39.51ms
+step:613/1555 train_time:24243ms step_avg:39.55ms
+step:614/1555 train_time:24302ms step_avg:39.58ms
+step:615/1555 train_time:24365ms step_avg:39.62ms
+step:616/1555 train_time:24424ms step_avg:39.65ms
+step:617/1555 train_time:24487ms step_avg:39.69ms
+step:618/1555 train_time:24547ms step_avg:39.72ms
+step:619/1555 train_time:24611ms step_avg:39.76ms
+step:620/1555 train_time:24670ms step_avg:39.79ms
+step:621/1555 train_time:24734ms step_avg:39.83ms
+step:622/1555 train_time:24793ms step_avg:39.86ms
+step:623/1555 train_time:24857ms step_avg:39.90ms
+step:624/1555 train_time:24916ms step_avg:39.93ms
+step:625/1555 train_time:24979ms step_avg:39.97ms
+step:626/1555 train_time:25039ms step_avg:40.00ms
+step:627/1555 train_time:25102ms step_avg:40.04ms
+step:628/1555 train_time:25161ms step_avg:40.07ms
+step:629/1555 train_time:25224ms step_avg:40.10ms
+step:630/1555 train_time:25284ms step_avg:40.13ms
+step:631/1555 train_time:25347ms step_avg:40.17ms
+step:632/1555 train_time:25406ms step_avg:40.20ms
+step:633/1555 train_time:25469ms step_avg:40.24ms
+step:634/1555 train_time:25529ms step_avg:40.27ms
+step:635/1555 train_time:25593ms step_avg:40.30ms
+step:636/1555 train_time:25652ms step_avg:40.33ms
+step:637/1555 train_time:25717ms step_avg:40.37ms
+step:638/1555 train_time:25775ms step_avg:40.40ms
+step:639/1555 train_time:25838ms step_avg:40.44ms
+step:640/1555 train_time:25898ms step_avg:40.46ms
+step:641/1555 train_time:25960ms step_avg:40.50ms
+step:642/1555 train_time:26019ms step_avg:40.53ms
+step:643/1555 train_time:26083ms step_avg:40.56ms
+step:644/1555 train_time:26142ms step_avg:40.59ms
+step:645/1555 train_time:26205ms step_avg:40.63ms
+step:646/1555 train_time:26264ms step_avg:40.66ms
+step:647/1555 train_time:26328ms step_avg:40.69ms
+step:648/1555 train_time:26386ms step_avg:40.72ms
+step:649/1555 train_time:26449ms step_avg:40.75ms
+step:650/1555 train_time:26509ms step_avg:40.78ms
+step:651/1555 train_time:26573ms step_avg:40.82ms
+step:652/1555 train_time:26632ms step_avg:40.85ms
+step:653/1555 train_time:26696ms step_avg:40.88ms
+step:654/1555 train_time:26755ms step_avg:40.91ms
+step:655/1555 train_time:26819ms step_avg:40.94ms
+step:656/1555 train_time:26878ms step_avg:40.97ms
+step:657/1555 train_time:26942ms step_avg:41.01ms
+step:658/1555 train_time:27001ms step_avg:41.03ms
+step:659/1555 train_time:27064ms step_avg:41.07ms
+step:660/1555 train_time:27123ms step_avg:41.10ms
+step:661/1555 train_time:27186ms step_avg:41.13ms
+step:662/1555 train_time:27246ms step_avg:41.16ms
+step:663/1555 train_time:27310ms step_avg:41.19ms
+step:664/1555 train_time:27369ms step_avg:41.22ms
+step:665/1555 train_time:27432ms step_avg:41.25ms
+step:666/1555 train_time:27491ms step_avg:41.28ms
+step:667/1555 train_time:27555ms step_avg:41.31ms
+step:668/1555 train_time:27614ms step_avg:41.34ms
+step:669/1555 train_time:27677ms step_avg:41.37ms
+step:670/1555 train_time:27737ms step_avg:41.40ms
+step:671/1555 train_time:27800ms step_avg:41.43ms
+step:672/1555 train_time:27860ms step_avg:41.46ms
+step:673/1555 train_time:27922ms step_avg:41.49ms
+step:674/1555 train_time:27981ms step_avg:41.52ms
+step:675/1555 train_time:28045ms step_avg:41.55ms
+step:676/1555 train_time:28104ms step_avg:41.57ms
+step:677/1555 train_time:28167ms step_avg:41.61ms
+step:678/1555 train_time:28227ms step_avg:41.63ms
+step:679/1555 train_time:28290ms step_avg:41.66ms
+step:680/1555 train_time:28350ms step_avg:41.69ms
+step:681/1555 train_time:28413ms step_avg:41.72ms
+step:682/1555 train_time:28472ms step_avg:41.75ms
+step:683/1555 train_time:28535ms step_avg:41.78ms
+step:684/1555 train_time:28594ms step_avg:41.80ms
+step:685/1555 train_time:28658ms step_avg:41.84ms
+step:686/1555 train_time:28717ms step_avg:41.86ms
+step:687/1555 train_time:28780ms step_avg:41.89ms
+step:688/1555 train_time:28839ms step_avg:41.92ms
+step:689/1555 train_time:28902ms step_avg:41.95ms
+step:690/1555 train_time:28962ms step_avg:41.97ms
+step:691/1555 train_time:29026ms step_avg:42.01ms
+step:692/1555 train_time:29085ms step_avg:42.03ms
+step:693/1555 train_time:29149ms step_avg:42.06ms
+step:694/1555 train_time:29209ms step_avg:42.09ms
+step:695/1555 train_time:29272ms step_avg:42.12ms
+step:696/1555 train_time:29332ms step_avg:42.14ms
+step:697/1555 train_time:29395ms step_avg:42.17ms
+step:698/1555 train_time:29454ms step_avg:42.20ms
+step:699/1555 train_time:29517ms step_avg:42.23ms
+step:700/1555 train_time:29576ms step_avg:42.25ms
+step:701/1555 train_time:29639ms step_avg:42.28ms
+step:702/1555 train_time:29698ms step_avg:42.31ms
+step:703/1555 train_time:29761ms step_avg:42.33ms
+step:704/1555 train_time:29821ms step_avg:42.36ms
+step:705/1555 train_time:29884ms step_avg:42.39ms
+step:706/1555 train_time:29943ms step_avg:42.41ms
+step:707/1555 train_time:30007ms step_avg:42.44ms
+step:708/1555 train_time:30065ms step_avg:42.47ms
+step:709/1555 train_time:30128ms step_avg:42.49ms
+step:710/1555 train_time:30188ms step_avg:42.52ms
+step:711/1555 train_time:30251ms step_avg:42.55ms
+step:712/1555 train_time:30310ms step_avg:42.57ms
+step:713/1555 train_time:30374ms step_avg:42.60ms
+step:714/1555 train_time:30433ms step_avg:42.62ms
+step:715/1555 train_time:30497ms step_avg:42.65ms
+step:716/1555 train_time:30557ms step_avg:42.68ms
+step:717/1555 train_time:30620ms step_avg:42.71ms
+step:718/1555 train_time:30679ms step_avg:42.73ms
+step:719/1555 train_time:30743ms step_avg:42.76ms
+step:720/1555 train_time:30802ms step_avg:42.78ms
+step:721/1555 train_time:30865ms step_avg:42.81ms
+step:722/1555 train_time:30924ms step_avg:42.83ms
+step:723/1555 train_time:30987ms step_avg:42.86ms
+step:724/1555 train_time:31047ms step_avg:42.88ms
+step:725/1555 train_time:31110ms step_avg:42.91ms
+step:726/1555 train_time:31169ms step_avg:42.93ms
+step:727/1555 train_time:31232ms step_avg:42.96ms
+step:728/1555 train_time:31292ms step_avg:42.98ms
+step:729/1555 train_time:31356ms step_avg:43.01ms
+step:730/1555 train_time:31415ms step_avg:43.03ms
+step:731/1555 train_time:31478ms step_avg:43.06ms
+step:732/1555 train_time:31537ms step_avg:43.08ms
+step:733/1555 train_time:31600ms step_avg:43.11ms
+step:734/1555 train_time:31660ms step_avg:43.13ms
+step:735/1555 train_time:31723ms step_avg:43.16ms
+step:736/1555 train_time:31782ms step_avg:43.18ms
+step:737/1555 train_time:31846ms step_avg:43.21ms
+step:738/1555 train_time:31905ms step_avg:43.23ms
+step:739/1555 train_time:31968ms step_avg:43.26ms
+step:740/1555 train_time:32028ms step_avg:43.28ms
+step:741/1555 train_time:32091ms step_avg:43.31ms
+step:742/1555 train_time:32150ms step_avg:43.33ms
+step:743/1555 train_time:32214ms step_avg:43.36ms
+step:744/1555 train_time:32273ms step_avg:43.38ms
+step:745/1555 train_time:32336ms step_avg:43.40ms
+step:746/1555 train_time:32396ms step_avg:43.43ms
+step:747/1555 train_time:32459ms step_avg:43.45ms
+step:748/1555 train_time:32518ms step_avg:43.47ms
+step:749/1555 train_time:32581ms step_avg:43.50ms
+step:750/1555 train_time:32640ms step_avg:43.52ms
+step:750/1555 val_loss:3.8698 train_time:32689ms step_avg:43.59ms
+step:751/1555 train_time:32708ms step_avg:43.55ms
+step:752/1555 train_time:32770ms step_avg:43.58ms
+step:753/1555 train_time:32835ms step_avg:43.61ms
+step:754/1555 train_time:32896ms step_avg:43.63ms
+step:755/1555 train_time:32959ms step_avg:43.65ms
+step:756/1555 train_time:33018ms step_avg:43.67ms
+step:757/1555 train_time:33081ms step_avg:43.70ms
+step:758/1555 train_time:33140ms step_avg:43.72ms
+step:759/1555 train_time:33203ms step_avg:43.75ms
+step:760/1555 train_time:33264ms step_avg:43.77ms
+step:761/1555 train_time:33327ms step_avg:43.79ms
+step:762/1555 train_time:33386ms step_avg:43.81ms
+step:763/1555 train_time:33448ms step_avg:43.84ms
+step:764/1555 train_time:33507ms step_avg:43.86ms
+step:765/1555 train_time:33570ms step_avg:43.88ms
+step:766/1555 train_time:33630ms step_avg:43.90ms
+step:767/1555 train_time:33697ms step_avg:43.93ms
+step:768/1555 train_time:33757ms step_avg:43.95ms
+step:769/1555 train_time:33821ms step_avg:43.98ms
+step:770/1555 train_time:33881ms step_avg:44.00ms
+step:771/1555 train_time:33944ms step_avg:44.03ms
+step:772/1555 train_time:34003ms step_avg:44.04ms
+step:773/1555 train_time:34071ms step_avg:44.08ms
+step:774/1555 train_time:34126ms step_avg:44.09ms
+step:775/1555 train_time:34188ms step_avg:44.11ms
+step:776/1555 train_time:34248ms step_avg:44.13ms
+step:777/1555 train_time:34311ms step_avg:44.16ms
+step:778/1555 train_time:34369ms step_avg:44.18ms
+step:779/1555 train_time:34432ms step_avg:44.20ms
+step:780/1555 train_time:34491ms step_avg:44.22ms
+step:781/1555 train_time:34554ms step_avg:44.24ms
+step:782/1555 train_time:34613ms step_avg:44.26ms
+step:783/1555 train_time:34678ms step_avg:44.29ms
+step:784/1555 train_time:34738ms step_avg:44.31ms
+step:785/1555 train_time:34802ms step_avg:44.33ms
+step:786/1555 train_time:34861ms step_avg:44.35ms
+step:787/1555 train_time:34925ms step_avg:44.38ms
+step:788/1555 train_time:34985ms step_avg:44.40ms
+step:789/1555 train_time:35048ms step_avg:44.42ms
+step:790/1555 train_time:35106ms step_avg:44.44ms
+step:791/1555 train_time:35170ms step_avg:44.46ms
+step:792/1555 train_time:35229ms step_avg:44.48ms
+step:793/1555 train_time:35293ms step_avg:44.51ms
+step:794/1555 train_time:35352ms step_avg:44.52ms
+step:795/1555 train_time:35415ms step_avg:44.55ms
+step:796/1555 train_time:35473ms step_avg:44.56ms
+step:797/1555 train_time:35536ms step_avg:44.59ms
+step:798/1555 train_time:35595ms step_avg:44.61ms
+step:799/1555 train_time:35659ms step_avg:44.63ms
+step:800/1555 train_time:35719ms step_avg:44.65ms
+step:801/1555 train_time:35783ms step_avg:44.67ms
+step:802/1555 train_time:35842ms step_avg:44.69ms
+step:803/1555 train_time:35906ms step_avg:44.71ms
+step:804/1555 train_time:35965ms step_avg:44.73ms
+step:805/1555 train_time:36029ms step_avg:44.76ms
+step:806/1555 train_time:36087ms step_avg:44.77ms
+step:807/1555 train_time:36150ms step_avg:44.80ms
+step:808/1555 train_time:36209ms step_avg:44.81ms
+step:809/1555 train_time:36272ms step_avg:44.84ms
+step:810/1555 train_time:36331ms step_avg:44.85ms
+step:811/1555 train_time:36394ms step_avg:44.88ms
+step:812/1555 train_time:36454ms step_avg:44.89ms
+step:813/1555 train_time:36516ms step_avg:44.92ms
+step:814/1555 train_time:36575ms step_avg:44.93ms
+step:815/1555 train_time:36639ms step_avg:44.96ms
+step:816/1555 train_time:36700ms step_avg:44.98ms
+step:817/1555 train_time:36763ms step_avg:45.00ms
+step:818/1555 train_time:36822ms step_avg:45.02ms
+step:819/1555 train_time:36887ms step_avg:45.04ms
+step:820/1555 train_time:36947ms step_avg:45.06ms
+step:821/1555 train_time:37010ms step_avg:45.08ms
+step:822/1555 train_time:37068ms step_avg:45.10ms
+step:823/1555 train_time:37132ms step_avg:45.12ms
+step:824/1555 train_time:37191ms step_avg:45.13ms
+step:825/1555 train_time:37254ms step_avg:45.16ms
+step:826/1555 train_time:37313ms step_avg:45.17ms
+step:827/1555 train_time:37376ms step_avg:45.20ms
+step:828/1555 train_time:37436ms step_avg:45.21ms
+step:829/1555 train_time:37499ms step_avg:45.23ms
+step:830/1555 train_time:37558ms step_avg:45.25ms
+step:831/1555 train_time:37622ms step_avg:45.27ms
+step:832/1555 train_time:37681ms step_avg:45.29ms
+step:833/1555 train_time:37745ms step_avg:45.31ms
+step:834/1555 train_time:37804ms step_avg:45.33ms
+step:835/1555 train_time:37867ms step_avg:45.35ms
+step:836/1555 train_time:37927ms step_avg:45.37ms
+step:837/1555 train_time:37990ms step_avg:45.39ms
+step:838/1555 train_time:38049ms step_avg:45.40ms
+step:839/1555 train_time:38112ms step_avg:45.43ms
+step:840/1555 train_time:38170ms step_avg:45.44ms
+step:841/1555 train_time:38234ms step_avg:45.46ms
+step:842/1555 train_time:38293ms step_avg:45.48ms
+step:843/1555 train_time:38356ms step_avg:45.50ms
+step:844/1555 train_time:38414ms step_avg:45.51ms
+step:845/1555 train_time:38477ms step_avg:45.54ms
+step:846/1555 train_time:38536ms step_avg:45.55ms
+step:847/1555 train_time:38600ms step_avg:45.57ms
+step:848/1555 train_time:38659ms step_avg:45.59ms
+step:849/1555 train_time:38722ms step_avg:45.61ms
+step:850/1555 train_time:38782ms step_avg:45.63ms
+step:851/1555 train_time:38846ms step_avg:45.65ms
+step:852/1555 train_time:38905ms step_avg:45.66ms
+step:853/1555 train_time:38970ms step_avg:45.69ms
+step:854/1555 train_time:39029ms step_avg:45.70ms
+step:855/1555 train_time:39092ms step_avg:45.72ms
+step:856/1555 train_time:39151ms step_avg:45.74ms
+step:857/1555 train_time:39214ms step_avg:45.76ms
+step:858/1555 train_time:39274ms step_avg:45.77ms
+step:859/1555 train_time:39337ms step_avg:45.79ms
+step:860/1555 train_time:39396ms step_avg:45.81ms
+step:861/1555 train_time:39458ms step_avg:45.83ms
+step:862/1555 train_time:39517ms step_avg:45.84ms
+step:863/1555 train_time:39580ms step_avg:45.86ms
+step:864/1555 train_time:39640ms step_avg:45.88ms
+step:865/1555 train_time:39704ms step_avg:45.90ms
+step:866/1555 train_time:39763ms step_avg:45.92ms
+step:867/1555 train_time:39827ms step_avg:45.94ms
+step:868/1555 train_time:39887ms step_avg:45.95ms
+step:869/1555 train_time:39950ms step_avg:45.97ms
+step:870/1555 train_time:40009ms step_avg:45.99ms
+step:871/1555 train_time:40073ms step_avg:46.01ms
+step:872/1555 train_time:40131ms step_avg:46.02ms
+step:873/1555 train_time:40194ms step_avg:46.04ms
+step:874/1555 train_time:40254ms step_avg:46.06ms
+step:875/1555 train_time:40317ms step_avg:46.08ms
+step:876/1555 train_time:40376ms step_avg:46.09ms
+step:877/1555 train_time:40439ms step_avg:46.11ms
+step:878/1555 train_time:40498ms step_avg:46.13ms
+step:879/1555 train_time:40561ms step_avg:46.14ms
+step:880/1555 train_time:40621ms step_avg:46.16ms
+step:881/1555 train_time:40683ms step_avg:46.18ms
+step:882/1555 train_time:40744ms step_avg:46.19ms
+step:883/1555 train_time:40811ms step_avg:46.22ms
+step:884/1555 train_time:40870ms step_avg:46.23ms
+step:885/1555 train_time:40932ms step_avg:46.25ms
+step:886/1555 train_time:40991ms step_avg:46.26ms
+step:887/1555 train_time:41054ms step_avg:46.28ms
+step:888/1555 train_time:41112ms step_avg:46.30ms
+step:889/1555 train_time:41175ms step_avg:46.32ms
+step:890/1555 train_time:41234ms step_avg:46.33ms
+step:891/1555 train_time:41302ms step_avg:46.35ms
+step:892/1555 train_time:41358ms step_avg:46.37ms
+step:893/1555 train_time:41421ms step_avg:46.38ms
+step:894/1555 train_time:41480ms step_avg:46.40ms
+step:895/1555 train_time:41542ms step_avg:46.42ms
+step:896/1555 train_time:41602ms step_avg:46.43ms
+step:897/1555 train_time:41665ms step_avg:46.45ms
+step:898/1555 train_time:41725ms step_avg:46.46ms
+step:899/1555 train_time:41790ms step_avg:46.49ms
+step:900/1555 train_time:41848ms step_avg:46.50ms
+step:901/1555 train_time:41911ms step_avg:46.52ms
+step:902/1555 train_time:41971ms step_avg:46.53ms
+step:903/1555 train_time:42034ms step_avg:46.55ms
+step:904/1555 train_time:42094ms step_avg:46.56ms
+step:905/1555 train_time:42157ms step_avg:46.58ms
+step:906/1555 train_time:42216ms step_avg:46.60ms
+step:907/1555 train_time:42279ms step_avg:46.61ms
+step:908/1555 train_time:42339ms step_avg:46.63ms
+step:909/1555 train_time:42402ms step_avg:46.65ms
+step:910/1555 train_time:42461ms step_avg:46.66ms
+step:911/1555 train_time:42524ms step_avg:46.68ms
+step:912/1555 train_time:42583ms step_avg:46.69ms
+step:913/1555 train_time:42646ms step_avg:46.71ms
+step:914/1555 train_time:42706ms step_avg:46.72ms
+step:915/1555 train_time:42769ms step_avg:46.74ms
+step:916/1555 train_time:42828ms step_avg:46.76ms
+step:917/1555 train_time:42893ms step_avg:46.78ms
+step:918/1555 train_time:42952ms step_avg:46.79ms
+step:919/1555 train_time:43015ms step_avg:46.81ms
+step:920/1555 train_time:43075ms step_avg:46.82ms
+step:921/1555 train_time:43139ms step_avg:46.84ms
+step:922/1555 train_time:43198ms step_avg:46.85ms
+step:923/1555 train_time:43261ms step_avg:46.87ms
+step:924/1555 train_time:43320ms step_avg:46.88ms
+step:925/1555 train_time:43384ms step_avg:46.90ms
+step:926/1555 train_time:43443ms step_avg:46.91ms
+step:927/1555 train_time:43506ms step_avg:46.93ms
+step:928/1555 train_time:43566ms step_avg:46.95ms
+step:929/1555 train_time:43629ms step_avg:46.96ms
+step:930/1555 train_time:43688ms step_avg:46.98ms
+step:931/1555 train_time:43752ms step_avg:46.99ms
+step:932/1555 train_time:43811ms step_avg:47.01ms
+step:933/1555 train_time:43874ms step_avg:47.02ms
+step:934/1555 train_time:43933ms step_avg:47.04ms
+step:935/1555 train_time:43996ms step_avg:47.05ms
+step:936/1555 train_time:44056ms step_avg:47.07ms
+step:937/1555 train_time:44120ms step_avg:47.09ms
+step:938/1555 train_time:44180ms step_avg:47.10ms
+step:939/1555 train_time:44243ms step_avg:47.12ms
+step:940/1555 train_time:44302ms step_avg:47.13ms
+step:941/1555 train_time:44365ms step_avg:47.15ms
+step:942/1555 train_time:44423ms step_avg:47.16ms
+step:943/1555 train_time:44487ms step_avg:47.18ms
+step:944/1555 train_time:44546ms step_avg:47.19ms
+step:945/1555 train_time:44609ms step_avg:47.21ms
+step:946/1555 train_time:44668ms step_avg:47.22ms
+step:947/1555 train_time:44732ms step_avg:47.24ms
+step:948/1555 train_time:44791ms step_avg:47.25ms
+step:949/1555 train_time:44855ms step_avg:47.27ms
+step:950/1555 train_time:44914ms step_avg:47.28ms
+step:951/1555 train_time:44977ms step_avg:47.29ms
+step:952/1555 train_time:45036ms step_avg:47.31ms
+step:953/1555 train_time:45100ms step_avg:47.32ms
+step:954/1555 train_time:45159ms step_avg:47.34ms
+step:955/1555 train_time:45222ms step_avg:47.35ms
+step:956/1555 train_time:45281ms step_avg:47.37ms
+step:957/1555 train_time:45344ms step_avg:47.38ms
+step:958/1555 train_time:45404ms step_avg:47.39ms
+step:959/1555 train_time:45468ms step_avg:47.41ms
+step:960/1555 train_time:45527ms step_avg:47.42ms
+step:961/1555 train_time:45591ms step_avg:47.44ms
+step:962/1555 train_time:45651ms step_avg:47.45ms
+step:963/1555 train_time:45714ms step_avg:47.47ms
+step:964/1555 train_time:45774ms step_avg:47.48ms
+step:965/1555 train_time:45837ms step_avg:47.50ms
+step:966/1555 train_time:45896ms step_avg:47.51ms
+step:967/1555 train_time:45960ms step_avg:47.53ms
+step:968/1555 train_time:46019ms step_avg:47.54ms
+step:969/1555 train_time:46082ms step_avg:47.56ms
+step:970/1555 train_time:46141ms step_avg:47.57ms
+step:971/1555 train_time:46205ms step_avg:47.58ms
+step:972/1555 train_time:46263ms step_avg:47.60ms
+step:973/1555 train_time:46327ms step_avg:47.61ms
+step:974/1555 train_time:46386ms step_avg:47.62ms
+step:975/1555 train_time:46449ms step_avg:47.64ms
+step:976/1555 train_time:46508ms step_avg:47.65ms
+step:977/1555 train_time:46572ms step_avg:47.67ms
+step:978/1555 train_time:46631ms step_avg:47.68ms
+step:979/1555 train_time:46694ms step_avg:47.70ms
+step:980/1555 train_time:46754ms step_avg:47.71ms
+step:981/1555 train_time:46817ms step_avg:47.72ms
+step:982/1555 train_time:46876ms step_avg:47.74ms
+step:983/1555 train_time:46940ms step_avg:47.75ms
+step:984/1555 train_time:46999ms step_avg:47.76ms
+step:985/1555 train_time:47063ms step_avg:47.78ms
+step:986/1555 train_time:47122ms step_avg:47.79ms
+step:987/1555 train_time:47185ms step_avg:47.81ms
+step:988/1555 train_time:47245ms step_avg:47.82ms
+step:989/1555 train_time:47309ms step_avg:47.83ms
+step:990/1555 train_time:47367ms step_avg:47.85ms
+step:991/1555 train_time:47431ms step_avg:47.86ms
+step:992/1555 train_time:47491ms step_avg:47.87ms
+step:993/1555 train_time:47554ms step_avg:47.89ms
+step:994/1555 train_time:47613ms step_avg:47.90ms
+step:995/1555 train_time:47677ms step_avg:47.92ms
+step:996/1555 train_time:47736ms step_avg:47.93ms
+step:997/1555 train_time:47799ms step_avg:47.94ms
+step:998/1555 train_time:47859ms step_avg:47.95ms
+step:999/1555 train_time:47923ms step_avg:47.97ms
+step:1000/1555 train_time:47982ms step_avg:47.98ms
+step:1000/1555 val_loss:3.5728 train_time:48031ms step_avg:48.03ms
+step:1001/1555 train_time:48050ms step_avg:48.00ms
+step:1002/1555 train_time:48108ms step_avg:48.01ms
+step:1003/1555 train_time:48173ms step_avg:48.03ms
+step:1004/1555 train_time:48239ms step_avg:48.05ms
+step:1005/1555 train_time:48303ms step_avg:48.06ms
+step:1006/1555 train_time:48362ms step_avg:48.07ms
+step:1007/1555 train_time:48425ms step_avg:48.09ms
+step:1008/1555 train_time:48484ms step_avg:48.10ms
+step:1009/1555 train_time:48547ms step_avg:48.11ms
+step:1010/1555 train_time:48606ms step_avg:48.12ms
+step:1011/1555 train_time:48678ms step_avg:48.15ms
+step:1012/1555 train_time:48760ms step_avg:48.18ms
+step:1013/1555 train_time:48849ms step_avg:48.22ms
+step:1014/1555 train_time:48933ms step_avg:48.26ms
+step:1015/1555 train_time:49025ms step_avg:48.30ms
+step:1016/1555 train_time:49112ms step_avg:48.34ms
+step:1017/1555 train_time:49204ms step_avg:48.38ms
+step:1018/1555 train_time:49292ms step_avg:48.42ms
+step:1019/1555 train_time:49383ms step_avg:48.46ms
+step:1020/1555 train_time:49469ms step_avg:48.50ms
+step:1021/1555 train_time:49557ms step_avg:48.54ms
+step:1022/1555 train_time:49642ms step_avg:48.57ms
+step:1023/1555 train_time:49731ms step_avg:48.61ms
+step:1024/1555 train_time:49815ms step_avg:48.65ms
+step:1025/1555 train_time:49904ms step_avg:48.69ms
+step:1026/1555 train_time:49989ms step_avg:48.72ms
+step:1027/1555 train_time:50079ms step_avg:48.76ms
+step:1028/1555 train_time:50165ms step_avg:48.80ms
+step:1029/1555 train_time:50256ms step_avg:48.84ms
+step:1030/1555 train_time:50342ms step_avg:48.88ms
+step:1031/1555 train_time:50431ms step_avg:48.91ms
+step:1032/1555 train_time:50517ms step_avg:48.95ms
+step:1033/1555 train_time:50606ms step_avg:48.99ms
+step:1034/1555 train_time:50692ms step_avg:49.03ms
+step:1035/1555 train_time:50782ms step_avg:49.06ms
+step:1036/1555 train_time:50867ms step_avg:49.10ms
+step:1037/1555 train_time:50957ms step_avg:49.14ms
+step:1038/1555 train_time:51042ms step_avg:49.17ms
+step:1039/1555 train_time:51132ms step_avg:49.21ms
+step:1040/1555 train_time:51219ms step_avg:49.25ms
+step:1041/1555 train_time:51309ms step_avg:49.29ms
+step:1042/1555 train_time:51396ms step_avg:49.32ms
+step:1043/1555 train_time:51486ms step_avg:49.36ms
+step:1044/1555 train_time:51572ms step_avg:49.40ms
+step:1045/1555 train_time:51662ms step_avg:49.44ms
+step:1046/1555 train_time:51747ms step_avg:49.47ms
+step:1047/1555 train_time:51836ms step_avg:49.51ms
+step:1048/1555 train_time:51921ms step_avg:49.54ms
+step:1049/1555 train_time:52011ms step_avg:49.58ms
+step:1050/1555 train_time:52098ms step_avg:49.62ms
+step:1051/1555 train_time:52187ms step_avg:49.65ms
+step:1052/1555 train_time:52275ms step_avg:49.69ms
+step:1053/1555 train_time:52364ms step_avg:49.73ms
+step:1054/1555 train_time:52451ms step_avg:49.76ms
+step:1055/1555 train_time:52543ms step_avg:49.80ms
+step:1056/1555 train_time:52626ms step_avg:49.84ms
+step:1057/1555 train_time:52714ms step_avg:49.87ms
+step:1058/1555 train_time:52800ms step_avg:49.91ms
+step:1059/1555 train_time:52890ms step_avg:49.94ms
+step:1060/1555 train_time:52975ms step_avg:49.98ms
+step:1061/1555 train_time:53066ms step_avg:50.01ms
+step:1062/1555 train_time:53151ms step_avg:50.05ms
+step:1063/1555 train_time:53241ms step_avg:50.09ms
+step:1064/1555 train_time:53328ms step_avg:50.12ms
+step:1065/1555 train_time:53418ms step_avg:50.16ms
+step:1066/1555 train_time:53504ms step_avg:50.19ms
+step:1067/1555 train_time:53595ms step_avg:50.23ms
+step:1068/1555 train_time:53680ms step_avg:50.26ms
+step:1069/1555 train_time:53770ms step_avg:50.30ms
+step:1070/1555 train_time:53855ms step_avg:50.33ms
+step:1071/1555 train_time:53944ms step_avg:50.37ms
+step:1072/1555 train_time:54029ms step_avg:50.40ms
+step:1073/1555 train_time:54118ms step_avg:50.44ms
+step:1074/1555 train_time:54204ms step_avg:50.47ms
+step:1075/1555 train_time:54294ms step_avg:50.51ms
+step:1076/1555 train_time:54379ms step_avg:50.54ms
+step:1077/1555 train_time:54469ms step_avg:50.57ms
+step:1078/1555 train_time:54555ms step_avg:50.61ms
+step:1079/1555 train_time:54645ms step_avg:50.64ms
+step:1080/1555 train_time:54731ms step_avg:50.68ms
+step:1081/1555 train_time:54821ms step_avg:50.71ms
+step:1082/1555 train_time:54906ms step_avg:50.75ms
+step:1083/1555 train_time:54996ms step_avg:50.78ms
+step:1084/1555 train_time:55082ms step_avg:50.81ms
+step:1085/1555 train_time:55171ms step_avg:50.85ms
+step:1086/1555 train_time:55257ms step_avg:50.88ms
+step:1087/1555 train_time:55348ms step_avg:50.92ms
+step:1088/1555 train_time:55433ms step_avg:50.95ms
+step:1089/1555 train_time:55523ms step_avg:50.98ms
+step:1090/1555 train_time:55608ms step_avg:51.02ms
+step:1091/1555 train_time:55699ms step_avg:51.05ms
+step:1092/1555 train_time:55786ms step_avg:51.09ms
+step:1093/1555 train_time:55876ms step_avg:51.12ms
+step:1094/1555 train_time:55961ms step_avg:51.15ms
+step:1095/1555 train_time:56050ms step_avg:51.19ms
+step:1096/1555 train_time:56136ms step_avg:51.22ms
+step:1097/1555 train_time:56224ms step_avg:51.25ms
+step:1098/1555 train_time:56311ms step_avg:51.28ms
+step:1099/1555 train_time:56400ms step_avg:51.32ms
+step:1100/1555 train_time:56486ms step_avg:51.35ms
+step:1101/1555 train_time:56576ms step_avg:51.39ms
+step:1102/1555 train_time:56662ms step_avg:51.42ms
+step:1103/1555 train_time:56751ms step_avg:51.45ms
+step:1104/1555 train_time:56836ms step_avg:51.48ms
+step:1105/1555 train_time:56925ms step_avg:51.52ms
+step:1106/1555 train_time:57012ms step_avg:51.55ms
+step:1107/1555 train_time:57102ms step_avg:51.58ms
+step:1108/1555 train_time:57187ms step_avg:51.61ms
+step:1109/1555 train_time:57278ms step_avg:51.65ms
+step:1110/1555 train_time:57363ms step_avg:51.68ms
+step:1111/1555 train_time:57453ms step_avg:51.71ms
+step:1112/1555 train_time:57538ms step_avg:51.74ms
+step:1113/1555 train_time:57627ms step_avg:51.78ms
+step:1114/1555 train_time:57714ms step_avg:51.81ms
+step:1115/1555 train_time:57803ms step_avg:51.84ms
+step:1116/1555 train_time:57888ms step_avg:51.87ms
+step:1117/1555 train_time:57979ms step_avg:51.91ms
+step:1118/1555 train_time:58065ms step_avg:51.94ms
+step:1119/1555 train_time:58155ms step_avg:51.97ms
+step:1120/1555 train_time:58240ms step_avg:52.00ms
+step:1121/1555 train_time:58329ms step_avg:52.03ms
+step:1122/1555 train_time:58414ms step_avg:52.06ms
+step:1123/1555 train_time:58504ms step_avg:52.10ms
+step:1124/1555 train_time:58589ms step_avg:52.13ms
+step:1125/1555 train_time:58679ms step_avg:52.16ms
+step:1126/1555 train_time:58765ms step_avg:52.19ms
+step:1127/1555 train_time:58854ms step_avg:52.22ms
+step:1128/1555 train_time:58940ms step_avg:52.25ms
+step:1129/1555 train_time:59029ms step_avg:52.28ms
+step:1130/1555 train_time:59115ms step_avg:52.31ms
+step:1131/1555 train_time:59205ms step_avg:52.35ms
+step:1132/1555 train_time:59291ms step_avg:52.38ms
+step:1133/1555 train_time:59381ms step_avg:52.41ms
+step:1134/1555 train_time:59466ms step_avg:52.44ms
+step:1135/1555 train_time:59557ms step_avg:52.47ms
+step:1136/1555 train_time:59642ms step_avg:52.50ms
+step:1137/1555 train_time:59731ms step_avg:52.53ms
+step:1138/1555 train_time:59816ms step_avg:52.56ms
+step:1139/1555 train_time:59908ms step_avg:52.60ms
+step:1140/1555 train_time:59996ms step_avg:52.63ms
+step:1141/1555 train_time:60084ms step_avg:52.66ms
+step:1142/1555 train_time:60169ms step_avg:52.69ms
+step:1143/1555 train_time:60259ms step_avg:52.72ms
+step:1144/1555 train_time:60345ms step_avg:52.75ms
+step:1145/1555 train_time:60434ms step_avg:52.78ms
+step:1146/1555 train_time:60520ms step_avg:52.81ms
+step:1147/1555 train_time:60609ms step_avg:52.84ms
+step:1148/1555 train_time:60696ms step_avg:52.87ms
+step:1149/1555 train_time:60785ms step_avg:52.90ms
+step:1150/1555 train_time:60871ms step_avg:52.93ms
+step:1151/1555 train_time:60960ms step_avg:52.96ms
+step:1152/1555 train_time:61045ms step_avg:52.99ms
+step:1153/1555 train_time:61135ms step_avg:53.02ms
+step:1154/1555 train_time:61222ms step_avg:53.05ms
+step:1155/1555 train_time:61312ms step_avg:53.08ms
+step:1156/1555 train_time:61399ms step_avg:53.11ms
+step:1157/1555 train_time:61487ms step_avg:53.14ms
+step:1158/1555 train_time:61573ms step_avg:53.17ms
+step:1159/1555 train_time:61663ms step_avg:53.20ms
+step:1160/1555 train_time:61748ms step_avg:53.23ms
+step:1161/1555 train_time:61839ms step_avg:53.26ms
+step:1162/1555 train_time:61925ms step_avg:53.29ms
+step:1163/1555 train_time:62014ms step_avg:53.32ms
+step:1164/1555 train_time:62100ms step_avg:53.35ms
+step:1165/1555 train_time:62189ms step_avg:53.38ms
+step:1166/1555 train_time:62275ms step_avg:53.41ms
+step:1167/1555 train_time:62367ms step_avg:53.44ms
+step:1168/1555 train_time:62451ms step_avg:53.47ms
+step:1169/1555 train_time:62540ms step_avg:53.50ms
+step:1170/1555 train_time:62627ms step_avg:53.53ms
+step:1171/1555 train_time:62716ms step_avg:53.56ms
+step:1172/1555 train_time:62804ms step_avg:53.59ms
+step:1173/1555 train_time:62892ms step_avg:53.62ms
+step:1174/1555 train_time:62978ms step_avg:53.64ms
+step:1175/1555 train_time:63068ms step_avg:53.68ms
+step:1176/1555 train_time:63154ms step_avg:53.70ms
+step:1177/1555 train_time:63243ms step_avg:53.73ms
+step:1178/1555 train_time:63329ms step_avg:53.76ms
+step:1179/1555 train_time:63419ms step_avg:53.79ms
+step:1180/1555 train_time:63504ms step_avg:53.82ms
+step:1181/1555 train_time:63595ms step_avg:53.85ms
+step:1182/1555 train_time:63680ms step_avg:53.87ms
+step:1183/1555 train_time:63769ms step_avg:53.90ms
+step:1184/1555 train_time:63853ms step_avg:53.93ms
+step:1185/1555 train_time:63943ms step_avg:53.96ms
+step:1186/1555 train_time:64029ms step_avg:53.99ms
+step:1187/1555 train_time:64120ms step_avg:54.02ms
+step:1188/1555 train_time:64206ms step_avg:54.05ms
+step:1189/1555 train_time:64295ms step_avg:54.08ms
+step:1190/1555 train_time:64381ms step_avg:54.10ms
+step:1191/1555 train_time:64472ms step_avg:54.13ms
+step:1192/1555 train_time:64557ms step_avg:54.16ms
+step:1193/1555 train_time:64648ms step_avg:54.19ms
+step:1194/1555 train_time:64735ms step_avg:54.22ms
+step:1195/1555 train_time:64824ms step_avg:54.25ms
+step:1196/1555 train_time:64910ms step_avg:54.27ms
+step:1197/1555 train_time:65000ms step_avg:54.30ms
+step:1198/1555 train_time:65087ms step_avg:54.33ms
+step:1199/1555 train_time:65178ms step_avg:54.36ms
+step:1200/1555 train_time:65263ms step_avg:54.39ms
+step:1201/1555 train_time:65353ms step_avg:54.42ms
+step:1202/1555 train_time:65438ms step_avg:54.44ms
+step:1203/1555 train_time:65528ms step_avg:54.47ms
+step:1204/1555 train_time:65614ms step_avg:54.50ms
+step:1205/1555 train_time:65704ms step_avg:54.53ms
+step:1206/1555 train_time:65789ms step_avg:54.55ms
+step:1207/1555 train_time:65879ms step_avg:54.58ms
+step:1208/1555 train_time:65964ms step_avg:54.61ms
+step:1209/1555 train_time:66054ms step_avg:54.64ms
+step:1210/1555 train_time:66140ms step_avg:54.66ms
+step:1211/1555 train_time:66230ms step_avg:54.69ms
+step:1212/1555 train_time:66315ms step_avg:54.72ms
+step:1213/1555 train_time:66405ms step_avg:54.74ms
+step:1214/1555 train_time:66491ms step_avg:54.77ms
+step:1215/1555 train_time:66581ms step_avg:54.80ms
+step:1216/1555 train_time:66668ms step_avg:54.83ms
+step:1217/1555 train_time:66758ms step_avg:54.85ms
+step:1218/1555 train_time:66843ms step_avg:54.88ms
+step:1219/1555 train_time:66932ms step_avg:54.91ms
+step:1220/1555 train_time:67018ms step_avg:54.93ms
+step:1221/1555 train_time:67108ms step_avg:54.96ms
+step:1222/1555 train_time:67194ms step_avg:54.99ms
+step:1223/1555 train_time:67284ms step_avg:55.02ms
+step:1224/1555 train_time:67370ms step_avg:55.04ms
+step:1225/1555 train_time:67459ms step_avg:55.07ms
+step:1226/1555 train_time:67545ms step_avg:55.09ms
+step:1227/1555 train_time:67635ms step_avg:55.12ms
+step:1228/1555 train_time:67720ms step_avg:55.15ms
+step:1229/1555 train_time:67810ms step_avg:55.17ms
+step:1230/1555 train_time:67895ms step_avg:55.20ms
+step:1231/1555 train_time:67985ms step_avg:55.23ms
+step:1232/1555 train_time:68071ms step_avg:55.25ms
+step:1233/1555 train_time:68161ms step_avg:55.28ms
+step:1234/1555 train_time:68247ms step_avg:55.31ms
+step:1235/1555 train_time:68337ms step_avg:55.33ms
+step:1236/1555 train_time:68422ms step_avg:55.36ms
+step:1237/1555 train_time:68511ms step_avg:55.39ms
+step:1238/1555 train_time:68598ms step_avg:55.41ms
+step:1239/1555 train_time:68686ms step_avg:55.44ms
+step:1240/1555 train_time:68773ms step_avg:55.46ms
+step:1241/1555 train_time:68863ms step_avg:55.49ms
+step:1242/1555 train_time:68948ms step_avg:55.51ms
+step:1243/1555 train_time:69038ms step_avg:55.54ms
+step:1244/1555 train_time:69125ms step_avg:55.57ms
+step:1245/1555 train_time:69214ms step_avg:55.59ms
+step:1246/1555 train_time:69300ms step_avg:55.62ms
+step:1247/1555 train_time:69389ms step_avg:55.65ms
+step:1248/1555 train_time:69475ms step_avg:55.67ms
+step:1249/1555 train_time:69565ms step_avg:55.70ms
+step:1250/1555 train_time:69651ms step_avg:55.72ms
+step:1250/1555 val_loss:3.3984 train_time:69726ms step_avg:55.78ms
+step:1251/1555 train_time:69754ms step_avg:55.76ms
+step:1252/1555 train_time:69844ms step_avg:55.79ms
+step:1253/1555 train_time:69934ms step_avg:55.81ms
+step:1254/1555 train_time:70021ms step_avg:55.84ms
+step:1255/1555 train_time:70110ms step_avg:55.86ms
+step:1256/1555 train_time:70195ms step_avg:55.89ms
+step:1257/1555 train_time:70284ms step_avg:55.91ms
+step:1258/1555 train_time:70368ms step_avg:55.94ms
+step:1259/1555 train_time:70457ms step_avg:55.96ms
+step:1260/1555 train_time:70541ms step_avg:55.99ms
+step:1261/1555 train_time:70631ms step_avg:56.01ms
+step:1262/1555 train_time:70717ms step_avg:56.04ms
+step:1263/1555 train_time:70811ms step_avg:56.07ms
+step:1264/1555 train_time:70900ms step_avg:56.09ms
+step:1265/1555 train_time:70988ms step_avg:56.12ms
+step:1266/1555 train_time:71076ms step_avg:56.14ms
+step:1267/1555 train_time:71164ms step_avg:56.17ms
+step:1268/1555 train_time:71248ms step_avg:56.19ms
+step:1269/1555 train_time:71337ms step_avg:56.22ms
+step:1270/1555 train_time:71422ms step_avg:56.24ms
+step:1271/1555 train_time:71512ms step_avg:56.26ms
+step:1272/1555 train_time:71596ms step_avg:56.29ms
+step:1273/1555 train_time:71685ms step_avg:56.31ms
+step:1274/1555 train_time:71773ms step_avg:56.34ms
+step:1275/1555 train_time:71865ms step_avg:56.36ms
+step:1276/1555 train_time:71953ms step_avg:56.39ms
+step:1277/1555 train_time:72043ms step_avg:56.42ms
+step:1278/1555 train_time:72129ms step_avg:56.44ms
+step:1279/1555 train_time:72218ms step_avg:56.46ms
+step:1280/1555 train_time:72303ms step_avg:56.49ms
+step:1281/1555 train_time:72391ms step_avg:56.51ms
+step:1282/1555 train_time:72478ms step_avg:56.54ms
+step:1283/1555 train_time:72565ms step_avg:56.56ms
+step:1284/1555 train_time:72650ms step_avg:56.58ms
+step:1285/1555 train_time:72752ms step_avg:56.62ms
+step:1286/1555 train_time:72834ms step_avg:56.64ms
+step:1287/1555 train_time:72919ms step_avg:56.66ms
+step:1288/1555 train_time:73005ms step_avg:56.68ms
+step:1289/1555 train_time:73096ms step_avg:56.71ms
+step:1290/1555 train_time:73184ms step_avg:56.73ms
+step:1291/1555 train_time:73271ms step_avg:56.76ms
+step:1292/1555 train_time:73357ms step_avg:56.78ms
+step:1293/1555 train_time:73444ms step_avg:56.80ms
+step:1294/1555 train_time:73529ms step_avg:56.82ms
+step:1295/1555 train_time:73618ms step_avg:56.85ms
+step:1296/1555 train_time:73705ms step_avg:56.87ms
+step:1297/1555 train_time:73795ms step_avg:56.90ms
+step:1298/1555 train_time:73882ms step_avg:56.92ms
+step:1299/1555 train_time:73972ms step_avg:56.95ms
+step:1300/1555 train_time:74058ms step_avg:56.97ms
+step:1301/1555 train_time:74148ms step_avg:56.99ms
+step:1302/1555 train_time:74233ms step_avg:57.01ms
+step:1303/1555 train_time:74323ms step_avg:57.04ms
+step:1304/1555 train_time:74408ms step_avg:57.06ms
+step:1305/1555 train_time:74497ms step_avg:57.09ms
+step:1306/1555 train_time:74583ms step_avg:57.11ms
+step:1307/1555 train_time:74672ms step_avg:57.13ms
+step:1308/1555 train_time:74759ms step_avg:57.16ms
+step:1309/1555 train_time:74849ms step_avg:57.18ms
+step:1310/1555 train_time:74935ms step_avg:57.20ms
+step:1311/1555 train_time:75025ms step_avg:57.23ms
+step:1312/1555 train_time:75114ms step_avg:57.25ms
+step:1313/1555 train_time:75201ms step_avg:57.27ms
+step:1314/1555 train_time:75286ms step_avg:57.30ms
+step:1315/1555 train_time:75377ms step_avg:57.32ms
+step:1316/1555 train_time:75462ms step_avg:57.34ms
+step:1317/1555 train_time:75550ms step_avg:57.37ms
+step:1318/1555 train_time:75637ms step_avg:57.39ms
+step:1319/1555 train_time:75726ms step_avg:57.41ms
+step:1320/1555 train_time:75812ms step_avg:57.43ms
+step:1321/1555 train_time:75902ms step_avg:57.46ms
+step:1322/1555 train_time:75989ms step_avg:57.48ms
+step:1323/1555 train_time:76077ms step_avg:57.50ms
+step:1324/1555 train_time:76163ms step_avg:57.52ms
+step:1325/1555 train_time:76252ms step_avg:57.55ms
+step:1326/1555 train_time:76338ms step_avg:57.57ms
+step:1327/1555 train_time:76426ms step_avg:57.59ms
+step:1328/1555 train_time:76511ms step_avg:57.61ms
+step:1329/1555 train_time:76603ms step_avg:57.64ms
+step:1330/1555 train_time:76687ms step_avg:57.66ms
+step:1331/1555 train_time:76777ms step_avg:57.68ms
+step:1332/1555 train_time:76863ms step_avg:57.70ms
+step:1333/1555 train_time:76953ms step_avg:57.73ms
+step:1334/1555 train_time:77039ms step_avg:57.75ms
+step:1335/1555 train_time:77130ms step_avg:57.78ms
+step:1336/1555 train_time:77215ms step_avg:57.80ms
+step:1337/1555 train_time:77306ms step_avg:57.82ms
+step:1338/1555 train_time:77392ms step_avg:57.84ms
+step:1339/1555 train_time:77481ms step_avg:57.86ms
+step:1340/1555 train_time:77566ms step_avg:57.88ms
+step:1341/1555 train_time:77656ms step_avg:57.91ms
+step:1342/1555 train_time:77742ms step_avg:57.93ms
+step:1343/1555 train_time:77831ms step_avg:57.95ms
+step:1344/1555 train_time:77917ms step_avg:57.97ms
+step:1345/1555 train_time:78007ms step_avg:58.00ms
+step:1346/1555 train_time:78093ms step_avg:58.02ms
+step:1347/1555 train_time:78183ms step_avg:58.04ms
+step:1348/1555 train_time:78268ms step_avg:58.06ms
+step:1349/1555 train_time:78358ms step_avg:58.09ms
+step:1350/1555 train_time:78444ms step_avg:58.11ms
+step:1351/1555 train_time:78540ms step_avg:58.13ms
+step:1352/1555 train_time:78622ms step_avg:58.15ms
+step:1353/1555 train_time:78710ms step_avg:58.17ms
+step:1354/1555 train_time:78796ms step_avg:58.19ms
+step:1355/1555 train_time:78885ms step_avg:58.22ms
+step:1356/1555 train_time:78970ms step_avg:58.24ms
+step:1357/1555 train_time:79061ms step_avg:58.26ms
+step:1358/1555 train_time:79147ms step_avg:58.28ms
+step:1359/1555 train_time:79236ms step_avg:58.30ms
+step:1360/1555 train_time:79322ms step_avg:58.33ms
+step:1361/1555 train_time:79411ms step_avg:58.35ms
+step:1362/1555 train_time:79497ms step_avg:58.37ms
+step:1363/1555 train_time:79587ms step_avg:58.39ms
+step:1364/1555 train_time:79672ms step_avg:58.41ms
+step:1365/1555 train_time:79762ms step_avg:58.43ms
+step:1366/1555 train_time:79848ms step_avg:58.45ms
+step:1367/1555 train_time:79938ms step_avg:58.48ms
+step:1368/1555 train_time:80023ms step_avg:58.50ms
+step:1369/1555 train_time:80112ms step_avg:58.52ms
+step:1370/1555 train_time:80198ms step_avg:58.54ms
+step:1371/1555 train_time:80287ms step_avg:58.56ms
+step:1372/1555 train_time:80373ms step_avg:58.58ms
+step:1373/1555 train_time:80462ms step_avg:58.60ms
+step:1374/1555 train_time:80550ms step_avg:58.62ms
+step:1375/1555 train_time:80638ms step_avg:58.65ms
+step:1376/1555 train_time:80725ms step_avg:58.67ms
+step:1377/1555 train_time:80814ms step_avg:58.69ms
+step:1378/1555 train_time:80901ms step_avg:58.71ms
+step:1379/1555 train_time:80989ms step_avg:58.73ms
+step:1380/1555 train_time:81077ms step_avg:58.75ms
+step:1381/1555 train_time:81165ms step_avg:58.77ms
+step:1382/1555 train_time:81251ms step_avg:58.79ms
+step:1383/1555 train_time:81340ms step_avg:58.81ms
+step:1384/1555 train_time:81432ms step_avg:58.84ms
+step:1385/1555 train_time:81516ms step_avg:58.86ms
+step:1386/1555 train_time:81606ms step_avg:58.88ms
+step:1387/1555 train_time:81693ms step_avg:58.90ms
+step:1388/1555 train_time:81778ms step_avg:58.92ms
+step:1389/1555 train_time:81868ms step_avg:58.94ms
+step:1390/1555 train_time:81954ms step_avg:58.96ms
+step:1391/1555 train_time:82045ms step_avg:58.98ms
+step:1392/1555 train_time:82129ms step_avg:59.00ms
+step:1393/1555 train_time:82218ms step_avg:59.02ms
+step:1394/1555 train_time:82305ms step_avg:59.04ms
+step:1395/1555 train_time:82394ms step_avg:59.06ms
+step:1396/1555 train_time:82480ms step_avg:59.08ms
+step:1397/1555 train_time:82569ms step_avg:59.10ms
+step:1398/1555 train_time:82655ms step_avg:59.12ms
+step:1399/1555 train_time:82745ms step_avg:59.15ms
+step:1400/1555 train_time:82831ms step_avg:59.16ms
+step:1401/1555 train_time:82921ms step_avg:59.19ms
+step:1402/1555 train_time:83007ms step_avg:59.21ms
+step:1403/1555 train_time:83096ms step_avg:59.23ms
+step:1404/1555 train_time:83182ms step_avg:59.25ms
+step:1405/1555 train_time:83271ms step_avg:59.27ms
+step:1406/1555 train_time:83357ms step_avg:59.29ms
+step:1407/1555 train_time:83447ms step_avg:59.31ms
+step:1408/1555 train_time:83533ms step_avg:59.33ms
+step:1409/1555 train_time:83623ms step_avg:59.35ms
+step:1410/1555 train_time:83708ms step_avg:59.37ms
+step:1411/1555 train_time:83798ms step_avg:59.39ms
+step:1412/1555 train_time:83883ms step_avg:59.41ms
+step:1413/1555 train_time:83972ms step_avg:59.43ms
+step:1414/1555 train_time:84059ms step_avg:59.45ms
+step:1415/1555 train_time:84148ms step_avg:59.47ms
+step:1416/1555 train_time:84234ms step_avg:59.49ms
+step:1417/1555 train_time:84324ms step_avg:59.51ms
+step:1418/1555 train_time:84410ms step_avg:59.53ms
+step:1419/1555 train_time:84499ms step_avg:59.55ms
+step:1420/1555 train_time:84585ms step_avg:59.57ms
+step:1421/1555 train_time:84674ms step_avg:59.59ms
+step:1422/1555 train_time:84760ms step_avg:59.61ms
+step:1423/1555 train_time:84850ms step_avg:59.63ms
+step:1424/1555 train_time:84936ms step_avg:59.65ms
+step:1425/1555 train_time:85025ms step_avg:59.67ms
+step:1426/1555 train_time:85111ms step_avg:59.69ms
+step:1427/1555 train_time:85201ms step_avg:59.71ms
+step:1428/1555 train_time:85286ms step_avg:59.72ms
+step:1429/1555 train_time:85376ms step_avg:59.75ms
+step:1430/1555 train_time:85462ms step_avg:59.76ms
+step:1431/1555 train_time:85552ms step_avg:59.78ms
+step:1432/1555 train_time:85637ms step_avg:59.80ms
+step:1433/1555 train_time:85727ms step_avg:59.82ms
+step:1434/1555 train_time:85813ms step_avg:59.84ms
+step:1435/1555 train_time:85903ms step_avg:59.86ms
+step:1436/1555 train_time:85989ms step_avg:59.88ms
+step:1437/1555 train_time:86078ms step_avg:59.90ms
+step:1438/1555 train_time:86164ms step_avg:59.92ms
+step:1439/1555 train_time:86253ms step_avg:59.94ms
+step:1440/1555 train_time:86340ms step_avg:59.96ms
+step:1441/1555 train_time:86430ms step_avg:59.98ms
+step:1442/1555 train_time:86515ms step_avg:60.00ms
+step:1443/1555 train_time:86604ms step_avg:60.02ms
+step:1444/1555 train_time:86690ms step_avg:60.03ms
+step:1445/1555 train_time:86779ms step_avg:60.05ms
+step:1446/1555 train_time:86864ms step_avg:60.07ms
+step:1447/1555 train_time:86954ms step_avg:60.09ms
+step:1448/1555 train_time:87040ms step_avg:60.11ms
+step:1449/1555 train_time:87130ms step_avg:60.13ms
+step:1450/1555 train_time:87217ms step_avg:60.15ms
+step:1451/1555 train_time:87306ms step_avg:60.17ms
+step:1452/1555 train_time:87392ms step_avg:60.19ms
+step:1453/1555 train_time:87482ms step_avg:60.21ms
+step:1454/1555 train_time:87568ms step_avg:60.23ms
+step:1455/1555 train_time:87657ms step_avg:60.25ms
+step:1456/1555 train_time:87742ms step_avg:60.26ms
+step:1457/1555 train_time:87833ms step_avg:60.28ms
+step:1458/1555 train_time:87918ms step_avg:60.30ms
+step:1459/1555 train_time:88008ms step_avg:60.32ms
+step:1460/1555 train_time:88094ms step_avg:60.34ms
+step:1461/1555 train_time:88184ms step_avg:60.36ms
+step:1462/1555 train_time:88270ms step_avg:60.38ms
+step:1463/1555 train_time:88359ms step_avg:60.40ms
+step:1464/1555 train_time:88446ms step_avg:60.41ms
+step:1465/1555 train_time:88535ms step_avg:60.43ms
+step:1466/1555 train_time:88621ms step_avg:60.45ms
+step:1467/1555 train_time:88710ms step_avg:60.47ms
+step:1468/1555 train_time:88797ms step_avg:60.49ms
+step:1469/1555 train_time:88887ms step_avg:60.51ms
+step:1470/1555 train_time:88973ms step_avg:60.53ms
+step:1471/1555 train_time:89063ms step_avg:60.55ms
+step:1472/1555 train_time:89149ms step_avg:60.56ms
+step:1473/1555 train_time:89238ms step_avg:60.58ms
+step:1474/1555 train_time:89324ms step_avg:60.60ms
+step:1475/1555 train_time:89414ms step_avg:60.62ms
+step:1476/1555 train_time:89499ms step_avg:60.64ms
+step:1477/1555 train_time:89588ms step_avg:60.66ms
+step:1478/1555 train_time:89674ms step_avg:60.67ms
+step:1479/1555 train_time:89763ms step_avg:60.69ms
+step:1480/1555 train_time:89849ms step_avg:60.71ms
+step:1481/1555 train_time:89939ms step_avg:60.73ms
+step:1482/1555 train_time:90024ms step_avg:60.74ms
+step:1483/1555 train_time:90113ms step_avg:60.76ms
+step:1484/1555 train_time:90199ms step_avg:60.78ms
+step:1485/1555 train_time:90289ms step_avg:60.80ms
+step:1486/1555 train_time:90375ms step_avg:60.82ms
+step:1487/1555 train_time:90465ms step_avg:60.84ms
+step:1488/1555 train_time:90550ms step_avg:60.85ms
+step:1489/1555 train_time:90640ms step_avg:60.87ms
+step:1490/1555 train_time:90730ms step_avg:60.89ms
+step:1491/1555 train_time:90825ms step_avg:60.92ms
+step:1492/1555 train_time:90906ms step_avg:60.93ms
+step:1493/1555 train_time:90995ms step_avg:60.95ms
+step:1494/1555 train_time:91079ms step_avg:60.96ms
+step:1495/1555 train_time:91171ms step_avg:60.98ms
+step:1496/1555 train_time:91255ms step_avg:61.00ms
+step:1497/1555 train_time:91343ms step_avg:61.02ms
+step:1498/1555 train_time:91429ms step_avg:61.03ms
+step:1499/1555 train_time:91518ms step_avg:61.05ms
+step:1500/1555 train_time:91604ms step_avg:61.07ms
+step:1500/1555 val_loss:3.2943 train_time:91679ms step_avg:61.12ms
+step:1501/1555 train_time:91703ms step_avg:61.09ms
+step:1502/1555 train_time:91791ms step_avg:61.11ms
+step:1503/1555 train_time:91883ms step_avg:61.13ms
+step:1504/1555 train_time:91969ms step_avg:61.15ms
+step:1505/1555 train_time:92058ms step_avg:61.17ms
+step:1506/1555 train_time:92144ms step_avg:61.18ms
+step:1507/1555 train_time:92232ms step_avg:61.20ms
+step:1508/1555 train_time:92317ms step_avg:61.22ms
+step:1509/1555 train_time:92406ms step_avg:61.24ms
+step:1510/1555 train_time:92491ms step_avg:61.25ms
+step:1511/1555 train_time:92579ms step_avg:61.27ms
+step:1512/1555 train_time:92665ms step_avg:61.29ms
+step:1513/1555 train_time:92758ms step_avg:61.31ms
+step:1514/1555 train_time:92847ms step_avg:61.33ms
+step:1515/1555 train_time:92938ms step_avg:61.35ms
+step:1516/1555 train_time:93035ms step_avg:61.37ms
+step:1517/1555 train_time:93121ms step_avg:61.38ms
+step:1518/1555 train_time:93206ms step_avg:61.40ms
+step:1519/1555 train_time:93295ms step_avg:61.42ms
+step:1520/1555 train_time:93381ms step_avg:61.43ms
+step:1521/1555 train_time:93471ms step_avg:61.45ms
+step:1522/1555 train_time:93555ms step_avg:61.47ms
+step:1523/1555 train_time:93644ms step_avg:61.49ms
+step:1524/1555 train_time:93732ms step_avg:61.50ms
+step:1525/1555 train_time:93823ms step_avg:61.52ms
+step:1526/1555 train_time:93911ms step_avg:61.54ms
+step:1527/1555 train_time:94001ms step_avg:61.56ms
+step:1528/1555 train_time:94088ms step_avg:61.58ms
+step:1529/1555 train_time:94177ms step_avg:61.59ms
+step:1530/1555 train_time:94263ms step_avg:61.61ms
+step:1531/1555 train_time:94353ms step_avg:61.63ms
+step:1532/1555 train_time:94437ms step_avg:61.64ms
+step:1533/1555 train_time:94528ms step_avg:61.66ms
+step:1534/1555 train_time:94613ms step_avg:61.68ms
+step:1535/1555 train_time:94703ms step_avg:61.70ms
+step:1536/1555 train_time:94792ms step_avg:61.71ms
+step:1537/1555 train_time:94881ms step_avg:61.73ms
+step:1538/1555 train_time:94970ms step_avg:61.75ms
+step:1539/1555 train_time:95058ms step_avg:61.77ms
+step:1540/1555 train_time:95143ms step_avg:61.78ms
+step:1541/1555 train_time:95233ms step_avg:61.80ms
+step:1542/1555 train_time:95318ms step_avg:61.81ms
+step:1543/1555 train_time:95408ms step_avg:61.83ms
+step:1544/1555 train_time:95495ms step_avg:61.85ms
+step:1545/1555 train_time:95584ms step_avg:61.87ms
+step:1546/1555 train_time:95669ms step_avg:61.88ms
+step:1547/1555 train_time:95760ms step_avg:61.90ms
+step:1548/1555 train_time:95848ms step_avg:61.92ms
+step:1549/1555 train_time:95938ms step_avg:61.94ms
+step:1550/1555 train_time:96026ms step_avg:61.95ms
+step:1551/1555 train_time:96116ms step_avg:61.97ms
+step:1552/1555 train_time:96201ms step_avg:61.99ms
+step:1553/1555 train_time:96291ms step_avg:62.00ms
+step:1554/1555 train_time:96376ms step_avg:62.02ms
+step:1555/1555 train_time:96466ms step_avg:62.04ms
+step:1555/1555 val_loss:3.2780 train_time:96535ms step_avg:62.08ms
+peak memory allocated: 31016 MiB reserved: 47018 MiB

--- a/records/track_1_short/2026-01-30_MimeticValueOutput/runs/d8181911-7c2c-46c2-870f-5d4172d2ebca.txt
+++ b/records/track_1_short/2026-01-30_MimeticValueOutput/runs/d8181911-7c2c-46c2-870f-5d4172d2ebca.txt
@@ -1,0 +1,4131 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# Mimetic V-O Initialization (Trockman & Kolter, ICML 2023)
+# Initialize V and O such that V @ O^T ≈ -βI (negative identity-like)
+# This enables attention to make meaningful contributions from step 1
+
+def mimetic_vo_init(attn_bank, model_dim=768, num_heads=6, head_dim=128, beta=0.1, noise_std=0.01):
+    """
+    Initialize attention bank with mimetic structure for V and O.
+    Q and K use standard uniform init, V and O use identity-like structure.
+
+    Args:
+        attn_bank: Tensor of shape (num_layers, 4*model_dim, hdim)
+        model_dim: Model dimension (768)
+        num_heads: Number of attention heads (6)
+        head_dim: Dimension per head (128)
+        beta: Scale for identity structure (0.1 recommended with attn_scale=0.1)
+        noise_std: Standard deviation of noise for symmetry breaking
+    """
+    num_layers = attn_bank.shape[0]
+    dim = model_dim
+    sqrt_beta = beta ** 0.5
+
+    # Standard init for Q and K (existing behavior)
+    attn_std = model_dim ** -0.5
+    attn_bound = (3 ** 0.5) * attn_std
+
+    with torch.no_grad():
+        # Q and K: uniform init (first 2*dim rows)
+        attn_bank[:, :2*dim, :].uniform_(-attn_bound, attn_bound)
+
+        # V and O: mimetic identity structure
+        for layer_idx in range(num_layers):
+            W_V = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+            W_O = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+
+            # Create per-head identity blocks
+            for h in range(num_heads):
+                start, end = h * head_dim, (h + 1) * head_dim
+                eye = torch.eye(head_dim, dtype=attn_bank.dtype, device=attn_bank.device)
+                W_V[start:end, start:end] = sqrt_beta * eye
+                W_O[start:end, start:end] = -sqrt_beta * eye
+
+            # Add noise for symmetry breaking
+            W_V += noise_std * torch.randn_like(W_V)
+            W_O += noise_std * torch.randn_like(W_O)
+
+            # Store in attn_bank: V is rows [2*dim:3*dim], O is rows [3*dim:4*dim]
+            attn_bank[layer_idx, 2*dim:3*dim, :] = W_V
+            attn_bank[layer_idx, 3*dim:4*dim, :] = W_O
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # MLP uses 0.5 * dim^-0.5
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank with MIMETIC V-O initialization
+            # Q and K: uniform init, V and O: identity-like structure for faster convergence
+            mimetic_vo_init(
+                self.attn_bank,
+                model_dim=model_dim,
+                num_heads=num_heads,
+                head_dim=head_dim,
+                beta=0.05,       # Scale for V@O^T ≈ -βI (tuned down from 0.1)
+                noise_std=0.01   # Symmetry breaking noise
+            )
+            # Init MLP bank (c_fc uniform, c_proj zero)
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 234 structure on token value embeddings by @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1515  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.11.14 (main, Oct 21 2025, 18:31:21) [GCC 11.2.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Fri Jan 30 18:39:45 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          Off |   00000000:19:00.0 Off |                    0 |
+| N/A   35C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          Off |   00000000:3B:00.0 Off |                    0 |
+| N/A   28C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          Off |   00000000:4C:00.0 Off |                    0 |
+| N/A   25C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          Off |   00000000:5D:00.0 Off |                    0 |
+| N/A   34C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          Off |   00000000:9B:00.0 Off |                    0 |
+| N/A   35C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          Off |   00000000:BB:00.0 Off |                    0 |
+| N/A   26C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          Off |   00000000:CB:00.0 Off |                    0 |
+| N/A   32C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          Off |   00000000:DB:00.0 Off |                    0 |
+| N/A   26C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1367669      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    1   N/A  N/A   1367670      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    2   N/A  N/A   1367671      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    3   N/A  N/A   1367672      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    4   N/A  N/A   1367673      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    5   N/A  N/A   1367674      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    6   N/A  N/A   1367675      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    7   N/A  N/A   1367676      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 504, 505, 506, 1009, 1010, 1011, 1514, 1515, 1516] for warmup
+Resetting Model
+step:0/1555 val_loss:10.8318 train_time:0ms step_avg:0.03ms
+step:1/1555 train_time:79ms step_avg:78.91ms
+step:2/1555 train_time:101ms step_avg:50.52ms
+step:3/1555 train_time:140ms step_avg:46.71ms
+step:4/1555 train_time:179ms step_avg:44.69ms
+step:5/1555 train_time:210ms step_avg:41.91ms
+step:6/1555 train_time:248ms step_avg:41.30ms
+step:7/1555 train_time:279ms step_avg:39.84ms
+step:8/1555 train_time:317ms step_avg:39.63ms
+step:9/1555 train_time:349ms step_avg:38.74ms
+step:10/1555 train_time:387ms step_avg:38.68ms
+step:11/1555 train_time:418ms step_avg:38.03ms
+step:12/1555 train_time:457ms step_avg:38.05ms
+step:13/1555 train_time:488ms step_avg:37.52ms
+step:14/1555 train_time:526ms step_avg:37.59ms
+step:15/1555 train_time:558ms step_avg:37.17ms
+step:16/1555 train_time:596ms step_avg:37.26ms
+step:17/1555 train_time:627ms step_avg:36.91ms
+step:18/1555 train_time:666ms step_avg:37.03ms
+step:19/1555 train_time:697ms step_avg:36.70ms
+step:20/1555 train_time:736ms step_avg:36.79ms
+step:21/1555 train_time:767ms step_avg:36.53ms
+step:22/1555 train_time:806ms step_avg:36.61ms
+step:23/1555 train_time:837ms step_avg:36.40ms
+step:24/1555 train_time:876ms step_avg:36.50ms
+step:25/1555 train_time:907ms step_avg:36.28ms
+step:26/1555 train_time:945ms step_avg:36.35ms
+step:27/1555 train_time:977ms step_avg:36.18ms
+step:28/1555 train_time:1016ms step_avg:36.28ms
+step:29/1555 train_time:1046ms step_avg:36.09ms
+step:30/1555 train_time:1085ms step_avg:36.16ms
+step:31/1555 train_time:1116ms step_avg:36.01ms
+step:32/1555 train_time:1155ms step_avg:36.08ms
+step:33/1555 train_time:1187ms step_avg:35.96ms
+step:34/1555 train_time:1224ms step_avg:36.01ms
+step:35/1555 train_time:1256ms step_avg:35.89ms
+step:36/1555 train_time:1294ms step_avg:35.95ms
+step:37/1555 train_time:1326ms step_avg:35.83ms
+step:38/1555 train_time:1364ms step_avg:35.90ms
+step:39/1555 train_time:1396ms step_avg:35.79ms
+step:40/1555 train_time:1435ms step_avg:35.87ms
+step:41/1555 train_time:1466ms step_avg:35.75ms
+step:42/1555 train_time:1504ms step_avg:35.81ms
+step:43/1555 train_time:1536ms step_avg:35.71ms
+step:44/1555 train_time:1574ms step_avg:35.78ms
+step:45/1555 train_time:1606ms step_avg:35.69ms
+step:46/1555 train_time:1644ms step_avg:35.75ms
+step:47/1555 train_time:1676ms step_avg:35.66ms
+step:48/1555 train_time:1714ms step_avg:35.71ms
+step:49/1555 train_time:1746ms step_avg:35.62ms
+step:50/1555 train_time:1784ms step_avg:35.68ms
+step:51/1555 train_time:1816ms step_avg:35.61ms
+step:52/1555 train_time:1854ms step_avg:35.66ms
+step:53/1555 train_time:1886ms step_avg:35.58ms
+step:54/1555 train_time:1924ms step_avg:35.63ms
+step:55/1555 train_time:1955ms step_avg:35.55ms
+step:56/1555 train_time:1994ms step_avg:35.61ms
+step:57/1555 train_time:2025ms step_avg:35.53ms
+step:58/1555 train_time:2063ms step_avg:35.57ms
+step:59/1555 train_time:2095ms step_avg:35.51ms
+step:60/1555 train_time:2134ms step_avg:35.56ms
+step:61/1555 train_time:2165ms step_avg:35.49ms
+step:62/1555 train_time:2203ms step_avg:35.54ms
+step:63/1555 train_time:2235ms step_avg:35.47ms
+step:64/1555 train_time:2273ms step_avg:35.51ms
+step:65/1555 train_time:2304ms step_avg:35.44ms
+step:66/1555 train_time:2343ms step_avg:35.49ms
+step:67/1555 train_time:2374ms step_avg:35.43ms
+step:68/1555 train_time:2412ms step_avg:35.47ms
+step:69/1555 train_time:2443ms step_avg:35.41ms
+step:70/1555 train_time:2481ms step_avg:35.45ms
+step:71/1555 train_time:2513ms step_avg:35.39ms
+step:72/1555 train_time:2551ms step_avg:35.43ms
+step:73/1555 train_time:2583ms step_avg:35.38ms
+step:74/1555 train_time:2621ms step_avg:35.42ms
+step:75/1555 train_time:2652ms step_avg:35.37ms
+step:76/1555 train_time:2690ms step_avg:35.40ms
+step:77/1555 train_time:2722ms step_avg:35.35ms
+step:78/1555 train_time:2760ms step_avg:35.39ms
+step:79/1555 train_time:2792ms step_avg:35.34ms
+step:80/1555 train_time:2830ms step_avg:35.38ms
+step:81/1555 train_time:2862ms step_avg:35.33ms
+step:82/1555 train_time:2901ms step_avg:35.37ms
+step:83/1555 train_time:2932ms step_avg:35.32ms
+step:84/1555 train_time:2970ms step_avg:35.36ms
+step:85/1555 train_time:3001ms step_avg:35.31ms
+step:86/1555 train_time:3039ms step_avg:35.34ms
+step:87/1555 train_time:3071ms step_avg:35.29ms
+step:88/1555 train_time:3109ms step_avg:35.33ms
+step:89/1555 train_time:3140ms step_avg:35.28ms
+step:90/1555 train_time:3178ms step_avg:35.31ms
+step:91/1555 train_time:3210ms step_avg:35.27ms
+step:92/1555 train_time:3248ms step_avg:35.30ms
+step:93/1555 train_time:3279ms step_avg:35.26ms
+step:94/1555 train_time:3317ms step_avg:35.29ms
+step:95/1555 train_time:3348ms step_avg:35.24ms
+step:96/1555 train_time:3387ms step_avg:35.28ms
+step:97/1555 train_time:3418ms step_avg:35.23ms
+step:98/1555 train_time:3456ms step_avg:35.27ms
+step:99/1555 train_time:3488ms step_avg:35.23ms
+step:100/1555 train_time:3526ms step_avg:35.26ms
+step:101/1555 train_time:3557ms step_avg:35.22ms
+step:102/1555 train_time:3595ms step_avg:35.25ms
+step:103/1555 train_time:3627ms step_avg:35.21ms
+step:104/1555 train_time:3665ms step_avg:35.24ms
+step:105/1555 train_time:3696ms step_avg:35.20ms
+step:106/1555 train_time:3735ms step_avg:35.23ms
+step:107/1555 train_time:3766ms step_avg:35.20ms
+step:108/1555 train_time:3805ms step_avg:35.23ms
+step:109/1555 train_time:3836ms step_avg:35.19ms
+step:110/1555 train_time:3874ms step_avg:35.22ms
+step:111/1555 train_time:3906ms step_avg:35.19ms
+step:112/1555 train_time:3944ms step_avg:35.21ms
+step:113/1555 train_time:3975ms step_avg:35.18ms
+step:114/1555 train_time:4014ms step_avg:35.21ms
+step:115/1555 train_time:4045ms step_avg:35.18ms
+step:116/1555 train_time:4083ms step_avg:35.20ms
+step:117/1555 train_time:4115ms step_avg:35.17ms
+step:118/1555 train_time:4153ms step_avg:35.19ms
+step:119/1555 train_time:4184ms step_avg:35.16ms
+step:120/1555 train_time:4222ms step_avg:35.19ms
+step:121/1555 train_time:4254ms step_avg:35.16ms
+step:122/1555 train_time:4292ms step_avg:35.18ms
+step:123/1555 train_time:4323ms step_avg:35.15ms
+step:124/1555 train_time:4361ms step_avg:35.17ms
+step:125/1555 train_time:4392ms step_avg:35.14ms
+step:126/1555 train_time:4430ms step_avg:35.16ms
+step:127/1555 train_time:4462ms step_avg:35.13ms
+step:128/1555 train_time:4500ms step_avg:35.16ms
+step:129/1555 train_time:4531ms step_avg:35.13ms
+step:130/1555 train_time:4569ms step_avg:35.15ms
+step:131/1555 train_time:4601ms step_avg:35.12ms
+step:132/1555 train_time:4640ms step_avg:35.15ms
+step:133/1555 train_time:4670ms step_avg:35.12ms
+step:134/1555 train_time:4708ms step_avg:35.14ms
+step:135/1555 train_time:4740ms step_avg:35.11ms
+step:136/1555 train_time:4778ms step_avg:35.13ms
+step:137/1555 train_time:4809ms step_avg:35.10ms
+step:138/1555 train_time:4847ms step_avg:35.13ms
+step:139/1555 train_time:4878ms step_avg:35.10ms
+step:140/1555 train_time:4917ms step_avg:35.12ms
+step:141/1555 train_time:4948ms step_avg:35.09ms
+step:142/1555 train_time:4986ms step_avg:35.11ms
+step:143/1555 train_time:5017ms step_avg:35.09ms
+step:144/1555 train_time:5056ms step_avg:35.11ms
+step:145/1555 train_time:5087ms step_avg:35.08ms
+step:146/1555 train_time:5125ms step_avg:35.10ms
+step:147/1555 train_time:5156ms step_avg:35.08ms
+step:148/1555 train_time:5195ms step_avg:35.10ms
+step:149/1555 train_time:5226ms step_avg:35.07ms
+step:150/1555 train_time:5264ms step_avg:35.09ms
+step:151/1555 train_time:5295ms step_avg:35.07ms
+step:152/1555 train_time:5334ms step_avg:35.09ms
+step:153/1555 train_time:5365ms step_avg:35.07ms
+step:154/1555 train_time:5403ms step_avg:35.09ms
+step:155/1555 train_time:5434ms step_avg:35.06ms
+step:156/1555 train_time:5473ms step_avg:35.08ms
+step:157/1555 train_time:5504ms step_avg:35.06ms
+step:158/1555 train_time:5542ms step_avg:35.08ms
+step:159/1555 train_time:5573ms step_avg:35.05ms
+step:160/1555 train_time:5612ms step_avg:35.07ms
+step:161/1555 train_time:5643ms step_avg:35.05ms
+step:162/1555 train_time:5682ms step_avg:35.07ms
+step:163/1555 train_time:5713ms step_avg:35.05ms
+step:164/1555 train_time:5751ms step_avg:35.07ms
+step:165/1555 train_time:5782ms step_avg:35.04ms
+step:166/1555 train_time:5821ms step_avg:35.07ms
+step:167/1555 train_time:5852ms step_avg:35.04ms
+step:168/1555 train_time:5890ms step_avg:35.06ms
+step:169/1555 train_time:5921ms step_avg:35.04ms
+step:170/1555 train_time:5960ms step_avg:35.06ms
+step:171/1555 train_time:5992ms step_avg:35.04ms
+step:172/1555 train_time:6030ms step_avg:35.06ms
+step:173/1555 train_time:6061ms step_avg:35.03ms
+step:174/1555 train_time:6099ms step_avg:35.05ms
+step:175/1555 train_time:6130ms step_avg:35.03ms
+step:176/1555 train_time:6169ms step_avg:35.05ms
+step:177/1555 train_time:6200ms step_avg:35.03ms
+step:178/1555 train_time:6238ms step_avg:35.05ms
+step:179/1555 train_time:6270ms step_avg:35.03ms
+step:180/1555 train_time:6309ms step_avg:35.05ms
+step:181/1555 train_time:6339ms step_avg:35.02ms
+step:182/1555 train_time:6377ms step_avg:35.04ms
+step:183/1555 train_time:6409ms step_avg:35.02ms
+step:184/1555 train_time:6447ms step_avg:35.04ms
+step:185/1555 train_time:6478ms step_avg:35.02ms
+step:186/1555 train_time:6516ms step_avg:35.03ms
+step:187/1555 train_time:6547ms step_avg:35.01ms
+step:188/1555 train_time:6585ms step_avg:35.03ms
+step:189/1555 train_time:6617ms step_avg:35.01ms
+step:190/1555 train_time:6655ms step_avg:35.03ms
+step:191/1555 train_time:6686ms step_avg:35.01ms
+step:192/1555 train_time:6724ms step_avg:35.02ms
+step:193/1555 train_time:6756ms step_avg:35.00ms
+step:194/1555 train_time:6795ms step_avg:35.03ms
+step:195/1555 train_time:6825ms step_avg:35.00ms
+step:196/1555 train_time:6863ms step_avg:35.02ms
+step:197/1555 train_time:6894ms step_avg:35.00ms
+step:198/1555 train_time:6932ms step_avg:35.01ms
+step:199/1555 train_time:6963ms step_avg:34.99ms
+step:200/1555 train_time:7002ms step_avg:35.01ms
+step:201/1555 train_time:7033ms step_avg:34.99ms
+step:202/1555 train_time:7071ms step_avg:35.00ms
+step:203/1555 train_time:7102ms step_avg:34.99ms
+step:204/1555 train_time:7140ms step_avg:35.00ms
+step:205/1555 train_time:7171ms step_avg:34.98ms
+step:206/1555 train_time:7209ms step_avg:35.00ms
+step:207/1555 train_time:7241ms step_avg:34.98ms
+step:208/1555 train_time:7279ms step_avg:34.99ms
+step:209/1555 train_time:7310ms step_avg:34.97ms
+step:210/1555 train_time:7348ms step_avg:34.99ms
+step:211/1555 train_time:7379ms step_avg:34.97ms
+step:212/1555 train_time:7418ms step_avg:34.99ms
+step:213/1555 train_time:7449ms step_avg:34.97ms
+step:214/1555 train_time:7487ms step_avg:34.99ms
+step:215/1555 train_time:7518ms step_avg:34.97ms
+step:216/1555 train_time:7556ms step_avg:34.98ms
+step:217/1555 train_time:7587ms step_avg:34.97ms
+step:218/1555 train_time:7626ms step_avg:34.98ms
+step:219/1555 train_time:7657ms step_avg:34.96ms
+step:220/1555 train_time:7695ms step_avg:34.98ms
+step:221/1555 train_time:7726ms step_avg:34.96ms
+step:222/1555 train_time:7764ms step_avg:34.97ms
+step:223/1555 train_time:7795ms step_avg:34.96ms
+step:224/1555 train_time:7834ms step_avg:34.97ms
+step:225/1555 train_time:7865ms step_avg:34.95ms
+step:226/1555 train_time:7903ms step_avg:34.97ms
+step:227/1555 train_time:7935ms step_avg:34.95ms
+step:228/1555 train_time:7973ms step_avg:34.97ms
+step:229/1555 train_time:8004ms step_avg:34.95ms
+step:230/1555 train_time:8042ms step_avg:34.97ms
+step:231/1555 train_time:8074ms step_avg:34.95ms
+step:232/1555 train_time:8112ms step_avg:34.97ms
+step:233/1555 train_time:8143ms step_avg:34.95ms
+step:234/1555 train_time:8182ms step_avg:34.97ms
+step:235/1555 train_time:8213ms step_avg:34.95ms
+step:236/1555 train_time:8252ms step_avg:34.97ms
+step:237/1555 train_time:8283ms step_avg:34.95ms
+step:238/1555 train_time:8322ms step_avg:34.97ms
+step:239/1555 train_time:8353ms step_avg:34.95ms
+step:240/1555 train_time:8391ms step_avg:34.96ms
+step:241/1555 train_time:8423ms step_avg:34.95ms
+step:242/1555 train_time:8461ms step_avg:34.96ms
+step:243/1555 train_time:8492ms step_avg:34.95ms
+step:244/1555 train_time:8530ms step_avg:34.96ms
+step:245/1555 train_time:8562ms step_avg:34.95ms
+step:246/1555 train_time:8600ms step_avg:34.96ms
+step:247/1555 train_time:8631ms step_avg:34.94ms
+step:248/1555 train_time:8669ms step_avg:34.96ms
+step:249/1555 train_time:8700ms step_avg:34.94ms
+step:250/1555 train_time:8739ms step_avg:34.95ms
+step:250/1555 val_loss:4.5718 train_time:8788ms step_avg:35.15ms
+step:251/1555 train_time:8809ms step_avg:35.10ms
+step:252/1555 train_time:8827ms step_avg:35.03ms
+step:253/1555 train_time:8844ms step_avg:34.96ms
+step:254/1555 train_time:8883ms step_avg:34.97ms
+step:255/1555 train_time:8915ms step_avg:34.96ms
+step:256/1555 train_time:8954ms step_avg:34.98ms
+step:257/1555 train_time:8986ms step_avg:34.96ms
+step:258/1555 train_time:9024ms step_avg:34.98ms
+step:259/1555 train_time:9056ms step_avg:34.97ms
+step:260/1555 train_time:9095ms step_avg:34.98ms
+step:261/1555 train_time:9126ms step_avg:34.97ms
+step:262/1555 train_time:9164ms step_avg:34.98ms
+step:263/1555 train_time:9195ms step_avg:34.96ms
+step:264/1555 train_time:9234ms step_avg:34.98ms
+step:265/1555 train_time:9265ms step_avg:34.96ms
+step:266/1555 train_time:9303ms step_avg:34.97ms
+step:267/1555 train_time:9334ms step_avg:34.96ms
+step:268/1555 train_time:9372ms step_avg:34.97ms
+step:269/1555 train_time:9404ms step_avg:34.96ms
+step:270/1555 train_time:9442ms step_avg:34.97ms
+step:271/1555 train_time:9473ms step_avg:34.96ms
+step:272/1555 train_time:9511ms step_avg:34.97ms
+step:273/1555 train_time:9543ms step_avg:34.95ms
+step:274/1555 train_time:9581ms step_avg:34.97ms
+step:275/1555 train_time:9612ms step_avg:34.95ms
+step:276/1555 train_time:9651ms step_avg:34.97ms
+step:277/1555 train_time:9682ms step_avg:34.95ms
+step:278/1555 train_time:9720ms step_avg:34.96ms
+step:279/1555 train_time:9752ms step_avg:34.95ms
+step:280/1555 train_time:9790ms step_avg:34.97ms
+step:281/1555 train_time:9821ms step_avg:34.95ms
+step:282/1555 train_time:9860ms step_avg:34.96ms
+step:283/1555 train_time:9891ms step_avg:34.95ms
+step:284/1555 train_time:9929ms step_avg:34.96ms
+step:285/1555 train_time:9961ms step_avg:34.95ms
+step:286/1555 train_time:9999ms step_avg:34.96ms
+step:287/1555 train_time:10030ms step_avg:34.95ms
+step:288/1555 train_time:10068ms step_avg:34.96ms
+step:289/1555 train_time:10100ms step_avg:34.95ms
+step:290/1555 train_time:10139ms step_avg:34.96ms
+step:291/1555 train_time:10170ms step_avg:34.95ms
+step:292/1555 train_time:10208ms step_avg:34.96ms
+step:293/1555 train_time:10240ms step_avg:34.95ms
+step:294/1555 train_time:10277ms step_avg:34.96ms
+step:295/1555 train_time:10309ms step_avg:34.95ms
+step:296/1555 train_time:10347ms step_avg:34.96ms
+step:297/1555 train_time:10378ms step_avg:34.94ms
+step:298/1555 train_time:10416ms step_avg:34.95ms
+step:299/1555 train_time:10447ms step_avg:34.94ms
+step:300/1555 train_time:10485ms step_avg:34.95ms
+step:301/1555 train_time:10516ms step_avg:34.94ms
+step:302/1555 train_time:10555ms step_avg:34.95ms
+step:303/1555 train_time:10586ms step_avg:34.94ms
+step:304/1555 train_time:10624ms step_avg:34.95ms
+step:305/1555 train_time:10655ms step_avg:34.93ms
+step:306/1555 train_time:10693ms step_avg:34.95ms
+step:307/1555 train_time:10724ms step_avg:34.93ms
+step:308/1555 train_time:10762ms step_avg:34.94ms
+step:309/1555 train_time:10794ms step_avg:34.93ms
+step:310/1555 train_time:10832ms step_avg:34.94ms
+step:311/1555 train_time:10863ms step_avg:34.93ms
+step:312/1555 train_time:10901ms step_avg:34.94ms
+step:313/1555 train_time:10932ms step_avg:34.93ms
+step:314/1555 train_time:10971ms step_avg:34.94ms
+step:315/1555 train_time:11001ms step_avg:34.93ms
+step:316/1555 train_time:11040ms step_avg:34.94ms
+step:317/1555 train_time:11071ms step_avg:34.93ms
+step:318/1555 train_time:11109ms step_avg:34.93ms
+step:319/1555 train_time:11140ms step_avg:34.92ms
+step:320/1555 train_time:11178ms step_avg:34.93ms
+step:321/1555 train_time:11210ms step_avg:34.92ms
+step:322/1555 train_time:11248ms step_avg:34.93ms
+step:323/1555 train_time:11279ms step_avg:34.92ms
+step:324/1555 train_time:11318ms step_avg:34.93ms
+step:325/1555 train_time:11349ms step_avg:34.92ms
+step:326/1555 train_time:11387ms step_avg:34.93ms
+step:327/1555 train_time:11418ms step_avg:34.92ms
+step:328/1555 train_time:11457ms step_avg:34.93ms
+step:329/1555 train_time:11488ms step_avg:34.92ms
+step:330/1555 train_time:11526ms step_avg:34.93ms
+step:331/1555 train_time:11557ms step_avg:34.92ms
+step:332/1555 train_time:11595ms step_avg:34.92ms
+step:333/1555 train_time:11626ms step_avg:34.91ms
+step:334/1555 train_time:11664ms step_avg:34.92ms
+step:335/1555 train_time:11696ms step_avg:34.91ms
+step:336/1555 train_time:11734ms step_avg:34.92ms
+step:337/1555 train_time:11765ms step_avg:34.91ms
+step:338/1555 train_time:11803ms step_avg:34.92ms
+step:339/1555 train_time:11835ms step_avg:34.91ms
+step:340/1555 train_time:11873ms step_avg:34.92ms
+step:341/1555 train_time:11904ms step_avg:34.91ms
+step:342/1555 train_time:11942ms step_avg:34.92ms
+step:343/1555 train_time:11973ms step_avg:34.91ms
+step:344/1555 train_time:12011ms step_avg:34.92ms
+step:345/1555 train_time:12042ms step_avg:34.91ms
+step:346/1555 train_time:12080ms step_avg:34.91ms
+step:347/1555 train_time:12112ms step_avg:34.90ms
+step:348/1555 train_time:12150ms step_avg:34.91ms
+step:349/1555 train_time:12181ms step_avg:34.90ms
+step:350/1555 train_time:12220ms step_avg:34.91ms
+step:351/1555 train_time:12251ms step_avg:34.90ms
+step:352/1555 train_time:12289ms step_avg:34.91ms
+step:353/1555 train_time:12320ms step_avg:34.90ms
+step:354/1555 train_time:12359ms step_avg:34.91ms
+step:355/1555 train_time:12390ms step_avg:34.90ms
+step:356/1555 train_time:12428ms step_avg:34.91ms
+step:357/1555 train_time:12459ms step_avg:34.90ms
+step:358/1555 train_time:12498ms step_avg:34.91ms
+step:359/1555 train_time:12529ms step_avg:34.90ms
+step:360/1555 train_time:12567ms step_avg:34.91ms
+step:361/1555 train_time:12598ms step_avg:34.90ms
+step:362/1555 train_time:12636ms step_avg:34.91ms
+step:363/1555 train_time:12668ms step_avg:34.90ms
+step:364/1555 train_time:12706ms step_avg:34.91ms
+step:365/1555 train_time:12737ms step_avg:34.90ms
+step:366/1555 train_time:12775ms step_avg:34.90ms
+step:367/1555 train_time:12806ms step_avg:34.89ms
+step:368/1555 train_time:12844ms step_avg:34.90ms
+step:369/1555 train_time:12875ms step_avg:34.89ms
+step:370/1555 train_time:12913ms step_avg:34.90ms
+step:371/1555 train_time:12945ms step_avg:34.89ms
+step:372/1555 train_time:12982ms step_avg:34.90ms
+step:373/1555 train_time:13014ms step_avg:34.89ms
+step:374/1555 train_time:13052ms step_avg:34.90ms
+step:375/1555 train_time:13083ms step_avg:34.89ms
+step:376/1555 train_time:13121ms step_avg:34.90ms
+step:377/1555 train_time:13153ms step_avg:34.89ms
+step:378/1555 train_time:13191ms step_avg:34.90ms
+step:379/1555 train_time:13222ms step_avg:34.89ms
+step:380/1555 train_time:13261ms step_avg:34.90ms
+step:381/1555 train_time:13292ms step_avg:34.89ms
+step:382/1555 train_time:13330ms step_avg:34.90ms
+step:383/1555 train_time:13361ms step_avg:34.89ms
+step:384/1555 train_time:13400ms step_avg:34.90ms
+step:385/1555 train_time:13431ms step_avg:34.89ms
+step:386/1555 train_time:13469ms step_avg:34.89ms
+step:387/1555 train_time:13500ms step_avg:34.88ms
+step:388/1555 train_time:13538ms step_avg:34.89ms
+step:389/1555 train_time:13569ms step_avg:34.88ms
+step:390/1555 train_time:13607ms step_avg:34.89ms
+step:391/1555 train_time:13638ms step_avg:34.88ms
+step:392/1555 train_time:13677ms step_avg:34.89ms
+step:393/1555 train_time:13708ms step_avg:34.88ms
+step:394/1555 train_time:13746ms step_avg:34.89ms
+step:395/1555 train_time:13777ms step_avg:34.88ms
+step:396/1555 train_time:13815ms step_avg:34.89ms
+step:397/1555 train_time:13846ms step_avg:34.88ms
+step:398/1555 train_time:13884ms step_avg:34.89ms
+step:399/1555 train_time:13916ms step_avg:34.88ms
+step:400/1555 train_time:13954ms step_avg:34.88ms
+step:401/1555 train_time:13985ms step_avg:34.88ms
+step:402/1555 train_time:14024ms step_avg:34.88ms
+step:403/1555 train_time:14054ms step_avg:34.87ms
+step:404/1555 train_time:14093ms step_avg:34.88ms
+step:405/1555 train_time:14124ms step_avg:34.87ms
+step:406/1555 train_time:14162ms step_avg:34.88ms
+step:407/1555 train_time:14194ms step_avg:34.87ms
+step:408/1555 train_time:14232ms step_avg:34.88ms
+step:409/1555 train_time:14263ms step_avg:34.87ms
+step:410/1555 train_time:14301ms step_avg:34.88ms
+step:411/1555 train_time:14332ms step_avg:34.87ms
+step:412/1555 train_time:14371ms step_avg:34.88ms
+step:413/1555 train_time:14402ms step_avg:34.87ms
+step:414/1555 train_time:14440ms step_avg:34.88ms
+step:415/1555 train_time:14471ms step_avg:34.87ms
+step:416/1555 train_time:14510ms step_avg:34.88ms
+step:417/1555 train_time:14541ms step_avg:34.87ms
+step:418/1555 train_time:14579ms step_avg:34.88ms
+step:419/1555 train_time:14610ms step_avg:34.87ms
+step:420/1555 train_time:14648ms step_avg:34.88ms
+step:421/1555 train_time:14680ms step_avg:34.87ms
+step:422/1555 train_time:14718ms step_avg:34.88ms
+step:423/1555 train_time:14749ms step_avg:34.87ms
+step:424/1555 train_time:14787ms step_avg:34.87ms
+step:425/1555 train_time:14818ms step_avg:34.87ms
+step:426/1555 train_time:14856ms step_avg:34.87ms
+step:427/1555 train_time:14887ms step_avg:34.86ms
+step:428/1555 train_time:14925ms step_avg:34.87ms
+step:429/1555 train_time:14956ms step_avg:34.86ms
+step:430/1555 train_time:14995ms step_avg:34.87ms
+step:431/1555 train_time:15026ms step_avg:34.86ms
+step:432/1555 train_time:15064ms step_avg:34.87ms
+step:433/1555 train_time:15095ms step_avg:34.86ms
+step:434/1555 train_time:15133ms step_avg:34.87ms
+step:435/1555 train_time:15164ms step_avg:34.86ms
+step:436/1555 train_time:15202ms step_avg:34.87ms
+step:437/1555 train_time:15233ms step_avg:34.86ms
+step:438/1555 train_time:15271ms step_avg:34.87ms
+step:439/1555 train_time:15303ms step_avg:34.86ms
+step:440/1555 train_time:15341ms step_avg:34.87ms
+step:441/1555 train_time:15372ms step_avg:34.86ms
+step:442/1555 train_time:15411ms step_avg:34.87ms
+step:443/1555 train_time:15441ms step_avg:34.86ms
+step:444/1555 train_time:15479ms step_avg:34.86ms
+step:445/1555 train_time:15510ms step_avg:34.85ms
+step:446/1555 train_time:15548ms step_avg:34.86ms
+step:447/1555 train_time:15580ms step_avg:34.85ms
+step:448/1555 train_time:15618ms step_avg:34.86ms
+step:449/1555 train_time:15649ms step_avg:34.85ms
+step:450/1555 train_time:15687ms step_avg:34.86ms
+step:451/1555 train_time:15719ms step_avg:34.85ms
+step:452/1555 train_time:15757ms step_avg:34.86ms
+step:453/1555 train_time:15788ms step_avg:34.85ms
+step:454/1555 train_time:15826ms step_avg:34.86ms
+step:455/1555 train_time:15858ms step_avg:34.85ms
+step:456/1555 train_time:15896ms step_avg:34.86ms
+step:457/1555 train_time:15927ms step_avg:34.85ms
+step:458/1555 train_time:15965ms step_avg:34.86ms
+step:459/1555 train_time:15996ms step_avg:34.85ms
+step:460/1555 train_time:16034ms step_avg:34.86ms
+step:461/1555 train_time:16065ms step_avg:34.85ms
+step:462/1555 train_time:16103ms step_avg:34.86ms
+step:463/1555 train_time:16135ms step_avg:34.85ms
+step:464/1555 train_time:16173ms step_avg:34.86ms
+step:465/1555 train_time:16204ms step_avg:34.85ms
+step:466/1555 train_time:16242ms step_avg:34.85ms
+step:467/1555 train_time:16274ms step_avg:34.85ms
+step:468/1555 train_time:16312ms step_avg:34.85ms
+step:469/1555 train_time:16343ms step_avg:34.85ms
+step:470/1555 train_time:16381ms step_avg:34.85ms
+step:471/1555 train_time:16413ms step_avg:34.85ms
+step:472/1555 train_time:16450ms step_avg:34.85ms
+step:473/1555 train_time:16482ms step_avg:34.84ms
+step:474/1555 train_time:16520ms step_avg:34.85ms
+step:475/1555 train_time:16551ms step_avg:34.85ms
+step:476/1555 train_time:16589ms step_avg:34.85ms
+step:477/1555 train_time:16621ms step_avg:34.84ms
+step:478/1555 train_time:16659ms step_avg:34.85ms
+step:479/1555 train_time:16690ms step_avg:34.84ms
+step:480/1555 train_time:16728ms step_avg:34.85ms
+step:481/1555 train_time:16759ms step_avg:34.84ms
+step:482/1555 train_time:16797ms step_avg:34.85ms
+step:483/1555 train_time:16828ms step_avg:34.84ms
+step:484/1555 train_time:16866ms step_avg:34.85ms
+step:485/1555 train_time:16898ms step_avg:34.84ms
+step:486/1555 train_time:16936ms step_avg:34.85ms
+step:487/1555 train_time:16967ms step_avg:34.84ms
+step:488/1555 train_time:17005ms step_avg:34.85ms
+step:489/1555 train_time:17037ms step_avg:34.84ms
+step:490/1555 train_time:17077ms step_avg:34.85ms
+step:491/1555 train_time:17106ms step_avg:34.84ms
+step:492/1555 train_time:17144ms step_avg:34.85ms
+step:493/1555 train_time:17175ms step_avg:34.84ms
+step:494/1555 train_time:17213ms step_avg:34.84ms
+step:495/1555 train_time:17244ms step_avg:34.84ms
+step:496/1555 train_time:17282ms step_avg:34.84ms
+step:497/1555 train_time:17314ms step_avg:34.84ms
+step:498/1555 train_time:17352ms step_avg:34.84ms
+step:499/1555 train_time:17383ms step_avg:34.84ms
+step:500/1555 train_time:17421ms step_avg:34.84ms
+step:500/1555 val_loss:4.2286 train_time:17470ms step_avg:34.94ms
+step:501/1555 train_time:17493ms step_avg:34.92ms
+step:502/1555 train_time:17512ms step_avg:34.88ms
+step:503/1555 train_time:17529ms step_avg:34.85ms
+step:504/1555 train_time:17565ms step_avg:34.85ms
+step:505/1555 train_time:17596ms step_avg:34.84ms
+step:506/1555 train_time:17674ms step_avg:34.93ms
+step:507/1555 train_time:17734ms step_avg:34.98ms
+step:508/1555 train_time:17792ms step_avg:35.02ms
+step:509/1555 train_time:17854ms step_avg:35.08ms
+step:510/1555 train_time:17916ms step_avg:35.13ms
+step:511/1555 train_time:17976ms step_avg:35.18ms
+step:512/1555 train_time:18035ms step_avg:35.22ms
+step:513/1555 train_time:18097ms step_avg:35.28ms
+step:514/1555 train_time:18158ms step_avg:35.33ms
+step:515/1555 train_time:18219ms step_avg:35.38ms
+step:516/1555 train_time:18278ms step_avg:35.42ms
+step:517/1555 train_time:18342ms step_avg:35.48ms
+step:518/1555 train_time:18402ms step_avg:35.52ms
+step:519/1555 train_time:18468ms step_avg:35.58ms
+step:520/1555 train_time:18528ms step_avg:35.63ms
+step:521/1555 train_time:18594ms step_avg:35.69ms
+step:522/1555 train_time:18652ms step_avg:35.73ms
+step:523/1555 train_time:18715ms step_avg:35.78ms
+step:524/1555 train_time:18778ms step_avg:35.84ms
+step:525/1555 train_time:18839ms step_avg:35.88ms
+step:526/1555 train_time:18899ms step_avg:35.93ms
+step:527/1555 train_time:18961ms step_avg:35.98ms
+step:528/1555 train_time:19020ms step_avg:36.02ms
+step:529/1555 train_time:19088ms step_avg:36.08ms
+step:530/1555 train_time:19143ms step_avg:36.12ms
+step:531/1555 train_time:19207ms step_avg:36.17ms
+step:532/1555 train_time:19266ms step_avg:36.21ms
+step:533/1555 train_time:19330ms step_avg:36.27ms
+step:534/1555 train_time:19389ms step_avg:36.31ms
+step:535/1555 train_time:19452ms step_avg:36.36ms
+step:536/1555 train_time:19513ms step_avg:36.41ms
+step:537/1555 train_time:19576ms step_avg:36.46ms
+step:538/1555 train_time:19636ms step_avg:36.50ms
+step:539/1555 train_time:19702ms step_avg:36.55ms
+step:540/1555 train_time:19761ms step_avg:36.59ms
+step:541/1555 train_time:19825ms step_avg:36.64ms
+step:542/1555 train_time:19884ms step_avg:36.69ms
+step:543/1555 train_time:19948ms step_avg:36.74ms
+step:544/1555 train_time:20008ms step_avg:36.78ms
+step:545/1555 train_time:20071ms step_avg:36.83ms
+step:546/1555 train_time:20131ms step_avg:36.87ms
+step:547/1555 train_time:20196ms step_avg:36.92ms
+step:548/1555 train_time:20254ms step_avg:36.96ms
+step:549/1555 train_time:20317ms step_avg:37.01ms
+step:550/1555 train_time:20376ms step_avg:37.05ms
+step:551/1555 train_time:20440ms step_avg:37.10ms
+step:552/1555 train_time:20502ms step_avg:37.14ms
+step:553/1555 train_time:20564ms step_avg:37.19ms
+step:554/1555 train_time:20623ms step_avg:37.23ms
+step:555/1555 train_time:20689ms step_avg:37.28ms
+step:556/1555 train_time:20747ms step_avg:37.31ms
+step:557/1555 train_time:20811ms step_avg:37.36ms
+step:558/1555 train_time:20870ms step_avg:37.40ms
+step:559/1555 train_time:20934ms step_avg:37.45ms
+step:560/1555 train_time:20994ms step_avg:37.49ms
+step:561/1555 train_time:21057ms step_avg:37.53ms
+step:562/1555 train_time:21117ms step_avg:37.57ms
+step:563/1555 train_time:21182ms step_avg:37.62ms
+step:564/1555 train_time:21240ms step_avg:37.66ms
+step:565/1555 train_time:21304ms step_avg:37.71ms
+step:566/1555 train_time:21373ms step_avg:37.76ms
+step:567/1555 train_time:21430ms step_avg:37.80ms
+step:568/1555 train_time:21488ms step_avg:37.83ms
+step:569/1555 train_time:21551ms step_avg:37.87ms
+step:570/1555 train_time:21611ms step_avg:37.91ms
+step:571/1555 train_time:21674ms step_avg:37.96ms
+step:572/1555 train_time:21735ms step_avg:38.00ms
+step:573/1555 train_time:21797ms step_avg:38.04ms
+step:574/1555 train_time:21857ms step_avg:38.08ms
+step:575/1555 train_time:21920ms step_avg:38.12ms
+step:576/1555 train_time:21982ms step_avg:38.16ms
+step:577/1555 train_time:22044ms step_avg:38.20ms
+step:578/1555 train_time:22104ms step_avg:38.24ms
+step:579/1555 train_time:22167ms step_avg:38.28ms
+step:580/1555 train_time:22227ms step_avg:38.32ms
+step:581/1555 train_time:22289ms step_avg:38.36ms
+step:582/1555 train_time:22348ms step_avg:38.40ms
+step:583/1555 train_time:22412ms step_avg:38.44ms
+step:584/1555 train_time:22472ms step_avg:38.48ms
+step:585/1555 train_time:22534ms step_avg:38.52ms
+step:586/1555 train_time:22595ms step_avg:38.56ms
+step:587/1555 train_time:22657ms step_avg:38.60ms
+step:588/1555 train_time:22716ms step_avg:38.63ms
+step:589/1555 train_time:22780ms step_avg:38.68ms
+step:590/1555 train_time:22839ms step_avg:38.71ms
+step:591/1555 train_time:22904ms step_avg:38.75ms
+step:592/1555 train_time:22963ms step_avg:38.79ms
+step:593/1555 train_time:23027ms step_avg:38.83ms
+step:594/1555 train_time:23086ms step_avg:38.86ms
+step:595/1555 train_time:23149ms step_avg:38.91ms
+step:596/1555 train_time:23208ms step_avg:38.94ms
+step:597/1555 train_time:23273ms step_avg:38.98ms
+step:598/1555 train_time:23331ms step_avg:39.01ms
+step:599/1555 train_time:23394ms step_avg:39.06ms
+step:600/1555 train_time:23454ms step_avg:39.09ms
+step:601/1555 train_time:23519ms step_avg:39.13ms
+step:602/1555 train_time:23576ms step_avg:39.16ms
+step:603/1555 train_time:23639ms step_avg:39.20ms
+step:604/1555 train_time:23698ms step_avg:39.24ms
+step:605/1555 train_time:23762ms step_avg:39.28ms
+step:606/1555 train_time:23821ms step_avg:39.31ms
+step:607/1555 train_time:23886ms step_avg:39.35ms
+step:608/1555 train_time:23944ms step_avg:39.38ms
+step:609/1555 train_time:24009ms step_avg:39.42ms
+step:610/1555 train_time:24068ms step_avg:39.46ms
+step:611/1555 train_time:24131ms step_avg:39.49ms
+step:612/1555 train_time:24190ms step_avg:39.53ms
+step:613/1555 train_time:24253ms step_avg:39.56ms
+step:614/1555 train_time:24313ms step_avg:39.60ms
+step:615/1555 train_time:24375ms step_avg:39.63ms
+step:616/1555 train_time:24436ms step_avg:39.67ms
+step:617/1555 train_time:24498ms step_avg:39.70ms
+step:618/1555 train_time:24557ms step_avg:39.74ms
+step:619/1555 train_time:24621ms step_avg:39.78ms
+step:620/1555 train_time:24679ms step_avg:39.81ms
+step:621/1555 train_time:24744ms step_avg:39.85ms
+step:622/1555 train_time:24802ms step_avg:39.88ms
+step:623/1555 train_time:24867ms step_avg:39.91ms
+step:624/1555 train_time:24925ms step_avg:39.94ms
+step:625/1555 train_time:24989ms step_avg:39.98ms
+step:626/1555 train_time:25049ms step_avg:40.01ms
+step:627/1555 train_time:25111ms step_avg:40.05ms
+step:628/1555 train_time:25171ms step_avg:40.08ms
+step:629/1555 train_time:25233ms step_avg:40.12ms
+step:630/1555 train_time:25293ms step_avg:40.15ms
+step:631/1555 train_time:25357ms step_avg:40.19ms
+step:632/1555 train_time:25416ms step_avg:40.21ms
+step:633/1555 train_time:25478ms step_avg:40.25ms
+step:634/1555 train_time:25539ms step_avg:40.28ms
+step:635/1555 train_time:25602ms step_avg:40.32ms
+step:636/1555 train_time:25662ms step_avg:40.35ms
+step:637/1555 train_time:25725ms step_avg:40.38ms
+step:638/1555 train_time:25784ms step_avg:40.41ms
+step:639/1555 train_time:25849ms step_avg:40.45ms
+step:640/1555 train_time:25907ms step_avg:40.48ms
+step:641/1555 train_time:25971ms step_avg:40.52ms
+step:642/1555 train_time:26031ms step_avg:40.55ms
+step:643/1555 train_time:26093ms step_avg:40.58ms
+step:644/1555 train_time:26155ms step_avg:40.61ms
+step:645/1555 train_time:26216ms step_avg:40.65ms
+step:646/1555 train_time:26275ms step_avg:40.67ms
+step:647/1555 train_time:26339ms step_avg:40.71ms
+step:648/1555 train_time:26398ms step_avg:40.74ms
+step:649/1555 train_time:26461ms step_avg:40.77ms
+step:650/1555 train_time:26522ms step_avg:40.80ms
+step:651/1555 train_time:26584ms step_avg:40.84ms
+step:652/1555 train_time:26643ms step_avg:40.86ms
+step:653/1555 train_time:26707ms step_avg:40.90ms
+step:654/1555 train_time:26766ms step_avg:40.93ms
+step:655/1555 train_time:26830ms step_avg:40.96ms
+step:656/1555 train_time:26889ms step_avg:40.99ms
+step:657/1555 train_time:26952ms step_avg:41.02ms
+step:658/1555 train_time:27012ms step_avg:41.05ms
+step:659/1555 train_time:27075ms step_avg:41.08ms
+step:660/1555 train_time:27133ms step_avg:41.11ms
+step:661/1555 train_time:27198ms step_avg:41.15ms
+step:662/1555 train_time:27257ms step_avg:41.17ms
+step:663/1555 train_time:27320ms step_avg:41.21ms
+step:664/1555 train_time:27380ms step_avg:41.24ms
+step:665/1555 train_time:27443ms step_avg:41.27ms
+step:666/1555 train_time:27502ms step_avg:41.29ms
+step:667/1555 train_time:27566ms step_avg:41.33ms
+step:668/1555 train_time:27624ms step_avg:41.35ms
+step:669/1555 train_time:27688ms step_avg:41.39ms
+step:670/1555 train_time:27749ms step_avg:41.42ms
+step:671/1555 train_time:27810ms step_avg:41.45ms
+step:672/1555 train_time:27869ms step_avg:41.47ms
+step:673/1555 train_time:27934ms step_avg:41.51ms
+step:674/1555 train_time:27992ms step_avg:41.53ms
+step:675/1555 train_time:28056ms step_avg:41.56ms
+step:676/1555 train_time:28116ms step_avg:41.59ms
+step:677/1555 train_time:28178ms step_avg:41.62ms
+step:678/1555 train_time:28237ms step_avg:41.65ms
+step:679/1555 train_time:28302ms step_avg:41.68ms
+step:680/1555 train_time:28360ms step_avg:41.71ms
+step:681/1555 train_time:28423ms step_avg:41.74ms
+step:682/1555 train_time:28484ms step_avg:41.77ms
+step:683/1555 train_time:28546ms step_avg:41.79ms
+step:684/1555 train_time:28605ms step_avg:41.82ms
+step:685/1555 train_time:28669ms step_avg:41.85ms
+step:686/1555 train_time:28728ms step_avg:41.88ms
+step:687/1555 train_time:28791ms step_avg:41.91ms
+step:688/1555 train_time:28850ms step_avg:41.93ms
+step:689/1555 train_time:28914ms step_avg:41.96ms
+step:690/1555 train_time:28973ms step_avg:41.99ms
+step:691/1555 train_time:29035ms step_avg:42.02ms
+step:692/1555 train_time:29096ms step_avg:42.05ms
+step:693/1555 train_time:29159ms step_avg:42.08ms
+step:694/1555 train_time:29218ms step_avg:42.10ms
+step:695/1555 train_time:29283ms step_avg:42.13ms
+step:696/1555 train_time:29342ms step_avg:42.16ms
+step:697/1555 train_time:29405ms step_avg:42.19ms
+step:698/1555 train_time:29466ms step_avg:42.22ms
+step:699/1555 train_time:29528ms step_avg:42.24ms
+step:700/1555 train_time:29587ms step_avg:42.27ms
+step:701/1555 train_time:29651ms step_avg:42.30ms
+step:702/1555 train_time:29710ms step_avg:42.32ms
+step:703/1555 train_time:29773ms step_avg:42.35ms
+step:704/1555 train_time:29832ms step_avg:42.37ms
+step:705/1555 train_time:29896ms step_avg:42.41ms
+step:706/1555 train_time:29955ms step_avg:42.43ms
+step:707/1555 train_time:30018ms step_avg:42.46ms
+step:708/1555 train_time:30078ms step_avg:42.48ms
+step:709/1555 train_time:30140ms step_avg:42.51ms
+step:710/1555 train_time:30199ms step_avg:42.53ms
+step:711/1555 train_time:30264ms step_avg:42.57ms
+step:712/1555 train_time:30325ms step_avg:42.59ms
+step:713/1555 train_time:30387ms step_avg:42.62ms
+step:714/1555 train_time:30447ms step_avg:42.64ms
+step:715/1555 train_time:30510ms step_avg:42.67ms
+step:716/1555 train_time:30570ms step_avg:42.70ms
+step:717/1555 train_time:30633ms step_avg:42.72ms
+step:718/1555 train_time:30692ms step_avg:42.75ms
+step:719/1555 train_time:30756ms step_avg:42.78ms
+step:720/1555 train_time:30815ms step_avg:42.80ms
+step:721/1555 train_time:30878ms step_avg:42.83ms
+step:722/1555 train_time:30938ms step_avg:42.85ms
+step:723/1555 train_time:31001ms step_avg:42.88ms
+step:724/1555 train_time:31059ms step_avg:42.90ms
+step:725/1555 train_time:31125ms step_avg:42.93ms
+step:726/1555 train_time:31185ms step_avg:42.95ms
+step:727/1555 train_time:31247ms step_avg:42.98ms
+step:728/1555 train_time:31306ms step_avg:43.00ms
+step:729/1555 train_time:31372ms step_avg:43.03ms
+step:730/1555 train_time:31429ms step_avg:43.05ms
+step:731/1555 train_time:31492ms step_avg:43.08ms
+step:732/1555 train_time:31552ms step_avg:43.10ms
+step:733/1555 train_time:31615ms step_avg:43.13ms
+step:734/1555 train_time:31675ms step_avg:43.15ms
+step:735/1555 train_time:31738ms step_avg:43.18ms
+step:736/1555 train_time:31797ms step_avg:43.20ms
+step:737/1555 train_time:31861ms step_avg:43.23ms
+step:738/1555 train_time:31920ms step_avg:43.25ms
+step:739/1555 train_time:31984ms step_avg:43.28ms
+step:740/1555 train_time:32042ms step_avg:43.30ms
+step:741/1555 train_time:32106ms step_avg:43.33ms
+step:742/1555 train_time:32165ms step_avg:43.35ms
+step:743/1555 train_time:32230ms step_avg:43.38ms
+step:744/1555 train_time:32288ms step_avg:43.40ms
+step:745/1555 train_time:32352ms step_avg:43.43ms
+step:746/1555 train_time:32411ms step_avg:43.45ms
+step:747/1555 train_time:32476ms step_avg:43.47ms
+step:748/1555 train_time:32534ms step_avg:43.50ms
+step:749/1555 train_time:32597ms step_avg:43.52ms
+step:750/1555 train_time:32656ms step_avg:43.54ms
+step:750/1555 val_loss:3.8725 train_time:32704ms step_avg:43.61ms
+step:751/1555 train_time:32726ms step_avg:43.58ms
+step:752/1555 train_time:32782ms step_avg:43.59ms
+step:753/1555 train_time:32851ms step_avg:43.63ms
+step:754/1555 train_time:32911ms step_avg:43.65ms
+step:755/1555 train_time:32975ms step_avg:43.68ms
+step:756/1555 train_time:33035ms step_avg:43.70ms
+step:757/1555 train_time:33097ms step_avg:43.72ms
+step:758/1555 train_time:33156ms step_avg:43.74ms
+step:759/1555 train_time:33219ms step_avg:43.77ms
+step:760/1555 train_time:33279ms step_avg:43.79ms
+step:761/1555 train_time:33343ms step_avg:43.81ms
+step:762/1555 train_time:33401ms step_avg:43.83ms
+step:763/1555 train_time:33463ms step_avg:43.86ms
+step:764/1555 train_time:33523ms step_avg:43.88ms
+step:765/1555 train_time:33586ms step_avg:43.90ms
+step:766/1555 train_time:33645ms step_avg:43.92ms
+step:767/1555 train_time:33709ms step_avg:43.95ms
+step:768/1555 train_time:33769ms step_avg:43.97ms
+step:769/1555 train_time:33835ms step_avg:44.00ms
+step:770/1555 train_time:33895ms step_avg:44.02ms
+step:771/1555 train_time:33959ms step_avg:44.05ms
+step:772/1555 train_time:34019ms step_avg:44.07ms
+step:773/1555 train_time:34084ms step_avg:44.09ms
+step:774/1555 train_time:34142ms step_avg:44.11ms
+step:775/1555 train_time:34207ms step_avg:44.14ms
+step:776/1555 train_time:34266ms step_avg:44.16ms
+step:777/1555 train_time:34329ms step_avg:44.18ms
+step:778/1555 train_time:34388ms step_avg:44.20ms
+step:779/1555 train_time:34450ms step_avg:44.22ms
+step:780/1555 train_time:34509ms step_avg:44.24ms
+step:781/1555 train_time:34573ms step_avg:44.27ms
+step:782/1555 train_time:34634ms step_avg:44.29ms
+step:783/1555 train_time:34698ms step_avg:44.31ms
+step:784/1555 train_time:34756ms step_avg:44.33ms
+step:785/1555 train_time:34821ms step_avg:44.36ms
+step:786/1555 train_time:34882ms step_avg:44.38ms
+step:787/1555 train_time:34945ms step_avg:44.40ms
+step:788/1555 train_time:35005ms step_avg:44.42ms
+step:789/1555 train_time:35068ms step_avg:44.45ms
+step:790/1555 train_time:35129ms step_avg:44.47ms
+step:791/1555 train_time:35192ms step_avg:44.49ms
+step:792/1555 train_time:35250ms step_avg:44.51ms
+step:793/1555 train_time:35313ms step_avg:44.53ms
+step:794/1555 train_time:35374ms step_avg:44.55ms
+step:795/1555 train_time:35435ms step_avg:44.57ms
+step:796/1555 train_time:35495ms step_avg:44.59ms
+step:797/1555 train_time:35558ms step_avg:44.62ms
+step:798/1555 train_time:35620ms step_avg:44.64ms
+step:799/1555 train_time:35682ms step_avg:44.66ms
+step:800/1555 train_time:35741ms step_avg:44.68ms
+step:801/1555 train_time:35805ms step_avg:44.70ms
+step:802/1555 train_time:35864ms step_avg:44.72ms
+step:803/1555 train_time:35928ms step_avg:44.74ms
+step:804/1555 train_time:35987ms step_avg:44.76ms
+step:805/1555 train_time:36051ms step_avg:44.78ms
+step:806/1555 train_time:36110ms step_avg:44.80ms
+step:807/1555 train_time:36174ms step_avg:44.83ms
+step:808/1555 train_time:36233ms step_avg:44.84ms
+step:809/1555 train_time:36297ms step_avg:44.87ms
+step:810/1555 train_time:36356ms step_avg:44.88ms
+step:811/1555 train_time:36419ms step_avg:44.91ms
+step:812/1555 train_time:36479ms step_avg:44.93ms
+step:813/1555 train_time:36542ms step_avg:44.95ms
+step:814/1555 train_time:36601ms step_avg:44.96ms
+step:815/1555 train_time:36664ms step_avg:44.99ms
+step:816/1555 train_time:36724ms step_avg:45.00ms
+step:817/1555 train_time:36787ms step_avg:45.03ms
+step:818/1555 train_time:36846ms step_avg:45.04ms
+step:819/1555 train_time:36910ms step_avg:45.07ms
+step:820/1555 train_time:36970ms step_avg:45.09ms
+step:821/1555 train_time:37035ms step_avg:45.11ms
+step:822/1555 train_time:37093ms step_avg:45.13ms
+step:823/1555 train_time:37159ms step_avg:45.15ms
+step:824/1555 train_time:37216ms step_avg:45.17ms
+step:825/1555 train_time:37279ms step_avg:45.19ms
+step:826/1555 train_time:37339ms step_avg:45.20ms
+step:827/1555 train_time:37402ms step_avg:45.23ms
+step:828/1555 train_time:37464ms step_avg:45.25ms
+step:829/1555 train_time:37525ms step_avg:45.26ms
+step:830/1555 train_time:37584ms step_avg:45.28ms
+step:831/1555 train_time:37650ms step_avg:45.31ms
+step:832/1555 train_time:37708ms step_avg:45.32ms
+step:833/1555 train_time:37772ms step_avg:45.34ms
+step:834/1555 train_time:37830ms step_avg:45.36ms
+step:835/1555 train_time:37895ms step_avg:45.38ms
+step:836/1555 train_time:37953ms step_avg:45.40ms
+step:837/1555 train_time:38017ms step_avg:45.42ms
+step:838/1555 train_time:38078ms step_avg:45.44ms
+step:839/1555 train_time:38140ms step_avg:45.46ms
+step:840/1555 train_time:38200ms step_avg:45.48ms
+step:841/1555 train_time:38264ms step_avg:45.50ms
+step:842/1555 train_time:38323ms step_avg:45.51ms
+step:843/1555 train_time:38387ms step_avg:45.54ms
+step:844/1555 train_time:38446ms step_avg:45.55ms
+step:845/1555 train_time:38509ms step_avg:45.57ms
+step:846/1555 train_time:38568ms step_avg:45.59ms
+step:847/1555 train_time:38631ms step_avg:45.61ms
+step:848/1555 train_time:38690ms step_avg:45.62ms
+step:849/1555 train_time:38755ms step_avg:45.65ms
+step:850/1555 train_time:38813ms step_avg:45.66ms
+step:851/1555 train_time:38876ms step_avg:45.68ms
+step:852/1555 train_time:38936ms step_avg:45.70ms
+step:853/1555 train_time:38998ms step_avg:45.72ms
+step:854/1555 train_time:39057ms step_avg:45.73ms
+step:855/1555 train_time:39123ms step_avg:45.76ms
+step:856/1555 train_time:39181ms step_avg:45.77ms
+step:857/1555 train_time:39244ms step_avg:45.79ms
+step:858/1555 train_time:39305ms step_avg:45.81ms
+step:859/1555 train_time:39366ms step_avg:45.83ms
+step:860/1555 train_time:39425ms step_avg:45.84ms
+step:861/1555 train_time:39491ms step_avg:45.87ms
+step:862/1555 train_time:39549ms step_avg:45.88ms
+step:863/1555 train_time:39612ms step_avg:45.90ms
+step:864/1555 train_time:39672ms step_avg:45.92ms
+step:865/1555 train_time:39735ms step_avg:45.94ms
+step:866/1555 train_time:39794ms step_avg:45.95ms
+step:867/1555 train_time:39860ms step_avg:45.97ms
+step:868/1555 train_time:39918ms step_avg:45.99ms
+step:869/1555 train_time:39981ms step_avg:46.01ms
+step:870/1555 train_time:40041ms step_avg:46.02ms
+step:871/1555 train_time:40104ms step_avg:46.04ms
+step:872/1555 train_time:40163ms step_avg:46.06ms
+step:873/1555 train_time:40226ms step_avg:46.08ms
+step:874/1555 train_time:40287ms step_avg:46.09ms
+step:875/1555 train_time:40349ms step_avg:46.11ms
+step:876/1555 train_time:40409ms step_avg:46.13ms
+step:877/1555 train_time:40472ms step_avg:46.15ms
+step:878/1555 train_time:40531ms step_avg:46.16ms
+step:879/1555 train_time:40595ms step_avg:46.18ms
+step:880/1555 train_time:40656ms step_avg:46.20ms
+step:881/1555 train_time:40717ms step_avg:46.22ms
+step:882/1555 train_time:40776ms step_avg:46.23ms
+step:883/1555 train_time:40857ms step_avg:46.27ms
+step:884/1555 train_time:40902ms step_avg:46.27ms
+step:885/1555 train_time:40964ms step_avg:46.29ms
+step:886/1555 train_time:41023ms step_avg:46.30ms
+step:887/1555 train_time:41088ms step_avg:46.32ms
+step:888/1555 train_time:41146ms step_avg:46.34ms
+step:889/1555 train_time:41210ms step_avg:46.36ms
+step:890/1555 train_time:41269ms step_avg:46.37ms
+step:891/1555 train_time:41332ms step_avg:46.39ms
+step:892/1555 train_time:41391ms step_avg:46.40ms
+step:893/1555 train_time:41456ms step_avg:46.42ms
+step:894/1555 train_time:41514ms step_avg:46.44ms
+step:895/1555 train_time:41577ms step_avg:46.45ms
+step:896/1555 train_time:41637ms step_avg:46.47ms
+step:897/1555 train_time:41701ms step_avg:46.49ms
+step:898/1555 train_time:41759ms step_avg:46.50ms
+step:899/1555 train_time:41822ms step_avg:46.52ms
+step:900/1555 train_time:41883ms step_avg:46.54ms
+step:901/1555 train_time:41946ms step_avg:46.56ms
+step:902/1555 train_time:42006ms step_avg:46.57ms
+step:903/1555 train_time:42070ms step_avg:46.59ms
+step:904/1555 train_time:42130ms step_avg:46.60ms
+step:905/1555 train_time:42193ms step_avg:46.62ms
+step:906/1555 train_time:42252ms step_avg:46.64ms
+step:907/1555 train_time:42316ms step_avg:46.66ms
+step:908/1555 train_time:42375ms step_avg:46.67ms
+step:909/1555 train_time:42438ms step_avg:46.69ms
+step:910/1555 train_time:42498ms step_avg:46.70ms
+step:911/1555 train_time:42561ms step_avg:46.72ms
+step:912/1555 train_time:42621ms step_avg:46.73ms
+step:913/1555 train_time:42688ms step_avg:46.76ms
+step:914/1555 train_time:42746ms step_avg:46.77ms
+step:915/1555 train_time:42808ms step_avg:46.79ms
+step:916/1555 train_time:42868ms step_avg:46.80ms
+step:917/1555 train_time:42931ms step_avg:46.82ms
+step:918/1555 train_time:42991ms step_avg:46.83ms
+step:919/1555 train_time:43054ms step_avg:46.85ms
+step:920/1555 train_time:43114ms step_avg:46.86ms
+step:921/1555 train_time:43180ms step_avg:46.88ms
+step:922/1555 train_time:43238ms step_avg:46.90ms
+step:923/1555 train_time:43300ms step_avg:46.91ms
+step:924/1555 train_time:43360ms step_avg:46.93ms
+step:925/1555 train_time:43423ms step_avg:46.94ms
+step:926/1555 train_time:43482ms step_avg:46.96ms
+step:927/1555 train_time:43546ms step_avg:46.98ms
+step:928/1555 train_time:43606ms step_avg:46.99ms
+step:929/1555 train_time:43668ms step_avg:47.01ms
+step:930/1555 train_time:43727ms step_avg:47.02ms
+step:931/1555 train_time:43791ms step_avg:47.04ms
+step:932/1555 train_time:43850ms step_avg:47.05ms
+step:933/1555 train_time:43914ms step_avg:47.07ms
+step:934/1555 train_time:43973ms step_avg:47.08ms
+step:935/1555 train_time:44036ms step_avg:47.10ms
+step:936/1555 train_time:44096ms step_avg:47.11ms
+step:937/1555 train_time:44159ms step_avg:47.13ms
+step:938/1555 train_time:44219ms step_avg:47.14ms
+step:939/1555 train_time:44282ms step_avg:47.16ms
+step:940/1555 train_time:44341ms step_avg:47.17ms
+step:941/1555 train_time:44404ms step_avg:47.19ms
+step:942/1555 train_time:44463ms step_avg:47.20ms
+step:943/1555 train_time:44528ms step_avg:47.22ms
+step:944/1555 train_time:44587ms step_avg:47.23ms
+step:945/1555 train_time:44651ms step_avg:47.25ms
+step:946/1555 train_time:44710ms step_avg:47.26ms
+step:947/1555 train_time:44774ms step_avg:47.28ms
+step:948/1555 train_time:44833ms step_avg:47.29ms
+step:949/1555 train_time:44896ms step_avg:47.31ms
+step:950/1555 train_time:44955ms step_avg:47.32ms
+step:951/1555 train_time:45019ms step_avg:47.34ms
+step:952/1555 train_time:45079ms step_avg:47.35ms
+step:953/1555 train_time:45142ms step_avg:47.37ms
+step:954/1555 train_time:45202ms step_avg:47.38ms
+step:955/1555 train_time:45265ms step_avg:47.40ms
+step:956/1555 train_time:45324ms step_avg:47.41ms
+step:957/1555 train_time:45387ms step_avg:47.43ms
+step:958/1555 train_time:45447ms step_avg:47.44ms
+step:959/1555 train_time:45510ms step_avg:47.46ms
+step:960/1555 train_time:45570ms step_avg:47.47ms
+step:961/1555 train_time:45633ms step_avg:47.48ms
+step:962/1555 train_time:45692ms step_avg:47.50ms
+step:963/1555 train_time:45756ms step_avg:47.51ms
+step:964/1555 train_time:45815ms step_avg:47.53ms
+step:965/1555 train_time:45878ms step_avg:47.54ms
+step:966/1555 train_time:45938ms step_avg:47.55ms
+step:967/1555 train_time:46001ms step_avg:47.57ms
+step:968/1555 train_time:46060ms step_avg:47.58ms
+step:969/1555 train_time:46124ms step_avg:47.60ms
+step:970/1555 train_time:46183ms step_avg:47.61ms
+step:971/1555 train_time:46247ms step_avg:47.63ms
+step:972/1555 train_time:46306ms step_avg:47.64ms
+step:973/1555 train_time:46369ms step_avg:47.66ms
+step:974/1555 train_time:46428ms step_avg:47.67ms
+step:975/1555 train_time:46492ms step_avg:47.68ms
+step:976/1555 train_time:46551ms step_avg:47.70ms
+step:977/1555 train_time:46614ms step_avg:47.71ms
+step:978/1555 train_time:46673ms step_avg:47.72ms
+step:979/1555 train_time:46736ms step_avg:47.74ms
+step:980/1555 train_time:46796ms step_avg:47.75ms
+step:981/1555 train_time:46859ms step_avg:47.77ms
+step:982/1555 train_time:46918ms step_avg:47.78ms
+step:983/1555 train_time:46982ms step_avg:47.79ms
+step:984/1555 train_time:47041ms step_avg:47.81ms
+step:985/1555 train_time:47105ms step_avg:47.82ms
+step:986/1555 train_time:47164ms step_avg:47.83ms
+step:987/1555 train_time:47228ms step_avg:47.85ms
+step:988/1555 train_time:47287ms step_avg:47.86ms
+step:989/1555 train_time:47350ms step_avg:47.88ms
+step:990/1555 train_time:47409ms step_avg:47.89ms
+step:991/1555 train_time:47472ms step_avg:47.90ms
+step:992/1555 train_time:47532ms step_avg:47.92ms
+step:993/1555 train_time:47595ms step_avg:47.93ms
+step:994/1555 train_time:47654ms step_avg:47.94ms
+step:995/1555 train_time:47717ms step_avg:47.96ms
+step:996/1555 train_time:47776ms step_avg:47.97ms
+step:997/1555 train_time:47841ms step_avg:47.98ms
+step:998/1555 train_time:47900ms step_avg:48.00ms
+step:999/1555 train_time:47964ms step_avg:48.01ms
+step:1000/1555 train_time:48023ms step_avg:48.02ms
+step:1000/1555 val_loss:3.5755 train_time:48071ms step_avg:48.07ms
+step:1001/1555 train_time:48091ms step_avg:48.04ms
+step:1002/1555 train_time:48149ms step_avg:48.05ms
+step:1003/1555 train_time:48217ms step_avg:48.07ms
+step:1004/1555 train_time:48277ms step_avg:48.08ms
+step:1005/1555 train_time:48340ms step_avg:48.10ms
+step:1006/1555 train_time:48400ms step_avg:48.11ms
+step:1007/1555 train_time:48462ms step_avg:48.12ms
+step:1008/1555 train_time:48520ms step_avg:48.14ms
+step:1009/1555 train_time:48583ms step_avg:48.15ms
+step:1010/1555 train_time:48643ms step_avg:48.16ms
+step:1011/1555 train_time:48716ms step_avg:48.19ms
+step:1012/1555 train_time:48796ms step_avg:48.22ms
+step:1013/1555 train_time:48886ms step_avg:48.26ms
+step:1014/1555 train_time:48970ms step_avg:48.29ms
+step:1015/1555 train_time:49064ms step_avg:48.34ms
+step:1016/1555 train_time:49151ms step_avg:48.38ms
+step:1017/1555 train_time:49241ms step_avg:48.42ms
+step:1018/1555 train_time:49328ms step_avg:48.46ms
+step:1019/1555 train_time:49417ms step_avg:48.50ms
+step:1020/1555 train_time:49503ms step_avg:48.53ms
+step:1021/1555 train_time:49594ms step_avg:48.57ms
+step:1022/1555 train_time:49678ms step_avg:48.61ms
+step:1023/1555 train_time:49767ms step_avg:48.65ms
+step:1024/1555 train_time:49852ms step_avg:48.68ms
+step:1025/1555 train_time:49941ms step_avg:48.72ms
+step:1026/1555 train_time:50028ms step_avg:48.76ms
+step:1027/1555 train_time:50118ms step_avg:48.80ms
+step:1028/1555 train_time:50204ms step_avg:48.84ms
+step:1029/1555 train_time:50296ms step_avg:48.88ms
+step:1030/1555 train_time:50381ms step_avg:48.91ms
+step:1031/1555 train_time:50471ms step_avg:48.95ms
+step:1032/1555 train_time:50557ms step_avg:48.99ms
+step:1033/1555 train_time:50645ms step_avg:49.03ms
+step:1034/1555 train_time:50731ms step_avg:49.06ms
+step:1035/1555 train_time:50821ms step_avg:49.10ms
+step:1036/1555 train_time:50906ms step_avg:49.14ms
+step:1037/1555 train_time:50997ms step_avg:49.18ms
+step:1038/1555 train_time:51086ms step_avg:49.22ms
+step:1039/1555 train_time:51174ms step_avg:49.25ms
+step:1040/1555 train_time:51261ms step_avg:49.29ms
+step:1041/1555 train_time:51352ms step_avg:49.33ms
+step:1042/1555 train_time:51436ms step_avg:49.36ms
+step:1043/1555 train_time:51525ms step_avg:49.40ms
+step:1044/1555 train_time:51610ms step_avg:49.43ms
+step:1045/1555 train_time:51699ms step_avg:49.47ms
+step:1046/1555 train_time:51785ms step_avg:49.51ms
+step:1047/1555 train_time:51874ms step_avg:49.54ms
+step:1048/1555 train_time:51961ms step_avg:49.58ms
+step:1049/1555 train_time:52049ms step_avg:49.62ms
+step:1050/1555 train_time:52134ms step_avg:49.65ms
+step:1051/1555 train_time:52225ms step_avg:49.69ms
+step:1052/1555 train_time:52311ms step_avg:49.73ms
+step:1053/1555 train_time:52401ms step_avg:49.76ms
+step:1054/1555 train_time:52487ms step_avg:49.80ms
+step:1055/1555 train_time:52578ms step_avg:49.84ms
+step:1056/1555 train_time:52666ms step_avg:49.87ms
+step:1057/1555 train_time:52753ms step_avg:49.91ms
+step:1058/1555 train_time:52838ms step_avg:49.94ms
+step:1059/1555 train_time:52929ms step_avg:49.98ms
+step:1060/1555 train_time:53014ms step_avg:50.01ms
+step:1061/1555 train_time:53104ms step_avg:50.05ms
+step:1062/1555 train_time:53189ms step_avg:50.08ms
+step:1063/1555 train_time:53280ms step_avg:50.12ms
+step:1064/1555 train_time:53365ms step_avg:50.16ms
+step:1065/1555 train_time:53455ms step_avg:50.19ms
+step:1066/1555 train_time:53543ms step_avg:50.23ms
+step:1067/1555 train_time:53631ms step_avg:50.26ms
+step:1068/1555 train_time:53717ms step_avg:50.30ms
+step:1069/1555 train_time:53807ms step_avg:50.33ms
+step:1070/1555 train_time:53892ms step_avg:50.37ms
+step:1071/1555 train_time:53981ms step_avg:50.40ms
+step:1072/1555 train_time:54070ms step_avg:50.44ms
+step:1073/1555 train_time:54157ms step_avg:50.47ms
+step:1074/1555 train_time:54242ms step_avg:50.50ms
+step:1075/1555 train_time:54332ms step_avg:50.54ms
+step:1076/1555 train_time:54418ms step_avg:50.57ms
+step:1077/1555 train_time:54507ms step_avg:50.61ms
+step:1078/1555 train_time:54594ms step_avg:50.64ms
+step:1079/1555 train_time:54686ms step_avg:50.68ms
+step:1080/1555 train_time:54770ms step_avg:50.71ms
+step:1081/1555 train_time:54859ms step_avg:50.75ms
+step:1082/1555 train_time:54945ms step_avg:50.78ms
+step:1083/1555 train_time:55035ms step_avg:50.82ms
+step:1084/1555 train_time:55121ms step_avg:50.85ms
+step:1085/1555 train_time:55211ms step_avg:50.89ms
+step:1086/1555 train_time:55298ms step_avg:50.92ms
+step:1087/1555 train_time:55386ms step_avg:50.95ms
+step:1088/1555 train_time:55472ms step_avg:50.99ms
+step:1089/1555 train_time:55565ms step_avg:51.02ms
+step:1090/1555 train_time:55649ms step_avg:51.05ms
+step:1091/1555 train_time:55737ms step_avg:51.09ms
+step:1092/1555 train_time:55823ms step_avg:51.12ms
+step:1093/1555 train_time:55913ms step_avg:51.16ms
+step:1094/1555 train_time:55998ms step_avg:51.19ms
+step:1095/1555 train_time:56088ms step_avg:51.22ms
+step:1096/1555 train_time:56176ms step_avg:51.26ms
+step:1097/1555 train_time:56263ms step_avg:51.29ms
+step:1098/1555 train_time:56350ms step_avg:51.32ms
+step:1099/1555 train_time:56438ms step_avg:51.35ms
+step:1100/1555 train_time:56525ms step_avg:51.39ms
+step:1101/1555 train_time:56613ms step_avg:51.42ms
+step:1102/1555 train_time:56699ms step_avg:51.45ms
+step:1103/1555 train_time:56790ms step_avg:51.49ms
+step:1104/1555 train_time:56874ms step_avg:51.52ms
+step:1105/1555 train_time:56964ms step_avg:51.55ms
+step:1106/1555 train_time:57050ms step_avg:51.58ms
+step:1107/1555 train_time:57139ms step_avg:51.62ms
+step:1108/1555 train_time:57225ms step_avg:51.65ms
+step:1109/1555 train_time:57315ms step_avg:51.68ms
+step:1110/1555 train_time:57402ms step_avg:51.71ms
+step:1111/1555 train_time:57491ms step_avg:51.75ms
+step:1112/1555 train_time:57577ms step_avg:51.78ms
+step:1113/1555 train_time:57666ms step_avg:51.81ms
+step:1114/1555 train_time:57752ms step_avg:51.84ms
+step:1115/1555 train_time:57841ms step_avg:51.88ms
+step:1116/1555 train_time:57928ms step_avg:51.91ms
+step:1117/1555 train_time:58017ms step_avg:51.94ms
+step:1118/1555 train_time:58104ms step_avg:51.97ms
+step:1119/1555 train_time:58193ms step_avg:52.00ms
+step:1120/1555 train_time:58279ms step_avg:52.03ms
+step:1121/1555 train_time:58369ms step_avg:52.07ms
+step:1122/1555 train_time:58455ms step_avg:52.10ms
+step:1123/1555 train_time:58544ms step_avg:52.13ms
+step:1124/1555 train_time:58631ms step_avg:52.16ms
+step:1125/1555 train_time:58721ms step_avg:52.20ms
+step:1126/1555 train_time:58805ms step_avg:52.23ms
+step:1127/1555 train_time:58894ms step_avg:52.26ms
+step:1128/1555 train_time:58980ms step_avg:52.29ms
+step:1129/1555 train_time:59072ms step_avg:52.32ms
+step:1130/1555 train_time:59156ms step_avg:52.35ms
+step:1131/1555 train_time:59245ms step_avg:52.38ms
+step:1132/1555 train_time:59331ms step_avg:52.41ms
+step:1133/1555 train_time:59422ms step_avg:52.45ms
+step:1134/1555 train_time:59508ms step_avg:52.48ms
+step:1135/1555 train_time:59600ms step_avg:52.51ms
+step:1136/1555 train_time:59684ms step_avg:52.54ms
+step:1137/1555 train_time:59773ms step_avg:52.57ms
+step:1138/1555 train_time:59858ms step_avg:52.60ms
+step:1139/1555 train_time:59951ms step_avg:52.63ms
+step:1140/1555 train_time:60035ms step_avg:52.66ms
+step:1141/1555 train_time:60125ms step_avg:52.69ms
+step:1142/1555 train_time:60209ms step_avg:52.72ms
+step:1143/1555 train_time:60298ms step_avg:52.75ms
+step:1144/1555 train_time:60384ms step_avg:52.78ms
+step:1145/1555 train_time:60474ms step_avg:52.82ms
+step:1146/1555 train_time:60560ms step_avg:52.84ms
+step:1147/1555 train_time:60651ms step_avg:52.88ms
+step:1148/1555 train_time:60736ms step_avg:52.91ms
+step:1149/1555 train_time:60826ms step_avg:52.94ms
+step:1150/1555 train_time:60912ms step_avg:52.97ms
+step:1151/1555 train_time:61001ms step_avg:53.00ms
+step:1152/1555 train_time:61086ms step_avg:53.03ms
+step:1153/1555 train_time:61176ms step_avg:53.06ms
+step:1154/1555 train_time:61261ms step_avg:53.09ms
+step:1155/1555 train_time:61351ms step_avg:53.12ms
+step:1156/1555 train_time:61437ms step_avg:53.15ms
+step:1157/1555 train_time:61527ms step_avg:53.18ms
+step:1158/1555 train_time:61615ms step_avg:53.21ms
+step:1159/1555 train_time:61703ms step_avg:53.24ms
+step:1160/1555 train_time:61788ms step_avg:53.27ms
+step:1161/1555 train_time:61878ms step_avg:53.30ms
+step:1162/1555 train_time:61963ms step_avg:53.32ms
+step:1163/1555 train_time:62053ms step_avg:53.36ms
+step:1164/1555 train_time:62141ms step_avg:53.39ms
+step:1165/1555 train_time:62228ms step_avg:53.41ms
+step:1166/1555 train_time:62314ms step_avg:53.44ms
+step:1167/1555 train_time:62404ms step_avg:53.47ms
+step:1168/1555 train_time:62491ms step_avg:53.50ms
+step:1169/1555 train_time:62582ms step_avg:53.53ms
+step:1170/1555 train_time:62667ms step_avg:53.56ms
+step:1171/1555 train_time:62756ms step_avg:53.59ms
+step:1172/1555 train_time:62842ms step_avg:53.62ms
+step:1173/1555 train_time:62931ms step_avg:53.65ms
+step:1174/1555 train_time:63017ms step_avg:53.68ms
+step:1175/1555 train_time:63108ms step_avg:53.71ms
+step:1176/1555 train_time:63192ms step_avg:53.73ms
+step:1177/1555 train_time:63283ms step_avg:53.77ms
+step:1178/1555 train_time:63369ms step_avg:53.79ms
+step:1179/1555 train_time:63458ms step_avg:53.82ms
+step:1180/1555 train_time:63543ms step_avg:53.85ms
+step:1181/1555 train_time:63634ms step_avg:53.88ms
+step:1182/1555 train_time:63719ms step_avg:53.91ms
+step:1183/1555 train_time:63808ms step_avg:53.94ms
+step:1184/1555 train_time:63896ms step_avg:53.97ms
+step:1185/1555 train_time:63984ms step_avg:53.99ms
+step:1186/1555 train_time:64069ms step_avg:54.02ms
+step:1187/1555 train_time:64159ms step_avg:54.05ms
+step:1188/1555 train_time:64243ms step_avg:54.08ms
+step:1189/1555 train_time:64334ms step_avg:54.11ms
+step:1190/1555 train_time:64422ms step_avg:54.14ms
+step:1191/1555 train_time:64510ms step_avg:54.16ms
+step:1192/1555 train_time:64595ms step_avg:54.19ms
+step:1193/1555 train_time:64685ms step_avg:54.22ms
+step:1194/1555 train_time:64770ms step_avg:54.25ms
+step:1195/1555 train_time:64859ms step_avg:54.28ms
+step:1196/1555 train_time:64947ms step_avg:54.30ms
+step:1197/1555 train_time:65035ms step_avg:54.33ms
+step:1198/1555 train_time:65122ms step_avg:54.36ms
+step:1199/1555 train_time:65211ms step_avg:54.39ms
+step:1200/1555 train_time:65297ms step_avg:54.41ms
+step:1201/1555 train_time:65386ms step_avg:54.44ms
+step:1202/1555 train_time:65472ms step_avg:54.47ms
+step:1203/1555 train_time:65563ms step_avg:54.50ms
+step:1204/1555 train_time:65648ms step_avg:54.52ms
+step:1205/1555 train_time:65738ms step_avg:54.55ms
+step:1206/1555 train_time:65825ms step_avg:54.58ms
+step:1207/1555 train_time:65913ms step_avg:54.61ms
+step:1208/1555 train_time:65999ms step_avg:54.63ms
+step:1209/1555 train_time:66089ms step_avg:54.66ms
+step:1210/1555 train_time:66174ms step_avg:54.69ms
+step:1211/1555 train_time:66263ms step_avg:54.72ms
+step:1212/1555 train_time:66351ms step_avg:54.74ms
+step:1213/1555 train_time:66440ms step_avg:54.77ms
+step:1214/1555 train_time:66526ms step_avg:54.80ms
+step:1215/1555 train_time:66617ms step_avg:54.83ms
+step:1216/1555 train_time:66702ms step_avg:54.85ms
+step:1217/1555 train_time:66790ms step_avg:54.88ms
+step:1218/1555 train_time:66876ms step_avg:54.91ms
+step:1219/1555 train_time:66965ms step_avg:54.93ms
+step:1220/1555 train_time:67055ms step_avg:54.96ms
+step:1221/1555 train_time:67141ms step_avg:54.99ms
+step:1222/1555 train_time:67228ms step_avg:55.01ms
+step:1223/1555 train_time:67317ms step_avg:55.04ms
+step:1224/1555 train_time:67403ms step_avg:55.07ms
+step:1225/1555 train_time:67493ms step_avg:55.10ms
+step:1226/1555 train_time:67580ms step_avg:55.12ms
+step:1227/1555 train_time:67668ms step_avg:55.15ms
+step:1228/1555 train_time:67754ms step_avg:55.17ms
+step:1229/1555 train_time:67843ms step_avg:55.20ms
+step:1230/1555 train_time:67930ms step_avg:55.23ms
+step:1231/1555 train_time:68019ms step_avg:55.26ms
+step:1232/1555 train_time:68106ms step_avg:55.28ms
+step:1233/1555 train_time:68195ms step_avg:55.31ms
+step:1234/1555 train_time:68281ms step_avg:55.33ms
+step:1235/1555 train_time:68372ms step_avg:55.36ms
+step:1236/1555 train_time:68457ms step_avg:55.39ms
+step:1237/1555 train_time:68546ms step_avg:55.41ms
+step:1238/1555 train_time:68631ms step_avg:55.44ms
+step:1239/1555 train_time:68722ms step_avg:55.47ms
+step:1240/1555 train_time:68808ms step_avg:55.49ms
+step:1241/1555 train_time:68897ms step_avg:55.52ms
+step:1242/1555 train_time:68983ms step_avg:55.54ms
+step:1243/1555 train_time:69073ms step_avg:55.57ms
+step:1244/1555 train_time:69159ms step_avg:55.59ms
+step:1245/1555 train_time:69249ms step_avg:55.62ms
+step:1246/1555 train_time:69334ms step_avg:55.65ms
+step:1247/1555 train_time:69424ms step_avg:55.67ms
+step:1248/1555 train_time:69512ms step_avg:55.70ms
+step:1249/1555 train_time:69600ms step_avg:55.72ms
+step:1250/1555 train_time:69685ms step_avg:55.75ms
+step:1250/1555 val_loss:3.4008 train_time:69761ms step_avg:55.81ms
+step:1251/1555 train_time:69781ms step_avg:55.78ms
+step:1252/1555 train_time:69875ms step_avg:55.81ms
+step:1253/1555 train_time:69970ms step_avg:55.84ms
+step:1254/1555 train_time:70057ms step_avg:55.87ms
+step:1255/1555 train_time:70145ms step_avg:55.89ms
+step:1256/1555 train_time:70233ms step_avg:55.92ms
+step:1257/1555 train_time:70319ms step_avg:55.94ms
+step:1258/1555 train_time:70404ms step_avg:55.96ms
+step:1259/1555 train_time:70492ms step_avg:55.99ms
+step:1260/1555 train_time:70576ms step_avg:56.01ms
+step:1261/1555 train_time:70666ms step_avg:56.04ms
+step:1262/1555 train_time:70752ms step_avg:56.06ms
+step:1263/1555 train_time:70842ms step_avg:56.09ms
+step:1264/1555 train_time:70931ms step_avg:56.12ms
+step:1265/1555 train_time:71022ms step_avg:56.14ms
+step:1266/1555 train_time:71108ms step_avg:56.17ms
+step:1267/1555 train_time:71197ms step_avg:56.19ms
+step:1268/1555 train_time:71283ms step_avg:56.22ms
+step:1269/1555 train_time:71372ms step_avg:56.24ms
+step:1270/1555 train_time:71458ms step_avg:56.27ms
+step:1271/1555 train_time:71548ms step_avg:56.29ms
+step:1272/1555 train_time:71635ms step_avg:56.32ms
+step:1273/1555 train_time:71722ms step_avg:56.34ms
+step:1274/1555 train_time:71808ms step_avg:56.36ms
+step:1275/1555 train_time:71900ms step_avg:56.39ms
+step:1276/1555 train_time:71987ms step_avg:56.42ms
+step:1277/1555 train_time:72078ms step_avg:56.44ms
+step:1278/1555 train_time:72165ms step_avg:56.47ms
+step:1279/1555 train_time:72253ms step_avg:56.49ms
+step:1280/1555 train_time:72339ms step_avg:56.51ms
+step:1281/1555 train_time:72428ms step_avg:56.54ms
+step:1282/1555 train_time:72513ms step_avg:56.56ms
+step:1283/1555 train_time:72603ms step_avg:56.59ms
+step:1284/1555 train_time:72688ms step_avg:56.61ms
+step:1285/1555 train_time:72778ms step_avg:56.64ms
+step:1286/1555 train_time:72865ms step_avg:56.66ms
+step:1287/1555 train_time:72954ms step_avg:56.69ms
+step:1288/1555 train_time:73041ms step_avg:56.71ms
+step:1289/1555 train_time:73131ms step_avg:56.74ms
+step:1290/1555 train_time:73217ms step_avg:56.76ms
+step:1291/1555 train_time:73307ms step_avg:56.78ms
+step:1292/1555 train_time:73393ms step_avg:56.81ms
+step:1293/1555 train_time:73481ms step_avg:56.83ms
+step:1294/1555 train_time:73566ms step_avg:56.85ms
+step:1295/1555 train_time:73656ms step_avg:56.88ms
+step:1296/1555 train_time:73742ms step_avg:56.90ms
+step:1297/1555 train_time:73832ms step_avg:56.92ms
+step:1298/1555 train_time:73917ms step_avg:56.95ms
+step:1299/1555 train_time:74008ms step_avg:56.97ms
+step:1300/1555 train_time:74093ms step_avg:56.99ms
+step:1301/1555 train_time:74183ms step_avg:57.02ms
+step:1302/1555 train_time:74271ms step_avg:57.04ms
+step:1303/1555 train_time:74358ms step_avg:57.07ms
+step:1304/1555 train_time:74443ms step_avg:57.09ms
+step:1305/1555 train_time:74534ms step_avg:57.11ms
+step:1306/1555 train_time:74619ms step_avg:57.14ms
+step:1307/1555 train_time:74708ms step_avg:57.16ms
+step:1308/1555 train_time:74797ms step_avg:57.18ms
+step:1309/1555 train_time:74885ms step_avg:57.21ms
+step:1310/1555 train_time:74971ms step_avg:57.23ms
+step:1311/1555 train_time:75062ms step_avg:57.26ms
+step:1312/1555 train_time:75148ms step_avg:57.28ms
+step:1313/1555 train_time:75238ms step_avg:57.30ms
+step:1314/1555 train_time:75324ms step_avg:57.32ms
+step:1315/1555 train_time:75413ms step_avg:57.35ms
+step:1316/1555 train_time:75500ms step_avg:57.37ms
+step:1317/1555 train_time:75588ms step_avg:57.39ms
+step:1318/1555 train_time:75675ms step_avg:57.42ms
+step:1319/1555 train_time:75764ms step_avg:57.44ms
+step:1320/1555 train_time:75849ms step_avg:57.46ms
+step:1321/1555 train_time:75940ms step_avg:57.49ms
+step:1322/1555 train_time:76025ms step_avg:57.51ms
+step:1323/1555 train_time:76115ms step_avg:57.53ms
+step:1324/1555 train_time:76203ms step_avg:57.56ms
+step:1325/1555 train_time:76291ms step_avg:57.58ms
+step:1326/1555 train_time:76377ms step_avg:57.60ms
+step:1327/1555 train_time:76466ms step_avg:57.62ms
+step:1328/1555 train_time:76551ms step_avg:57.64ms
+step:1329/1555 train_time:76639ms step_avg:57.67ms
+step:1330/1555 train_time:76725ms step_avg:57.69ms
+step:1331/1555 train_time:76817ms step_avg:57.71ms
+step:1332/1555 train_time:76901ms step_avg:57.73ms
+step:1333/1555 train_time:76991ms step_avg:57.76ms
+step:1334/1555 train_time:77078ms step_avg:57.78ms
+step:1335/1555 train_time:77167ms step_avg:57.80ms
+step:1336/1555 train_time:77253ms step_avg:57.82ms
+step:1337/1555 train_time:77346ms step_avg:57.85ms
+step:1338/1555 train_time:77430ms step_avg:57.87ms
+step:1339/1555 train_time:77519ms step_avg:57.89ms
+step:1340/1555 train_time:77605ms step_avg:57.91ms
+step:1341/1555 train_time:77694ms step_avg:57.94ms
+step:1342/1555 train_time:77780ms step_avg:57.96ms
+step:1343/1555 train_time:77869ms step_avg:57.98ms
+step:1344/1555 train_time:77956ms step_avg:58.00ms
+step:1345/1555 train_time:78045ms step_avg:58.03ms
+step:1346/1555 train_time:78133ms step_avg:58.05ms
+step:1347/1555 train_time:78222ms step_avg:58.07ms
+step:1348/1555 train_time:78307ms step_avg:58.09ms
+step:1349/1555 train_time:78397ms step_avg:58.11ms
+step:1350/1555 train_time:78486ms step_avg:58.14ms
+step:1351/1555 train_time:78594ms step_avg:58.17ms
+step:1352/1555 train_time:78661ms step_avg:58.18ms
+step:1353/1555 train_time:78750ms step_avg:58.20ms
+step:1354/1555 train_time:78835ms step_avg:58.22ms
+step:1355/1555 train_time:78925ms step_avg:58.25ms
+step:1356/1555 train_time:79010ms step_avg:58.27ms
+step:1357/1555 train_time:79101ms step_avg:58.29ms
+step:1358/1555 train_time:79187ms step_avg:58.31ms
+step:1359/1555 train_time:79279ms step_avg:58.34ms
+step:1360/1555 train_time:79364ms step_avg:58.36ms
+step:1361/1555 train_time:79453ms step_avg:58.38ms
+step:1362/1555 train_time:79539ms step_avg:58.40ms
+step:1363/1555 train_time:79628ms step_avg:58.42ms
+step:1364/1555 train_time:79715ms step_avg:58.44ms
+step:1365/1555 train_time:79806ms step_avg:58.47ms
+step:1366/1555 train_time:79890ms step_avg:58.48ms
+step:1367/1555 train_time:79980ms step_avg:58.51ms
+step:1368/1555 train_time:80066ms step_avg:58.53ms
+step:1369/1555 train_time:80156ms step_avg:58.55ms
+step:1370/1555 train_time:80242ms step_avg:58.57ms
+step:1371/1555 train_time:80331ms step_avg:58.59ms
+step:1372/1555 train_time:80418ms step_avg:58.61ms
+step:1373/1555 train_time:80506ms step_avg:58.63ms
+step:1374/1555 train_time:80592ms step_avg:58.66ms
+step:1375/1555 train_time:80683ms step_avg:58.68ms
+step:1376/1555 train_time:80768ms step_avg:58.70ms
+step:1377/1555 train_time:80858ms step_avg:58.72ms
+step:1378/1555 train_time:80944ms step_avg:58.74ms
+step:1379/1555 train_time:81035ms step_avg:58.76ms
+step:1380/1555 train_time:81119ms step_avg:58.78ms
+step:1381/1555 train_time:81209ms step_avg:58.80ms
+step:1382/1555 train_time:81298ms step_avg:58.83ms
+step:1383/1555 train_time:81386ms step_avg:58.85ms
+step:1384/1555 train_time:81472ms step_avg:58.87ms
+step:1385/1555 train_time:81562ms step_avg:58.89ms
+step:1386/1555 train_time:81648ms step_avg:58.91ms
+step:1387/1555 train_time:81737ms step_avg:58.93ms
+step:1388/1555 train_time:81823ms step_avg:58.95ms
+step:1389/1555 train_time:81914ms step_avg:58.97ms
+step:1390/1555 train_time:81999ms step_avg:58.99ms
+step:1391/1555 train_time:82089ms step_avg:59.01ms
+step:1392/1555 train_time:82177ms step_avg:59.04ms
+step:1393/1555 train_time:82265ms step_avg:59.06ms
+step:1394/1555 train_time:82351ms step_avg:59.08ms
+step:1395/1555 train_time:82442ms step_avg:59.10ms
+step:1396/1555 train_time:82527ms step_avg:59.12ms
+step:1397/1555 train_time:82617ms step_avg:59.14ms
+step:1398/1555 train_time:82703ms step_avg:59.16ms
+step:1399/1555 train_time:82795ms step_avg:59.18ms
+step:1400/1555 train_time:82879ms step_avg:59.20ms
+step:1401/1555 train_time:82970ms step_avg:59.22ms
+step:1402/1555 train_time:83055ms step_avg:59.24ms
+step:1403/1555 train_time:83144ms step_avg:59.26ms
+step:1404/1555 train_time:83232ms step_avg:59.28ms
+step:1405/1555 train_time:83321ms step_avg:59.30ms
+step:1406/1555 train_time:83406ms step_avg:59.32ms
+step:1407/1555 train_time:83495ms step_avg:59.34ms
+step:1408/1555 train_time:83581ms step_avg:59.36ms
+step:1409/1555 train_time:83672ms step_avg:59.38ms
+step:1410/1555 train_time:83756ms step_avg:59.40ms
+step:1411/1555 train_time:83847ms step_avg:59.42ms
+step:1412/1555 train_time:83933ms step_avg:59.44ms
+step:1413/1555 train_time:84021ms step_avg:59.46ms
+step:1414/1555 train_time:84107ms step_avg:59.48ms
+step:1415/1555 train_time:84197ms step_avg:59.50ms
+step:1416/1555 train_time:84284ms step_avg:59.52ms
+step:1417/1555 train_time:84373ms step_avg:59.54ms
+step:1418/1555 train_time:84459ms step_avg:59.56ms
+step:1419/1555 train_time:84549ms step_avg:59.58ms
+step:1420/1555 train_time:84638ms step_avg:59.60ms
+step:1421/1555 train_time:84725ms step_avg:59.62ms
+step:1422/1555 train_time:84811ms step_avg:59.64ms
+step:1423/1555 train_time:84902ms step_avg:59.66ms
+step:1424/1555 train_time:84987ms step_avg:59.68ms
+step:1425/1555 train_time:85078ms step_avg:59.70ms
+step:1426/1555 train_time:85163ms step_avg:59.72ms
+step:1427/1555 train_time:85255ms step_avg:59.74ms
+step:1428/1555 train_time:85339ms step_avg:59.76ms
+step:1429/1555 train_time:85429ms step_avg:59.78ms
+step:1430/1555 train_time:85515ms step_avg:59.80ms
+step:1431/1555 train_time:85605ms step_avg:59.82ms
+step:1432/1555 train_time:85690ms step_avg:59.84ms
+step:1433/1555 train_time:85781ms step_avg:59.86ms
+step:1434/1555 train_time:85868ms step_avg:59.88ms
+step:1435/1555 train_time:85956ms step_avg:59.90ms
+step:1436/1555 train_time:86041ms step_avg:59.92ms
+step:1437/1555 train_time:86131ms step_avg:59.94ms
+step:1438/1555 train_time:86218ms step_avg:59.96ms
+step:1439/1555 train_time:86306ms step_avg:59.98ms
+step:1440/1555 train_time:86394ms step_avg:60.00ms
+step:1441/1555 train_time:86482ms step_avg:60.02ms
+step:1442/1555 train_time:86571ms step_avg:60.04ms
+step:1443/1555 train_time:86659ms step_avg:60.05ms
+step:1444/1555 train_time:86745ms step_avg:60.07ms
+step:1445/1555 train_time:86834ms step_avg:60.09ms
+step:1446/1555 train_time:86920ms step_avg:60.11ms
+step:1447/1555 train_time:87011ms step_avg:60.13ms
+step:1448/1555 train_time:87096ms step_avg:60.15ms
+step:1449/1555 train_time:87187ms step_avg:60.17ms
+step:1450/1555 train_time:87272ms step_avg:60.19ms
+step:1451/1555 train_time:87361ms step_avg:60.21ms
+step:1452/1555 train_time:87447ms step_avg:60.23ms
+step:1453/1555 train_time:87540ms step_avg:60.25ms
+step:1454/1555 train_time:87624ms step_avg:60.26ms
+step:1455/1555 train_time:87713ms step_avg:60.28ms
+step:1456/1555 train_time:87797ms step_avg:60.30ms
+step:1457/1555 train_time:87887ms step_avg:60.32ms
+step:1458/1555 train_time:87976ms step_avg:60.34ms
+step:1459/1555 train_time:88063ms step_avg:60.36ms
+step:1460/1555 train_time:88149ms step_avg:60.38ms
+step:1461/1555 train_time:88239ms step_avg:60.40ms
+step:1462/1555 train_time:88325ms step_avg:60.41ms
+step:1463/1555 train_time:88414ms step_avg:60.43ms
+step:1464/1555 train_time:88500ms step_avg:60.45ms
+step:1465/1555 train_time:88590ms step_avg:60.47ms
+step:1466/1555 train_time:88676ms step_avg:60.49ms
+step:1467/1555 train_time:88767ms step_avg:60.51ms
+step:1468/1555 train_time:88851ms step_avg:60.52ms
+step:1469/1555 train_time:88941ms step_avg:60.55ms
+step:1470/1555 train_time:89027ms step_avg:60.56ms
+step:1471/1555 train_time:89117ms step_avg:60.58ms
+step:1472/1555 train_time:89203ms step_avg:60.60ms
+step:1473/1555 train_time:89293ms step_avg:60.62ms
+step:1474/1555 train_time:89380ms step_avg:60.64ms
+step:1475/1555 train_time:89469ms step_avg:60.66ms
+step:1476/1555 train_time:89555ms step_avg:60.67ms
+step:1477/1555 train_time:89645ms step_avg:60.69ms
+step:1478/1555 train_time:89733ms step_avg:60.71ms
+step:1479/1555 train_time:89821ms step_avg:60.73ms
+step:1480/1555 train_time:89906ms step_avg:60.75ms
+step:1481/1555 train_time:89996ms step_avg:60.77ms
+step:1482/1555 train_time:90082ms step_avg:60.78ms
+step:1483/1555 train_time:90173ms step_avg:60.80ms
+step:1484/1555 train_time:90260ms step_avg:60.82ms
+step:1485/1555 train_time:90351ms step_avg:60.84ms
+step:1486/1555 train_time:90436ms step_avg:60.86ms
+step:1487/1555 train_time:90524ms step_avg:60.88ms
+step:1488/1555 train_time:90610ms step_avg:60.89ms
+step:1489/1555 train_time:90702ms step_avg:60.91ms
+step:1490/1555 train_time:90787ms step_avg:60.93ms
+step:1491/1555 train_time:90875ms step_avg:60.95ms
+step:1492/1555 train_time:90961ms step_avg:60.97ms
+step:1493/1555 train_time:91052ms step_avg:60.99ms
+step:1494/1555 train_time:91138ms step_avg:61.00ms
+step:1495/1555 train_time:91228ms step_avg:61.02ms
+step:1496/1555 train_time:91314ms step_avg:61.04ms
+step:1497/1555 train_time:91403ms step_avg:61.06ms
+step:1498/1555 train_time:91489ms step_avg:61.07ms
+step:1499/1555 train_time:91581ms step_avg:61.09ms
+step:1500/1555 train_time:91665ms step_avg:61.11ms
+step:1500/1555 val_loss:3.2973 train_time:91739ms step_avg:61.16ms
+step:1501/1555 train_time:91760ms step_avg:61.13ms
+step:1502/1555 train_time:91845ms step_avg:61.15ms
+step:1503/1555 train_time:91939ms step_avg:61.17ms
+step:1504/1555 train_time:92026ms step_avg:61.19ms
+step:1505/1555 train_time:92114ms step_avg:61.21ms
+step:1506/1555 train_time:92199ms step_avg:61.22ms
+step:1507/1555 train_time:92287ms step_avg:61.24ms
+step:1508/1555 train_time:92374ms step_avg:61.26ms
+step:1509/1555 train_time:92462ms step_avg:61.27ms
+step:1510/1555 train_time:92547ms step_avg:61.29ms
+step:1511/1555 train_time:92636ms step_avg:61.31ms
+step:1512/1555 train_time:92724ms step_avg:61.33ms
+step:1513/1555 train_time:92815ms step_avg:61.34ms
+step:1514/1555 train_time:92903ms step_avg:61.36ms
+step:1515/1555 train_time:92994ms step_avg:61.38ms
+step:1516/1555 train_time:93091ms step_avg:61.41ms
+step:1517/1555 train_time:93175ms step_avg:61.42ms
+step:1518/1555 train_time:93260ms step_avg:61.44ms
+step:1519/1555 train_time:93349ms step_avg:61.45ms
+step:1520/1555 train_time:93434ms step_avg:61.47ms
+step:1521/1555 train_time:93523ms step_avg:61.49ms
+step:1522/1555 train_time:93608ms step_avg:61.50ms
+step:1523/1555 train_time:93700ms step_avg:61.52ms
+step:1524/1555 train_time:93786ms step_avg:61.54ms
+step:1525/1555 train_time:93877ms step_avg:61.56ms
+step:1526/1555 train_time:93964ms step_avg:61.58ms
+step:1527/1555 train_time:94056ms step_avg:61.60ms
+step:1528/1555 train_time:94142ms step_avg:61.61ms
+step:1529/1555 train_time:94231ms step_avg:61.63ms
+step:1530/1555 train_time:94319ms step_avg:61.65ms
+step:1531/1555 train_time:94407ms step_avg:61.66ms
+step:1532/1555 train_time:94493ms step_avg:61.68ms
+step:1533/1555 train_time:94582ms step_avg:61.70ms
+step:1534/1555 train_time:94668ms step_avg:61.71ms
+step:1535/1555 train_time:94759ms step_avg:61.73ms
+step:1536/1555 train_time:94848ms step_avg:61.75ms
+step:1537/1555 train_time:94936ms step_avg:61.77ms
+step:1538/1555 train_time:95023ms step_avg:61.78ms
+step:1539/1555 train_time:95114ms step_avg:61.80ms
+step:1540/1555 train_time:95201ms step_avg:61.82ms
+step:1541/1555 train_time:95292ms step_avg:61.84ms
+step:1542/1555 train_time:95375ms step_avg:61.85ms
+step:1543/1555 train_time:95466ms step_avg:61.87ms
+step:1544/1555 train_time:95552ms step_avg:61.89ms
+step:1545/1555 train_time:95642ms step_avg:61.90ms
+step:1546/1555 train_time:95727ms step_avg:61.92ms
+step:1547/1555 train_time:95818ms step_avg:61.94ms
+step:1548/1555 train_time:95905ms step_avg:61.95ms
+step:1549/1555 train_time:95998ms step_avg:61.97ms
+step:1550/1555 train_time:96082ms step_avg:61.99ms
+step:1551/1555 train_time:96172ms step_avg:62.01ms
+step:1552/1555 train_time:96258ms step_avg:62.02ms
+step:1553/1555 train_time:96348ms step_avg:62.04ms
+step:1554/1555 train_time:96433ms step_avg:62.05ms
+step:1555/1555 train_time:96522ms step_avg:62.07ms
+step:1555/1555 val_loss:3.2805 train_time:96590ms step_avg:62.12ms
+peak memory allocated: 30933 MiB reserved: 47038 MiB

--- a/records/track_1_short/2026-01-30_MimeticValueOutput/runs/f4983f74-bd98-4a43-9670-9f3e3fabc6a6.txt
+++ b/records/track_1_short/2026-01-30_MimeticValueOutput/runs/f4983f74-bd98-4a43-9670-9f3e3fabc6a6.txt
@@ -1,0 +1,4131 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# Mimetic V-O Initialization (Trockman & Kolter, ICML 2023)
+# Initialize V and O such that V @ O^T ≈ -βI (negative identity-like)
+# This enables attention to make meaningful contributions from step 1
+
+def mimetic_vo_init(attn_bank, model_dim=768, num_heads=6, head_dim=128, beta=0.1, noise_std=0.01):
+    """
+    Initialize attention bank with mimetic structure for V and O.
+    Q and K use standard uniform init, V and O use identity-like structure.
+
+    Args:
+        attn_bank: Tensor of shape (num_layers, 4*model_dim, hdim)
+        model_dim: Model dimension (768)
+        num_heads: Number of attention heads (6)
+        head_dim: Dimension per head (128)
+        beta: Scale for identity structure (0.1 recommended with attn_scale=0.1)
+        noise_std: Standard deviation of noise for symmetry breaking
+    """
+    num_layers = attn_bank.shape[0]
+    dim = model_dim
+    sqrt_beta = beta ** 0.5
+
+    # Standard init for Q and K (existing behavior)
+    attn_std = model_dim ** -0.5
+    attn_bound = (3 ** 0.5) * attn_std
+
+    with torch.no_grad():
+        # Q and K: uniform init (first 2*dim rows)
+        attn_bank[:, :2*dim, :].uniform_(-attn_bound, attn_bound)
+
+        # V and O: mimetic identity structure
+        for layer_idx in range(num_layers):
+            W_V = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+            W_O = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+
+            # Create per-head identity blocks
+            for h in range(num_heads):
+                start, end = h * head_dim, (h + 1) * head_dim
+                eye = torch.eye(head_dim, dtype=attn_bank.dtype, device=attn_bank.device)
+                W_V[start:end, start:end] = sqrt_beta * eye
+                W_O[start:end, start:end] = -sqrt_beta * eye
+
+            # Add noise for symmetry breaking
+            W_V += noise_std * torch.randn_like(W_V)
+            W_O += noise_std * torch.randn_like(W_O)
+
+            # Store in attn_bank: V is rows [2*dim:3*dim], O is rows [3*dim:4*dim]
+            attn_bank[layer_idx, 2*dim:3*dim, :] = W_V
+            attn_bank[layer_idx, 3*dim:4*dim, :] = W_O
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # MLP uses 0.5 * dim^-0.5
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank with MIMETIC V-O initialization
+            # Q and K: uniform init, V and O: identity-like structure for faster convergence
+            mimetic_vo_init(
+                self.attn_bank,
+                model_dim=model_dim,
+                num_heads=num_heads,
+                head_dim=head_dim,
+                beta=0.05,       # Scale for V@O^T ≈ -βI (tuned down from 0.1)
+                noise_std=0.01   # Symmetry breaking noise
+            )
+            # Init MLP bank (c_fc uniform, c_proj zero)
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 234 structure on token value embeddings by @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1515  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.11.14 (main, Oct 21 2025, 18:31:21) [GCC 11.2.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Fri Jan 30 18:36:24 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          Off |   00000000:19:00.0 Off |                    0 |
+| N/A   35C    P0            126W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          Off |   00000000:3B:00.0 Off |                    0 |
+| N/A   28C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          Off |   00000000:4C:00.0 Off |                    0 |
+| N/A   25C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          Off |   00000000:5D:00.0 Off |                    0 |
+| N/A   34C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          Off |   00000000:9B:00.0 Off |                    0 |
+| N/A   34C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          Off |   00000000:BB:00.0 Off |                    0 |
+| N/A   26C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          Off |   00000000:CB:00.0 Off |                    0 |
+| N/A   32C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          Off |   00000000:DB:00.0 Off |                    0 |
+| N/A   26C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1363217      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    1   N/A  N/A   1363218      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    2   N/A  N/A   1363219      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    3   N/A  N/A   1363220      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    4   N/A  N/A   1363221      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    5   N/A  N/A   1363222      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    6   N/A  N/A   1363223      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
+|    7   N/A  N/A   1363224      C   ...miniconda3/envs/nanogpt/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 504, 505, 506, 1009, 1010, 1011, 1514, 1515, 1516] for warmup
+Resetting Model
+step:0/1555 val_loss:10.8314 train_time:0ms step_avg:0.04ms
+step:1/1555 train_time:90ms step_avg:89.69ms
+step:2/1555 train_time:112ms step_avg:55.90ms
+step:3/1555 train_time:150ms step_avg:50.13ms
+step:4/1555 train_time:189ms step_avg:47.20ms
+step:5/1555 train_time:220ms step_avg:43.95ms
+step:6/1555 train_time:258ms step_avg:43.04ms
+step:7/1555 train_time:289ms step_avg:41.35ms
+step:8/1555 train_time:327ms step_avg:40.93ms
+step:9/1555 train_time:359ms step_avg:39.88ms
+step:10/1555 train_time:397ms step_avg:39.71ms
+step:11/1555 train_time:428ms step_avg:38.95ms
+step:12/1555 train_time:467ms step_avg:38.89ms
+step:13/1555 train_time:498ms step_avg:38.34ms
+step:14/1555 train_time:537ms step_avg:38.33ms
+step:15/1555 train_time:568ms step_avg:37.87ms
+step:16/1555 train_time:607ms step_avg:37.91ms
+step:17/1555 train_time:638ms step_avg:37.55ms
+step:18/1555 train_time:677ms step_avg:37.60ms
+step:19/1555 train_time:708ms step_avg:37.28ms
+step:20/1555 train_time:747ms step_avg:37.33ms
+step:21/1555 train_time:778ms step_avg:37.05ms
+step:22/1555 train_time:816ms step_avg:37.11ms
+step:23/1555 train_time:848ms step_avg:36.87ms
+step:24/1555 train_time:887ms step_avg:36.94ms
+step:25/1555 train_time:918ms step_avg:36.72ms
+step:26/1555 train_time:957ms step_avg:36.79ms
+step:27/1555 train_time:989ms step_avg:36.61ms
+step:28/1555 train_time:1027ms step_avg:36.67ms
+step:29/1555 train_time:1058ms step_avg:36.50ms
+step:30/1555 train_time:1097ms step_avg:36.57ms
+step:31/1555 train_time:1128ms step_avg:36.40ms
+step:32/1555 train_time:1167ms step_avg:36.46ms
+step:33/1555 train_time:1199ms step_avg:36.32ms
+step:34/1555 train_time:1237ms step_avg:36.38ms
+step:35/1555 train_time:1268ms step_avg:36.24ms
+step:36/1555 train_time:1307ms step_avg:36.30ms
+step:37/1555 train_time:1338ms step_avg:36.17ms
+step:38/1555 train_time:1376ms step_avg:36.22ms
+step:39/1555 train_time:1408ms step_avg:36.10ms
+step:40/1555 train_time:1446ms step_avg:36.15ms
+step:41/1555 train_time:1477ms step_avg:36.03ms
+step:42/1555 train_time:1515ms step_avg:36.08ms
+step:43/1555 train_time:1547ms step_avg:35.98ms
+step:44/1555 train_time:1585ms step_avg:36.03ms
+step:45/1555 train_time:1617ms step_avg:35.92ms
+step:46/1555 train_time:1655ms step_avg:35.98ms
+step:47/1555 train_time:1686ms step_avg:35.88ms
+step:48/1555 train_time:1725ms step_avg:35.93ms
+step:49/1555 train_time:1756ms step_avg:35.83ms
+step:50/1555 train_time:1794ms step_avg:35.88ms
+step:51/1555 train_time:1825ms step_avg:35.79ms
+step:52/1555 train_time:1864ms step_avg:35.84ms
+step:53/1555 train_time:1895ms step_avg:35.76ms
+step:54/1555 train_time:1934ms step_avg:35.81ms
+step:55/1555 train_time:1965ms step_avg:35.73ms
+step:56/1555 train_time:2003ms step_avg:35.78ms
+step:57/1555 train_time:2035ms step_avg:35.70ms
+step:58/1555 train_time:2073ms step_avg:35.74ms
+step:59/1555 train_time:2105ms step_avg:35.67ms
+step:60/1555 train_time:2143ms step_avg:35.71ms
+step:61/1555 train_time:2174ms step_avg:35.64ms
+step:62/1555 train_time:2213ms step_avg:35.69ms
+step:63/1555 train_time:2244ms step_avg:35.62ms
+step:64/1555 train_time:2282ms step_avg:35.66ms
+step:65/1555 train_time:2314ms step_avg:35.59ms
+step:66/1555 train_time:2352ms step_avg:35.63ms
+step:67/1555 train_time:2383ms step_avg:35.57ms
+step:68/1555 train_time:2422ms step_avg:35.61ms
+step:69/1555 train_time:2453ms step_avg:35.55ms
+step:70/1555 train_time:2491ms step_avg:35.59ms
+step:71/1555 train_time:2522ms step_avg:35.53ms
+step:72/1555 train_time:2561ms step_avg:35.57ms
+step:73/1555 train_time:2592ms step_avg:35.51ms
+step:74/1555 train_time:2630ms step_avg:35.54ms
+step:75/1555 train_time:2662ms step_avg:35.49ms
+step:76/1555 train_time:2700ms step_avg:35.52ms
+step:77/1555 train_time:2731ms step_avg:35.47ms
+step:78/1555 train_time:2770ms step_avg:35.51ms
+step:79/1555 train_time:2801ms step_avg:35.46ms
+step:80/1555 train_time:2839ms step_avg:35.49ms
+step:81/1555 train_time:2871ms step_avg:35.44ms
+step:82/1555 train_time:2909ms step_avg:35.47ms
+step:83/1555 train_time:2940ms step_avg:35.43ms
+step:84/1555 train_time:2979ms step_avg:35.46ms
+step:85/1555 train_time:3010ms step_avg:35.41ms
+step:86/1555 train_time:3048ms step_avg:35.44ms
+step:87/1555 train_time:3079ms step_avg:35.40ms
+step:88/1555 train_time:3118ms step_avg:35.43ms
+step:89/1555 train_time:3149ms step_avg:35.38ms
+step:90/1555 train_time:3187ms step_avg:35.41ms
+step:91/1555 train_time:3219ms step_avg:35.37ms
+step:92/1555 train_time:3257ms step_avg:35.40ms
+step:93/1555 train_time:3289ms step_avg:35.36ms
+step:94/1555 train_time:3327ms step_avg:35.39ms
+step:95/1555 train_time:3358ms step_avg:35.34ms
+step:96/1555 train_time:3396ms step_avg:35.38ms
+step:97/1555 train_time:3428ms step_avg:35.34ms
+step:98/1555 train_time:3466ms step_avg:35.37ms
+step:99/1555 train_time:3497ms step_avg:35.33ms
+step:100/1555 train_time:3536ms step_avg:35.36ms
+step:101/1555 train_time:3567ms step_avg:35.32ms
+step:102/1555 train_time:3606ms step_avg:35.35ms
+step:103/1555 train_time:3637ms step_avg:35.31ms
+step:104/1555 train_time:3676ms step_avg:35.35ms
+step:105/1555 train_time:3707ms step_avg:35.31ms
+step:106/1555 train_time:3745ms step_avg:35.33ms
+step:107/1555 train_time:3777ms step_avg:35.30ms
+step:108/1555 train_time:3815ms step_avg:35.33ms
+step:109/1555 train_time:3847ms step_avg:35.29ms
+step:110/1555 train_time:3884ms step_avg:35.31ms
+step:111/1555 train_time:3916ms step_avg:35.28ms
+step:112/1555 train_time:3955ms step_avg:35.31ms
+step:113/1555 train_time:3986ms step_avg:35.27ms
+step:114/1555 train_time:4024ms step_avg:35.30ms
+step:115/1555 train_time:4055ms step_avg:35.26ms
+step:116/1555 train_time:4093ms step_avg:35.29ms
+step:117/1555 train_time:4125ms step_avg:35.25ms
+step:118/1555 train_time:4163ms step_avg:35.28ms
+step:119/1555 train_time:4194ms step_avg:35.24ms
+step:120/1555 train_time:4232ms step_avg:35.27ms
+step:121/1555 train_time:4263ms step_avg:35.23ms
+step:122/1555 train_time:4301ms step_avg:35.26ms
+step:123/1555 train_time:4333ms step_avg:35.22ms
+step:124/1555 train_time:4371ms step_avg:35.25ms
+step:125/1555 train_time:4402ms step_avg:35.22ms
+step:126/1555 train_time:4440ms step_avg:35.24ms
+step:127/1555 train_time:4472ms step_avg:35.21ms
+step:128/1555 train_time:4510ms step_avg:35.23ms
+step:129/1555 train_time:4541ms step_avg:35.20ms
+step:130/1555 train_time:4579ms step_avg:35.23ms
+step:131/1555 train_time:4611ms step_avg:35.20ms
+step:132/1555 train_time:4649ms step_avg:35.22ms
+step:133/1555 train_time:4680ms step_avg:35.19ms
+step:134/1555 train_time:4718ms step_avg:35.21ms
+step:135/1555 train_time:4750ms step_avg:35.18ms
+step:136/1555 train_time:4788ms step_avg:35.20ms
+step:137/1555 train_time:4819ms step_avg:35.18ms
+step:138/1555 train_time:4858ms step_avg:35.20ms
+step:139/1555 train_time:4890ms step_avg:35.18ms
+step:140/1555 train_time:4927ms step_avg:35.20ms
+step:141/1555 train_time:4959ms step_avg:35.17ms
+step:142/1555 train_time:4997ms step_avg:35.19ms
+step:143/1555 train_time:5028ms step_avg:35.16ms
+step:144/1555 train_time:5066ms step_avg:35.18ms
+step:145/1555 train_time:5097ms step_avg:35.16ms
+step:146/1555 train_time:5135ms step_avg:35.17ms
+step:147/1555 train_time:5167ms step_avg:35.15ms
+step:148/1555 train_time:5205ms step_avg:35.17ms
+step:149/1555 train_time:5237ms step_avg:35.15ms
+step:150/1555 train_time:5276ms step_avg:35.17ms
+step:151/1555 train_time:5307ms step_avg:35.15ms
+step:152/1555 train_time:5345ms step_avg:35.17ms
+step:153/1555 train_time:5377ms step_avg:35.14ms
+step:154/1555 train_time:5415ms step_avg:35.16ms
+step:155/1555 train_time:5446ms step_avg:35.14ms
+step:156/1555 train_time:5484ms step_avg:35.16ms
+step:157/1555 train_time:5516ms step_avg:35.13ms
+step:158/1555 train_time:5555ms step_avg:35.16ms
+step:159/1555 train_time:5586ms step_avg:35.13ms
+step:160/1555 train_time:5624ms step_avg:35.15ms
+step:161/1555 train_time:5655ms step_avg:35.13ms
+step:162/1555 train_time:5694ms step_avg:35.15ms
+step:163/1555 train_time:5725ms step_avg:35.12ms
+step:164/1555 train_time:5763ms step_avg:35.14ms
+step:165/1555 train_time:5795ms step_avg:35.12ms
+step:166/1555 train_time:5833ms step_avg:35.14ms
+step:167/1555 train_time:5864ms step_avg:35.12ms
+step:168/1555 train_time:5902ms step_avg:35.13ms
+step:169/1555 train_time:5934ms step_avg:35.11ms
+step:170/1555 train_time:5972ms step_avg:35.13ms
+step:171/1555 train_time:6004ms step_avg:35.11ms
+step:172/1555 train_time:6042ms step_avg:35.13ms
+step:173/1555 train_time:6073ms step_avg:35.11ms
+step:174/1555 train_time:6111ms step_avg:35.12ms
+step:175/1555 train_time:6143ms step_avg:35.10ms
+step:176/1555 train_time:6181ms step_avg:35.12ms
+step:177/1555 train_time:6212ms step_avg:35.10ms
+step:178/1555 train_time:6250ms step_avg:35.11ms
+step:179/1555 train_time:6282ms step_avg:35.09ms
+step:180/1555 train_time:6320ms step_avg:35.11ms
+step:181/1555 train_time:6351ms step_avg:35.09ms
+step:182/1555 train_time:6389ms step_avg:35.10ms
+step:183/1555 train_time:6420ms step_avg:35.08ms
+step:184/1555 train_time:6458ms step_avg:35.10ms
+step:185/1555 train_time:6490ms step_avg:35.08ms
+step:186/1555 train_time:6528ms step_avg:35.09ms
+step:187/1555 train_time:6559ms step_avg:35.07ms
+step:188/1555 train_time:6597ms step_avg:35.09ms
+step:189/1555 train_time:6628ms step_avg:35.07ms
+step:190/1555 train_time:6666ms step_avg:35.09ms
+step:191/1555 train_time:6698ms step_avg:35.07ms
+step:192/1555 train_time:6736ms step_avg:35.08ms
+step:193/1555 train_time:6767ms step_avg:35.06ms
+step:194/1555 train_time:6805ms step_avg:35.08ms
+step:195/1555 train_time:6837ms step_avg:35.06ms
+step:196/1555 train_time:6875ms step_avg:35.08ms
+step:197/1555 train_time:6907ms step_avg:35.06ms
+step:198/1555 train_time:6944ms step_avg:35.07ms
+step:199/1555 train_time:6976ms step_avg:35.05ms
+step:200/1555 train_time:7014ms step_avg:35.07ms
+step:201/1555 train_time:7046ms step_avg:35.05ms
+step:202/1555 train_time:7084ms step_avg:35.07ms
+step:203/1555 train_time:7115ms step_avg:35.05ms
+step:204/1555 train_time:7154ms step_avg:35.07ms
+step:205/1555 train_time:7185ms step_avg:35.05ms
+step:206/1555 train_time:7223ms step_avg:35.06ms
+step:207/1555 train_time:7254ms step_avg:35.04ms
+step:208/1555 train_time:7292ms step_avg:35.06ms
+step:209/1555 train_time:7323ms step_avg:35.04ms
+step:210/1555 train_time:7362ms step_avg:35.06ms
+step:211/1555 train_time:7393ms step_avg:35.04ms
+step:212/1555 train_time:7431ms step_avg:35.05ms
+step:213/1555 train_time:7462ms step_avg:35.03ms
+step:214/1555 train_time:7500ms step_avg:35.05ms
+step:215/1555 train_time:7531ms step_avg:35.03ms
+step:216/1555 train_time:7569ms step_avg:35.04ms
+step:217/1555 train_time:7600ms step_avg:35.02ms
+step:218/1555 train_time:7639ms step_avg:35.04ms
+step:219/1555 train_time:7670ms step_avg:35.02ms
+step:220/1555 train_time:7708ms step_avg:35.04ms
+step:221/1555 train_time:7739ms step_avg:35.02ms
+step:222/1555 train_time:7777ms step_avg:35.03ms
+step:223/1555 train_time:7809ms step_avg:35.02ms
+step:224/1555 train_time:7847ms step_avg:35.03ms
+step:225/1555 train_time:7878ms step_avg:35.01ms
+step:226/1555 train_time:7916ms step_avg:35.03ms
+step:227/1555 train_time:7948ms step_avg:35.01ms
+step:228/1555 train_time:7986ms step_avg:35.03ms
+step:229/1555 train_time:8017ms step_avg:35.01ms
+step:230/1555 train_time:8056ms step_avg:35.03ms
+step:231/1555 train_time:8087ms step_avg:35.01ms
+step:232/1555 train_time:8125ms step_avg:35.02ms
+step:233/1555 train_time:8157ms step_avg:35.01ms
+step:234/1555 train_time:8195ms step_avg:35.02ms
+step:235/1555 train_time:8226ms step_avg:35.01ms
+step:236/1555 train_time:8264ms step_avg:35.02ms
+step:237/1555 train_time:8296ms step_avg:35.00ms
+step:238/1555 train_time:8334ms step_avg:35.01ms
+step:239/1555 train_time:8365ms step_avg:35.00ms
+step:240/1555 train_time:8403ms step_avg:35.01ms
+step:241/1555 train_time:8434ms step_avg:35.00ms
+step:242/1555 train_time:8473ms step_avg:35.01ms
+step:243/1555 train_time:8504ms step_avg:35.00ms
+step:244/1555 train_time:8542ms step_avg:35.01ms
+step:245/1555 train_time:8573ms step_avg:34.99ms
+step:246/1555 train_time:8611ms step_avg:35.01ms
+step:247/1555 train_time:8642ms step_avg:34.99ms
+step:248/1555 train_time:8680ms step_avg:35.00ms
+step:249/1555 train_time:8712ms step_avg:34.99ms
+step:250/1555 train_time:8750ms step_avg:35.00ms
+step:250/1555 val_loss:4.5563 train_time:8798ms step_avg:35.19ms
+step:251/1555 train_time:8817ms step_avg:35.13ms
+step:252/1555 train_time:8835ms step_avg:35.06ms
+step:253/1555 train_time:8854ms step_avg:35.00ms
+step:254/1555 train_time:8892ms step_avg:35.01ms
+step:255/1555 train_time:8924ms step_avg:35.00ms
+step:256/1555 train_time:8964ms step_avg:35.01ms
+step:257/1555 train_time:8995ms step_avg:35.00ms
+step:258/1555 train_time:9034ms step_avg:35.01ms
+step:259/1555 train_time:9065ms step_avg:35.00ms
+step:260/1555 train_time:9103ms step_avg:35.01ms
+step:261/1555 train_time:9135ms step_avg:35.00ms
+step:262/1555 train_time:9173ms step_avg:35.01ms
+step:263/1555 train_time:9204ms step_avg:35.00ms
+step:264/1555 train_time:9243ms step_avg:35.01ms
+step:265/1555 train_time:9274ms step_avg:35.00ms
+step:266/1555 train_time:9312ms step_avg:35.01ms
+step:267/1555 train_time:9343ms step_avg:34.99ms
+step:268/1555 train_time:9382ms step_avg:35.01ms
+step:269/1555 train_time:9413ms step_avg:34.99ms
+step:270/1555 train_time:9451ms step_avg:35.00ms
+step:271/1555 train_time:9482ms step_avg:34.99ms
+step:272/1555 train_time:9521ms step_avg:35.00ms
+step:273/1555 train_time:9552ms step_avg:34.99ms
+step:274/1555 train_time:9590ms step_avg:35.00ms
+step:275/1555 train_time:9621ms step_avg:34.99ms
+step:276/1555 train_time:9659ms step_avg:35.00ms
+step:277/1555 train_time:9691ms step_avg:34.98ms
+step:278/1555 train_time:9729ms step_avg:35.00ms
+step:279/1555 train_time:9760ms step_avg:34.98ms
+step:280/1555 train_time:9798ms step_avg:34.99ms
+step:281/1555 train_time:9829ms step_avg:34.98ms
+step:282/1555 train_time:9867ms step_avg:34.99ms
+step:283/1555 train_time:9899ms step_avg:34.98ms
+step:284/1555 train_time:9937ms step_avg:34.99ms
+step:285/1555 train_time:9968ms step_avg:34.98ms
+step:286/1555 train_time:10006ms step_avg:34.99ms
+step:287/1555 train_time:10037ms step_avg:34.97ms
+step:288/1555 train_time:10076ms step_avg:34.98ms
+step:289/1555 train_time:10107ms step_avg:34.97ms
+step:290/1555 train_time:10145ms step_avg:34.98ms
+step:291/1555 train_time:10176ms step_avg:34.97ms
+step:292/1555 train_time:10214ms step_avg:34.98ms
+step:293/1555 train_time:10245ms step_avg:34.97ms
+step:294/1555 train_time:10284ms step_avg:34.98ms
+step:295/1555 train_time:10315ms step_avg:34.97ms
+step:296/1555 train_time:10353ms step_avg:34.98ms
+step:297/1555 train_time:10384ms step_avg:34.96ms
+step:298/1555 train_time:10423ms step_avg:34.98ms
+step:299/1555 train_time:10454ms step_avg:34.96ms
+step:300/1555 train_time:10492ms step_avg:34.97ms
+step:301/1555 train_time:10523ms step_avg:34.96ms
+step:302/1555 train_time:10562ms step_avg:34.97ms
+step:303/1555 train_time:10593ms step_avg:34.96ms
+step:304/1555 train_time:10631ms step_avg:34.97ms
+step:305/1555 train_time:10663ms step_avg:34.96ms
+step:306/1555 train_time:10701ms step_avg:34.97ms
+step:307/1555 train_time:10733ms step_avg:34.96ms
+step:308/1555 train_time:10770ms step_avg:34.97ms
+step:309/1555 train_time:10802ms step_avg:34.96ms
+step:310/1555 train_time:10840ms step_avg:34.97ms
+step:311/1555 train_time:10871ms step_avg:34.95ms
+step:312/1555 train_time:10909ms step_avg:34.96ms
+step:313/1555 train_time:10941ms step_avg:34.95ms
+step:314/1555 train_time:10980ms step_avg:34.97ms
+step:315/1555 train_time:11011ms step_avg:34.95ms
+step:316/1555 train_time:11049ms step_avg:34.96ms
+step:317/1555 train_time:11080ms step_avg:34.95ms
+step:318/1555 train_time:11118ms step_avg:34.96ms
+step:319/1555 train_time:11149ms step_avg:34.95ms
+step:320/1555 train_time:11188ms step_avg:34.96ms
+step:321/1555 train_time:11219ms step_avg:34.95ms
+step:322/1555 train_time:11257ms step_avg:34.96ms
+step:323/1555 train_time:11288ms step_avg:34.95ms
+step:324/1555 train_time:11326ms step_avg:34.96ms
+step:325/1555 train_time:11357ms step_avg:34.95ms
+step:326/1555 train_time:11395ms step_avg:34.96ms
+step:327/1555 train_time:11427ms step_avg:34.94ms
+step:328/1555 train_time:11465ms step_avg:34.95ms
+step:329/1555 train_time:11496ms step_avg:34.94ms
+step:330/1555 train_time:11534ms step_avg:34.95ms
+step:331/1555 train_time:11565ms step_avg:34.94ms
+step:332/1555 train_time:11603ms step_avg:34.95ms
+step:333/1555 train_time:11635ms step_avg:34.94ms
+step:334/1555 train_time:11673ms step_avg:34.95ms
+step:335/1555 train_time:11704ms step_avg:34.94ms
+step:336/1555 train_time:11742ms step_avg:34.95ms
+step:337/1555 train_time:11774ms step_avg:34.94ms
+step:338/1555 train_time:11812ms step_avg:34.95ms
+step:339/1555 train_time:11843ms step_avg:34.94ms
+step:340/1555 train_time:11881ms step_avg:34.95ms
+step:341/1555 train_time:11913ms step_avg:34.94ms
+step:342/1555 train_time:11951ms step_avg:34.94ms
+step:343/1555 train_time:11982ms step_avg:34.93ms
+step:344/1555 train_time:12020ms step_avg:34.94ms
+step:345/1555 train_time:12052ms step_avg:34.93ms
+step:346/1555 train_time:12090ms step_avg:34.94ms
+step:347/1555 train_time:12121ms step_avg:34.93ms
+step:348/1555 train_time:12159ms step_avg:34.94ms
+step:349/1555 train_time:12190ms step_avg:34.93ms
+step:350/1555 train_time:12228ms step_avg:34.94ms
+step:351/1555 train_time:12259ms step_avg:34.93ms
+step:352/1555 train_time:12297ms step_avg:34.94ms
+step:353/1555 train_time:12329ms step_avg:34.93ms
+step:354/1555 train_time:12367ms step_avg:34.93ms
+step:355/1555 train_time:12398ms step_avg:34.92ms
+step:356/1555 train_time:12436ms step_avg:34.93ms
+step:357/1555 train_time:12467ms step_avg:34.92ms
+step:358/1555 train_time:12505ms step_avg:34.93ms
+step:359/1555 train_time:12536ms step_avg:34.92ms
+step:360/1555 train_time:12574ms step_avg:34.93ms
+step:361/1555 train_time:12606ms step_avg:34.92ms
+step:362/1555 train_time:12644ms step_avg:34.93ms
+step:363/1555 train_time:12675ms step_avg:34.92ms
+step:364/1555 train_time:12713ms step_avg:34.93ms
+step:365/1555 train_time:12744ms step_avg:34.92ms
+step:366/1555 train_time:12783ms step_avg:34.93ms
+step:367/1555 train_time:12814ms step_avg:34.92ms
+step:368/1555 train_time:12852ms step_avg:34.92ms
+step:369/1555 train_time:12883ms step_avg:34.91ms
+step:370/1555 train_time:12921ms step_avg:34.92ms
+step:371/1555 train_time:12953ms step_avg:34.91ms
+step:372/1555 train_time:12991ms step_avg:34.92ms
+step:373/1555 train_time:13022ms step_avg:34.91ms
+step:374/1555 train_time:13060ms step_avg:34.92ms
+step:375/1555 train_time:13092ms step_avg:34.91ms
+step:376/1555 train_time:13130ms step_avg:34.92ms
+step:377/1555 train_time:13161ms step_avg:34.91ms
+step:378/1555 train_time:13199ms step_avg:34.92ms
+step:379/1555 train_time:13230ms step_avg:34.91ms
+step:380/1555 train_time:13268ms step_avg:34.92ms
+step:381/1555 train_time:13299ms step_avg:34.91ms
+step:382/1555 train_time:13337ms step_avg:34.91ms
+step:383/1555 train_time:13369ms step_avg:34.90ms
+step:384/1555 train_time:13407ms step_avg:34.91ms
+step:385/1555 train_time:13438ms step_avg:34.90ms
+step:386/1555 train_time:13476ms step_avg:34.91ms
+step:387/1555 train_time:13507ms step_avg:34.90ms
+step:388/1555 train_time:13545ms step_avg:34.91ms
+step:389/1555 train_time:13577ms step_avg:34.90ms
+step:390/1555 train_time:13615ms step_avg:34.91ms
+step:391/1555 train_time:13646ms step_avg:34.90ms
+step:392/1555 train_time:13685ms step_avg:34.91ms
+step:393/1555 train_time:13716ms step_avg:34.90ms
+step:394/1555 train_time:13754ms step_avg:34.91ms
+step:395/1555 train_time:13785ms step_avg:34.90ms
+step:396/1555 train_time:13823ms step_avg:34.91ms
+step:397/1555 train_time:13854ms step_avg:34.90ms
+step:398/1555 train_time:13892ms step_avg:34.90ms
+step:399/1555 train_time:13923ms step_avg:34.90ms
+step:400/1555 train_time:13962ms step_avg:34.90ms
+step:401/1555 train_time:13993ms step_avg:34.90ms
+step:402/1555 train_time:14031ms step_avg:34.90ms
+step:403/1555 train_time:14062ms step_avg:34.89ms
+step:404/1555 train_time:14101ms step_avg:34.90ms
+step:405/1555 train_time:14132ms step_avg:34.89ms
+step:406/1555 train_time:14170ms step_avg:34.90ms
+step:407/1555 train_time:14202ms step_avg:34.89ms
+step:408/1555 train_time:14241ms step_avg:34.90ms
+step:409/1555 train_time:14273ms step_avg:34.90ms
+step:410/1555 train_time:14311ms step_avg:34.90ms
+step:411/1555 train_time:14342ms step_avg:34.90ms
+step:412/1555 train_time:14381ms step_avg:34.91ms
+step:413/1555 train_time:14412ms step_avg:34.90ms
+step:414/1555 train_time:14450ms step_avg:34.90ms
+step:415/1555 train_time:14482ms step_avg:34.90ms
+step:416/1555 train_time:14521ms step_avg:34.91ms
+step:417/1555 train_time:14553ms step_avg:34.90ms
+step:418/1555 train_time:14591ms step_avg:34.91ms
+step:419/1555 train_time:14622ms step_avg:34.90ms
+step:420/1555 train_time:14661ms step_avg:34.91ms
+step:421/1555 train_time:14693ms step_avg:34.90ms
+step:422/1555 train_time:14731ms step_avg:34.91ms
+step:423/1555 train_time:14762ms step_avg:34.90ms
+step:424/1555 train_time:14800ms step_avg:34.91ms
+step:425/1555 train_time:14832ms step_avg:34.90ms
+step:426/1555 train_time:14870ms step_avg:34.91ms
+step:427/1555 train_time:14901ms step_avg:34.90ms
+step:428/1555 train_time:14939ms step_avg:34.90ms
+step:429/1555 train_time:14971ms step_avg:34.90ms
+step:430/1555 train_time:15009ms step_avg:34.90ms
+step:431/1555 train_time:15040ms step_avg:34.90ms
+step:432/1555 train_time:15078ms step_avg:34.90ms
+step:433/1555 train_time:15109ms step_avg:34.89ms
+step:434/1555 train_time:15147ms step_avg:34.90ms
+step:435/1555 train_time:15178ms step_avg:34.89ms
+step:436/1555 train_time:15216ms step_avg:34.90ms
+step:437/1555 train_time:15247ms step_avg:34.89ms
+step:438/1555 train_time:15285ms step_avg:34.90ms
+step:439/1555 train_time:15317ms step_avg:34.89ms
+step:440/1555 train_time:15355ms step_avg:34.90ms
+step:441/1555 train_time:15386ms step_avg:34.89ms
+step:442/1555 train_time:15424ms step_avg:34.90ms
+step:443/1555 train_time:15455ms step_avg:34.89ms
+step:444/1555 train_time:15493ms step_avg:34.89ms
+step:445/1555 train_time:15524ms step_avg:34.89ms
+step:446/1555 train_time:15562ms step_avg:34.89ms
+step:447/1555 train_time:15594ms step_avg:34.89ms
+step:448/1555 train_time:15632ms step_avg:34.89ms
+step:449/1555 train_time:15663ms step_avg:34.88ms
+step:450/1555 train_time:15701ms step_avg:34.89ms
+step:451/1555 train_time:15733ms step_avg:34.88ms
+step:452/1555 train_time:15771ms step_avg:34.89ms
+step:453/1555 train_time:15802ms step_avg:34.88ms
+step:454/1555 train_time:15841ms step_avg:34.89ms
+step:455/1555 train_time:15872ms step_avg:34.88ms
+step:456/1555 train_time:15910ms step_avg:34.89ms
+step:457/1555 train_time:15941ms step_avg:34.88ms
+step:458/1555 train_time:15979ms step_avg:34.89ms
+step:459/1555 train_time:16011ms step_avg:34.88ms
+step:460/1555 train_time:16048ms step_avg:34.89ms
+step:461/1555 train_time:16080ms step_avg:34.88ms
+step:462/1555 train_time:16118ms step_avg:34.89ms
+step:463/1555 train_time:16150ms step_avg:34.88ms
+step:464/1555 train_time:16188ms step_avg:34.89ms
+step:465/1555 train_time:16219ms step_avg:34.88ms
+step:466/1555 train_time:16257ms step_avg:34.89ms
+step:467/1555 train_time:16288ms step_avg:34.88ms
+step:468/1555 train_time:16327ms step_avg:34.89ms
+step:469/1555 train_time:16358ms step_avg:34.88ms
+step:470/1555 train_time:16396ms step_avg:34.88ms
+step:471/1555 train_time:16427ms step_avg:34.88ms
+step:472/1555 train_time:16465ms step_avg:34.88ms
+step:473/1555 train_time:16497ms step_avg:34.88ms
+step:474/1555 train_time:16535ms step_avg:34.88ms
+step:475/1555 train_time:16566ms step_avg:34.88ms
+step:476/1555 train_time:16604ms step_avg:34.88ms
+step:477/1555 train_time:16635ms step_avg:34.87ms
+step:478/1555 train_time:16673ms step_avg:34.88ms
+step:479/1555 train_time:16705ms step_avg:34.87ms
+step:480/1555 train_time:16743ms step_avg:34.88ms
+step:481/1555 train_time:16774ms step_avg:34.87ms
+step:482/1555 train_time:16812ms step_avg:34.88ms
+step:483/1555 train_time:16843ms step_avg:34.87ms
+step:484/1555 train_time:16882ms step_avg:34.88ms
+step:485/1555 train_time:16913ms step_avg:34.87ms
+step:486/1555 train_time:16951ms step_avg:34.88ms
+step:487/1555 train_time:16982ms step_avg:34.87ms
+step:488/1555 train_time:17021ms step_avg:34.88ms
+step:489/1555 train_time:17052ms step_avg:34.87ms
+step:490/1555 train_time:17090ms step_avg:34.88ms
+step:491/1555 train_time:17121ms step_avg:34.87ms
+step:492/1555 train_time:17159ms step_avg:34.88ms
+step:493/1555 train_time:17191ms step_avg:34.87ms
+step:494/1555 train_time:17229ms step_avg:34.88ms
+step:495/1555 train_time:17260ms step_avg:34.87ms
+step:496/1555 train_time:17298ms step_avg:34.87ms
+step:497/1555 train_time:17329ms step_avg:34.87ms
+step:498/1555 train_time:17367ms step_avg:34.87ms
+step:499/1555 train_time:17398ms step_avg:34.87ms
+step:500/1555 train_time:17436ms step_avg:34.87ms
+step:500/1555 val_loss:4.2252 train_time:17485ms step_avg:34.97ms
+step:501/1555 train_time:17503ms step_avg:34.94ms
+step:502/1555 train_time:17520ms step_avg:34.90ms
+step:503/1555 train_time:17540ms step_avg:34.87ms
+step:504/1555 train_time:17578ms step_avg:34.88ms
+step:505/1555 train_time:17611ms step_avg:34.87ms
+step:506/1555 train_time:17688ms step_avg:34.96ms
+step:507/1555 train_time:17747ms step_avg:35.00ms
+step:508/1555 train_time:17806ms step_avg:35.05ms
+step:509/1555 train_time:17868ms step_avg:35.11ms
+step:510/1555 train_time:17928ms step_avg:35.15ms
+step:511/1555 train_time:17992ms step_avg:35.21ms
+step:512/1555 train_time:18050ms step_avg:35.25ms
+step:513/1555 train_time:18113ms step_avg:35.31ms
+step:514/1555 train_time:18172ms step_avg:35.35ms
+step:515/1555 train_time:18234ms step_avg:35.41ms
+step:516/1555 train_time:18293ms step_avg:35.45ms
+step:517/1555 train_time:18356ms step_avg:35.50ms
+step:518/1555 train_time:18414ms step_avg:35.55ms
+step:519/1555 train_time:18479ms step_avg:35.60ms
+step:520/1555 train_time:18539ms step_avg:35.65ms
+step:521/1555 train_time:18605ms step_avg:35.71ms
+step:522/1555 train_time:18665ms step_avg:35.76ms
+step:523/1555 train_time:18729ms step_avg:35.81ms
+step:524/1555 train_time:18788ms step_avg:35.86ms
+step:525/1555 train_time:18852ms step_avg:35.91ms
+step:526/1555 train_time:18911ms step_avg:35.95ms
+step:527/1555 train_time:18974ms step_avg:36.00ms
+step:528/1555 train_time:19033ms step_avg:36.05ms
+step:529/1555 train_time:19096ms step_avg:36.10ms
+step:530/1555 train_time:19155ms step_avg:36.14ms
+step:531/1555 train_time:19219ms step_avg:36.19ms
+step:532/1555 train_time:19277ms step_avg:36.23ms
+step:533/1555 train_time:19339ms step_avg:36.28ms
+step:534/1555 train_time:19398ms step_avg:36.33ms
+step:535/1555 train_time:19462ms step_avg:36.38ms
+step:536/1555 train_time:19522ms step_avg:36.42ms
+step:537/1555 train_time:19585ms step_avg:36.47ms
+step:538/1555 train_time:19645ms step_avg:36.52ms
+step:539/1555 train_time:19709ms step_avg:36.57ms
+step:540/1555 train_time:19769ms step_avg:36.61ms
+step:541/1555 train_time:19833ms step_avg:36.66ms
+step:542/1555 train_time:19891ms step_avg:36.70ms
+step:543/1555 train_time:19954ms step_avg:36.75ms
+step:544/1555 train_time:20013ms step_avg:36.79ms
+step:545/1555 train_time:20077ms step_avg:36.84ms
+step:546/1555 train_time:20135ms step_avg:36.88ms
+step:547/1555 train_time:20199ms step_avg:36.93ms
+step:548/1555 train_time:20258ms step_avg:36.97ms
+step:549/1555 train_time:20321ms step_avg:37.01ms
+step:550/1555 train_time:20379ms step_avg:37.05ms
+step:551/1555 train_time:20443ms step_avg:37.10ms
+step:552/1555 train_time:20502ms step_avg:37.14ms
+step:553/1555 train_time:20565ms step_avg:37.19ms
+step:554/1555 train_time:20624ms step_avg:37.23ms
+step:555/1555 train_time:20688ms step_avg:37.27ms
+step:556/1555 train_time:20747ms step_avg:37.32ms
+step:557/1555 train_time:20811ms step_avg:37.36ms
+step:558/1555 train_time:20870ms step_avg:37.40ms
+step:559/1555 train_time:20934ms step_avg:37.45ms
+step:560/1555 train_time:20993ms step_avg:37.49ms
+step:561/1555 train_time:21057ms step_avg:37.53ms
+step:562/1555 train_time:21116ms step_avg:37.57ms
+step:563/1555 train_time:21178ms step_avg:37.62ms
+step:564/1555 train_time:21237ms step_avg:37.65ms
+step:565/1555 train_time:21300ms step_avg:37.70ms
+step:566/1555 train_time:21365ms step_avg:37.75ms
+step:567/1555 train_time:21426ms step_avg:37.79ms
+step:568/1555 train_time:21483ms step_avg:37.82ms
+step:569/1555 train_time:21546ms step_avg:37.87ms
+step:570/1555 train_time:21605ms step_avg:37.90ms
+step:571/1555 train_time:21669ms step_avg:37.95ms
+step:572/1555 train_time:21728ms step_avg:37.99ms
+step:573/1555 train_time:21792ms step_avg:38.03ms
+step:574/1555 train_time:21852ms step_avg:38.07ms
+step:575/1555 train_time:21915ms step_avg:38.11ms
+step:576/1555 train_time:21975ms step_avg:38.15ms
+step:577/1555 train_time:22038ms step_avg:38.19ms
+step:578/1555 train_time:22097ms step_avg:38.23ms
+step:579/1555 train_time:22161ms step_avg:38.27ms
+step:580/1555 train_time:22220ms step_avg:38.31ms
+step:581/1555 train_time:22283ms step_avg:38.35ms
+step:582/1555 train_time:22342ms step_avg:38.39ms
+step:583/1555 train_time:22406ms step_avg:38.43ms
+step:584/1555 train_time:22465ms step_avg:38.47ms
+step:585/1555 train_time:22528ms step_avg:38.51ms
+step:586/1555 train_time:22588ms step_avg:38.55ms
+step:587/1555 train_time:22651ms step_avg:38.59ms
+step:588/1555 train_time:22710ms step_avg:38.62ms
+step:589/1555 train_time:22774ms step_avg:38.66ms
+step:590/1555 train_time:22833ms step_avg:38.70ms
+step:591/1555 train_time:22897ms step_avg:38.74ms
+step:592/1555 train_time:22958ms step_avg:38.78ms
+step:593/1555 train_time:23020ms step_avg:38.82ms
+step:594/1555 train_time:23079ms step_avg:38.85ms
+step:595/1555 train_time:23142ms step_avg:38.89ms
+step:596/1555 train_time:23201ms step_avg:38.93ms
+step:597/1555 train_time:23264ms step_avg:38.97ms
+step:598/1555 train_time:23323ms step_avg:39.00ms
+step:599/1555 train_time:23387ms step_avg:39.04ms
+step:600/1555 train_time:23446ms step_avg:39.08ms
+step:601/1555 train_time:23511ms step_avg:39.12ms
+step:602/1555 train_time:23570ms step_avg:39.15ms
+step:603/1555 train_time:23633ms step_avg:39.19ms
+step:604/1555 train_time:23692ms step_avg:39.23ms
+step:605/1555 train_time:23756ms step_avg:39.27ms
+step:606/1555 train_time:23816ms step_avg:39.30ms
+step:607/1555 train_time:23879ms step_avg:39.34ms
+step:608/1555 train_time:23939ms step_avg:39.37ms
+step:609/1555 train_time:24002ms step_avg:39.41ms
+step:610/1555 train_time:24061ms step_avg:39.44ms
+step:611/1555 train_time:24125ms step_avg:39.48ms
+step:612/1555 train_time:24184ms step_avg:39.52ms
+step:613/1555 train_time:24247ms step_avg:39.55ms
+step:614/1555 train_time:24306ms step_avg:39.59ms
+step:615/1555 train_time:24369ms step_avg:39.63ms
+step:616/1555 train_time:24429ms step_avg:39.66ms
+step:617/1555 train_time:24492ms step_avg:39.70ms
+step:618/1555 train_time:24551ms step_avg:39.73ms
+step:619/1555 train_time:24614ms step_avg:39.76ms
+step:620/1555 train_time:24673ms step_avg:39.80ms
+step:621/1555 train_time:24737ms step_avg:39.83ms
+step:622/1555 train_time:24796ms step_avg:39.86ms
+step:623/1555 train_time:24859ms step_avg:39.90ms
+step:624/1555 train_time:24919ms step_avg:39.93ms
+step:625/1555 train_time:24982ms step_avg:39.97ms
+step:626/1555 train_time:25041ms step_avg:40.00ms
+step:627/1555 train_time:25105ms step_avg:40.04ms
+step:628/1555 train_time:25165ms step_avg:40.07ms
+step:629/1555 train_time:25228ms step_avg:40.11ms
+step:630/1555 train_time:25288ms step_avg:40.14ms
+step:631/1555 train_time:25351ms step_avg:40.18ms
+step:632/1555 train_time:25412ms step_avg:40.21ms
+step:633/1555 train_time:25475ms step_avg:40.24ms
+step:634/1555 train_time:25534ms step_avg:40.27ms
+step:635/1555 train_time:25597ms step_avg:40.31ms
+step:636/1555 train_time:25656ms step_avg:40.34ms
+step:637/1555 train_time:25720ms step_avg:40.38ms
+step:638/1555 train_time:25779ms step_avg:40.41ms
+step:639/1555 train_time:25842ms step_avg:40.44ms
+step:640/1555 train_time:25902ms step_avg:40.47ms
+step:641/1555 train_time:25966ms step_avg:40.51ms
+step:642/1555 train_time:26025ms step_avg:40.54ms
+step:643/1555 train_time:26088ms step_avg:40.57ms
+step:644/1555 train_time:26147ms step_avg:40.60ms
+step:645/1555 train_time:26211ms step_avg:40.64ms
+step:646/1555 train_time:26270ms step_avg:40.67ms
+step:647/1555 train_time:26333ms step_avg:40.70ms
+step:648/1555 train_time:26393ms step_avg:40.73ms
+step:649/1555 train_time:26456ms step_avg:40.76ms
+step:650/1555 train_time:26515ms step_avg:40.79ms
+step:651/1555 train_time:26579ms step_avg:40.83ms
+step:652/1555 train_time:26638ms step_avg:40.86ms
+step:653/1555 train_time:26702ms step_avg:40.89ms
+step:654/1555 train_time:26762ms step_avg:40.92ms
+step:655/1555 train_time:26826ms step_avg:40.96ms
+step:656/1555 train_time:26886ms step_avg:40.98ms
+step:657/1555 train_time:26950ms step_avg:41.02ms
+step:658/1555 train_time:27009ms step_avg:41.05ms
+step:659/1555 train_time:27072ms step_avg:41.08ms
+step:660/1555 train_time:27131ms step_avg:41.11ms
+step:661/1555 train_time:27196ms step_avg:41.14ms
+step:662/1555 train_time:27255ms step_avg:41.17ms
+step:663/1555 train_time:27318ms step_avg:41.20ms
+step:664/1555 train_time:27377ms step_avg:41.23ms
+step:665/1555 train_time:27440ms step_avg:41.26ms
+step:666/1555 train_time:27499ms step_avg:41.29ms
+step:667/1555 train_time:27563ms step_avg:41.32ms
+step:668/1555 train_time:27623ms step_avg:41.35ms
+step:669/1555 train_time:27687ms step_avg:41.39ms
+step:670/1555 train_time:27747ms step_avg:41.41ms
+step:671/1555 train_time:27810ms step_avg:41.45ms
+step:672/1555 train_time:27869ms step_avg:41.47ms
+step:673/1555 train_time:27932ms step_avg:41.50ms
+step:674/1555 train_time:27991ms step_avg:41.53ms
+step:675/1555 train_time:28055ms step_avg:41.56ms
+step:676/1555 train_time:28114ms step_avg:41.59ms
+step:677/1555 train_time:28178ms step_avg:41.62ms
+step:678/1555 train_time:28237ms step_avg:41.65ms
+step:679/1555 train_time:28300ms step_avg:41.68ms
+step:680/1555 train_time:28359ms step_avg:41.70ms
+step:681/1555 train_time:28423ms step_avg:41.74ms
+step:682/1555 train_time:28482ms step_avg:41.76ms
+step:683/1555 train_time:28546ms step_avg:41.79ms
+step:684/1555 train_time:28607ms step_avg:41.82ms
+step:685/1555 train_time:28670ms step_avg:41.85ms
+step:686/1555 train_time:28729ms step_avg:41.88ms
+step:687/1555 train_time:28793ms step_avg:41.91ms
+step:688/1555 train_time:28852ms step_avg:41.94ms
+step:689/1555 train_time:28915ms step_avg:41.97ms
+step:690/1555 train_time:28974ms step_avg:41.99ms
+step:691/1555 train_time:29037ms step_avg:42.02ms
+step:692/1555 train_time:29096ms step_avg:42.05ms
+step:693/1555 train_time:29160ms step_avg:42.08ms
+step:694/1555 train_time:29220ms step_avg:42.10ms
+step:695/1555 train_time:29284ms step_avg:42.13ms
+step:696/1555 train_time:29343ms step_avg:42.16ms
+step:697/1555 train_time:29406ms step_avg:42.19ms
+step:698/1555 train_time:29465ms step_avg:42.21ms
+step:699/1555 train_time:29529ms step_avg:42.24ms
+step:700/1555 train_time:29588ms step_avg:42.27ms
+step:701/1555 train_time:29652ms step_avg:42.30ms
+step:702/1555 train_time:29712ms step_avg:42.32ms
+step:703/1555 train_time:29774ms step_avg:42.35ms
+step:704/1555 train_time:29833ms step_avg:42.38ms
+step:705/1555 train_time:29897ms step_avg:42.41ms
+step:706/1555 train_time:29956ms step_avg:42.43ms
+step:707/1555 train_time:30020ms step_avg:42.46ms
+step:708/1555 train_time:30079ms step_avg:42.48ms
+step:709/1555 train_time:30142ms step_avg:42.51ms
+step:710/1555 train_time:30201ms step_avg:42.54ms
+step:711/1555 train_time:30266ms step_avg:42.57ms
+step:712/1555 train_time:30325ms step_avg:42.59ms
+step:713/1555 train_time:30389ms step_avg:42.62ms
+step:714/1555 train_time:30448ms step_avg:42.64ms
+step:715/1555 train_time:30511ms step_avg:42.67ms
+step:716/1555 train_time:30571ms step_avg:42.70ms
+step:717/1555 train_time:30634ms step_avg:42.72ms
+step:718/1555 train_time:30693ms step_avg:42.75ms
+step:719/1555 train_time:30756ms step_avg:42.78ms
+step:720/1555 train_time:30815ms step_avg:42.80ms
+step:721/1555 train_time:30879ms step_avg:42.83ms
+step:722/1555 train_time:30939ms step_avg:42.85ms
+step:723/1555 train_time:31003ms step_avg:42.88ms
+step:724/1555 train_time:31062ms step_avg:42.90ms
+step:725/1555 train_time:31125ms step_avg:42.93ms
+step:726/1555 train_time:31184ms step_avg:42.95ms
+step:727/1555 train_time:31248ms step_avg:42.98ms
+step:728/1555 train_time:31307ms step_avg:43.00ms
+step:729/1555 train_time:31370ms step_avg:43.03ms
+step:730/1555 train_time:31429ms step_avg:43.05ms
+step:731/1555 train_time:31493ms step_avg:43.08ms
+step:732/1555 train_time:31552ms step_avg:43.10ms
+step:733/1555 train_time:31616ms step_avg:43.13ms
+step:734/1555 train_time:31676ms step_avg:43.16ms
+step:735/1555 train_time:31739ms step_avg:43.18ms
+step:736/1555 train_time:31798ms step_avg:43.20ms
+step:737/1555 train_time:31862ms step_avg:43.23ms
+step:738/1555 train_time:31921ms step_avg:43.25ms
+step:739/1555 train_time:31984ms step_avg:43.28ms
+step:740/1555 train_time:32043ms step_avg:43.30ms
+step:741/1555 train_time:32107ms step_avg:43.33ms
+step:742/1555 train_time:32166ms step_avg:43.35ms
+step:743/1555 train_time:32229ms step_avg:43.38ms
+step:744/1555 train_time:32288ms step_avg:43.40ms
+step:745/1555 train_time:32352ms step_avg:43.43ms
+step:746/1555 train_time:32412ms step_avg:43.45ms
+step:747/1555 train_time:32475ms step_avg:43.47ms
+step:748/1555 train_time:32534ms step_avg:43.49ms
+step:749/1555 train_time:32598ms step_avg:43.52ms
+step:750/1555 train_time:32657ms step_avg:43.54ms
+step:750/1555 val_loss:3.8759 train_time:32706ms step_avg:43.61ms
+step:751/1555 train_time:32724ms step_avg:43.57ms
+step:752/1555 train_time:32783ms step_avg:43.59ms
+step:753/1555 train_time:32849ms step_avg:43.62ms
+step:754/1555 train_time:32911ms step_avg:43.65ms
+step:755/1555 train_time:32975ms step_avg:43.68ms
+step:756/1555 train_time:33036ms step_avg:43.70ms
+step:757/1555 train_time:33098ms step_avg:43.72ms
+step:758/1555 train_time:33157ms step_avg:43.74ms
+step:759/1555 train_time:33220ms step_avg:43.77ms
+step:760/1555 train_time:33278ms step_avg:43.79ms
+step:761/1555 train_time:33341ms step_avg:43.81ms
+step:762/1555 train_time:33400ms step_avg:43.83ms
+step:763/1555 train_time:33464ms step_avg:43.86ms
+step:764/1555 train_time:33522ms step_avg:43.88ms
+step:765/1555 train_time:33586ms step_avg:43.90ms
+step:766/1555 train_time:33648ms step_avg:43.93ms
+step:767/1555 train_time:33712ms step_avg:43.95ms
+step:768/1555 train_time:33774ms step_avg:43.98ms
+step:769/1555 train_time:33839ms step_avg:44.00ms
+step:770/1555 train_time:33899ms step_avg:44.03ms
+step:771/1555 train_time:33963ms step_avg:44.05ms
+step:772/1555 train_time:34023ms step_avg:44.07ms
+step:773/1555 train_time:34086ms step_avg:44.10ms
+step:774/1555 train_time:34146ms step_avg:44.12ms
+step:775/1555 train_time:34209ms step_avg:44.14ms
+step:776/1555 train_time:34267ms step_avg:44.16ms
+step:777/1555 train_time:34331ms step_avg:44.18ms
+step:778/1555 train_time:34390ms step_avg:44.20ms
+step:779/1555 train_time:34454ms step_avg:44.23ms
+step:780/1555 train_time:34514ms step_avg:44.25ms
+step:781/1555 train_time:34577ms step_avg:44.27ms
+step:782/1555 train_time:34636ms step_avg:44.29ms
+step:783/1555 train_time:34699ms step_avg:44.32ms
+step:784/1555 train_time:34759ms step_avg:44.34ms
+step:785/1555 train_time:34823ms step_avg:44.36ms
+step:786/1555 train_time:34882ms step_avg:44.38ms
+step:787/1555 train_time:34946ms step_avg:44.40ms
+step:788/1555 train_time:35006ms step_avg:44.42ms
+step:789/1555 train_time:35069ms step_avg:44.45ms
+step:790/1555 train_time:35128ms step_avg:44.47ms
+step:791/1555 train_time:35191ms step_avg:44.49ms
+step:792/1555 train_time:35251ms step_avg:44.51ms
+step:793/1555 train_time:35314ms step_avg:44.53ms
+step:794/1555 train_time:35373ms step_avg:44.55ms
+step:795/1555 train_time:35436ms step_avg:44.57ms
+step:796/1555 train_time:35495ms step_avg:44.59ms
+step:797/1555 train_time:35559ms step_avg:44.62ms
+step:798/1555 train_time:35618ms step_avg:44.63ms
+step:799/1555 train_time:35683ms step_avg:44.66ms
+step:800/1555 train_time:35742ms step_avg:44.68ms
+step:801/1555 train_time:35806ms step_avg:44.70ms
+step:802/1555 train_time:35865ms step_avg:44.72ms
+step:803/1555 train_time:35930ms step_avg:44.75ms
+step:804/1555 train_time:35989ms step_avg:44.76ms
+step:805/1555 train_time:36051ms step_avg:44.78ms
+step:806/1555 train_time:36111ms step_avg:44.80ms
+step:807/1555 train_time:36174ms step_avg:44.83ms
+step:808/1555 train_time:36233ms step_avg:44.84ms
+step:809/1555 train_time:36296ms step_avg:44.87ms
+step:810/1555 train_time:36355ms step_avg:44.88ms
+step:811/1555 train_time:36418ms step_avg:44.91ms
+step:812/1555 train_time:36477ms step_avg:44.92ms
+step:813/1555 train_time:36541ms step_avg:44.95ms
+step:814/1555 train_time:36601ms step_avg:44.96ms
+step:815/1555 train_time:36665ms step_avg:44.99ms
+step:816/1555 train_time:36723ms step_avg:45.00ms
+step:817/1555 train_time:36787ms step_avg:45.03ms
+step:818/1555 train_time:36847ms step_avg:45.05ms
+step:819/1555 train_time:36911ms step_avg:45.07ms
+step:820/1555 train_time:36970ms step_avg:45.09ms
+step:821/1555 train_time:37034ms step_avg:45.11ms
+step:822/1555 train_time:37093ms step_avg:45.13ms
+step:823/1555 train_time:37157ms step_avg:45.15ms
+step:824/1555 train_time:37216ms step_avg:45.16ms
+step:825/1555 train_time:37279ms step_avg:45.19ms
+step:826/1555 train_time:37339ms step_avg:45.20ms
+step:827/1555 train_time:37404ms step_avg:45.23ms
+step:828/1555 train_time:37462ms step_avg:45.24ms
+step:829/1555 train_time:37525ms step_avg:45.27ms
+step:830/1555 train_time:37585ms step_avg:45.28ms
+step:831/1555 train_time:37648ms step_avg:45.30ms
+step:832/1555 train_time:37707ms step_avg:45.32ms
+step:833/1555 train_time:37771ms step_avg:45.34ms
+step:834/1555 train_time:37830ms step_avg:45.36ms
+step:835/1555 train_time:37893ms step_avg:45.38ms
+step:836/1555 train_time:37952ms step_avg:45.40ms
+step:837/1555 train_time:38015ms step_avg:45.42ms
+step:838/1555 train_time:38074ms step_avg:45.43ms
+step:839/1555 train_time:38138ms step_avg:45.46ms
+step:840/1555 train_time:38197ms step_avg:45.47ms
+step:841/1555 train_time:38260ms step_avg:45.49ms
+step:842/1555 train_time:38319ms step_avg:45.51ms
+step:843/1555 train_time:38383ms step_avg:45.53ms
+step:844/1555 train_time:38442ms step_avg:45.55ms
+step:845/1555 train_time:38506ms step_avg:45.57ms
+step:846/1555 train_time:38565ms step_avg:45.59ms
+step:847/1555 train_time:38629ms step_avg:45.61ms
+step:848/1555 train_time:38687ms step_avg:45.62ms
+step:849/1555 train_time:38751ms step_avg:45.64ms
+step:850/1555 train_time:38810ms step_avg:45.66ms
+step:851/1555 train_time:38874ms step_avg:45.68ms
+step:852/1555 train_time:38933ms step_avg:45.70ms
+step:853/1555 train_time:38996ms step_avg:45.72ms
+step:854/1555 train_time:39055ms step_avg:45.73ms
+step:855/1555 train_time:39119ms step_avg:45.75ms
+step:856/1555 train_time:39178ms step_avg:45.77ms
+step:857/1555 train_time:39242ms step_avg:45.79ms
+step:858/1555 train_time:39301ms step_avg:45.81ms
+step:859/1555 train_time:39364ms step_avg:45.83ms
+step:860/1555 train_time:39423ms step_avg:45.84ms
+step:861/1555 train_time:39488ms step_avg:45.86ms
+step:862/1555 train_time:39547ms step_avg:45.88ms
+step:863/1555 train_time:39611ms step_avg:45.90ms
+step:864/1555 train_time:39670ms step_avg:45.91ms
+step:865/1555 train_time:39733ms step_avg:45.93ms
+step:866/1555 train_time:39792ms step_avg:45.95ms
+step:867/1555 train_time:39856ms step_avg:45.97ms
+step:868/1555 train_time:39915ms step_avg:45.99ms
+step:869/1555 train_time:39980ms step_avg:46.01ms
+step:870/1555 train_time:40039ms step_avg:46.02ms
+step:871/1555 train_time:40103ms step_avg:46.04ms
+step:872/1555 train_time:40162ms step_avg:46.06ms
+step:873/1555 train_time:40225ms step_avg:46.08ms
+step:874/1555 train_time:40284ms step_avg:46.09ms
+step:875/1555 train_time:40347ms step_avg:46.11ms
+step:876/1555 train_time:40407ms step_avg:46.13ms
+step:877/1555 train_time:40470ms step_avg:46.15ms
+step:878/1555 train_time:40529ms step_avg:46.16ms
+step:879/1555 train_time:40592ms step_avg:46.18ms
+step:880/1555 train_time:40652ms step_avg:46.20ms
+step:881/1555 train_time:40714ms step_avg:46.21ms
+step:882/1555 train_time:40773ms step_avg:46.23ms
+step:883/1555 train_time:40841ms step_avg:46.25ms
+step:884/1555 train_time:40900ms step_avg:46.27ms
+step:885/1555 train_time:40961ms step_avg:46.28ms
+step:886/1555 train_time:41021ms step_avg:46.30ms
+step:887/1555 train_time:41084ms step_avg:46.32ms
+step:888/1555 train_time:41143ms step_avg:46.33ms
+step:889/1555 train_time:41207ms step_avg:46.35ms
+step:890/1555 train_time:41266ms step_avg:46.37ms
+step:891/1555 train_time:41329ms step_avg:46.38ms
+step:892/1555 train_time:41388ms step_avg:46.40ms
+step:893/1555 train_time:41451ms step_avg:46.42ms
+step:894/1555 train_time:41510ms step_avg:46.43ms
+step:895/1555 train_time:41574ms step_avg:46.45ms
+step:896/1555 train_time:41633ms step_avg:46.47ms
+step:897/1555 train_time:41697ms step_avg:46.48ms
+step:898/1555 train_time:41755ms step_avg:46.50ms
+step:899/1555 train_time:41818ms step_avg:46.52ms
+step:900/1555 train_time:41878ms step_avg:46.53ms
+step:901/1555 train_time:41942ms step_avg:46.55ms
+step:902/1555 train_time:42001ms step_avg:46.56ms
+step:903/1555 train_time:42065ms step_avg:46.58ms
+step:904/1555 train_time:42123ms step_avg:46.60ms
+step:905/1555 train_time:42187ms step_avg:46.62ms
+step:906/1555 train_time:42246ms step_avg:46.63ms
+step:907/1555 train_time:42309ms step_avg:46.65ms
+step:908/1555 train_time:42368ms step_avg:46.66ms
+step:909/1555 train_time:42431ms step_avg:46.68ms
+step:910/1555 train_time:42492ms step_avg:46.69ms
+step:911/1555 train_time:42555ms step_avg:46.71ms
+step:912/1555 train_time:42614ms step_avg:46.73ms
+step:913/1555 train_time:42677ms step_avg:46.74ms
+step:914/1555 train_time:42737ms step_avg:46.76ms
+step:915/1555 train_time:42800ms step_avg:46.78ms
+step:916/1555 train_time:42860ms step_avg:46.79ms
+step:917/1555 train_time:42923ms step_avg:46.81ms
+step:918/1555 train_time:42983ms step_avg:46.82ms
+step:919/1555 train_time:43046ms step_avg:46.84ms
+step:920/1555 train_time:43105ms step_avg:46.85ms
+step:921/1555 train_time:43168ms step_avg:46.87ms
+step:922/1555 train_time:43228ms step_avg:46.88ms
+step:923/1555 train_time:43291ms step_avg:46.90ms
+step:924/1555 train_time:43352ms step_avg:46.92ms
+step:925/1555 train_time:43413ms step_avg:46.93ms
+step:926/1555 train_time:43473ms step_avg:46.95ms
+step:927/1555 train_time:43537ms step_avg:46.97ms
+step:928/1555 train_time:43596ms step_avg:46.98ms
+step:929/1555 train_time:43660ms step_avg:47.00ms
+step:930/1555 train_time:43719ms step_avg:47.01ms
+step:931/1555 train_time:43783ms step_avg:47.03ms
+step:932/1555 train_time:43842ms step_avg:47.04ms
+step:933/1555 train_time:43906ms step_avg:47.06ms
+step:934/1555 train_time:43965ms step_avg:47.07ms
+step:935/1555 train_time:44028ms step_avg:47.09ms
+step:936/1555 train_time:44087ms step_avg:47.10ms
+step:937/1555 train_time:44151ms step_avg:47.12ms
+step:938/1555 train_time:44210ms step_avg:47.13ms
+step:939/1555 train_time:44274ms step_avg:47.15ms
+step:940/1555 train_time:44332ms step_avg:47.16ms
+step:941/1555 train_time:44396ms step_avg:47.18ms
+step:942/1555 train_time:44455ms step_avg:47.19ms
+step:943/1555 train_time:44518ms step_avg:47.21ms
+step:944/1555 train_time:44578ms step_avg:47.22ms
+step:945/1555 train_time:44641ms step_avg:47.24ms
+step:946/1555 train_time:44701ms step_avg:47.25ms
+step:947/1555 train_time:44765ms step_avg:47.27ms
+step:948/1555 train_time:44824ms step_avg:47.28ms
+step:949/1555 train_time:44887ms step_avg:47.30ms
+step:950/1555 train_time:44946ms step_avg:47.31ms
+step:951/1555 train_time:45009ms step_avg:47.33ms
+step:952/1555 train_time:45068ms step_avg:47.34ms
+step:953/1555 train_time:45132ms step_avg:47.36ms
+step:954/1555 train_time:45191ms step_avg:47.37ms
+step:955/1555 train_time:45254ms step_avg:47.39ms
+step:956/1555 train_time:45313ms step_avg:47.40ms
+step:957/1555 train_time:45376ms step_avg:47.41ms
+step:958/1555 train_time:45435ms step_avg:47.43ms
+step:959/1555 train_time:45499ms step_avg:47.44ms
+step:960/1555 train_time:45559ms step_avg:47.46ms
+step:961/1555 train_time:45622ms step_avg:47.47ms
+step:962/1555 train_time:45682ms step_avg:47.49ms
+step:963/1555 train_time:45746ms step_avg:47.50ms
+step:964/1555 train_time:45805ms step_avg:47.52ms
+step:965/1555 train_time:45868ms step_avg:47.53ms
+step:966/1555 train_time:45927ms step_avg:47.54ms
+step:967/1555 train_time:45992ms step_avg:47.56ms
+step:968/1555 train_time:46051ms step_avg:47.57ms
+step:969/1555 train_time:46114ms step_avg:47.59ms
+step:970/1555 train_time:46173ms step_avg:47.60ms
+step:971/1555 train_time:46237ms step_avg:47.62ms
+step:972/1555 train_time:46297ms step_avg:47.63ms
+step:973/1555 train_time:46360ms step_avg:47.65ms
+step:974/1555 train_time:46420ms step_avg:47.66ms
+step:975/1555 train_time:46483ms step_avg:47.67ms
+step:976/1555 train_time:46542ms step_avg:47.69ms
+step:977/1555 train_time:46606ms step_avg:47.70ms
+step:978/1555 train_time:46665ms step_avg:47.71ms
+step:979/1555 train_time:46728ms step_avg:47.73ms
+step:980/1555 train_time:46788ms step_avg:47.74ms
+step:981/1555 train_time:46851ms step_avg:47.76ms
+step:982/1555 train_time:46911ms step_avg:47.77ms
+step:983/1555 train_time:46974ms step_avg:47.79ms
+step:984/1555 train_time:47033ms step_avg:47.80ms
+step:985/1555 train_time:47097ms step_avg:47.81ms
+step:986/1555 train_time:47156ms step_avg:47.83ms
+step:987/1555 train_time:47220ms step_avg:47.84ms
+step:988/1555 train_time:47279ms step_avg:47.85ms
+step:989/1555 train_time:47343ms step_avg:47.87ms
+step:990/1555 train_time:47403ms step_avg:47.88ms
+step:991/1555 train_time:47466ms step_avg:47.90ms
+step:992/1555 train_time:47524ms step_avg:47.91ms
+step:993/1555 train_time:47588ms step_avg:47.92ms
+step:994/1555 train_time:47648ms step_avg:47.94ms
+step:995/1555 train_time:47711ms step_avg:47.95ms
+step:996/1555 train_time:47773ms step_avg:47.96ms
+step:997/1555 train_time:47833ms step_avg:47.98ms
+step:998/1555 train_time:47893ms step_avg:47.99ms
+step:999/1555 train_time:47956ms step_avg:48.00ms
+step:1000/1555 train_time:48015ms step_avg:48.02ms
+step:1000/1555 val_loss:3.5720 train_time:48064ms step_avg:48.06ms
+step:1001/1555 train_time:48081ms step_avg:48.03ms
+step:1002/1555 train_time:48142ms step_avg:48.05ms
+step:1003/1555 train_time:48208ms step_avg:48.06ms
+step:1004/1555 train_time:48268ms step_avg:48.08ms
+step:1005/1555 train_time:48331ms step_avg:48.09ms
+step:1006/1555 train_time:48390ms step_avg:48.10ms
+step:1007/1555 train_time:48454ms step_avg:48.12ms
+step:1008/1555 train_time:48513ms step_avg:48.13ms
+step:1009/1555 train_time:48577ms step_avg:48.14ms
+step:1010/1555 train_time:48635ms step_avg:48.15ms
+step:1011/1555 train_time:48707ms step_avg:48.18ms
+step:1012/1555 train_time:48789ms step_avg:48.21ms
+step:1013/1555 train_time:48879ms step_avg:48.25ms
+step:1014/1555 train_time:48964ms step_avg:48.29ms
+step:1015/1555 train_time:49057ms step_avg:48.33ms
+step:1016/1555 train_time:49145ms step_avg:48.37ms
+step:1017/1555 train_time:49234ms step_avg:48.41ms
+step:1018/1555 train_time:49321ms step_avg:48.45ms
+step:1019/1555 train_time:49410ms step_avg:48.49ms
+step:1020/1555 train_time:49496ms step_avg:48.53ms
+step:1021/1555 train_time:49585ms step_avg:48.57ms
+step:1022/1555 train_time:49670ms step_avg:48.60ms
+step:1023/1555 train_time:49760ms step_avg:48.64ms
+step:1024/1555 train_time:49845ms step_avg:48.68ms
+step:1025/1555 train_time:49934ms step_avg:48.72ms
+step:1026/1555 train_time:50021ms step_avg:48.75ms
+step:1027/1555 train_time:50112ms step_avg:48.79ms
+step:1028/1555 train_time:50198ms step_avg:48.83ms
+step:1029/1555 train_time:50287ms step_avg:48.87ms
+step:1030/1555 train_time:50373ms step_avg:48.91ms
+step:1031/1555 train_time:50462ms step_avg:48.94ms
+step:1032/1555 train_time:50548ms step_avg:48.98ms
+step:1033/1555 train_time:50638ms step_avg:49.02ms
+step:1034/1555 train_time:50724ms step_avg:49.06ms
+step:1035/1555 train_time:50813ms step_avg:49.09ms
+step:1036/1555 train_time:50898ms step_avg:49.13ms
+step:1037/1555 train_time:50988ms step_avg:49.17ms
+step:1038/1555 train_time:51074ms step_avg:49.20ms
+step:1039/1555 train_time:51165ms step_avg:49.24ms
+step:1040/1555 train_time:51250ms step_avg:49.28ms
+step:1041/1555 train_time:51340ms step_avg:49.32ms
+step:1042/1555 train_time:51426ms step_avg:49.35ms
+step:1043/1555 train_time:51516ms step_avg:49.39ms
+step:1044/1555 train_time:51602ms step_avg:49.43ms
+step:1045/1555 train_time:51692ms step_avg:49.47ms
+step:1046/1555 train_time:51777ms step_avg:49.50ms
+step:1047/1555 train_time:51866ms step_avg:49.54ms
+step:1048/1555 train_time:51952ms step_avg:49.57ms
+step:1049/1555 train_time:52042ms step_avg:49.61ms
+step:1050/1555 train_time:52128ms step_avg:49.65ms
+step:1051/1555 train_time:52218ms step_avg:49.68ms
+step:1052/1555 train_time:52305ms step_avg:49.72ms
+step:1053/1555 train_time:52395ms step_avg:49.76ms
+step:1054/1555 train_time:52480ms step_avg:49.79ms
+step:1055/1555 train_time:52570ms step_avg:49.83ms
+step:1056/1555 train_time:52656ms step_avg:49.86ms
+step:1057/1555 train_time:52745ms step_avg:49.90ms
+step:1058/1555 train_time:52830ms step_avg:49.93ms
+step:1059/1555 train_time:52919ms step_avg:49.97ms
+step:1060/1555 train_time:53005ms step_avg:50.00ms
+step:1061/1555 train_time:53095ms step_avg:50.04ms
+step:1062/1555 train_time:53181ms step_avg:50.08ms
+step:1063/1555 train_time:53271ms step_avg:50.11ms
+step:1064/1555 train_time:53357ms step_avg:50.15ms
+step:1065/1555 train_time:53447ms step_avg:50.19ms
+step:1066/1555 train_time:53535ms step_avg:50.22ms
+step:1067/1555 train_time:53624ms step_avg:50.26ms
+step:1068/1555 train_time:53709ms step_avg:50.29ms
+step:1069/1555 train_time:53799ms step_avg:50.33ms
+step:1070/1555 train_time:53884ms step_avg:50.36ms
+step:1071/1555 train_time:53974ms step_avg:50.40ms
+step:1072/1555 train_time:54060ms step_avg:50.43ms
+step:1073/1555 train_time:54149ms step_avg:50.47ms
+step:1074/1555 train_time:54235ms step_avg:50.50ms
+step:1075/1555 train_time:54326ms step_avg:50.54ms
+step:1076/1555 train_time:54413ms step_avg:50.57ms
+step:1077/1555 train_time:54502ms step_avg:50.61ms
+step:1078/1555 train_time:54591ms step_avg:50.64ms
+step:1079/1555 train_time:54679ms step_avg:50.68ms
+step:1080/1555 train_time:54764ms step_avg:50.71ms
+step:1081/1555 train_time:54854ms step_avg:50.74ms
+step:1082/1555 train_time:54938ms step_avg:50.77ms
+step:1083/1555 train_time:55029ms step_avg:50.81ms
+step:1084/1555 train_time:55114ms step_avg:50.84ms
+step:1085/1555 train_time:55203ms step_avg:50.88ms
+step:1086/1555 train_time:55292ms step_avg:50.91ms
+step:1087/1555 train_time:55380ms step_avg:50.95ms
+step:1088/1555 train_time:55466ms step_avg:50.98ms
+step:1089/1555 train_time:55556ms step_avg:51.02ms
+step:1090/1555 train_time:55642ms step_avg:51.05ms
+step:1091/1555 train_time:55732ms step_avg:51.08ms
+step:1092/1555 train_time:55817ms step_avg:51.11ms
+step:1093/1555 train_time:55907ms step_avg:51.15ms
+step:1094/1555 train_time:55993ms step_avg:51.18ms
+step:1095/1555 train_time:56082ms step_avg:51.22ms
+step:1096/1555 train_time:56167ms step_avg:51.25ms
+step:1097/1555 train_time:56257ms step_avg:51.28ms
+step:1098/1555 train_time:56343ms step_avg:51.31ms
+step:1099/1555 train_time:56432ms step_avg:51.35ms
+step:1100/1555 train_time:56518ms step_avg:51.38ms
+step:1101/1555 train_time:56608ms step_avg:51.41ms
+step:1102/1555 train_time:56693ms step_avg:51.45ms
+step:1103/1555 train_time:56783ms step_avg:51.48ms
+step:1104/1555 train_time:56868ms step_avg:51.51ms
+step:1105/1555 train_time:56958ms step_avg:51.55ms
+step:1106/1555 train_time:57044ms step_avg:51.58ms
+step:1107/1555 train_time:57134ms step_avg:51.61ms
+step:1108/1555 train_time:57220ms step_avg:51.64ms
+step:1109/1555 train_time:57310ms step_avg:51.68ms
+step:1110/1555 train_time:57396ms step_avg:51.71ms
+step:1111/1555 train_time:57486ms step_avg:51.74ms
+step:1112/1555 train_time:57572ms step_avg:51.77ms
+step:1113/1555 train_time:57661ms step_avg:51.81ms
+step:1114/1555 train_time:57747ms step_avg:51.84ms
+step:1115/1555 train_time:57837ms step_avg:51.87ms
+step:1116/1555 train_time:57923ms step_avg:51.90ms
+step:1117/1555 train_time:58012ms step_avg:51.94ms
+step:1118/1555 train_time:58098ms step_avg:51.97ms
+step:1119/1555 train_time:58188ms step_avg:52.00ms
+step:1120/1555 train_time:58274ms step_avg:52.03ms
+step:1121/1555 train_time:58364ms step_avg:52.06ms
+step:1122/1555 train_time:58449ms step_avg:52.09ms
+step:1123/1555 train_time:58539ms step_avg:52.13ms
+step:1124/1555 train_time:58625ms step_avg:52.16ms
+step:1125/1555 train_time:58715ms step_avg:52.19ms
+step:1126/1555 train_time:58800ms step_avg:52.22ms
+step:1127/1555 train_time:58890ms step_avg:52.25ms
+step:1128/1555 train_time:58975ms step_avg:52.28ms
+step:1129/1555 train_time:59065ms step_avg:52.32ms
+step:1130/1555 train_time:59150ms step_avg:52.35ms
+step:1131/1555 train_time:59240ms step_avg:52.38ms
+step:1132/1555 train_time:59326ms step_avg:52.41ms
+step:1133/1555 train_time:59416ms step_avg:52.44ms
+step:1134/1555 train_time:59501ms step_avg:52.47ms
+step:1135/1555 train_time:59590ms step_avg:52.50ms
+step:1136/1555 train_time:59676ms step_avg:52.53ms
+step:1137/1555 train_time:59766ms step_avg:52.56ms
+step:1138/1555 train_time:59852ms step_avg:52.59ms
+step:1139/1555 train_time:59956ms step_avg:52.64ms
+step:1140/1555 train_time:60029ms step_avg:52.66ms
+step:1141/1555 train_time:60118ms step_avg:52.69ms
+step:1142/1555 train_time:60204ms step_avg:52.72ms
+step:1143/1555 train_time:60293ms step_avg:52.75ms
+step:1144/1555 train_time:60379ms step_avg:52.78ms
+step:1145/1555 train_time:60469ms step_avg:52.81ms
+step:1146/1555 train_time:60555ms step_avg:52.84ms
+step:1147/1555 train_time:60645ms step_avg:52.87ms
+step:1148/1555 train_time:60732ms step_avg:52.90ms
+step:1149/1555 train_time:60821ms step_avg:52.93ms
+step:1150/1555 train_time:60907ms step_avg:52.96ms
+step:1151/1555 train_time:60998ms step_avg:53.00ms
+step:1152/1555 train_time:61083ms step_avg:53.02ms
+step:1153/1555 train_time:61173ms step_avg:53.06ms
+step:1154/1555 train_time:61258ms step_avg:53.08ms
+step:1155/1555 train_time:61347ms step_avg:53.11ms
+step:1156/1555 train_time:61436ms step_avg:53.15ms
+step:1157/1555 train_time:61525ms step_avg:53.18ms
+step:1158/1555 train_time:61610ms step_avg:53.20ms
+step:1159/1555 train_time:61700ms step_avg:53.24ms
+step:1160/1555 train_time:61785ms step_avg:53.26ms
+step:1161/1555 train_time:61875ms step_avg:53.29ms
+step:1162/1555 train_time:61961ms step_avg:53.32ms
+step:1163/1555 train_time:62050ms step_avg:53.35ms
+step:1164/1555 train_time:62136ms step_avg:53.38ms
+step:1165/1555 train_time:62225ms step_avg:53.41ms
+step:1166/1555 train_time:62311ms step_avg:53.44ms
+step:1167/1555 train_time:62401ms step_avg:53.47ms
+step:1168/1555 train_time:62487ms step_avg:53.50ms
+step:1169/1555 train_time:62577ms step_avg:53.53ms
+step:1170/1555 train_time:62663ms step_avg:53.56ms
+step:1171/1555 train_time:62753ms step_avg:53.59ms
+step:1172/1555 train_time:62838ms step_avg:53.62ms
+step:1173/1555 train_time:62927ms step_avg:53.65ms
+step:1174/1555 train_time:63013ms step_avg:53.67ms
+step:1175/1555 train_time:63103ms step_avg:53.70ms
+step:1176/1555 train_time:63189ms step_avg:53.73ms
+step:1177/1555 train_time:63279ms step_avg:53.76ms
+step:1178/1555 train_time:63365ms step_avg:53.79ms
+step:1179/1555 train_time:63455ms step_avg:53.82ms
+step:1180/1555 train_time:63540ms step_avg:53.85ms
+step:1181/1555 train_time:63630ms step_avg:53.88ms
+step:1182/1555 train_time:63715ms step_avg:53.90ms
+step:1183/1555 train_time:63805ms step_avg:53.93ms
+step:1184/1555 train_time:63890ms step_avg:53.96ms
+step:1185/1555 train_time:63980ms step_avg:53.99ms
+step:1186/1555 train_time:64065ms step_avg:54.02ms
+step:1187/1555 train_time:64154ms step_avg:54.05ms
+step:1188/1555 train_time:64240ms step_avg:54.07ms
+step:1189/1555 train_time:64329ms step_avg:54.10ms
+step:1190/1555 train_time:64415ms step_avg:54.13ms
+step:1191/1555 train_time:64505ms step_avg:54.16ms
+step:1192/1555 train_time:64592ms step_avg:54.19ms
+step:1193/1555 train_time:64681ms step_avg:54.22ms
+step:1194/1555 train_time:64768ms step_avg:54.24ms
+step:1195/1555 train_time:64858ms step_avg:54.27ms
+step:1196/1555 train_time:64944ms step_avg:54.30ms
+step:1197/1555 train_time:65035ms step_avg:54.33ms
+step:1198/1555 train_time:65120ms step_avg:54.36ms
+step:1199/1555 train_time:65209ms step_avg:54.39ms
+step:1200/1555 train_time:65295ms step_avg:54.41ms
+step:1201/1555 train_time:65385ms step_avg:54.44ms
+step:1202/1555 train_time:65470ms step_avg:54.47ms
+step:1203/1555 train_time:65561ms step_avg:54.50ms
+step:1204/1555 train_time:65646ms step_avg:54.52ms
+step:1205/1555 train_time:65736ms step_avg:54.55ms
+step:1206/1555 train_time:65821ms step_avg:54.58ms
+step:1207/1555 train_time:65910ms step_avg:54.61ms
+step:1208/1555 train_time:65997ms step_avg:54.63ms
+step:1209/1555 train_time:66085ms step_avg:54.66ms
+step:1210/1555 train_time:66174ms step_avg:54.69ms
+step:1211/1555 train_time:66262ms step_avg:54.72ms
+step:1212/1555 train_time:66347ms step_avg:54.74ms
+step:1213/1555 train_time:66439ms step_avg:54.77ms
+step:1214/1555 train_time:66524ms step_avg:54.80ms
+step:1215/1555 train_time:66613ms step_avg:54.83ms
+step:1216/1555 train_time:66698ms step_avg:54.85ms
+step:1217/1555 train_time:66788ms step_avg:54.88ms
+step:1218/1555 train_time:66874ms step_avg:54.90ms
+step:1219/1555 train_time:66963ms step_avg:54.93ms
+step:1220/1555 train_time:67049ms step_avg:54.96ms
+step:1221/1555 train_time:67139ms step_avg:54.99ms
+step:1222/1555 train_time:67225ms step_avg:55.01ms
+step:1223/1555 train_time:67315ms step_avg:55.04ms
+step:1224/1555 train_time:67400ms step_avg:55.07ms
+step:1225/1555 train_time:67490ms step_avg:55.09ms
+step:1226/1555 train_time:67575ms step_avg:55.12ms
+step:1227/1555 train_time:67666ms step_avg:55.15ms
+step:1228/1555 train_time:67752ms step_avg:55.17ms
+step:1229/1555 train_time:67841ms step_avg:55.20ms
+step:1230/1555 train_time:67927ms step_avg:55.22ms
+step:1231/1555 train_time:68016ms step_avg:55.25ms
+step:1232/1555 train_time:68102ms step_avg:55.28ms
+step:1233/1555 train_time:68193ms step_avg:55.31ms
+step:1234/1555 train_time:68279ms step_avg:55.33ms
+step:1235/1555 train_time:68369ms step_avg:55.36ms
+step:1236/1555 train_time:68455ms step_avg:55.38ms
+step:1237/1555 train_time:68545ms step_avg:55.41ms
+step:1238/1555 train_time:68630ms step_avg:55.44ms
+step:1239/1555 train_time:68720ms step_avg:55.46ms
+step:1240/1555 train_time:68806ms step_avg:55.49ms
+step:1241/1555 train_time:68897ms step_avg:55.52ms
+step:1242/1555 train_time:68982ms step_avg:55.54ms
+step:1243/1555 train_time:69072ms step_avg:55.57ms
+step:1244/1555 train_time:69158ms step_avg:55.59ms
+step:1245/1555 train_time:69247ms step_avg:55.62ms
+step:1246/1555 train_time:69334ms step_avg:55.65ms
+step:1247/1555 train_time:69424ms step_avg:55.67ms
+step:1248/1555 train_time:69510ms step_avg:55.70ms
+step:1249/1555 train_time:69600ms step_avg:55.72ms
+step:1250/1555 train_time:69686ms step_avg:55.75ms
+step:1250/1555 val_loss:3.3996 train_time:69762ms step_avg:55.81ms
+step:1251/1555 train_time:69792ms step_avg:55.79ms
+step:1252/1555 train_time:69881ms step_avg:55.82ms
+step:1253/1555 train_time:69973ms step_avg:55.84ms
+step:1254/1555 train_time:70058ms step_avg:55.87ms
+step:1255/1555 train_time:70147ms step_avg:55.89ms
+step:1256/1555 train_time:70231ms step_avg:55.92ms
+step:1257/1555 train_time:70320ms step_avg:55.94ms
+step:1258/1555 train_time:70404ms step_avg:55.97ms
+step:1259/1555 train_time:70494ms step_avg:55.99ms
+step:1260/1555 train_time:70579ms step_avg:56.02ms
+step:1261/1555 train_time:70668ms step_avg:56.04ms
+step:1262/1555 train_time:70755ms step_avg:56.07ms
+step:1263/1555 train_time:70848ms step_avg:56.10ms
+step:1264/1555 train_time:70935ms step_avg:56.12ms
+step:1265/1555 train_time:71024ms step_avg:56.15ms
+step:1266/1555 train_time:71110ms step_avg:56.17ms
+step:1267/1555 train_time:71199ms step_avg:56.19ms
+step:1268/1555 train_time:71284ms step_avg:56.22ms
+step:1269/1555 train_time:71373ms step_avg:56.24ms
+step:1270/1555 train_time:71458ms step_avg:56.27ms
+step:1271/1555 train_time:71547ms step_avg:56.29ms
+step:1272/1555 train_time:71632ms step_avg:56.31ms
+step:1273/1555 train_time:71724ms step_avg:56.34ms
+step:1274/1555 train_time:71811ms step_avg:56.37ms
+step:1275/1555 train_time:71902ms step_avg:56.39ms
+step:1276/1555 train_time:71988ms step_avg:56.42ms
+step:1277/1555 train_time:72079ms step_avg:56.44ms
+step:1278/1555 train_time:72164ms step_avg:56.47ms
+step:1279/1555 train_time:72253ms step_avg:56.49ms
+step:1280/1555 train_time:72339ms step_avg:56.52ms
+step:1281/1555 train_time:72428ms step_avg:56.54ms
+step:1282/1555 train_time:72513ms step_avg:56.56ms
+step:1283/1555 train_time:72603ms step_avg:56.59ms
+step:1284/1555 train_time:72690ms step_avg:56.61ms
+step:1285/1555 train_time:72780ms step_avg:56.64ms
+step:1286/1555 train_time:72866ms step_avg:56.66ms
+step:1287/1555 train_time:72957ms step_avg:56.69ms
+step:1288/1555 train_time:73043ms step_avg:56.71ms
+step:1289/1555 train_time:73133ms step_avg:56.74ms
+step:1290/1555 train_time:73218ms step_avg:56.76ms
+step:1291/1555 train_time:73308ms step_avg:56.78ms
+step:1292/1555 train_time:73393ms step_avg:56.81ms
+step:1293/1555 train_time:73482ms step_avg:56.83ms
+step:1294/1555 train_time:73567ms step_avg:56.85ms
+step:1295/1555 train_time:73657ms step_avg:56.88ms
+step:1296/1555 train_time:73743ms step_avg:56.90ms
+step:1297/1555 train_time:73833ms step_avg:56.93ms
+step:1298/1555 train_time:73920ms step_avg:56.95ms
+step:1299/1555 train_time:74009ms step_avg:56.97ms
+step:1300/1555 train_time:74095ms step_avg:57.00ms
+step:1301/1555 train_time:74186ms step_avg:57.02ms
+step:1302/1555 train_time:74272ms step_avg:57.04ms
+step:1303/1555 train_time:74361ms step_avg:57.07ms
+step:1304/1555 train_time:74447ms step_avg:57.09ms
+step:1305/1555 train_time:74536ms step_avg:57.12ms
+step:1306/1555 train_time:74621ms step_avg:57.14ms
+step:1307/1555 train_time:74711ms step_avg:57.16ms
+step:1308/1555 train_time:74798ms step_avg:57.18ms
+step:1309/1555 train_time:74888ms step_avg:57.21ms
+step:1310/1555 train_time:74974ms step_avg:57.23ms
+step:1311/1555 train_time:75065ms step_avg:57.26ms
+step:1312/1555 train_time:75151ms step_avg:57.28ms
+step:1313/1555 train_time:75241ms step_avg:57.30ms
+step:1314/1555 train_time:75326ms step_avg:57.33ms
+step:1315/1555 train_time:75416ms step_avg:57.35ms
+step:1316/1555 train_time:75501ms step_avg:57.37ms
+step:1317/1555 train_time:75591ms step_avg:57.40ms
+step:1318/1555 train_time:75677ms step_avg:57.42ms
+step:1319/1555 train_time:75766ms step_avg:57.44ms
+step:1320/1555 train_time:75852ms step_avg:57.46ms
+step:1321/1555 train_time:75942ms step_avg:57.49ms
+step:1322/1555 train_time:76027ms step_avg:57.51ms
+step:1323/1555 train_time:76118ms step_avg:57.53ms
+step:1324/1555 train_time:76203ms step_avg:57.55ms
+step:1325/1555 train_time:76293ms step_avg:57.58ms
+step:1326/1555 train_time:76379ms step_avg:57.60ms
+step:1327/1555 train_time:76468ms step_avg:57.62ms
+step:1328/1555 train_time:76554ms step_avg:57.65ms
+step:1329/1555 train_time:76644ms step_avg:57.67ms
+step:1330/1555 train_time:76730ms step_avg:57.69ms
+step:1331/1555 train_time:76819ms step_avg:57.72ms
+step:1332/1555 train_time:76905ms step_avg:57.74ms
+step:1333/1555 train_time:76995ms step_avg:57.76ms
+step:1334/1555 train_time:77081ms step_avg:57.78ms
+step:1335/1555 train_time:77170ms step_avg:57.81ms
+step:1336/1555 train_time:77256ms step_avg:57.83ms
+step:1337/1555 train_time:77346ms step_avg:57.85ms
+step:1338/1555 train_time:77431ms step_avg:57.87ms
+step:1339/1555 train_time:77521ms step_avg:57.89ms
+step:1340/1555 train_time:77607ms step_avg:57.92ms
+step:1341/1555 train_time:77697ms step_avg:57.94ms
+step:1342/1555 train_time:77782ms step_avg:57.96ms
+step:1343/1555 train_time:77872ms step_avg:57.98ms
+step:1344/1555 train_time:77958ms step_avg:58.00ms
+step:1345/1555 train_time:78048ms step_avg:58.03ms
+step:1346/1555 train_time:78133ms step_avg:58.05ms
+step:1347/1555 train_time:78224ms step_avg:58.07ms
+step:1348/1555 train_time:78309ms step_avg:58.09ms
+step:1349/1555 train_time:78399ms step_avg:58.12ms
+step:1350/1555 train_time:78486ms step_avg:58.14ms
+step:1351/1555 train_time:78578ms step_avg:58.16ms
+step:1352/1555 train_time:78664ms step_avg:58.18ms
+step:1353/1555 train_time:78752ms step_avg:58.21ms
+step:1354/1555 train_time:78839ms step_avg:58.23ms
+step:1355/1555 train_time:78928ms step_avg:58.25ms
+step:1356/1555 train_time:79014ms step_avg:58.27ms
+step:1357/1555 train_time:79105ms step_avg:58.29ms
+step:1358/1555 train_time:79191ms step_avg:58.31ms
+step:1359/1555 train_time:79281ms step_avg:58.34ms
+step:1360/1555 train_time:79367ms step_avg:58.36ms
+step:1361/1555 train_time:79456ms step_avg:58.38ms
+step:1362/1555 train_time:79541ms step_avg:58.40ms
+step:1363/1555 train_time:79631ms step_avg:58.42ms
+step:1364/1555 train_time:79718ms step_avg:58.44ms
+step:1365/1555 train_time:79808ms step_avg:58.47ms
+step:1366/1555 train_time:79894ms step_avg:58.49ms
+step:1367/1555 train_time:79985ms step_avg:58.51ms
+step:1368/1555 train_time:80070ms step_avg:58.53ms
+step:1369/1555 train_time:80161ms step_avg:58.55ms
+step:1370/1555 train_time:80246ms step_avg:58.57ms
+step:1371/1555 train_time:80336ms step_avg:58.60ms
+step:1372/1555 train_time:80421ms step_avg:58.62ms
+step:1373/1555 train_time:80512ms step_avg:58.64ms
+step:1374/1555 train_time:80597ms step_avg:58.66ms
+step:1375/1555 train_time:80688ms step_avg:58.68ms
+step:1376/1555 train_time:80773ms step_avg:58.70ms
+step:1377/1555 train_time:80864ms step_avg:58.72ms
+step:1378/1555 train_time:80949ms step_avg:58.74ms
+step:1379/1555 train_time:81040ms step_avg:58.77ms
+step:1380/1555 train_time:81124ms step_avg:58.79ms
+step:1381/1555 train_time:81215ms step_avg:58.81ms
+step:1382/1555 train_time:81301ms step_avg:58.83ms
+step:1383/1555 train_time:81390ms step_avg:58.85ms
+step:1384/1555 train_time:81474ms step_avg:58.87ms
+step:1385/1555 train_time:81565ms step_avg:58.89ms
+step:1386/1555 train_time:81651ms step_avg:58.91ms
+step:1387/1555 train_time:81739ms step_avg:58.93ms
+step:1388/1555 train_time:81826ms step_avg:58.95ms
+step:1389/1555 train_time:81916ms step_avg:58.97ms
+step:1390/1555 train_time:82002ms step_avg:58.99ms
+step:1391/1555 train_time:82093ms step_avg:59.02ms
+step:1392/1555 train_time:82178ms step_avg:59.04ms
+step:1393/1555 train_time:82267ms step_avg:59.06ms
+step:1394/1555 train_time:82354ms step_avg:59.08ms
+step:1395/1555 train_time:82442ms step_avg:59.10ms
+step:1396/1555 train_time:82528ms step_avg:59.12ms
+step:1397/1555 train_time:82618ms step_avg:59.14ms
+step:1398/1555 train_time:82704ms step_avg:59.16ms
+step:1399/1555 train_time:82793ms step_avg:59.18ms
+step:1400/1555 train_time:82879ms step_avg:59.20ms
+step:1401/1555 train_time:82968ms step_avg:59.22ms
+step:1402/1555 train_time:83054ms step_avg:59.24ms
+step:1403/1555 train_time:83145ms step_avg:59.26ms
+step:1404/1555 train_time:83231ms step_avg:59.28ms
+step:1405/1555 train_time:83320ms step_avg:59.30ms
+step:1406/1555 train_time:83405ms step_avg:59.32ms
+step:1407/1555 train_time:83494ms step_avg:59.34ms
+step:1408/1555 train_time:83581ms step_avg:59.36ms
+step:1409/1555 train_time:83671ms step_avg:59.38ms
+step:1410/1555 train_time:83756ms step_avg:59.40ms
+step:1411/1555 train_time:83846ms step_avg:59.42ms
+step:1412/1555 train_time:83933ms step_avg:59.44ms
+step:1413/1555 train_time:84022ms step_avg:59.46ms
+step:1414/1555 train_time:84107ms step_avg:59.48ms
+step:1415/1555 train_time:84197ms step_avg:59.50ms
+step:1416/1555 train_time:84282ms step_avg:59.52ms
+step:1417/1555 train_time:84372ms step_avg:59.54ms
+step:1418/1555 train_time:84458ms step_avg:59.56ms
+step:1419/1555 train_time:84548ms step_avg:59.58ms
+step:1420/1555 train_time:84634ms step_avg:59.60ms
+step:1421/1555 train_time:84724ms step_avg:59.62ms
+step:1422/1555 train_time:84810ms step_avg:59.64ms
+step:1423/1555 train_time:84900ms step_avg:59.66ms
+step:1424/1555 train_time:84985ms step_avg:59.68ms
+step:1425/1555 train_time:85075ms step_avg:59.70ms
+step:1426/1555 train_time:85161ms step_avg:59.72ms
+step:1427/1555 train_time:85251ms step_avg:59.74ms
+step:1428/1555 train_time:85337ms step_avg:59.76ms
+step:1429/1555 train_time:85427ms step_avg:59.78ms
+step:1430/1555 train_time:85512ms step_avg:59.80ms
+step:1431/1555 train_time:85602ms step_avg:59.82ms
+step:1432/1555 train_time:85688ms step_avg:59.84ms
+step:1433/1555 train_time:85778ms step_avg:59.86ms
+step:1434/1555 train_time:85863ms step_avg:59.88ms
+step:1435/1555 train_time:85953ms step_avg:59.90ms
+step:1436/1555 train_time:86040ms step_avg:59.92ms
+step:1437/1555 train_time:86130ms step_avg:59.94ms
+step:1438/1555 train_time:86221ms step_avg:59.96ms
+step:1439/1555 train_time:86305ms step_avg:59.98ms
+step:1440/1555 train_time:86391ms step_avg:59.99ms
+step:1441/1555 train_time:86480ms step_avg:60.01ms
+step:1442/1555 train_time:86568ms step_avg:60.03ms
+step:1443/1555 train_time:86656ms step_avg:60.05ms
+step:1444/1555 train_time:86742ms step_avg:60.07ms
+step:1445/1555 train_time:86832ms step_avg:60.09ms
+step:1446/1555 train_time:86917ms step_avg:60.11ms
+step:1447/1555 train_time:87007ms step_avg:60.13ms
+step:1448/1555 train_time:87094ms step_avg:60.15ms
+step:1449/1555 train_time:87183ms step_avg:60.17ms
+step:1450/1555 train_time:87269ms step_avg:60.19ms
+step:1451/1555 train_time:87359ms step_avg:60.21ms
+step:1452/1555 train_time:87445ms step_avg:60.22ms
+step:1453/1555 train_time:87535ms step_avg:60.24ms
+step:1454/1555 train_time:87621ms step_avg:60.26ms
+step:1455/1555 train_time:87710ms step_avg:60.28ms
+step:1456/1555 train_time:87795ms step_avg:60.30ms
+step:1457/1555 train_time:87885ms step_avg:60.32ms
+step:1458/1555 train_time:87971ms step_avg:60.34ms
+step:1459/1555 train_time:88061ms step_avg:60.36ms
+step:1460/1555 train_time:88146ms step_avg:60.37ms
+step:1461/1555 train_time:88235ms step_avg:60.39ms
+step:1462/1555 train_time:88321ms step_avg:60.41ms
+step:1463/1555 train_time:88411ms step_avg:60.43ms
+step:1464/1555 train_time:88497ms step_avg:60.45ms
+step:1465/1555 train_time:88587ms step_avg:60.47ms
+step:1466/1555 train_time:88672ms step_avg:60.49ms
+step:1467/1555 train_time:88761ms step_avg:60.51ms
+step:1468/1555 train_time:88846ms step_avg:60.52ms
+step:1469/1555 train_time:88936ms step_avg:60.54ms
+step:1470/1555 train_time:89022ms step_avg:60.56ms
+step:1471/1555 train_time:89112ms step_avg:60.58ms
+step:1472/1555 train_time:89197ms step_avg:60.60ms
+step:1473/1555 train_time:89287ms step_avg:60.62ms
+step:1474/1555 train_time:89373ms step_avg:60.63ms
+step:1475/1555 train_time:89463ms step_avg:60.65ms
+step:1476/1555 train_time:89548ms step_avg:60.67ms
+step:1477/1555 train_time:89639ms step_avg:60.69ms
+step:1478/1555 train_time:89725ms step_avg:60.71ms
+step:1479/1555 train_time:89815ms step_avg:60.73ms
+step:1480/1555 train_time:89901ms step_avg:60.74ms
+step:1481/1555 train_time:89992ms step_avg:60.76ms
+step:1482/1555 train_time:90077ms step_avg:60.78ms
+step:1483/1555 train_time:90167ms step_avg:60.80ms
+step:1484/1555 train_time:90253ms step_avg:60.82ms
+step:1485/1555 train_time:90343ms step_avg:60.84ms
+step:1486/1555 train_time:90431ms step_avg:60.86ms
+step:1487/1555 train_time:90519ms step_avg:60.87ms
+step:1488/1555 train_time:90606ms step_avg:60.89ms
+step:1489/1555 train_time:90695ms step_avg:60.91ms
+step:1490/1555 train_time:90780ms step_avg:60.93ms
+step:1491/1555 train_time:90873ms step_avg:60.95ms
+step:1492/1555 train_time:90957ms step_avg:60.96ms
+step:1493/1555 train_time:91047ms step_avg:60.98ms
+step:1494/1555 train_time:91132ms step_avg:61.00ms
+step:1495/1555 train_time:91222ms step_avg:61.02ms
+step:1496/1555 train_time:91307ms step_avg:61.03ms
+step:1497/1555 train_time:91397ms step_avg:61.05ms
+step:1498/1555 train_time:91483ms step_avg:61.07ms
+step:1499/1555 train_time:91574ms step_avg:61.09ms
+step:1500/1555 train_time:91659ms step_avg:61.11ms
+step:1500/1555 val_loss:3.2952 train_time:91734ms step_avg:61.16ms
+step:1501/1555 train_time:91752ms step_avg:61.13ms
+step:1502/1555 train_time:91842ms step_avg:61.15ms
+step:1503/1555 train_time:91936ms step_avg:61.17ms
+step:1504/1555 train_time:92021ms step_avg:61.18ms
+step:1505/1555 train_time:92110ms step_avg:61.20ms
+step:1506/1555 train_time:92195ms step_avg:61.22ms
+step:1507/1555 train_time:92284ms step_avg:61.24ms
+step:1508/1555 train_time:92368ms step_avg:61.25ms
+step:1509/1555 train_time:92456ms step_avg:61.27ms
+step:1510/1555 train_time:92540ms step_avg:61.29ms
+step:1511/1555 train_time:92629ms step_avg:61.30ms
+step:1512/1555 train_time:92715ms step_avg:61.32ms
+step:1513/1555 train_time:92808ms step_avg:61.34ms
+step:1514/1555 train_time:92895ms step_avg:61.36ms
+step:1515/1555 train_time:92986ms step_avg:61.38ms
+step:1516/1555 train_time:93081ms step_avg:61.40ms
+step:1517/1555 train_time:93168ms step_avg:61.42ms
+step:1518/1555 train_time:93253ms step_avg:61.43ms
+step:1519/1555 train_time:93342ms step_avg:61.45ms
+step:1520/1555 train_time:93427ms step_avg:61.47ms
+step:1521/1555 train_time:93516ms step_avg:61.48ms
+step:1522/1555 train_time:93601ms step_avg:61.50ms
+step:1523/1555 train_time:93691ms step_avg:61.52ms
+step:1524/1555 train_time:93779ms step_avg:61.53ms
+step:1525/1555 train_time:93870ms step_avg:61.55ms
+step:1526/1555 train_time:93957ms step_avg:61.57ms
+step:1527/1555 train_time:94048ms step_avg:61.59ms
+step:1528/1555 train_time:94135ms step_avg:61.61ms
+step:1529/1555 train_time:94225ms step_avg:61.63ms
+step:1530/1555 train_time:94310ms step_avg:61.64ms
+step:1531/1555 train_time:94399ms step_avg:61.66ms
+step:1532/1555 train_time:94484ms step_avg:61.67ms
+step:1533/1555 train_time:94575ms step_avg:61.69ms
+step:1534/1555 train_time:94661ms step_avg:61.71ms
+step:1535/1555 train_time:94751ms step_avg:61.73ms
+step:1536/1555 train_time:94838ms step_avg:61.74ms
+step:1537/1555 train_time:94929ms step_avg:61.76ms
+step:1538/1555 train_time:95015ms step_avg:61.78ms
+step:1539/1555 train_time:95106ms step_avg:61.80ms
+step:1540/1555 train_time:95191ms step_avg:61.81ms
+step:1541/1555 train_time:95282ms step_avg:61.83ms
+step:1542/1555 train_time:95367ms step_avg:61.85ms
+step:1543/1555 train_time:95456ms step_avg:61.86ms
+step:1544/1555 train_time:95543ms step_avg:61.88ms
+step:1545/1555 train_time:95634ms step_avg:61.90ms
+step:1546/1555 train_time:95720ms step_avg:61.91ms
+step:1547/1555 train_time:95809ms step_avg:61.93ms
+step:1548/1555 train_time:95896ms step_avg:61.95ms
+step:1549/1555 train_time:95986ms step_avg:61.97ms
+step:1550/1555 train_time:96074ms step_avg:61.98ms
+step:1551/1555 train_time:96164ms step_avg:62.00ms
+step:1552/1555 train_time:96250ms step_avg:62.02ms
+step:1553/1555 train_time:96340ms step_avg:62.03ms
+step:1554/1555 train_time:96425ms step_avg:62.05ms
+step:1555/1555 train_time:96517ms step_avg:62.07ms
+step:1555/1555 val_loss:3.2791 train_time:96586ms step_avg:62.11ms
+peak memory allocated: 30933 MiB reserved: 47018 MiB

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -1059,6 +1059,56 @@ class Block(nn.Module):
         return x
 
 # -----------------------------------------------------------------------------
+# Mimetic V-O Initialization (Trockman & Kolter, ICML 2023)
+# Initialize V and O such that V @ O^T ≈ -βI (negative identity-like)
+# This enables attention to make meaningful contributions from step 1
+
+def mimetic_vo_init(attn_bank, model_dim=768, num_heads=6, head_dim=128, beta=0.1, noise_std=0.01):
+    """
+    Initialize attention bank with mimetic structure for V and O.
+    Q and K use standard uniform init, V and O use identity-like structure.
+
+    Args:
+        attn_bank: Tensor of shape (num_layers, 4*model_dim, hdim)
+        model_dim: Model dimension (768)
+        num_heads: Number of attention heads (6)
+        head_dim: Dimension per head (128)
+        beta: Scale for identity structure (0.1 recommended with attn_scale=0.1)
+        noise_std: Standard deviation of noise for symmetry breaking
+    """
+    num_layers = attn_bank.shape[0]
+    dim = model_dim
+    sqrt_beta = beta ** 0.5
+
+    # Standard init for Q and K (existing behavior)
+    attn_std = model_dim ** -0.5
+    attn_bound = (3 ** 0.5) * attn_std
+
+    with torch.no_grad():
+        # Q and K: uniform init (first 2*dim rows)
+        attn_bank[:, :2*dim, :].uniform_(-attn_bound, attn_bound)
+
+        # V and O: mimetic identity structure
+        for layer_idx in range(num_layers):
+            W_V = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+            W_O = torch.zeros(dim, dim, dtype=attn_bank.dtype, device=attn_bank.device)
+
+            # Create per-head identity blocks
+            for h in range(num_heads):
+                start, end = h * head_dim, (h + 1) * head_dim
+                eye = torch.eye(head_dim, dtype=attn_bank.dtype, device=attn_bank.device)
+                W_V[start:end, start:end] = sqrt_beta * eye
+                W_O[start:end, start:end] = -sqrt_beta * eye
+
+            # Add noise for symmetry breaking
+            W_V += noise_std * torch.randn_like(W_V)
+            W_O += noise_std * torch.randn_like(W_O)
+
+            # Store in attn_bank: V is rows [2*dim:3*dim], O is rows [3*dim:4*dim]
+            attn_bank[layer_idx, 2*dim:3*dim, :] = W_V
+            attn_bank[layer_idx, 3*dim:4*dim, :] = W_O
+
+# -----------------------------------------------------------------------------
 # The main model
 
 def next_multiple_of_n(v: float | int, *, n: int):
@@ -1134,16 +1184,21 @@ class GPT(nn.Module):
         self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
 
         # improved init scale by @YouJiacheng
-        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
-        attn_std = model_dim ** -0.5
-        attn_bound = (3 ** 0.5) * attn_std
+        # MLP uses 0.5 * dim^-0.5
         mlp_std = 0.5 * (model_dim ** -0.5)
         mlp_bound = (3 ** 0.5) * mlp_std
         with torch.no_grad():
-            # Init attention bank (QKV uniform, O zero)
-            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
-            self.attn_bank[:, model_dim * 3:, :].zero_()
-            # Init MLP bank (c_fc uniform, c_proj zero) 
+            # Init attention bank with MIMETIC V-O initialization
+            # Q and K: uniform init, V and O: identity-like structure for faster convergence
+            mimetic_vo_init(
+                self.attn_bank,
+                model_dim=model_dim,
+                num_heads=num_heads,
+                head_dim=head_dim,
+                beta=0.05,       # Scale for V@O^T ≈ -βI (tuned down from 0.1)
+                noise_std=0.01   # Symmetry breaking noise
+            )
+            # Init MLP bank (c_fc uniform, c_proj zero)
             self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
             self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
 
@@ -1720,8 +1775,8 @@ class TrainingManager():
 @dataclass
 class Hyperparameters:
     # data
-    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
-    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    train_files: str = "data/fineweb/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb/fineweb_val_*.bin" # input .bin to eval validation loss on
     val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
     # batch sizes
     train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
@@ -1729,7 +1784,7 @@ class Hyperparameters:
     train_max_seq_len: int = 128 * 16
     val_batch_size: int = 4 * 64 * 1024 * 8
     # optimization
-    num_scheduled_iterations: int = 1535  # number of steps to complete lr and ws schedule
+    num_scheduled_iterations: int = 1515  # number of steps to complete lr and ws schedule
     num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
     num_iterations: int = num_scheduled_iterations + num_extension_iterations
     cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate


### PR DESCRIPTION
Changes

1. Mimetic V-O Initialization: initialize attention V and O projection weights with negative identity structure, idea taken from this paper by Trockman & Kolter (2023): https://arxiv.org/abs/2305.09828

```python
def mimetic_vo_init(W_V, W_O, num_heads, head_dim, beta=0.05, noise_std=0.01):
    """Initialize V and O matrices so W_V @ W_O.T ≈ -beta*I per head."""
    sqrt_beta = beta ** 0.5
    for h in range(num_heads):
        start, end = h * head_dim, (h + 1) * head_dim
        W_V.data[start:end, start:end] = sqrt_beta * torch.eye(head_dim)
        W_O.data[start:end, start:end] = -sqrt_beta * torch.eye(head_dim)
    # Noise for symmetry breaking
    W_V.data += noise_std * torch.randn_like(W_V)
    W_O.data += noise_std * torch.randn_like(W_O)
```

2. Reduced step count from 1575 to 1555

### Why it works

Standard transformer init zeros the output projections, making attention layers no-ops at init. Model wastes early steps learning to break this symmetry before attention contributes anything meaningful. Trockman & Kolter show that trained transformers naturally develop the `W_V @ W_O.T ≈ -βI` structure. Starting near this manifold skips wasted optimization steps.

The negative identity means attention outputs immediately subtract from the residual stream rather than doing nothing. This gives the model a head start on developing the typical "residual subtraction" pattern.

### What didn't work

- beta ≥ 0.10 was too aggressive, destabilizes training
- Mimetic initialization on Q-K showed no gain

### Timing and Validation

```python
import scipy.stats
import torch

# Record (1555 steps, mimetic init)
losses = [3.2775, 3.2791, 3.2805, 3.278, 3.2778, 3.2772, 3.2777]
times = [96.493, 96.586, 96.590, 96.535, 96.552, 96.556, 96.559]
print("p=%.4f" % scipy.stats.ttest_1samp(losses, 3.28, alternative="less").pvalue)
# p=0.0036
print("losses:", torch.std_mean(torch.tensor(losses)))
# losses: (tensor(0.0011), tensor(3.2783))
print("time:", torch.std_mean(torch.tensor(times)))
# time: (tensor(0.0330), tensor(96.5530))

# Baseline (1575 steps, no mimetic init just retiming with my setup)
baseline_losses = [3.2759, 3.28, 3.2756, 3.2786, 3.2767, 3.2789, 3.2782]
baseline_times = [97.709, 97.617, 97.700, 97.726, 97.791, 97.705, 97.730]
print("baseline p=%.4f" % scipy.stats.ttest_1samp(baseline_losses, 3.28, alternative="less").pvalue)
# baseline p=0.0052
print("baseline losses:", torch.std_mean(torch.tensor(baseline_losses)))
# baseline losses: (tensor(0.0017), tensor(3.2777))
print("baseline time:", torch.std_mean(torch.tensor(baseline_times)))
# baseline time: (tensor(0.0520), tensor(97.7111))

# Baseline at 1555 steps (no mimetic init) - fails
baseline_reduced_losses = [3.2802, 3.2798, 3.2794, 3.2798, 3.2783, 3.2808, 3.2798, 3.2802, 3.2787, 3.28]
print("baseline reduced p=%.4f" % scipy.stats.ttest_1samp(baseline_reduced_losses, 3.28, alternative="less").pvalue)
# baseline reduced steps p=0.1149
```

Baseline at 1555 steps does not seem to reach significance, I think the init is doing real work.

Done with support from @bremen79

### References

Asher Trockman, & J. Zico Kolter. (2023). Mimetic Initialization of Self-Attention Layers. https://arxiv.org/abs/2305.09828