### PR TITLE
fix: replace bare except with except Exception in SOAP eigendecomposition

### DIFF
--- a/records/track_1_short/2024-10-09_SOAP/train_gpt2.py
+++ b/records/track_1_short/2024-10-09_SOAP/train_gpt2.py
@@ -349,7 +349,7 @@ class SOAP(optim.Optimizer):
                 continue
             try:
                 _, Q = torch.linalg.eigh(m+1e-30*torch.eye(m.shape[0], device=m.device))
-            except:
+            except Exception:
                 _, Q = torch.linalg.eigh(m.to(torch.float64)+1e-30*torch.eye(m.shape[0], device=m.device))
                 Q = Q.to(m.dtype)
             Q = torch.flip(Q, [1])


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in the SOAP optimizer's eigendecomposition fallback. The float64 fallback for `torch.linalg.eigh` should only catch numerical errors, not `KeyboardInterrupt`.