### PR TITLE
New Record: Reduce max_num_docs, -500ms

### DIFF
--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/README.md
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/README.md
@@ -1,0 +1,36 @@
+# Reduce Varlen max_num_docs
+
+While working on refactoring `nanochat` for FlashAttention varlen, I discovered that the size of the `cu_seqlens` tensor (which contains the document offsets in our 1D training batch) matters more than expected. 
+
+Analyzing the fineweb dataset and better tailoring the size of `cu_seqlens` gave a ~500ms speed improvement.
+
+Additionally, I tried some recent `nanochat` changes and found that the reduction of Muon's second beta from `0.95 --> 0.9` slightly improved loss, so I included that as well (no reduction in steps).
+
+```
+                    Runs  Steps   Time μ   Time σ  Time +/-   Time p   Loss μ   Loss σ  Loss +/-        p
+baseline               8   1490  86.7400   0.0497    0.0000       NaN  3.2787   0.0015    0.0000   0.0218 
+max_num_docs           4   1490  86.2422   0.0479   -0.4977   0.0000   3.2785   0.0012   -0.0002   0.0444 
+muon-beta2             4   1490  86.7758   0.0274    0.0358   0.9296   3.2785   0.0007   -0.0002   0.0122 
+combined (this PR)     8   1490  86.2246   0.0300   -0.5154   0.0000   3.2784   0.0013   -0.0003   0.0054 
+```
+
+### Choosing max_num_docs
+
+We need `cu_seqlens` to be a fixed size for `torch.compile`. However, because we have a separate compute graph per batch size, we can safely choose a different `cu_seqlens` size for each batch size.
+
+To determine appropriate sizes, I analyzed the first 10 shards (1.45M documents).
+
+For token counts overall:
+* median 403
+* mean 690 
+* min 32
+
+I constructed the actual batches used and counted the number of documents in each, across our three batch sizes / stages:
+
+| Stage | tokens/rank | current `max_num_docs` | observed max | proposed | savings |
+|-------|-------------|----------------------|--------------|----------|---------|
+| Stage 1 | 16,384 | 128 | 56 | **64** | -64 slots (50%) |
+| Stage 2 | 32,768 | 128 | 90 | **96** | -32 slots (25%) |
+| Stage 3 | 49,152 | 256 | 121 | **128** | -128 slots (50%) |
+
+I've hardcoded those batch size --> num docs mappings, but with a fallback to the original method of rounding up conservatively if a different batch size is encountered.

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/baseline/2026-03-22_18-07-13_time-389_secs_baseline_f26ba7.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/baseline/2026-03-22_18-07-13_time-389_secs_baseline_f26ba7.txt
@@ -1,0 +1,4456 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 18:07:28 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   31C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   28C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   31C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   30C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   29C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   30C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   27C    P0            114W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1320568      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1320569      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1320570      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1320571      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1320572      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1320573      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1320574      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1320575      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8320 train_time:0ms step_avg:0.04ms
+step:1/1490 train_time:86ms step_avg:86.38ms
+step:2/1490 train_time:112ms step_avg:56.15ms
+step:3/1490 train_time:132ms step_avg:43.97ms
+step:4/1490 train_time:153ms step_avg:38.13ms
+step:5/1490 train_time:179ms step_avg:35.79ms
+step:6/1490 train_time:214ms step_avg:35.62ms
+step:7/1490 train_time:241ms step_avg:34.44ms
+step:8/1490 train_time:276ms step_avg:34.47ms
+step:9/1490 train_time:303ms step_avg:33.70ms
+step:10/1490 train_time:338ms step_avg:33.81ms
+step:11/1490 train_time:366ms step_avg:33.27ms
+step:12/1490 train_time:400ms step_avg:33.35ms
+step:13/1490 train_time:429ms step_avg:32.97ms
+step:14/1490 train_time:463ms step_avg:33.06ms
+step:15/1490 train_time:492ms step_avg:32.77ms
+step:16/1490 train_time:526ms step_avg:32.85ms
+step:17/1490 train_time:554ms step_avg:32.58ms
+step:18/1490 train_time:588ms step_avg:32.67ms
+step:19/1490 train_time:616ms step_avg:32.43ms
+step:20/1490 train_time:651ms step_avg:32.55ms
+step:21/1490 train_time:679ms step_avg:32.34ms
+step:22/1490 train_time:714ms step_avg:32.44ms
+step:23/1490 train_time:742ms step_avg:32.26ms
+step:24/1490 train_time:776ms step_avg:32.35ms
+step:25/1490 train_time:805ms step_avg:32.19ms
+step:26/1490 train_time:839ms step_avg:32.28ms
+step:27/1490 train_time:868ms step_avg:32.13ms
+step:28/1490 train_time:902ms step_avg:32.21ms
+step:29/1490 train_time:930ms step_avg:32.08ms
+step:30/1490 train_time:965ms step_avg:32.16ms
+step:31/1490 train_time:994ms step_avg:32.06ms
+step:32/1490 train_time:1029ms step_avg:32.16ms
+step:33/1490 train_time:1059ms step_avg:32.08ms
+step:34/1490 train_time:1094ms step_avg:32.17ms
+step:35/1490 train_time:1122ms step_avg:32.07ms
+step:36/1490 train_time:1157ms step_avg:32.14ms
+step:37/1490 train_time:1186ms step_avg:32.05ms
+step:38/1490 train_time:1220ms step_avg:32.12ms
+step:39/1490 train_time:1250ms step_avg:32.04ms
+step:40/1490 train_time:1284ms step_avg:32.11ms
+step:41/1490 train_time:1313ms step_avg:32.02ms
+step:42/1490 train_time:1347ms step_avg:32.07ms
+step:43/1490 train_time:1375ms step_avg:31.99ms
+step:44/1490 train_time:1410ms step_avg:32.04ms
+step:45/1490 train_time:1438ms step_avg:31.96ms
+step:46/1490 train_time:1473ms step_avg:32.03ms
+step:47/1490 train_time:1502ms step_avg:31.95ms
+step:48/1490 train_time:1536ms step_avg:32.00ms
+step:49/1490 train_time:1564ms step_avg:31.93ms
+step:50/1490 train_time:1599ms step_avg:31.97ms
+step:51/1490 train_time:1627ms step_avg:31.90ms
+step:52/1490 train_time:1661ms step_avg:31.94ms
+step:53/1490 train_time:1690ms step_avg:31.88ms
+step:54/1490 train_time:1724ms step_avg:31.92ms
+step:55/1490 train_time:1753ms step_avg:31.87ms
+step:56/1490 train_time:1787ms step_avg:31.91ms
+step:57/1490 train_time:1815ms step_avg:31.85ms
+step:58/1490 train_time:1850ms step_avg:31.90ms
+step:59/1490 train_time:1878ms step_avg:31.84ms
+step:60/1490 train_time:1913ms step_avg:31.88ms
+step:61/1490 train_time:1941ms step_avg:31.82ms
+step:62/1490 train_time:1976ms step_avg:31.87ms
+step:63/1490 train_time:2004ms step_avg:31.81ms
+step:64/1490 train_time:2039ms step_avg:31.86ms
+step:65/1490 train_time:2068ms step_avg:31.81ms
+step:66/1490 train_time:2102ms step_avg:31.85ms
+step:67/1490 train_time:2131ms step_avg:31.81ms
+step:68/1490 train_time:2166ms step_avg:31.85ms
+step:69/1490 train_time:2194ms step_avg:31.80ms
+step:70/1490 train_time:2229ms step_avg:31.84ms
+step:71/1490 train_time:2258ms step_avg:31.80ms
+step:72/1490 train_time:2293ms step_avg:31.84ms
+step:73/1490 train_time:2321ms step_avg:31.79ms
+step:74/1490 train_time:2355ms step_avg:31.83ms
+step:75/1490 train_time:2384ms step_avg:31.79ms
+step:76/1490 train_time:2419ms step_avg:31.83ms
+step:77/1490 train_time:2447ms step_avg:31.79ms
+step:78/1490 train_time:2482ms step_avg:31.82ms
+step:79/1490 train_time:2511ms step_avg:31.78ms
+step:80/1490 train_time:2545ms step_avg:31.81ms
+step:81/1490 train_time:2573ms step_avg:31.77ms
+step:82/1490 train_time:2607ms step_avg:31.80ms
+step:83/1490 train_time:2636ms step_avg:31.76ms
+step:84/1490 train_time:2670ms step_avg:31.79ms
+step:85/1490 train_time:2698ms step_avg:31.75ms
+step:86/1490 train_time:2733ms step_avg:31.78ms
+step:87/1490 train_time:2761ms step_avg:31.74ms
+step:88/1490 train_time:2796ms step_avg:31.77ms
+step:89/1490 train_time:2824ms step_avg:31.73ms
+step:90/1490 train_time:2859ms step_avg:31.76ms
+step:91/1490 train_time:2887ms step_avg:31.73ms
+step:92/1490 train_time:2921ms step_avg:31.75ms
+step:93/1490 train_time:2950ms step_avg:31.72ms
+step:94/1490 train_time:2984ms step_avg:31.75ms
+step:95/1490 train_time:3013ms step_avg:31.72ms
+step:96/1490 train_time:3048ms step_avg:31.75ms
+step:97/1490 train_time:3077ms step_avg:31.72ms
+step:98/1490 train_time:3111ms step_avg:31.74ms
+step:99/1490 train_time:3139ms step_avg:31.71ms
+step:100/1490 train_time:3174ms step_avg:31.74ms
+step:101/1490 train_time:3202ms step_avg:31.70ms
+step:102/1490 train_time:3236ms step_avg:31.73ms
+step:103/1490 train_time:3265ms step_avg:31.70ms
+step:104/1490 train_time:3300ms step_avg:31.73ms
+step:105/1490 train_time:3328ms step_avg:31.70ms
+step:106/1490 train_time:3363ms step_avg:31.72ms
+step:107/1490 train_time:3391ms step_avg:31.69ms
+step:108/1490 train_time:3426ms step_avg:31.72ms
+step:109/1490 train_time:3454ms step_avg:31.69ms
+step:110/1490 train_time:3488ms step_avg:31.71ms
+step:111/1490 train_time:3516ms step_avg:31.68ms
+step:112/1490 train_time:3551ms step_avg:31.71ms
+step:113/1490 train_time:3579ms step_avg:31.68ms
+step:114/1490 train_time:3614ms step_avg:31.70ms
+step:115/1490 train_time:3642ms step_avg:31.67ms
+step:116/1490 train_time:3677ms step_avg:31.70ms
+step:117/1490 train_time:3705ms step_avg:31.67ms
+step:118/1490 train_time:3739ms step_avg:31.69ms
+step:119/1490 train_time:3768ms step_avg:31.66ms
+step:120/1490 train_time:3803ms step_avg:31.70ms
+step:121/1490 train_time:3831ms step_avg:31.66ms
+step:122/1490 train_time:3865ms step_avg:31.68ms
+step:123/1490 train_time:3893ms step_avg:31.65ms
+step:124/1490 train_time:3928ms step_avg:31.68ms
+step:125/1490 train_time:3957ms step_avg:31.66ms
+step:126/1490 train_time:3991ms step_avg:31.68ms
+step:127/1490 train_time:4019ms step_avg:31.65ms
+step:128/1490 train_time:4054ms step_avg:31.67ms
+step:129/1490 train_time:4082ms step_avg:31.65ms
+step:130/1490 train_time:4117ms step_avg:31.67ms
+step:131/1490 train_time:4145ms step_avg:31.64ms
+step:132/1490 train_time:4180ms step_avg:31.67ms
+step:133/1490 train_time:4208ms step_avg:31.64ms
+step:134/1490 train_time:4243ms step_avg:31.66ms
+step:135/1490 train_time:4271ms step_avg:31.64ms
+step:136/1490 train_time:4306ms step_avg:31.66ms
+step:137/1490 train_time:4334ms step_avg:31.64ms
+step:138/1490 train_time:4368ms step_avg:31.65ms
+step:139/1490 train_time:4397ms step_avg:31.63ms
+step:140/1490 train_time:4432ms step_avg:31.66ms
+step:141/1490 train_time:4460ms step_avg:31.63ms
+step:142/1490 train_time:4495ms step_avg:31.66ms
+step:143/1490 train_time:4523ms step_avg:31.63ms
+step:144/1490 train_time:4558ms step_avg:31.65ms
+step:145/1490 train_time:4586ms step_avg:31.63ms
+step:146/1490 train_time:4620ms step_avg:31.65ms
+step:147/1490 train_time:4649ms step_avg:31.62ms
+step:148/1490 train_time:4683ms step_avg:31.64ms
+step:149/1490 train_time:4712ms step_avg:31.62ms
+step:150/1490 train_time:4746ms step_avg:31.64ms
+step:151/1490 train_time:4774ms step_avg:31.62ms
+step:152/1490 train_time:4809ms step_avg:31.64ms
+step:153/1490 train_time:4837ms step_avg:31.62ms
+step:154/1490 train_time:4872ms step_avg:31.64ms
+step:155/1490 train_time:4900ms step_avg:31.61ms
+step:156/1490 train_time:4934ms step_avg:31.63ms
+step:157/1490 train_time:4963ms step_avg:31.61ms
+step:158/1490 train_time:4998ms step_avg:31.63ms
+step:159/1490 train_time:5026ms step_avg:31.61ms
+step:160/1490 train_time:5060ms step_avg:31.63ms
+step:161/1490 train_time:5088ms step_avg:31.61ms
+step:162/1490 train_time:5123ms step_avg:31.62ms
+step:163/1490 train_time:5152ms step_avg:31.60ms
+step:164/1490 train_time:5186ms step_avg:31.62ms
+step:165/1490 train_time:5215ms step_avg:31.60ms
+step:166/1490 train_time:5249ms step_avg:31.62ms
+step:167/1490 train_time:5277ms step_avg:31.60ms
+step:168/1490 train_time:5312ms step_avg:31.62ms
+step:169/1490 train_time:5340ms step_avg:31.60ms
+step:170/1490 train_time:5375ms step_avg:31.62ms
+step:171/1490 train_time:5403ms step_avg:31.60ms
+step:172/1490 train_time:5437ms step_avg:31.61ms
+step:173/1490 train_time:5466ms step_avg:31.59ms
+step:174/1490 train_time:5500ms step_avg:31.61ms
+step:175/1490 train_time:5529ms step_avg:31.59ms
+step:176/1490 train_time:5563ms step_avg:31.61ms
+step:177/1490 train_time:5592ms step_avg:31.59ms
+step:178/1490 train_time:5626ms step_avg:31.61ms
+step:179/1490 train_time:5655ms step_avg:31.59ms
+step:180/1490 train_time:5690ms step_avg:31.61ms
+step:181/1490 train_time:5718ms step_avg:31.59ms
+step:182/1490 train_time:5753ms step_avg:31.61ms
+step:183/1490 train_time:5782ms step_avg:31.59ms
+step:184/1490 train_time:5816ms step_avg:31.61ms
+step:185/1490 train_time:5844ms step_avg:31.59ms
+step:186/1490 train_time:5879ms step_avg:31.61ms
+step:187/1490 train_time:5907ms step_avg:31.59ms
+step:188/1490 train_time:5941ms step_avg:31.60ms
+step:189/1490 train_time:5970ms step_avg:31.59ms
+step:190/1490 train_time:6004ms step_avg:31.60ms
+step:191/1490 train_time:6033ms step_avg:31.59ms
+step:192/1490 train_time:6067ms step_avg:31.60ms
+step:193/1490 train_time:6095ms step_avg:31.58ms
+step:194/1490 train_time:6130ms step_avg:31.60ms
+step:195/1490 train_time:6158ms step_avg:31.58ms
+step:196/1490 train_time:6193ms step_avg:31.60ms
+step:197/1490 train_time:6221ms step_avg:31.58ms
+step:198/1490 train_time:6256ms step_avg:31.59ms
+step:199/1490 train_time:6284ms step_avg:31.58ms
+step:200/1490 train_time:6318ms step_avg:31.59ms
+step:201/1490 train_time:6347ms step_avg:31.57ms
+step:202/1490 train_time:6381ms step_avg:31.59ms
+step:203/1490 train_time:6410ms step_avg:31.57ms
+step:204/1490 train_time:6444ms step_avg:31.59ms
+step:205/1490 train_time:6472ms step_avg:31.57ms
+step:206/1490 train_time:6507ms step_avg:31.59ms
+step:207/1490 train_time:6535ms step_avg:31.57ms
+step:208/1490 train_time:6569ms step_avg:31.58ms
+step:209/1490 train_time:6597ms step_avg:31.57ms
+step:210/1490 train_time:6632ms step_avg:31.58ms
+step:211/1490 train_time:6660ms step_avg:31.57ms
+step:212/1490 train_time:6695ms step_avg:31.58ms
+step:213/1490 train_time:6724ms step_avg:31.57ms
+step:214/1490 train_time:6758ms step_avg:31.58ms
+step:215/1490 train_time:6786ms step_avg:31.56ms
+step:216/1490 train_time:6821ms step_avg:31.58ms
+step:217/1490 train_time:6849ms step_avg:31.56ms
+step:218/1490 train_time:6884ms step_avg:31.58ms
+step:219/1490 train_time:6912ms step_avg:31.56ms
+step:220/1490 train_time:6946ms step_avg:31.57ms
+step:221/1490 train_time:6975ms step_avg:31.56ms
+step:222/1490 train_time:7010ms step_avg:31.57ms
+step:223/1490 train_time:7038ms step_avg:31.56ms
+step:224/1490 train_time:7072ms step_avg:31.57ms
+step:225/1490 train_time:7100ms step_avg:31.56ms
+step:226/1490 train_time:7135ms step_avg:31.57ms
+step:227/1490 train_time:7163ms step_avg:31.56ms
+step:228/1490 train_time:7198ms step_avg:31.57ms
+step:229/1490 train_time:7226ms step_avg:31.55ms
+step:230/1490 train_time:7260ms step_avg:31.57ms
+step:231/1490 train_time:7289ms step_avg:31.55ms
+step:232/1490 train_time:7324ms step_avg:31.57ms
+step:233/1490 train_time:7352ms step_avg:31.55ms
+step:234/1490 train_time:7386ms step_avg:31.57ms
+step:235/1490 train_time:7415ms step_avg:31.55ms
+step:236/1490 train_time:7449ms step_avg:31.56ms
+step:237/1490 train_time:7478ms step_avg:31.55ms
+step:238/1490 train_time:7513ms step_avg:31.57ms
+step:239/1490 train_time:7541ms step_avg:31.55ms
+step:240/1490 train_time:7576ms step_avg:31.56ms
+step:241/1490 train_time:7604ms step_avg:31.55ms
+step:242/1490 train_time:7638ms step_avg:31.56ms
+step:243/1490 train_time:7666ms step_avg:31.55ms
+step:244/1490 train_time:7701ms step_avg:31.56ms
+step:245/1490 train_time:7730ms step_avg:31.55ms
+step:246/1490 train_time:7765ms step_avg:31.56ms
+step:247/1490 train_time:7793ms step_avg:31.55ms
+step:248/1490 train_time:7828ms step_avg:31.56ms
+step:249/1490 train_time:7856ms step_avg:31.55ms
+step:250/1490 train_time:7891ms step_avg:31.56ms
+step:250/1490 val_loss:4.5059 train_time:7934ms step_avg:31.73ms
+step:251/1490 train_time:7950ms step_avg:31.67ms
+step:252/1490 train_time:7968ms step_avg:31.62ms
+step:253/1490 train_time:7983ms step_avg:31.55ms
+step:254/1490 train_time:8019ms step_avg:31.57ms
+step:255/1490 train_time:8049ms step_avg:31.56ms
+step:256/1490 train_time:8086ms step_avg:31.59ms
+step:257/1490 train_time:8115ms step_avg:31.57ms
+step:258/1490 train_time:8149ms step_avg:31.59ms
+step:259/1490 train_time:8178ms step_avg:31.57ms
+step:260/1490 train_time:8212ms step_avg:31.59ms
+step:261/1490 train_time:8241ms step_avg:31.57ms
+step:262/1490 train_time:8275ms step_avg:31.58ms
+step:263/1490 train_time:8303ms step_avg:31.57ms
+step:264/1490 train_time:8337ms step_avg:31.58ms
+step:265/1490 train_time:8365ms step_avg:31.57ms
+step:266/1490 train_time:8400ms step_avg:31.58ms
+step:267/1490 train_time:8428ms step_avg:31.56ms
+step:268/1490 train_time:8462ms step_avg:31.58ms
+step:269/1490 train_time:8491ms step_avg:31.56ms
+step:270/1490 train_time:8525ms step_avg:31.57ms
+step:271/1490 train_time:8553ms step_avg:31.56ms
+step:272/1490 train_time:8587ms step_avg:31.57ms
+step:273/1490 train_time:8616ms step_avg:31.56ms
+step:274/1490 train_time:8650ms step_avg:31.57ms
+step:275/1490 train_time:8678ms step_avg:31.56ms
+step:276/1490 train_time:8712ms step_avg:31.56ms
+step:277/1490 train_time:8740ms step_avg:31.55ms
+step:278/1490 train_time:8774ms step_avg:31.56ms
+step:279/1490 train_time:8802ms step_avg:31.55ms
+step:280/1490 train_time:8836ms step_avg:31.56ms
+step:281/1490 train_time:8865ms step_avg:31.55ms
+step:282/1490 train_time:8899ms step_avg:31.56ms
+step:283/1490 train_time:8927ms step_avg:31.54ms
+step:284/1490 train_time:8962ms step_avg:31.56ms
+step:285/1490 train_time:8990ms step_avg:31.54ms
+step:286/1490 train_time:9026ms step_avg:31.56ms
+step:287/1490 train_time:9054ms step_avg:31.55ms
+step:288/1490 train_time:9089ms step_avg:31.56ms
+step:289/1490 train_time:9118ms step_avg:31.55ms
+step:290/1490 train_time:9153ms step_avg:31.56ms
+step:291/1490 train_time:9182ms step_avg:31.55ms
+step:292/1490 train_time:9216ms step_avg:31.56ms
+step:293/1490 train_time:9245ms step_avg:31.55ms
+step:294/1490 train_time:9280ms step_avg:31.56ms
+step:295/1490 train_time:9308ms step_avg:31.55ms
+step:296/1490 train_time:9343ms step_avg:31.56ms
+step:297/1490 train_time:9371ms step_avg:31.55ms
+step:298/1490 train_time:9405ms step_avg:31.56ms
+step:299/1490 train_time:9433ms step_avg:31.55ms
+step:300/1490 train_time:9468ms step_avg:31.56ms
+step:301/1490 train_time:9496ms step_avg:31.55ms
+step:302/1490 train_time:9530ms step_avg:31.56ms
+step:303/1490 train_time:9559ms step_avg:31.55ms
+step:304/1490 train_time:9593ms step_avg:31.55ms
+step:305/1490 train_time:9621ms step_avg:31.54ms
+step:306/1490 train_time:9655ms step_avg:31.55ms
+step:307/1490 train_time:9683ms step_avg:31.54ms
+step:308/1490 train_time:9717ms step_avg:31.55ms
+step:309/1490 train_time:9745ms step_avg:31.54ms
+step:310/1490 train_time:9779ms step_avg:31.55ms
+step:311/1490 train_time:9808ms step_avg:31.54ms
+step:312/1490 train_time:9842ms step_avg:31.55ms
+step:313/1490 train_time:9870ms step_avg:31.53ms
+step:314/1490 train_time:9904ms step_avg:31.54ms
+step:315/1490 train_time:9933ms step_avg:31.53ms
+step:316/1490 train_time:9967ms step_avg:31.54ms
+step:317/1490 train_time:9996ms step_avg:31.53ms
+step:318/1490 train_time:10030ms step_avg:31.54ms
+step:319/1490 train_time:10059ms step_avg:31.53ms
+step:320/1490 train_time:10094ms step_avg:31.54ms
+step:321/1490 train_time:10123ms step_avg:31.53ms
+step:322/1490 train_time:10157ms step_avg:31.54ms
+step:323/1490 train_time:10185ms step_avg:31.53ms
+step:324/1490 train_time:10220ms step_avg:31.54ms
+step:325/1490 train_time:10249ms step_avg:31.54ms
+step:326/1490 train_time:10284ms step_avg:31.55ms
+step:327/1490 train_time:10312ms step_avg:31.54ms
+step:328/1490 train_time:10347ms step_avg:31.55ms
+step:329/1490 train_time:10375ms step_avg:31.54ms
+step:330/1490 train_time:10409ms step_avg:31.54ms
+step:331/1490 train_time:10438ms step_avg:31.54ms
+step:332/1490 train_time:10472ms step_avg:31.54ms
+step:333/1490 train_time:10501ms step_avg:31.53ms
+step:334/1490 train_time:10535ms step_avg:31.54ms
+step:335/1490 train_time:10563ms step_avg:31.53ms
+step:336/1490 train_time:10598ms step_avg:31.54ms
+step:337/1490 train_time:10626ms step_avg:31.53ms
+step:338/1490 train_time:10661ms step_avg:31.54ms
+step:339/1490 train_time:10689ms step_avg:31.53ms
+step:340/1490 train_time:10723ms step_avg:31.54ms
+step:341/1490 train_time:10752ms step_avg:31.53ms
+step:342/1490 train_time:10786ms step_avg:31.54ms
+step:343/1490 train_time:10815ms step_avg:31.53ms
+step:344/1490 train_time:10849ms step_avg:31.54ms
+step:345/1490 train_time:10878ms step_avg:31.53ms
+step:346/1490 train_time:10912ms step_avg:31.54ms
+step:347/1490 train_time:10941ms step_avg:31.53ms
+step:348/1490 train_time:10975ms step_avg:31.54ms
+step:349/1490 train_time:11003ms step_avg:31.53ms
+step:350/1490 train_time:11037ms step_avg:31.53ms
+step:351/1490 train_time:11065ms step_avg:31.53ms
+step:352/1490 train_time:11100ms step_avg:31.53ms
+step:353/1490 train_time:11129ms step_avg:31.53ms
+step:354/1490 train_time:11163ms step_avg:31.53ms
+step:355/1490 train_time:11192ms step_avg:31.53ms
+step:356/1490 train_time:11226ms step_avg:31.54ms
+step:357/1490 train_time:11255ms step_avg:31.53ms
+step:358/1490 train_time:11289ms step_avg:31.53ms
+step:359/1490 train_time:11318ms step_avg:31.53ms
+step:360/1490 train_time:11353ms step_avg:31.54ms
+step:361/1490 train_time:11381ms step_avg:31.53ms
+step:362/1490 train_time:11415ms step_avg:31.53ms
+step:363/1490 train_time:11444ms step_avg:31.53ms
+step:364/1490 train_time:11478ms step_avg:31.53ms
+step:365/1490 train_time:11507ms step_avg:31.52ms
+step:366/1490 train_time:11541ms step_avg:31.53ms
+step:367/1490 train_time:11569ms step_avg:31.52ms
+step:368/1490 train_time:11604ms step_avg:31.53ms
+step:369/1490 train_time:11632ms step_avg:31.52ms
+step:370/1490 train_time:11666ms step_avg:31.53ms
+step:371/1490 train_time:11694ms step_avg:31.52ms
+step:372/1490 train_time:11729ms step_avg:31.53ms
+step:373/1490 train_time:11757ms step_avg:31.52ms
+step:374/1490 train_time:11792ms step_avg:31.53ms
+step:375/1490 train_time:11820ms step_avg:31.52ms
+step:376/1490 train_time:11854ms step_avg:31.53ms
+step:377/1490 train_time:11883ms step_avg:31.52ms
+step:378/1490 train_time:11917ms step_avg:31.53ms
+step:379/1490 train_time:11945ms step_avg:31.52ms
+step:380/1490 train_time:11980ms step_avg:31.53ms
+step:381/1490 train_time:12008ms step_avg:31.52ms
+step:382/1490 train_time:12042ms step_avg:31.52ms
+step:383/1490 train_time:12070ms step_avg:31.51ms
+step:384/1490 train_time:12105ms step_avg:31.52ms
+step:385/1490 train_time:12133ms step_avg:31.52ms
+step:386/1490 train_time:12168ms step_avg:31.52ms
+step:387/1490 train_time:12196ms step_avg:31.51ms
+step:388/1490 train_time:12230ms step_avg:31.52ms
+step:389/1490 train_time:12259ms step_avg:31.51ms
+step:390/1490 train_time:12294ms step_avg:31.52ms
+step:391/1490 train_time:12322ms step_avg:31.51ms
+step:392/1490 train_time:12357ms step_avg:31.52ms
+step:393/1490 train_time:12385ms step_avg:31.51ms
+step:394/1490 train_time:12420ms step_avg:31.52ms
+step:395/1490 train_time:12448ms step_avg:31.51ms
+step:396/1490 train_time:12483ms step_avg:31.52ms
+step:397/1490 train_time:12511ms step_avg:31.51ms
+step:398/1490 train_time:12546ms step_avg:31.52ms
+step:399/1490 train_time:12574ms step_avg:31.51ms
+step:400/1490 train_time:12608ms step_avg:31.52ms
+step:401/1490 train_time:12637ms step_avg:31.51ms
+step:402/1490 train_time:12672ms step_avg:31.52ms
+step:403/1490 train_time:12700ms step_avg:31.51ms
+step:404/1490 train_time:12734ms step_avg:31.52ms
+step:405/1490 train_time:12763ms step_avg:31.51ms
+step:406/1490 train_time:12797ms step_avg:31.52ms
+step:407/1490 train_time:12826ms step_avg:31.51ms
+step:408/1490 train_time:12860ms step_avg:31.52ms
+step:409/1490 train_time:12889ms step_avg:31.51ms
+step:410/1490 train_time:12923ms step_avg:31.52ms
+step:411/1490 train_time:12952ms step_avg:31.51ms
+step:412/1490 train_time:12986ms step_avg:31.52ms
+step:413/1490 train_time:13014ms step_avg:31.51ms
+step:414/1490 train_time:13049ms step_avg:31.52ms
+step:415/1490 train_time:13077ms step_avg:31.51ms
+step:416/1490 train_time:13111ms step_avg:31.52ms
+step:417/1490 train_time:13139ms step_avg:31.51ms
+step:418/1490 train_time:13174ms step_avg:31.52ms
+step:419/1490 train_time:13202ms step_avg:31.51ms
+step:420/1490 train_time:13237ms step_avg:31.52ms
+step:421/1490 train_time:13265ms step_avg:31.51ms
+step:422/1490 train_time:13299ms step_avg:31.51ms
+step:423/1490 train_time:13327ms step_avg:31.51ms
+step:424/1490 train_time:13362ms step_avg:31.51ms
+step:425/1490 train_time:13391ms step_avg:31.51ms
+step:426/1490 train_time:13425ms step_avg:31.51ms
+step:427/1490 train_time:13453ms step_avg:31.51ms
+step:428/1490 train_time:13488ms step_avg:31.51ms
+step:429/1490 train_time:13517ms step_avg:31.51ms
+step:430/1490 train_time:13551ms step_avg:31.51ms
+step:431/1490 train_time:13579ms step_avg:31.51ms
+step:432/1490 train_time:13614ms step_avg:31.51ms
+step:433/1490 train_time:13642ms step_avg:31.51ms
+step:434/1490 train_time:13676ms step_avg:31.51ms
+step:435/1490 train_time:13704ms step_avg:31.50ms
+step:436/1490 train_time:13739ms step_avg:31.51ms
+step:437/1490 train_time:13767ms step_avg:31.50ms
+step:438/1490 train_time:13802ms step_avg:31.51ms
+step:439/1490 train_time:13830ms step_avg:31.50ms
+step:440/1490 train_time:13865ms step_avg:31.51ms
+step:441/1490 train_time:13893ms step_avg:31.50ms
+step:442/1490 train_time:13928ms step_avg:31.51ms
+step:443/1490 train_time:13956ms step_avg:31.50ms
+step:444/1490 train_time:13991ms step_avg:31.51ms
+step:445/1490 train_time:14019ms step_avg:31.50ms
+step:446/1490 train_time:14053ms step_avg:31.51ms
+step:447/1490 train_time:14082ms step_avg:31.50ms
+step:448/1490 train_time:14116ms step_avg:31.51ms
+step:449/1490 train_time:14145ms step_avg:31.50ms
+step:450/1490 train_time:14179ms step_avg:31.51ms
+step:451/1490 train_time:14207ms step_avg:31.50ms
+step:452/1490 train_time:14242ms step_avg:31.51ms
+step:453/1490 train_time:14270ms step_avg:31.50ms
+step:454/1490 train_time:14305ms step_avg:31.51ms
+step:455/1490 train_time:14333ms step_avg:31.50ms
+step:456/1490 train_time:14367ms step_avg:31.51ms
+step:457/1490 train_time:14396ms step_avg:31.50ms
+step:458/1490 train_time:14430ms step_avg:31.51ms
+step:459/1490 train_time:14459ms step_avg:31.50ms
+step:460/1490 train_time:14493ms step_avg:31.51ms
+step:461/1490 train_time:14522ms step_avg:31.50ms
+step:462/1490 train_time:14556ms step_avg:31.51ms
+step:463/1490 train_time:14585ms step_avg:31.50ms
+step:464/1490 train_time:14619ms step_avg:31.51ms
+step:465/1490 train_time:14647ms step_avg:31.50ms
+step:466/1490 train_time:14682ms step_avg:31.51ms
+step:467/1490 train_time:14710ms step_avg:31.50ms
+step:468/1490 train_time:14745ms step_avg:31.51ms
+step:469/1490 train_time:14773ms step_avg:31.50ms
+step:470/1490 train_time:14808ms step_avg:31.51ms
+step:471/1490 train_time:14837ms step_avg:31.50ms
+step:472/1490 train_time:14871ms step_avg:31.51ms
+step:473/1490 train_time:14899ms step_avg:31.50ms
+step:474/1490 train_time:14934ms step_avg:31.51ms
+step:475/1490 train_time:14962ms step_avg:31.50ms
+step:476/1490 train_time:14996ms step_avg:31.50ms
+step:477/1490 train_time:15025ms step_avg:31.50ms
+step:478/1490 train_time:15059ms step_avg:31.50ms
+step:479/1490 train_time:15087ms step_avg:31.50ms
+step:480/1490 train_time:15122ms step_avg:31.50ms
+step:481/1490 train_time:15150ms step_avg:31.50ms
+step:482/1490 train_time:15185ms step_avg:31.50ms
+step:483/1490 train_time:15213ms step_avg:31.50ms
+step:484/1490 train_time:15250ms step_avg:31.51ms
+step:485/1490 train_time:15302ms step_avg:31.55ms
+step:486/1490 train_time:15362ms step_avg:31.61ms
+step:487/1490 train_time:15417ms step_avg:31.66ms
+step:488/1490 train_time:15476ms step_avg:31.71ms
+step:489/1490 train_time:15530ms step_avg:31.76ms
+step:490/1490 train_time:15590ms step_avg:31.82ms
+step:491/1490 train_time:15645ms step_avg:31.86ms
+step:492/1490 train_time:15704ms step_avg:31.92ms
+step:493/1490 train_time:15759ms step_avg:31.97ms
+step:494/1490 train_time:15818ms step_avg:32.02ms
+step:495/1490 train_time:15872ms step_avg:32.07ms
+step:496/1490 train_time:15932ms step_avg:32.12ms
+step:497/1490 train_time:15986ms step_avg:32.17ms
+step:498/1490 train_time:16047ms step_avg:32.22ms
+step:499/1490 train_time:16102ms step_avg:32.27ms
+step:500/1490 train_time:16162ms step_avg:32.32ms
+step:500/1490 val_loss:4.2314 train_time:16234ms step_avg:32.47ms
+step:501/1490 train_time:16251ms step_avg:32.44ms
+step:502/1490 train_time:16279ms step_avg:32.43ms
+step:503/1490 train_time:16337ms step_avg:32.48ms
+step:504/1490 train_time:16401ms step_avg:32.54ms
+step:505/1490 train_time:16456ms step_avg:32.59ms
+step:506/1490 train_time:16515ms step_avg:32.64ms
+step:507/1490 train_time:16569ms step_avg:32.68ms
+step:508/1490 train_time:16629ms step_avg:32.73ms
+step:509/1490 train_time:16683ms step_avg:32.78ms
+step:510/1490 train_time:16742ms step_avg:32.83ms
+step:511/1490 train_time:16796ms step_avg:32.87ms
+step:512/1490 train_time:16855ms step_avg:32.92ms
+step:513/1490 train_time:16908ms step_avg:32.96ms
+step:514/1490 train_time:16968ms step_avg:33.01ms
+step:515/1490 train_time:17021ms step_avg:33.05ms
+step:516/1490 train_time:17080ms step_avg:33.10ms
+step:517/1490 train_time:17133ms step_avg:33.14ms
+step:518/1490 train_time:17192ms step_avg:33.19ms
+step:519/1490 train_time:17249ms step_avg:33.23ms
+step:520/1490 train_time:17309ms step_avg:33.29ms
+step:521/1490 train_time:17365ms step_avg:33.33ms
+step:522/1490 train_time:17427ms step_avg:33.38ms
+step:523/1490 train_time:17482ms step_avg:33.43ms
+step:524/1490 train_time:17543ms step_avg:33.48ms
+step:525/1490 train_time:17598ms step_avg:33.52ms
+step:526/1490 train_time:17657ms step_avg:33.57ms
+step:527/1490 train_time:17710ms step_avg:33.61ms
+step:528/1490 train_time:17770ms step_avg:33.65ms
+step:529/1490 train_time:17823ms step_avg:33.69ms
+step:530/1490 train_time:17883ms step_avg:33.74ms
+step:531/1490 train_time:17937ms step_avg:33.78ms
+step:532/1490 train_time:17996ms step_avg:33.83ms
+step:533/1490 train_time:18050ms step_avg:33.87ms
+step:534/1490 train_time:18110ms step_avg:33.91ms
+step:535/1490 train_time:18163ms step_avg:33.95ms
+step:536/1490 train_time:18224ms step_avg:34.00ms
+step:537/1490 train_time:18281ms step_avg:34.04ms
+step:538/1490 train_time:18341ms step_avg:34.09ms
+step:539/1490 train_time:18395ms step_avg:34.13ms
+step:540/1490 train_time:18456ms step_avg:34.18ms
+step:541/1490 train_time:18511ms step_avg:34.22ms
+step:542/1490 train_time:18571ms step_avg:34.26ms
+step:543/1490 train_time:18625ms step_avg:34.30ms
+step:544/1490 train_time:18686ms step_avg:34.35ms
+step:545/1490 train_time:18739ms step_avg:34.38ms
+step:546/1490 train_time:18799ms step_avg:34.43ms
+step:547/1490 train_time:18852ms step_avg:34.46ms
+step:548/1490 train_time:18911ms step_avg:34.51ms
+step:549/1490 train_time:18965ms step_avg:34.55ms
+step:550/1490 train_time:19025ms step_avg:34.59ms
+step:551/1490 train_time:19079ms step_avg:34.63ms
+step:552/1490 train_time:19138ms step_avg:34.67ms
+step:553/1490 train_time:19191ms step_avg:34.70ms
+step:554/1490 train_time:19252ms step_avg:34.75ms
+step:555/1490 train_time:19307ms step_avg:34.79ms
+step:556/1490 train_time:19368ms step_avg:34.83ms
+step:557/1490 train_time:19422ms step_avg:34.87ms
+step:558/1490 train_time:19484ms step_avg:34.92ms
+step:559/1490 train_time:19539ms step_avg:34.95ms
+step:560/1490 train_time:19599ms step_avg:35.00ms
+step:561/1490 train_time:19653ms step_avg:35.03ms
+step:562/1490 train_time:19712ms step_avg:35.07ms
+step:563/1490 train_time:19766ms step_avg:35.11ms
+step:564/1490 train_time:19826ms step_avg:35.15ms
+step:565/1490 train_time:19880ms step_avg:35.19ms
+step:566/1490 train_time:19940ms step_avg:35.23ms
+step:567/1490 train_time:19993ms step_avg:35.26ms
+step:568/1490 train_time:20053ms step_avg:35.30ms
+step:569/1490 train_time:20107ms step_avg:35.34ms
+step:570/1490 train_time:20167ms step_avg:35.38ms
+step:571/1490 train_time:20223ms step_avg:35.42ms
+step:572/1490 train_time:20284ms step_avg:35.46ms
+step:573/1490 train_time:20338ms step_avg:35.49ms
+step:574/1490 train_time:20398ms step_avg:35.54ms
+step:575/1490 train_time:20453ms step_avg:35.57ms
+step:576/1490 train_time:20512ms step_avg:35.61ms
+step:577/1490 train_time:20568ms step_avg:35.65ms
+step:578/1490 train_time:20628ms step_avg:35.69ms
+step:579/1490 train_time:20681ms step_avg:35.72ms
+step:580/1490 train_time:20741ms step_avg:35.76ms
+step:581/1490 train_time:20795ms step_avg:35.79ms
+step:582/1490 train_time:20855ms step_avg:35.83ms
+step:583/1490 train_time:20909ms step_avg:35.86ms
+step:584/1490 train_time:20968ms step_avg:35.90ms
+step:585/1490 train_time:21023ms step_avg:35.94ms
+step:586/1490 train_time:21083ms step_avg:35.98ms
+step:587/1490 train_time:21137ms step_avg:36.01ms
+step:588/1490 train_time:21197ms step_avg:36.05ms
+step:589/1490 train_time:21251ms step_avg:36.08ms
+step:590/1490 train_time:21311ms step_avg:36.12ms
+step:591/1490 train_time:21366ms step_avg:36.15ms
+step:592/1490 train_time:21427ms step_avg:36.19ms
+step:593/1490 train_time:21482ms step_avg:36.23ms
+step:594/1490 train_time:21542ms step_avg:36.27ms
+step:595/1490 train_time:21596ms step_avg:36.30ms
+step:596/1490 train_time:21655ms step_avg:36.33ms
+step:597/1490 train_time:21708ms step_avg:36.36ms
+step:598/1490 train_time:21769ms step_avg:36.40ms
+step:599/1490 train_time:21823ms step_avg:36.43ms
+step:600/1490 train_time:21883ms step_avg:36.47ms
+step:601/1490 train_time:21937ms step_avg:36.50ms
+step:602/1490 train_time:21997ms step_avg:36.54ms
+step:603/1490 train_time:22051ms step_avg:36.57ms
+step:604/1490 train_time:22110ms step_avg:36.61ms
+step:605/1490 train_time:22166ms step_avg:36.64ms
+step:606/1490 train_time:22225ms step_avg:36.68ms
+step:607/1490 train_time:22279ms step_avg:36.70ms
+step:608/1490 train_time:22339ms step_avg:36.74ms
+step:609/1490 train_time:22393ms step_avg:36.77ms
+step:610/1490 train_time:22454ms step_avg:36.81ms
+step:611/1490 train_time:22508ms step_avg:36.84ms
+step:612/1490 train_time:22568ms step_avg:36.88ms
+step:613/1490 train_time:22623ms step_avg:36.90ms
+step:614/1490 train_time:22682ms step_avg:36.94ms
+step:615/1490 train_time:22736ms step_avg:36.97ms
+step:616/1490 train_time:22796ms step_avg:37.01ms
+step:617/1490 train_time:22851ms step_avg:37.03ms
+step:618/1490 train_time:22911ms step_avg:37.07ms
+step:619/1490 train_time:22965ms step_avg:37.10ms
+step:620/1490 train_time:23025ms step_avg:37.14ms
+step:621/1490 train_time:23080ms step_avg:37.17ms
+step:622/1490 train_time:23140ms step_avg:37.20ms
+step:623/1490 train_time:23195ms step_avg:37.23ms
+step:624/1490 train_time:23255ms step_avg:37.27ms
+step:625/1490 train_time:23308ms step_avg:37.29ms
+step:626/1490 train_time:23368ms step_avg:37.33ms
+step:627/1490 train_time:23423ms step_avg:37.36ms
+step:628/1490 train_time:23484ms step_avg:37.39ms
+step:629/1490 train_time:23539ms step_avg:37.42ms
+step:630/1490 train_time:23598ms step_avg:37.46ms
+step:631/1490 train_time:23651ms step_avg:37.48ms
+step:632/1490 train_time:23711ms step_avg:37.52ms
+step:633/1490 train_time:23765ms step_avg:37.54ms
+step:634/1490 train_time:23826ms step_avg:37.58ms
+step:635/1490 train_time:23880ms step_avg:37.61ms
+step:636/1490 train_time:23940ms step_avg:37.64ms
+step:637/1490 train_time:23993ms step_avg:37.67ms
+step:638/1490 train_time:24054ms step_avg:37.70ms
+step:639/1490 train_time:24107ms step_avg:37.73ms
+step:640/1490 train_time:24168ms step_avg:37.76ms
+step:641/1490 train_time:24223ms step_avg:37.79ms
+step:642/1490 train_time:24283ms step_avg:37.82ms
+step:643/1490 train_time:24338ms step_avg:37.85ms
+step:644/1490 train_time:24398ms step_avg:37.88ms
+step:645/1490 train_time:24452ms step_avg:37.91ms
+step:646/1490 train_time:24511ms step_avg:37.94ms
+step:647/1490 train_time:24566ms step_avg:37.97ms
+step:648/1490 train_time:24626ms step_avg:38.00ms
+step:649/1490 train_time:24680ms step_avg:38.03ms
+step:650/1490 train_time:24740ms step_avg:38.06ms
+step:651/1490 train_time:24794ms step_avg:38.09ms
+step:652/1490 train_time:24854ms step_avg:38.12ms
+step:653/1490 train_time:24908ms step_avg:38.14ms
+step:654/1490 train_time:24967ms step_avg:38.18ms
+step:655/1490 train_time:25021ms step_avg:38.20ms
+step:656/1490 train_time:25082ms step_avg:38.23ms
+step:657/1490 train_time:25135ms step_avg:38.26ms
+step:658/1490 train_time:25195ms step_avg:38.29ms
+step:659/1490 train_time:25249ms step_avg:38.31ms
+step:660/1490 train_time:25308ms step_avg:38.35ms
+step:661/1490 train_time:25363ms step_avg:38.37ms
+step:662/1490 train_time:25423ms step_avg:38.40ms
+step:663/1490 train_time:25478ms step_avg:38.43ms
+step:664/1490 train_time:25537ms step_avg:38.46ms
+step:665/1490 train_time:25591ms step_avg:38.48ms
+step:666/1490 train_time:25651ms step_avg:38.52ms
+step:667/1490 train_time:25706ms step_avg:38.54ms
+step:668/1490 train_time:25766ms step_avg:38.57ms
+step:669/1490 train_time:25820ms step_avg:38.59ms
+step:670/1490 train_time:25879ms step_avg:38.63ms
+step:671/1490 train_time:25933ms step_avg:38.65ms
+step:672/1490 train_time:25992ms step_avg:38.68ms
+step:673/1490 train_time:26047ms step_avg:38.70ms
+step:674/1490 train_time:26107ms step_avg:38.73ms
+step:675/1490 train_time:26161ms step_avg:38.76ms
+step:676/1490 train_time:26222ms step_avg:38.79ms
+step:677/1490 train_time:26277ms step_avg:38.81ms
+step:678/1490 train_time:26336ms step_avg:38.84ms
+step:679/1490 train_time:26390ms step_avg:38.87ms
+step:680/1490 train_time:26450ms step_avg:38.90ms
+step:681/1490 train_time:26504ms step_avg:38.92ms
+step:682/1490 train_time:26564ms step_avg:38.95ms
+step:683/1490 train_time:26619ms step_avg:38.97ms
+step:684/1490 train_time:26679ms step_avg:39.00ms
+step:685/1490 train_time:26733ms step_avg:39.03ms
+step:686/1490 train_time:26792ms step_avg:39.05ms
+step:687/1490 train_time:26847ms step_avg:39.08ms
+step:688/1490 train_time:26907ms step_avg:39.11ms
+step:689/1490 train_time:26961ms step_avg:39.13ms
+step:690/1490 train_time:27021ms step_avg:39.16ms
+step:691/1490 train_time:27076ms step_avg:39.18ms
+step:692/1490 train_time:27135ms step_avg:39.21ms
+step:693/1490 train_time:27189ms step_avg:39.23ms
+step:694/1490 train_time:27249ms step_avg:39.26ms
+step:695/1490 train_time:27304ms step_avg:39.29ms
+step:696/1490 train_time:27365ms step_avg:39.32ms
+step:697/1490 train_time:27419ms step_avg:39.34ms
+step:698/1490 train_time:27480ms step_avg:39.37ms
+step:699/1490 train_time:27535ms step_avg:39.39ms
+step:700/1490 train_time:27595ms step_avg:39.42ms
+step:701/1490 train_time:27649ms step_avg:39.44ms
+step:702/1490 train_time:27708ms step_avg:39.47ms
+step:703/1490 train_time:27763ms step_avg:39.49ms
+step:704/1490 train_time:27824ms step_avg:39.52ms
+step:705/1490 train_time:27879ms step_avg:39.54ms
+step:706/1490 train_time:27938ms step_avg:39.57ms
+step:707/1490 train_time:27991ms step_avg:39.59ms
+step:708/1490 train_time:28052ms step_avg:39.62ms
+step:709/1490 train_time:28106ms step_avg:39.64ms
+step:710/1490 train_time:28166ms step_avg:39.67ms
+step:711/1490 train_time:28220ms step_avg:39.69ms
+step:712/1490 train_time:28280ms step_avg:39.72ms
+step:713/1490 train_time:28334ms step_avg:39.74ms
+step:714/1490 train_time:28395ms step_avg:39.77ms
+step:715/1490 train_time:28449ms step_avg:39.79ms
+step:716/1490 train_time:28509ms step_avg:39.82ms
+step:717/1490 train_time:28563ms step_avg:39.84ms
+step:718/1490 train_time:28624ms step_avg:39.87ms
+step:719/1490 train_time:28678ms step_avg:39.89ms
+step:720/1490 train_time:28738ms step_avg:39.91ms
+step:721/1490 train_time:28792ms step_avg:39.93ms
+step:722/1490 train_time:28852ms step_avg:39.96ms
+step:723/1490 train_time:28906ms step_avg:39.98ms
+step:724/1490 train_time:28966ms step_avg:40.01ms
+step:725/1490 train_time:29020ms step_avg:40.03ms
+step:726/1490 train_time:29080ms step_avg:40.05ms
+step:727/1490 train_time:29133ms step_avg:40.07ms
+step:728/1490 train_time:29193ms step_avg:40.10ms
+step:729/1490 train_time:29249ms step_avg:40.12ms
+step:730/1490 train_time:29308ms step_avg:40.15ms
+step:731/1490 train_time:29362ms step_avg:40.17ms
+step:732/1490 train_time:29422ms step_avg:40.19ms
+step:733/1490 train_time:29476ms step_avg:40.21ms
+step:734/1490 train_time:29536ms step_avg:40.24ms
+step:735/1490 train_time:29590ms step_avg:40.26ms
+step:736/1490 train_time:29650ms step_avg:40.29ms
+step:737/1490 train_time:29705ms step_avg:40.30ms
+step:738/1490 train_time:29765ms step_avg:40.33ms
+step:739/1490 train_time:29819ms step_avg:40.35ms
+step:740/1490 train_time:29878ms step_avg:40.38ms
+step:741/1490 train_time:29932ms step_avg:40.39ms
+step:742/1490 train_time:29991ms step_avg:40.42ms
+step:743/1490 train_time:30046ms step_avg:40.44ms
+step:744/1490 train_time:30106ms step_avg:40.47ms
+step:745/1490 train_time:30160ms step_avg:40.48ms
+step:746/1490 train_time:30220ms step_avg:40.51ms
+step:747/1490 train_time:30274ms step_avg:40.53ms
+step:748/1490 train_time:30333ms step_avg:40.55ms
+step:749/1490 train_time:30388ms step_avg:40.57ms
+step:750/1490 train_time:30448ms step_avg:40.60ms
+step:750/1490 val_loss:3.8145 train_time:30520ms step_avg:40.69ms
+step:751/1490 train_time:30536ms step_avg:40.66ms
+step:752/1490 train_time:30564ms step_avg:40.64ms
+step:753/1490 train_time:30621ms step_avg:40.67ms
+step:754/1490 train_time:30684ms step_avg:40.69ms
+step:755/1490 train_time:30739ms step_avg:40.71ms
+step:756/1490 train_time:30800ms step_avg:40.74ms
+step:757/1490 train_time:30853ms step_avg:40.76ms
+step:758/1490 train_time:30913ms step_avg:40.78ms
+step:759/1490 train_time:30967ms step_avg:40.80ms
+step:760/1490 train_time:31027ms step_avg:40.83ms
+step:761/1490 train_time:31080ms step_avg:40.84ms
+step:762/1490 train_time:31139ms step_avg:40.87ms
+step:763/1490 train_time:31192ms step_avg:40.88ms
+step:764/1490 train_time:31251ms step_avg:40.90ms
+step:765/1490 train_time:31304ms step_avg:40.92ms
+step:766/1490 train_time:31364ms step_avg:40.95ms
+step:767/1490 train_time:31417ms step_avg:40.96ms
+step:768/1490 train_time:31477ms step_avg:40.99ms
+step:769/1490 train_time:31533ms step_avg:41.01ms
+step:770/1490 train_time:31594ms step_avg:41.03ms
+step:771/1490 train_time:31650ms step_avg:41.05ms
+step:772/1490 train_time:31711ms step_avg:41.08ms
+step:773/1490 train_time:31766ms step_avg:41.09ms
+step:774/1490 train_time:31826ms step_avg:41.12ms
+step:775/1490 train_time:31880ms step_avg:41.14ms
+step:776/1490 train_time:31941ms step_avg:41.16ms
+step:777/1490 train_time:31995ms step_avg:41.18ms
+step:778/1490 train_time:32055ms step_avg:41.20ms
+step:779/1490 train_time:32108ms step_avg:41.22ms
+step:780/1490 train_time:32168ms step_avg:41.24ms
+step:781/1490 train_time:32221ms step_avg:41.26ms
+step:782/1490 train_time:32281ms step_avg:41.28ms
+step:783/1490 train_time:32334ms step_avg:41.30ms
+step:784/1490 train_time:32393ms step_avg:41.32ms
+step:785/1490 train_time:32447ms step_avg:41.33ms
+step:786/1490 train_time:32507ms step_avg:41.36ms
+step:787/1490 train_time:32563ms step_avg:41.38ms
+step:788/1490 train_time:32623ms step_avg:41.40ms
+step:789/1490 train_time:32678ms step_avg:41.42ms
+step:790/1490 train_time:32739ms step_avg:41.44ms
+step:791/1490 train_time:32793ms step_avg:41.46ms
+step:792/1490 train_time:32853ms step_avg:41.48ms
+step:793/1490 train_time:32907ms step_avg:41.50ms
+step:794/1490 train_time:32966ms step_avg:41.52ms
+step:795/1490 train_time:33020ms step_avg:41.53ms
+step:796/1490 train_time:33080ms step_avg:41.56ms
+step:797/1490 train_time:33134ms step_avg:41.57ms
+step:798/1490 train_time:33192ms step_avg:41.59ms
+step:799/1490 train_time:33246ms step_avg:41.61ms
+step:800/1490 train_time:33305ms step_avg:41.63ms
+step:801/1490 train_time:33360ms step_avg:41.65ms
+step:802/1490 train_time:33420ms step_avg:41.67ms
+step:803/1490 train_time:33475ms step_avg:41.69ms
+step:804/1490 train_time:33535ms step_avg:41.71ms
+step:805/1490 train_time:33588ms step_avg:41.72ms
+step:806/1490 train_time:33648ms step_avg:41.75ms
+step:807/1490 train_time:33704ms step_avg:41.76ms
+step:808/1490 train_time:33764ms step_avg:41.79ms
+step:809/1490 train_time:33818ms step_avg:41.80ms
+step:810/1490 train_time:33880ms step_avg:41.83ms
+step:811/1490 train_time:33934ms step_avg:41.84ms
+step:812/1490 train_time:33994ms step_avg:41.86ms
+step:813/1490 train_time:34048ms step_avg:41.88ms
+step:814/1490 train_time:34107ms step_avg:41.90ms
+step:815/1490 train_time:34161ms step_avg:41.92ms
+step:816/1490 train_time:34220ms step_avg:41.94ms
+step:817/1490 train_time:34275ms step_avg:41.95ms
+step:818/1490 train_time:34335ms step_avg:41.97ms
+step:819/1490 train_time:34389ms step_avg:41.99ms
+step:820/1490 train_time:34448ms step_avg:42.01ms
+step:821/1490 train_time:34503ms step_avg:42.03ms
+step:822/1490 train_time:34563ms step_avg:42.05ms
+step:823/1490 train_time:34617ms step_avg:42.06ms
+step:824/1490 train_time:34678ms step_avg:42.09ms
+step:825/1490 train_time:34733ms step_avg:42.10ms
+step:826/1490 train_time:34792ms step_avg:42.12ms
+step:827/1490 train_time:34846ms step_avg:42.14ms
+step:828/1490 train_time:34906ms step_avg:42.16ms
+step:829/1490 train_time:34961ms step_avg:42.17ms
+step:830/1490 train_time:35020ms step_avg:42.19ms
+step:831/1490 train_time:35074ms step_avg:42.21ms
+step:832/1490 train_time:35133ms step_avg:42.23ms
+step:833/1490 train_time:35187ms step_avg:42.24ms
+step:834/1490 train_time:35247ms step_avg:42.26ms
+step:835/1490 train_time:35302ms step_avg:42.28ms
+step:836/1490 train_time:35361ms step_avg:42.30ms
+step:837/1490 train_time:35415ms step_avg:42.31ms
+step:838/1490 train_time:35475ms step_avg:42.33ms
+step:839/1490 train_time:35528ms step_avg:42.35ms
+step:840/1490 train_time:35588ms step_avg:42.37ms
+step:841/1490 train_time:35643ms step_avg:42.38ms
+step:842/1490 train_time:35703ms step_avg:42.40ms
+step:843/1490 train_time:35757ms step_avg:42.42ms
+step:844/1490 train_time:35817ms step_avg:42.44ms
+step:845/1490 train_time:35872ms step_avg:42.45ms
+step:846/1490 train_time:35931ms step_avg:42.47ms
+step:847/1490 train_time:35985ms step_avg:42.49ms
+step:848/1490 train_time:36044ms step_avg:42.51ms
+step:849/1490 train_time:36098ms step_avg:42.52ms
+step:850/1490 train_time:36159ms step_avg:42.54ms
+step:851/1490 train_time:36214ms step_avg:42.55ms
+step:852/1490 train_time:36273ms step_avg:42.57ms
+step:853/1490 train_time:36327ms step_avg:42.59ms
+step:854/1490 train_time:36387ms step_avg:42.61ms
+step:855/1490 train_time:36441ms step_avg:42.62ms
+step:856/1490 train_time:36501ms step_avg:42.64ms
+step:857/1490 train_time:36555ms step_avg:42.65ms
+step:858/1490 train_time:36616ms step_avg:42.68ms
+step:859/1490 train_time:36669ms step_avg:42.69ms
+step:860/1490 train_time:36729ms step_avg:42.71ms
+step:861/1490 train_time:36783ms step_avg:42.72ms
+step:862/1490 train_time:36843ms step_avg:42.74ms
+step:863/1490 train_time:36897ms step_avg:42.75ms
+step:864/1490 train_time:36958ms step_avg:42.77ms
+step:865/1490 train_time:37012ms step_avg:42.79ms
+step:866/1490 train_time:37071ms step_avg:42.81ms
+step:867/1490 train_time:37125ms step_avg:42.82ms
+step:868/1490 train_time:37185ms step_avg:42.84ms
+step:869/1490 train_time:37239ms step_avg:42.85ms
+step:870/1490 train_time:37300ms step_avg:42.87ms
+step:871/1490 train_time:37353ms step_avg:42.89ms
+step:872/1490 train_time:37413ms step_avg:42.91ms
+step:873/1490 train_time:37467ms step_avg:42.92ms
+step:874/1490 train_time:37527ms step_avg:42.94ms
+step:875/1490 train_time:37581ms step_avg:42.95ms
+step:876/1490 train_time:37641ms step_avg:42.97ms
+step:877/1490 train_time:37696ms step_avg:42.98ms
+step:878/1490 train_time:37757ms step_avg:43.00ms
+step:879/1490 train_time:37810ms step_avg:43.01ms
+step:880/1490 train_time:37870ms step_avg:43.03ms
+step:881/1490 train_time:37924ms step_avg:43.05ms
+step:882/1490 train_time:37984ms step_avg:43.07ms
+step:883/1490 train_time:38038ms step_avg:43.08ms
+step:884/1490 train_time:38098ms step_avg:43.10ms
+step:885/1490 train_time:38152ms step_avg:43.11ms
+step:886/1490 train_time:38212ms step_avg:43.13ms
+step:887/1490 train_time:38267ms step_avg:43.14ms
+step:888/1490 train_time:38326ms step_avg:43.16ms
+step:889/1490 train_time:38380ms step_avg:43.17ms
+step:890/1490 train_time:38440ms step_avg:43.19ms
+step:891/1490 train_time:38494ms step_avg:43.20ms
+step:892/1490 train_time:38554ms step_avg:43.22ms
+step:893/1490 train_time:38608ms step_avg:43.23ms
+step:894/1490 train_time:38668ms step_avg:43.25ms
+step:895/1490 train_time:38722ms step_avg:43.26ms
+step:896/1490 train_time:38782ms step_avg:43.28ms
+step:897/1490 train_time:38836ms step_avg:43.30ms
+step:898/1490 train_time:38896ms step_avg:43.31ms
+step:899/1490 train_time:38950ms step_avg:43.33ms
+step:900/1490 train_time:39009ms step_avg:43.34ms
+step:901/1490 train_time:39064ms step_avg:43.36ms
+step:902/1490 train_time:39124ms step_avg:43.37ms
+step:903/1490 train_time:39178ms step_avg:43.39ms
+step:904/1490 train_time:39237ms step_avg:43.40ms
+step:905/1490 train_time:39292ms step_avg:43.42ms
+step:906/1490 train_time:39351ms step_avg:43.43ms
+step:907/1490 train_time:39405ms step_avg:43.45ms
+step:908/1490 train_time:39465ms step_avg:43.46ms
+step:909/1490 train_time:39520ms step_avg:43.48ms
+step:910/1490 train_time:39581ms step_avg:43.50ms
+step:911/1490 train_time:39634ms step_avg:43.51ms
+step:912/1490 train_time:39694ms step_avg:43.52ms
+step:913/1490 train_time:39748ms step_avg:43.54ms
+step:914/1490 train_time:39807ms step_avg:43.55ms
+step:915/1490 train_time:39862ms step_avg:43.57ms
+step:916/1490 train_time:39922ms step_avg:43.58ms
+step:917/1490 train_time:39976ms step_avg:43.59ms
+step:918/1490 train_time:40036ms step_avg:43.61ms
+step:919/1490 train_time:40090ms step_avg:43.62ms
+step:920/1490 train_time:40149ms step_avg:43.64ms
+step:921/1490 train_time:40204ms step_avg:43.65ms
+step:922/1490 train_time:40264ms step_avg:43.67ms
+step:923/1490 train_time:40318ms step_avg:43.68ms
+step:924/1490 train_time:40378ms step_avg:43.70ms
+step:925/1490 train_time:40432ms step_avg:43.71ms
+step:926/1490 train_time:40492ms step_avg:43.73ms
+step:927/1490 train_time:40546ms step_avg:43.74ms
+step:928/1490 train_time:40605ms step_avg:43.76ms
+step:929/1490 train_time:40659ms step_avg:43.77ms
+step:930/1490 train_time:40719ms step_avg:43.78ms
+step:931/1490 train_time:40774ms step_avg:43.80ms
+step:932/1490 train_time:40834ms step_avg:43.81ms
+step:933/1490 train_time:40887ms step_avg:43.82ms
+step:934/1490 train_time:40947ms step_avg:43.84ms
+step:935/1490 train_time:41001ms step_avg:43.85ms
+step:936/1490 train_time:41062ms step_avg:43.87ms
+step:937/1490 train_time:41116ms step_avg:43.88ms
+step:938/1490 train_time:41175ms step_avg:43.90ms
+step:939/1490 train_time:41229ms step_avg:43.91ms
+step:940/1490 train_time:41289ms step_avg:43.92ms
+step:941/1490 train_time:41344ms step_avg:43.94ms
+step:942/1490 train_time:41403ms step_avg:43.95ms
+step:943/1490 train_time:41457ms step_avg:43.96ms
+step:944/1490 train_time:41517ms step_avg:43.98ms
+step:945/1490 train_time:41570ms step_avg:43.99ms
+step:946/1490 train_time:41630ms step_avg:44.01ms
+step:947/1490 train_time:41684ms step_avg:44.02ms
+step:948/1490 train_time:41744ms step_avg:44.03ms
+step:949/1490 train_time:41799ms step_avg:44.05ms
+step:950/1490 train_time:41860ms step_avg:44.06ms
+step:951/1490 train_time:41914ms step_avg:44.07ms
+step:952/1490 train_time:41974ms step_avg:44.09ms
+step:953/1490 train_time:42028ms step_avg:44.10ms
+step:954/1490 train_time:42087ms step_avg:44.12ms
+step:955/1490 train_time:42142ms step_avg:44.13ms
+step:956/1490 train_time:42202ms step_avg:44.14ms
+step:957/1490 train_time:42256ms step_avg:44.15ms
+step:958/1490 train_time:42315ms step_avg:44.17ms
+step:959/1490 train_time:42370ms step_avg:44.18ms
+step:960/1490 train_time:42428ms step_avg:44.20ms
+step:961/1490 train_time:42482ms step_avg:44.21ms
+step:962/1490 train_time:42542ms step_avg:44.22ms
+step:963/1490 train_time:42597ms step_avg:44.23ms
+step:964/1490 train_time:42657ms step_avg:44.25ms
+step:965/1490 train_time:42711ms step_avg:44.26ms
+step:966/1490 train_time:42771ms step_avg:44.28ms
+step:967/1490 train_time:42825ms step_avg:44.29ms
+step:968/1490 train_time:42888ms step_avg:44.31ms
+step:969/1490 train_time:42967ms step_avg:44.34ms
+step:970/1490 train_time:43053ms step_avg:44.38ms
+step:971/1490 train_time:43135ms step_avg:44.42ms
+step:972/1490 train_time:43221ms step_avg:44.47ms
+step:973/1490 train_time:43302ms step_avg:44.50ms
+step:974/1490 train_time:43388ms step_avg:44.55ms
+step:975/1490 train_time:43468ms step_avg:44.58ms
+step:976/1490 train_time:43555ms step_avg:44.63ms
+step:977/1490 train_time:43635ms step_avg:44.66ms
+step:978/1490 train_time:43722ms step_avg:44.71ms
+step:979/1490 train_time:43802ms step_avg:44.74ms
+step:980/1490 train_time:43889ms step_avg:44.78ms
+step:981/1490 train_time:43969ms step_avg:44.82ms
+step:982/1490 train_time:44055ms step_avg:44.86ms
+step:983/1490 train_time:44137ms step_avg:44.90ms
+step:984/1490 train_time:44225ms step_avg:44.94ms
+step:985/1490 train_time:44306ms step_avg:44.98ms
+step:986/1490 train_time:44392ms step_avg:45.02ms
+step:987/1490 train_time:44472ms step_avg:45.06ms
+step:988/1490 train_time:44558ms step_avg:45.10ms
+step:989/1490 train_time:44639ms step_avg:45.14ms
+step:990/1490 train_time:44726ms step_avg:45.18ms
+step:991/1490 train_time:44808ms step_avg:45.21ms
+step:992/1490 train_time:44894ms step_avg:45.26ms
+step:993/1490 train_time:44974ms step_avg:45.29ms
+step:994/1490 train_time:45060ms step_avg:45.33ms
+step:995/1490 train_time:45141ms step_avg:45.37ms
+step:996/1490 train_time:45228ms step_avg:45.41ms
+step:997/1490 train_time:45308ms step_avg:45.44ms
+step:998/1490 train_time:45394ms step_avg:45.48ms
+step:999/1490 train_time:45475ms step_avg:45.52ms
+step:1000/1490 train_time:45561ms step_avg:45.56ms
+step:1000/1490 val_loss:3.5172 train_time:45664ms step_avg:45.66ms
+step:1001/1490 train_time:45682ms step_avg:45.64ms
+step:1002/1490 train_time:45731ms step_avg:45.64ms
+step:1003/1490 train_time:45817ms step_avg:45.68ms
+step:1004/1490 train_time:45905ms step_avg:45.72ms
+step:1005/1490 train_time:45988ms step_avg:45.76ms
+step:1006/1490 train_time:46072ms step_avg:45.80ms
+step:1007/1490 train_time:46151ms step_avg:45.83ms
+step:1008/1490 train_time:46236ms step_avg:45.87ms
+step:1009/1490 train_time:46316ms step_avg:45.90ms
+step:1010/1490 train_time:46402ms step_avg:45.94ms
+step:1011/1490 train_time:46482ms step_avg:45.98ms
+step:1012/1490 train_time:46567ms step_avg:46.01ms
+step:1013/1490 train_time:46649ms step_avg:46.05ms
+step:1014/1490 train_time:46736ms step_avg:46.09ms
+step:1015/1490 train_time:46818ms step_avg:46.13ms
+step:1016/1490 train_time:46906ms step_avg:46.17ms
+step:1017/1490 train_time:46988ms step_avg:46.20ms
+step:1018/1490 train_time:47075ms step_avg:46.24ms
+step:1019/1490 train_time:47155ms step_avg:46.28ms
+step:1020/1490 train_time:47242ms step_avg:46.32ms
+step:1021/1490 train_time:47323ms step_avg:46.35ms
+step:1022/1490 train_time:47408ms step_avg:46.39ms
+step:1023/1490 train_time:47488ms step_avg:46.42ms
+step:1024/1490 train_time:47574ms step_avg:46.46ms
+step:1025/1490 train_time:47655ms step_avg:46.49ms
+step:1026/1490 train_time:47743ms step_avg:46.53ms
+step:1027/1490 train_time:47825ms step_avg:46.57ms
+step:1028/1490 train_time:47912ms step_avg:46.61ms
+step:1029/1490 train_time:47994ms step_avg:46.64ms
+step:1030/1490 train_time:48079ms step_avg:46.68ms
+step:1031/1490 train_time:48159ms step_avg:46.71ms
+step:1032/1490 train_time:48244ms step_avg:46.75ms
+step:1033/1490 train_time:48325ms step_avg:46.78ms
+step:1034/1490 train_time:48411ms step_avg:46.82ms
+step:1035/1490 train_time:48492ms step_avg:46.85ms
+step:1036/1490 train_time:48578ms step_avg:46.89ms
+step:1037/1490 train_time:48658ms step_avg:46.92ms
+step:1038/1490 train_time:48745ms step_avg:46.96ms
+step:1039/1490 train_time:48829ms step_avg:47.00ms
+step:1040/1490 train_time:48917ms step_avg:47.04ms
+step:1041/1490 train_time:48999ms step_avg:47.07ms
+step:1042/1490 train_time:49084ms step_avg:47.11ms
+step:1043/1490 train_time:49165ms step_avg:47.14ms
+step:1044/1490 train_time:49250ms step_avg:47.17ms
+step:1045/1490 train_time:49331ms step_avg:47.21ms
+step:1046/1490 train_time:49417ms step_avg:47.24ms
+step:1047/1490 train_time:49498ms step_avg:47.28ms
+step:1048/1490 train_time:49583ms step_avg:47.31ms
+step:1049/1490 train_time:49664ms step_avg:47.34ms
+step:1050/1490 train_time:49751ms step_avg:47.38ms
+step:1051/1490 train_time:49834ms step_avg:47.42ms
+step:1052/1490 train_time:49921ms step_avg:47.45ms
+step:1053/1490 train_time:50003ms step_avg:47.49ms
+step:1054/1490 train_time:50089ms step_avg:47.52ms
+step:1055/1490 train_time:50169ms step_avg:47.55ms
+step:1056/1490 train_time:50255ms step_avg:47.59ms
+step:1057/1490 train_time:50336ms step_avg:47.62ms
+step:1058/1490 train_time:50422ms step_avg:47.66ms
+step:1059/1490 train_time:50502ms step_avg:47.69ms
+step:1060/1490 train_time:50588ms step_avg:47.72ms
+step:1061/1490 train_time:50669ms step_avg:47.76ms
+step:1062/1490 train_time:50756ms step_avg:47.79ms
+step:1063/1490 train_time:50839ms step_avg:47.83ms
+step:1064/1490 train_time:50925ms step_avg:47.86ms
+step:1065/1490 train_time:51006ms step_avg:47.89ms
+step:1066/1490 train_time:51092ms step_avg:47.93ms
+step:1067/1490 train_time:51173ms step_avg:47.96ms
+step:1068/1490 train_time:51258ms step_avg:47.99ms
+step:1069/1490 train_time:51339ms step_avg:48.03ms
+step:1070/1490 train_time:51425ms step_avg:48.06ms
+step:1071/1490 train_time:51505ms step_avg:48.09ms
+step:1072/1490 train_time:51592ms step_avg:48.13ms
+step:1073/1490 train_time:51673ms step_avg:48.16ms
+step:1074/1490 train_time:51759ms step_avg:48.19ms
+step:1075/1490 train_time:51841ms step_avg:48.22ms
+step:1076/1490 train_time:51927ms step_avg:48.26ms
+step:1077/1490 train_time:52008ms step_avg:48.29ms
+step:1078/1490 train_time:52095ms step_avg:48.33ms
+step:1079/1490 train_time:52175ms step_avg:48.35ms
+step:1080/1490 train_time:52261ms step_avg:48.39ms
+step:1081/1490 train_time:52342ms step_avg:48.42ms
+step:1082/1490 train_time:52429ms step_avg:48.46ms
+step:1083/1490 train_time:52510ms step_avg:48.49ms
+step:1084/1490 train_time:52597ms step_avg:48.52ms
+step:1085/1490 train_time:52678ms step_avg:48.55ms
+step:1086/1490 train_time:52763ms step_avg:48.59ms
+step:1087/1490 train_time:52844ms step_avg:48.61ms
+step:1088/1490 train_time:52932ms step_avg:48.65ms
+step:1089/1490 train_time:53014ms step_avg:48.68ms
+step:1090/1490 train_time:53101ms step_avg:48.72ms
+step:1091/1490 train_time:53181ms step_avg:48.75ms
+step:1092/1490 train_time:53266ms step_avg:48.78ms
+step:1093/1490 train_time:53347ms step_avg:48.81ms
+step:1094/1490 train_time:53434ms step_avg:48.84ms
+step:1095/1490 train_time:53515ms step_avg:48.87ms
+step:1096/1490 train_time:53602ms step_avg:48.91ms
+step:1097/1490 train_time:53683ms step_avg:48.94ms
+step:1098/1490 train_time:53768ms step_avg:48.97ms
+step:1099/1490 train_time:53848ms step_avg:49.00ms
+step:1100/1490 train_time:53937ms step_avg:49.03ms
+step:1101/1490 train_time:54018ms step_avg:49.06ms
+step:1102/1490 train_time:54105ms step_avg:49.10ms
+step:1103/1490 train_time:54187ms step_avg:49.13ms
+step:1104/1490 train_time:54273ms step_avg:49.16ms
+step:1105/1490 train_time:54359ms step_avg:49.19ms
+step:1106/1490 train_time:54439ms step_avg:49.22ms
+step:1107/1490 train_time:54520ms step_avg:49.25ms
+step:1108/1490 train_time:54606ms step_avg:49.28ms
+step:1109/1490 train_time:54688ms step_avg:49.31ms
+step:1110/1490 train_time:54772ms step_avg:49.34ms
+step:1111/1490 train_time:54852ms step_avg:49.37ms
+step:1112/1490 train_time:54938ms step_avg:49.40ms
+step:1113/1490 train_time:55019ms step_avg:49.43ms
+step:1114/1490 train_time:55106ms step_avg:49.47ms
+step:1115/1490 train_time:55187ms step_avg:49.50ms
+step:1116/1490 train_time:55274ms step_avg:49.53ms
+step:1117/1490 train_time:55356ms step_avg:49.56ms
+step:1118/1490 train_time:55442ms step_avg:49.59ms
+step:1119/1490 train_time:55523ms step_avg:49.62ms
+step:1120/1490 train_time:55609ms step_avg:49.65ms
+step:1121/1490 train_time:55689ms step_avg:49.68ms
+step:1122/1490 train_time:55775ms step_avg:49.71ms
+step:1123/1490 train_time:55857ms step_avg:49.74ms
+step:1124/1490 train_time:55944ms step_avg:49.77ms
+step:1125/1490 train_time:56025ms step_avg:49.80ms
+step:1126/1490 train_time:56111ms step_avg:49.83ms
+step:1127/1490 train_time:56193ms step_avg:49.86ms
+step:1128/1490 train_time:56279ms step_avg:49.89ms
+step:1129/1490 train_time:56359ms step_avg:49.92ms
+step:1130/1490 train_time:56445ms step_avg:49.95ms
+step:1131/1490 train_time:56527ms step_avg:49.98ms
+step:1132/1490 train_time:56614ms step_avg:50.01ms
+step:1133/1490 train_time:56695ms step_avg:50.04ms
+step:1134/1490 train_time:56782ms step_avg:50.07ms
+step:1135/1490 train_time:56863ms step_avg:50.10ms
+step:1136/1490 train_time:56949ms step_avg:50.13ms
+step:1137/1490 train_time:57029ms step_avg:50.16ms
+step:1138/1490 train_time:57116ms step_avg:50.19ms
+step:1139/1490 train_time:57198ms step_avg:50.22ms
+step:1140/1490 train_time:57283ms step_avg:50.25ms
+step:1141/1490 train_time:57363ms step_avg:50.27ms
+step:1142/1490 train_time:57449ms step_avg:50.31ms
+step:1143/1490 train_time:57530ms step_avg:50.33ms
+step:1144/1490 train_time:57618ms step_avg:50.37ms
+step:1145/1490 train_time:57699ms step_avg:50.39ms
+step:1146/1490 train_time:57784ms step_avg:50.42ms
+step:1147/1490 train_time:57864ms step_avg:50.45ms
+step:1148/1490 train_time:57950ms step_avg:50.48ms
+step:1149/1490 train_time:58032ms step_avg:50.51ms
+step:1150/1490 train_time:58118ms step_avg:50.54ms
+step:1151/1490 train_time:58198ms step_avg:50.56ms
+step:1152/1490 train_time:58284ms step_avg:50.59ms
+step:1153/1490 train_time:58365ms step_avg:50.62ms
+step:1154/1490 train_time:58453ms step_avg:50.65ms
+step:1155/1490 train_time:58535ms step_avg:50.68ms
+step:1156/1490 train_time:58622ms step_avg:50.71ms
+step:1157/1490 train_time:58703ms step_avg:50.74ms
+step:1158/1490 train_time:58789ms step_avg:50.77ms
+step:1159/1490 train_time:58870ms step_avg:50.79ms
+step:1160/1490 train_time:58955ms step_avg:50.82ms
+step:1161/1490 train_time:59037ms step_avg:50.85ms
+step:1162/1490 train_time:59122ms step_avg:50.88ms
+step:1163/1490 train_time:59205ms step_avg:50.91ms
+step:1164/1490 train_time:59290ms step_avg:50.94ms
+step:1165/1490 train_time:59370ms step_avg:50.96ms
+step:1166/1490 train_time:59458ms step_avg:50.99ms
+step:1167/1490 train_time:59539ms step_avg:51.02ms
+step:1168/1490 train_time:59625ms step_avg:51.05ms
+step:1169/1490 train_time:59706ms step_avg:51.07ms
+step:1170/1490 train_time:59793ms step_avg:51.10ms
+step:1171/1490 train_time:59873ms step_avg:51.13ms
+step:1172/1490 train_time:59959ms step_avg:51.16ms
+step:1173/1490 train_time:60040ms step_avg:51.19ms
+step:1174/1490 train_time:60126ms step_avg:51.21ms
+step:1175/1490 train_time:60206ms step_avg:51.24ms
+step:1176/1490 train_time:60294ms step_avg:51.27ms
+step:1177/1490 train_time:60373ms step_avg:51.29ms
+step:1178/1490 train_time:60459ms step_avg:51.32ms
+step:1179/1490 train_time:60540ms step_avg:51.35ms
+step:1180/1490 train_time:60627ms step_avg:51.38ms
+step:1181/1490 train_time:60708ms step_avg:51.40ms
+step:1182/1490 train_time:60794ms step_avg:51.43ms
+step:1183/1490 train_time:60874ms step_avg:51.46ms
+step:1184/1490 train_time:60961ms step_avg:51.49ms
+step:1185/1490 train_time:61043ms step_avg:51.51ms
+step:1186/1490 train_time:61129ms step_avg:51.54ms
+step:1187/1490 train_time:61210ms step_avg:51.57ms
+step:1188/1490 train_time:61296ms step_avg:51.60ms
+step:1189/1490 train_time:61377ms step_avg:51.62ms
+step:1190/1490 train_time:61463ms step_avg:51.65ms
+step:1191/1490 train_time:61545ms step_avg:51.67ms
+step:1192/1490 train_time:61632ms step_avg:51.70ms
+step:1193/1490 train_time:61712ms step_avg:51.73ms
+step:1194/1490 train_time:61799ms step_avg:51.76ms
+step:1195/1490 train_time:61879ms step_avg:51.78ms
+step:1196/1490 train_time:61964ms step_avg:51.81ms
+step:1197/1490 train_time:62044ms step_avg:51.83ms
+step:1198/1490 train_time:62133ms step_avg:51.86ms
+step:1199/1490 train_time:62215ms step_avg:51.89ms
+step:1200/1490 train_time:62301ms step_avg:51.92ms
+step:1201/1490 train_time:62382ms step_avg:51.94ms
+step:1202/1490 train_time:62467ms step_avg:51.97ms
+step:1203/1490 train_time:62548ms step_avg:51.99ms
+step:1204/1490 train_time:62636ms step_avg:52.02ms
+step:1205/1490 train_time:62716ms step_avg:52.05ms
+step:1206/1490 train_time:62805ms step_avg:52.08ms
+step:1207/1490 train_time:62885ms step_avg:52.10ms
+step:1208/1490 train_time:62970ms step_avg:52.13ms
+step:1209/1490 train_time:63050ms step_avg:52.15ms
+step:1210/1490 train_time:63138ms step_avg:52.18ms
+step:1211/1490 train_time:63218ms step_avg:52.20ms
+step:1212/1490 train_time:63304ms step_avg:52.23ms
+step:1213/1490 train_time:63385ms step_avg:52.25ms
+step:1214/1490 train_time:63471ms step_avg:52.28ms
+step:1215/1490 train_time:63551ms step_avg:52.31ms
+step:1216/1490 train_time:63637ms step_avg:52.33ms
+step:1217/1490 train_time:63719ms step_avg:52.36ms
+step:1218/1490 train_time:63805ms step_avg:52.39ms
+step:1219/1490 train_time:63886ms step_avg:52.41ms
+step:1220/1490 train_time:63972ms step_avg:52.44ms
+step:1221/1490 train_time:64052ms step_avg:52.46ms
+step:1222/1490 train_time:64138ms step_avg:52.49ms
+step:1223/1490 train_time:64219ms step_avg:52.51ms
+step:1224/1490 train_time:64305ms step_avg:52.54ms
+step:1225/1490 train_time:64385ms step_avg:52.56ms
+step:1226/1490 train_time:64472ms step_avg:52.59ms
+step:1227/1490 train_time:64552ms step_avg:52.61ms
+step:1228/1490 train_time:64638ms step_avg:52.64ms
+step:1229/1490 train_time:64720ms step_avg:52.66ms
+step:1230/1490 train_time:64806ms step_avg:52.69ms
+step:1231/1490 train_time:64887ms step_avg:52.71ms
+step:1232/1490 train_time:64972ms step_avg:52.74ms
+step:1233/1490 train_time:65054ms step_avg:52.76ms
+step:1234/1490 train_time:65140ms step_avg:52.79ms
+step:1235/1490 train_time:65220ms step_avg:52.81ms
+step:1236/1490 train_time:65306ms step_avg:52.84ms
+step:1237/1490 train_time:65387ms step_avg:52.86ms
+step:1238/1490 train_time:65472ms step_avg:52.89ms
+step:1239/1490 train_time:65553ms step_avg:52.91ms
+step:1240/1490 train_time:65640ms step_avg:52.94ms
+step:1241/1490 train_time:65719ms step_avg:52.96ms
+step:1242/1490 train_time:65805ms step_avg:52.98ms
+step:1243/1490 train_time:65886ms step_avg:53.01ms
+step:1244/1490 train_time:65972ms step_avg:53.03ms
+step:1245/1490 train_time:66054ms step_avg:53.06ms
+step:1246/1490 train_time:66139ms step_avg:53.08ms
+step:1247/1490 train_time:66221ms step_avg:53.10ms
+step:1248/1490 train_time:66308ms step_avg:53.13ms
+step:1249/1490 train_time:66389ms step_avg:53.15ms
+step:1250/1490 train_time:66476ms step_avg:53.18ms
+step:1250/1490 val_loss:3.3718 train_time:66580ms step_avg:53.26ms
+step:1251/1490 train_time:66597ms step_avg:53.24ms
+step:1252/1490 train_time:66645ms step_avg:53.23ms
+step:1253/1490 train_time:66736ms step_avg:53.26ms
+step:1254/1490 train_time:66823ms step_avg:53.29ms
+step:1255/1490 train_time:66903ms step_avg:53.31ms
+step:1256/1490 train_time:66988ms step_avg:53.33ms
+step:1257/1490 train_time:67069ms step_avg:53.36ms
+step:1258/1490 train_time:67155ms step_avg:53.38ms
+step:1259/1490 train_time:67236ms step_avg:53.40ms
+step:1260/1490 train_time:67321ms step_avg:53.43ms
+step:1261/1490 train_time:67401ms step_avg:53.45ms
+step:1262/1490 train_time:67486ms step_avg:53.48ms
+step:1263/1490 train_time:67566ms step_avg:53.50ms
+step:1264/1490 train_time:67656ms step_avg:53.53ms
+step:1265/1490 train_time:67741ms step_avg:53.55ms
+step:1266/1490 train_time:67829ms step_avg:53.58ms
+step:1267/1490 train_time:67911ms step_avg:53.60ms
+step:1268/1490 train_time:67996ms step_avg:53.62ms
+step:1269/1490 train_time:68075ms step_avg:53.64ms
+step:1270/1490 train_time:68161ms step_avg:53.67ms
+step:1271/1490 train_time:68241ms step_avg:53.69ms
+step:1272/1490 train_time:68326ms step_avg:53.72ms
+step:1273/1490 train_time:68405ms step_avg:53.74ms
+step:1274/1490 train_time:68490ms step_avg:53.76ms
+step:1275/1490 train_time:68570ms step_avg:53.78ms
+step:1276/1490 train_time:68660ms step_avg:53.81ms
+step:1277/1490 train_time:68742ms step_avg:53.83ms
+step:1278/1490 train_time:68829ms step_avg:53.86ms
+step:1279/1490 train_time:68912ms step_avg:53.88ms
+step:1280/1490 train_time:68999ms step_avg:53.91ms
+step:1281/1490 train_time:69079ms step_avg:53.93ms
+step:1282/1490 train_time:69165ms step_avg:53.95ms
+step:1283/1490 train_time:69246ms step_avg:53.97ms
+step:1284/1490 train_time:69331ms step_avg:54.00ms
+step:1285/1490 train_time:69411ms step_avg:54.02ms
+step:1286/1490 train_time:69497ms step_avg:54.04ms
+step:1287/1490 train_time:69577ms step_avg:54.06ms
+step:1288/1490 train_time:69665ms step_avg:54.09ms
+step:1289/1490 train_time:69748ms step_avg:54.11ms
+step:1290/1490 train_time:69835ms step_avg:54.14ms
+step:1291/1490 train_time:69917ms step_avg:54.16ms
+step:1292/1490 train_time:70004ms step_avg:54.18ms
+step:1293/1490 train_time:70084ms step_avg:54.20ms
+step:1294/1490 train_time:70170ms step_avg:54.23ms
+step:1295/1490 train_time:70251ms step_avg:54.25ms
+step:1296/1490 train_time:70336ms step_avg:54.27ms
+step:1297/1490 train_time:70416ms step_avg:54.29ms
+step:1298/1490 train_time:70504ms step_avg:54.32ms
+step:1299/1490 train_time:70583ms step_avg:54.34ms
+step:1300/1490 train_time:70669ms step_avg:54.36ms
+step:1301/1490 train_time:70752ms step_avg:54.38ms
+step:1302/1490 train_time:70840ms step_avg:54.41ms
+step:1303/1490 train_time:70921ms step_avg:54.43ms
+step:1304/1490 train_time:71007ms step_avg:54.45ms
+step:1305/1490 train_time:71087ms step_avg:54.47ms
+step:1306/1490 train_time:71174ms step_avg:54.50ms
+step:1307/1490 train_time:71254ms step_avg:54.52ms
+step:1308/1490 train_time:71340ms step_avg:54.54ms
+step:1309/1490 train_time:71421ms step_avg:54.56ms
+step:1310/1490 train_time:71508ms step_avg:54.59ms
+step:1311/1490 train_time:71587ms step_avg:54.61ms
+step:1312/1490 train_time:71673ms step_avg:54.63ms
+step:1313/1490 train_time:71756ms step_avg:54.65ms
+step:1314/1490 train_time:71843ms step_avg:54.68ms
+step:1315/1490 train_time:71925ms step_avg:54.70ms
+step:1316/1490 train_time:72012ms step_avg:54.72ms
+step:1317/1490 train_time:72093ms step_avg:54.74ms
+step:1318/1490 train_time:72179ms step_avg:54.76ms
+step:1319/1490 train_time:72260ms step_avg:54.78ms
+step:1320/1490 train_time:72347ms step_avg:54.81ms
+step:1321/1490 train_time:72428ms step_avg:54.83ms
+step:1322/1490 train_time:72514ms step_avg:54.85ms
+step:1323/1490 train_time:72595ms step_avg:54.87ms
+step:1324/1490 train_time:72681ms step_avg:54.89ms
+step:1325/1490 train_time:72761ms step_avg:54.91ms
+step:1326/1490 train_time:72848ms step_avg:54.94ms
+step:1327/1490 train_time:72929ms step_avg:54.96ms
+step:1328/1490 train_time:73016ms step_avg:54.98ms
+step:1329/1490 train_time:73097ms step_avg:55.00ms
+step:1330/1490 train_time:73183ms step_avg:55.02ms
+step:1331/1490 train_time:73265ms step_avg:55.04ms
+step:1332/1490 train_time:73351ms step_avg:55.07ms
+step:1333/1490 train_time:73432ms step_avg:55.09ms
+step:1334/1490 train_time:73518ms step_avg:55.11ms
+step:1335/1490 train_time:73599ms step_avg:55.13ms
+step:1336/1490 train_time:73686ms step_avg:55.15ms
+step:1337/1490 train_time:73768ms step_avg:55.17ms
+step:1338/1490 train_time:73853ms step_avg:55.20ms
+step:1339/1490 train_time:73935ms step_avg:55.22ms
+step:1340/1490 train_time:74021ms step_avg:55.24ms
+step:1341/1490 train_time:74101ms step_avg:55.26ms
+step:1342/1490 train_time:74187ms step_avg:55.28ms
+step:1343/1490 train_time:74268ms step_avg:55.30ms
+step:1344/1490 train_time:74355ms step_avg:55.32ms
+step:1345/1490 train_time:74435ms step_avg:55.34ms
+step:1346/1490 train_time:74522ms step_avg:55.37ms
+step:1347/1490 train_time:74602ms step_avg:55.38ms
+step:1348/1490 train_time:74688ms step_avg:55.41ms
+step:1349/1490 train_time:74768ms step_avg:55.42ms
+step:1350/1490 train_time:74855ms step_avg:55.45ms
+step:1351/1490 train_time:74937ms step_avg:55.47ms
+step:1352/1490 train_time:75024ms step_avg:55.49ms
+step:1353/1490 train_time:75104ms step_avg:55.51ms
+step:1354/1490 train_time:75189ms step_avg:55.53ms
+step:1355/1490 train_time:75270ms step_avg:55.55ms
+step:1356/1490 train_time:75357ms step_avg:55.57ms
+step:1357/1490 train_time:75436ms step_avg:55.59ms
+step:1358/1490 train_time:75523ms step_avg:55.61ms
+step:1359/1490 train_time:75603ms step_avg:55.63ms
+step:1360/1490 train_time:75690ms step_avg:55.65ms
+step:1361/1490 train_time:75769ms step_avg:55.67ms
+step:1362/1490 train_time:75855ms step_avg:55.69ms
+step:1363/1490 train_time:75938ms step_avg:55.71ms
+step:1364/1490 train_time:76024ms step_avg:55.74ms
+step:1365/1490 train_time:76105ms step_avg:55.75ms
+step:1366/1490 train_time:76191ms step_avg:55.78ms
+step:1367/1490 train_time:76271ms step_avg:55.79ms
+step:1368/1490 train_time:76357ms step_avg:55.82ms
+step:1369/1490 train_time:76439ms step_avg:55.84ms
+step:1370/1490 train_time:76525ms step_avg:55.86ms
+step:1371/1490 train_time:76607ms step_avg:55.88ms
+step:1372/1490 train_time:76693ms step_avg:55.90ms
+step:1373/1490 train_time:76773ms step_avg:55.92ms
+step:1374/1490 train_time:76859ms step_avg:55.94ms
+step:1375/1490 train_time:76941ms step_avg:55.96ms
+step:1376/1490 train_time:77027ms step_avg:55.98ms
+step:1377/1490 train_time:77109ms step_avg:56.00ms
+step:1378/1490 train_time:77194ms step_avg:56.02ms
+step:1379/1490 train_time:77275ms step_avg:56.04ms
+step:1380/1490 train_time:77362ms step_avg:56.06ms
+step:1381/1490 train_time:77442ms step_avg:56.08ms
+step:1382/1490 train_time:77529ms step_avg:56.10ms
+step:1383/1490 train_time:77609ms step_avg:56.12ms
+step:1384/1490 train_time:77696ms step_avg:56.14ms
+step:1385/1490 train_time:77776ms step_avg:56.16ms
+step:1386/1490 train_time:77863ms step_avg:56.18ms
+step:1387/1490 train_time:77944ms step_avg:56.20ms
+step:1388/1490 train_time:78033ms step_avg:56.22ms
+step:1389/1490 train_time:78114ms step_avg:56.24ms
+step:1390/1490 train_time:78200ms step_avg:56.26ms
+step:1391/1490 train_time:78280ms step_avg:56.28ms
+step:1392/1490 train_time:78368ms step_avg:56.30ms
+step:1393/1490 train_time:78450ms step_avg:56.32ms
+step:1394/1490 train_time:78535ms step_avg:56.34ms
+step:1395/1490 train_time:78616ms step_avg:56.36ms
+step:1396/1490 train_time:78703ms step_avg:56.38ms
+step:1397/1490 train_time:78783ms step_avg:56.39ms
+step:1398/1490 train_time:78868ms step_avg:56.42ms
+step:1399/1490 train_time:78950ms step_avg:56.43ms
+step:1400/1490 train_time:79036ms step_avg:56.45ms
+step:1401/1490 train_time:79117ms step_avg:56.47ms
+step:1402/1490 train_time:79204ms step_avg:56.49ms
+step:1403/1490 train_time:79284ms step_avg:56.51ms
+step:1404/1490 train_time:79371ms step_avg:56.53ms
+step:1405/1490 train_time:79452ms step_avg:56.55ms
+step:1406/1490 train_time:79537ms step_avg:56.57ms
+step:1407/1490 train_time:79618ms step_avg:56.59ms
+step:1408/1490 train_time:79705ms step_avg:56.61ms
+step:1409/1490 train_time:79786ms step_avg:56.63ms
+step:1410/1490 train_time:79872ms step_avg:56.65ms
+step:1411/1490 train_time:79953ms step_avg:56.66ms
+step:1412/1490 train_time:80039ms step_avg:56.68ms
+step:1413/1490 train_time:80120ms step_avg:56.70ms
+step:1414/1490 train_time:80206ms step_avg:56.72ms
+step:1415/1490 train_time:80286ms step_avg:56.74ms
+step:1416/1490 train_time:80373ms step_avg:56.76ms
+step:1417/1490 train_time:80456ms step_avg:56.78ms
+step:1418/1490 train_time:80542ms step_avg:56.80ms
+step:1419/1490 train_time:80623ms step_avg:56.82ms
+step:1420/1490 train_time:80710ms step_avg:56.84ms
+step:1421/1490 train_time:80790ms step_avg:56.85ms
+step:1422/1490 train_time:80877ms step_avg:56.88ms
+step:1423/1490 train_time:80959ms step_avg:56.89ms
+step:1424/1490 train_time:81046ms step_avg:56.91ms
+step:1425/1490 train_time:81128ms step_avg:56.93ms
+step:1426/1490 train_time:81214ms step_avg:56.95ms
+step:1427/1490 train_time:81295ms step_avg:56.97ms
+step:1428/1490 train_time:81381ms step_avg:56.99ms
+step:1429/1490 train_time:81460ms step_avg:57.00ms
+step:1430/1490 train_time:81547ms step_avg:57.03ms
+step:1431/1490 train_time:81629ms step_avg:57.04ms
+step:1432/1490 train_time:81715ms step_avg:57.06ms
+step:1433/1490 train_time:81796ms step_avg:57.08ms
+step:1434/1490 train_time:81882ms step_avg:57.10ms
+step:1435/1490 train_time:81962ms step_avg:57.12ms
+step:1436/1490 train_time:82049ms step_avg:57.14ms
+step:1437/1490 train_time:82130ms step_avg:57.15ms
+step:1438/1490 train_time:82217ms step_avg:57.17ms
+step:1439/1490 train_time:82297ms step_avg:57.19ms
+step:1440/1490 train_time:82382ms step_avg:57.21ms
+step:1441/1490 train_time:82463ms step_avg:57.23ms
+step:1442/1490 train_time:82551ms step_avg:57.25ms
+step:1443/1490 train_time:82630ms step_avg:57.26ms
+step:1444/1490 train_time:82717ms step_avg:57.28ms
+step:1445/1490 train_time:82799ms step_avg:57.30ms
+step:1446/1490 train_time:82885ms step_avg:57.32ms
+step:1447/1490 train_time:82966ms step_avg:57.34ms
+step:1448/1490 train_time:83053ms step_avg:57.36ms
+step:1449/1490 train_time:83135ms step_avg:57.37ms
+step:1450/1490 train_time:83222ms step_avg:57.39ms
+step:1451/1490 train_time:83308ms step_avg:57.41ms
+step:1452/1490 train_time:83394ms step_avg:57.43ms
+step:1453/1490 train_time:83476ms step_avg:57.45ms
+step:1454/1490 train_time:83564ms step_avg:57.47ms
+step:1455/1490 train_time:83644ms step_avg:57.49ms
+step:1456/1490 train_time:83730ms step_avg:57.51ms
+step:1457/1490 train_time:83812ms step_avg:57.52ms
+step:1458/1490 train_time:83900ms step_avg:57.54ms
+step:1459/1490 train_time:83981ms step_avg:57.56ms
+step:1460/1490 train_time:84069ms step_avg:57.58ms
+step:1461/1490 train_time:84149ms step_avg:57.60ms
+step:1462/1490 train_time:84236ms step_avg:57.62ms
+step:1463/1490 train_time:84317ms step_avg:57.63ms
+step:1464/1490 train_time:84404ms step_avg:57.65ms
+step:1465/1490 train_time:84485ms step_avg:57.67ms
+step:1466/1490 train_time:84571ms step_avg:57.69ms
+step:1467/1490 train_time:84652ms step_avg:57.70ms
+step:1468/1490 train_time:84738ms step_avg:57.72ms
+step:1469/1490 train_time:84820ms step_avg:57.74ms
+step:1470/1490 train_time:84908ms step_avg:57.76ms
+step:1471/1490 train_time:84989ms step_avg:57.78ms
+step:1472/1490 train_time:85076ms step_avg:57.80ms
+step:1473/1490 train_time:85157ms step_avg:57.81ms
+step:1474/1490 train_time:85243ms step_avg:57.83ms
+step:1475/1490 train_time:85324ms step_avg:57.85ms
+step:1476/1490 train_time:85413ms step_avg:57.87ms
+step:1477/1490 train_time:85495ms step_avg:57.88ms
+step:1478/1490 train_time:85581ms step_avg:57.90ms
+step:1479/1490 train_time:85663ms step_avg:57.92ms
+step:1480/1490 train_time:85749ms step_avg:57.94ms
+step:1481/1490 train_time:85830ms step_avg:57.95ms
+step:1482/1490 train_time:85916ms step_avg:57.97ms
+step:1483/1490 train_time:85998ms step_avg:57.99ms
+step:1484/1490 train_time:86085ms step_avg:58.01ms
+step:1485/1490 train_time:86167ms step_avg:58.03ms
+step:1486/1490 train_time:86254ms step_avg:58.04ms
+step:1487/1490 train_time:86336ms step_avg:58.06ms
+step:1488/1490 train_time:86423ms step_avg:58.08ms
+step:1489/1490 train_time:86505ms step_avg:58.10ms
+step:1490/1490 train_time:86591ms step_avg:58.11ms
+step:1490/1490 val_loss:3.2786 train_time:86694ms step_avg:58.18ms
+peak memory allocated: 31296 MiB reserved: 47582 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/baseline/2026-03-22_18-22-46_time-186_secs_baseline_6506eb.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/baseline/2026-03-22_18-22-46_time-186_secs_baseline_6506eb.txt
@@ -1,0 +1,4456 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 18:23:01 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   32C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   30C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   33C    P0            124W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   33C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   30C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   32C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   29C    P0            114W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1365527      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1365528      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1365529      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1365530      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1365531      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1365532      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1365533      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1365534      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8269 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:91ms step_avg:91.25ms
+step:2/1490 train_time:112ms step_avg:56.22ms
+step:3/1490 train_time:129ms step_avg:43.04ms
+step:4/1490 train_time:155ms step_avg:38.66ms
+step:5/1490 train_time:182ms step_avg:36.41ms
+step:6/1490 train_time:217ms step_avg:36.18ms
+step:7/1490 train_time:245ms step_avg:34.98ms
+step:8/1490 train_time:280ms step_avg:34.97ms
+step:9/1490 train_time:308ms step_avg:34.17ms
+step:10/1490 train_time:342ms step_avg:34.18ms
+step:11/1490 train_time:370ms step_avg:33.62ms
+step:12/1490 train_time:404ms step_avg:33.69ms
+step:13/1490 train_time:433ms step_avg:33.27ms
+step:14/1490 train_time:467ms step_avg:33.37ms
+step:15/1490 train_time:496ms step_avg:33.04ms
+step:16/1490 train_time:530ms step_avg:33.12ms
+step:17/1490 train_time:559ms step_avg:32.88ms
+step:18/1490 train_time:593ms step_avg:32.96ms
+step:19/1490 train_time:622ms step_avg:32.73ms
+step:20/1490 train_time:656ms step_avg:32.80ms
+step:21/1490 train_time:684ms step_avg:32.58ms
+step:22/1490 train_time:719ms step_avg:32.66ms
+step:23/1490 train_time:747ms step_avg:32.47ms
+step:24/1490 train_time:782ms step_avg:32.57ms
+step:25/1490 train_time:810ms step_avg:32.40ms
+step:26/1490 train_time:844ms step_avg:32.47ms
+step:27/1490 train_time:872ms step_avg:32.31ms
+step:28/1490 train_time:906ms step_avg:32.37ms
+step:29/1490 train_time:935ms step_avg:32.24ms
+step:30/1490 train_time:970ms step_avg:32.35ms
+step:31/1490 train_time:1000ms step_avg:32.26ms
+step:32/1490 train_time:1036ms step_avg:32.36ms
+step:33/1490 train_time:1065ms step_avg:32.27ms
+step:34/1490 train_time:1100ms step_avg:32.34ms
+step:35/1490 train_time:1129ms step_avg:32.25ms
+step:36/1490 train_time:1164ms step_avg:32.34ms
+step:37/1490 train_time:1193ms step_avg:32.24ms
+step:38/1490 train_time:1228ms step_avg:32.31ms
+step:39/1490 train_time:1257ms step_avg:32.22ms
+step:40/1490 train_time:1292ms step_avg:32.30ms
+step:41/1490 train_time:1321ms step_avg:32.21ms
+step:42/1490 train_time:1355ms step_avg:32.26ms
+step:43/1490 train_time:1383ms step_avg:32.17ms
+step:44/1490 train_time:1418ms step_avg:32.22ms
+step:45/1490 train_time:1446ms step_avg:32.13ms
+step:46/1490 train_time:1480ms step_avg:32.18ms
+step:47/1490 train_time:1509ms step_avg:32.10ms
+step:48/1490 train_time:1543ms step_avg:32.15ms
+step:49/1490 train_time:1572ms step_avg:32.08ms
+step:50/1490 train_time:1607ms step_avg:32.13ms
+step:51/1490 train_time:1635ms step_avg:32.06ms
+step:52/1490 train_time:1669ms step_avg:32.10ms
+step:53/1490 train_time:1698ms step_avg:32.04ms
+step:54/1490 train_time:1732ms step_avg:32.07ms
+step:55/1490 train_time:1761ms step_avg:32.02ms
+step:56/1490 train_time:1795ms step_avg:32.05ms
+step:57/1490 train_time:1823ms step_avg:31.99ms
+step:58/1490 train_time:1858ms step_avg:32.03ms
+step:59/1490 train_time:1886ms step_avg:31.97ms
+step:60/1490 train_time:1920ms step_avg:32.00ms
+step:61/1490 train_time:1948ms step_avg:31.94ms
+step:62/1490 train_time:1984ms step_avg:31.99ms
+step:63/1490 train_time:2012ms step_avg:31.93ms
+step:64/1490 train_time:2046ms step_avg:31.97ms
+step:65/1490 train_time:2075ms step_avg:31.92ms
+step:66/1490 train_time:2110ms step_avg:31.97ms
+step:67/1490 train_time:2139ms step_avg:31.93ms
+step:68/1490 train_time:2174ms step_avg:31.96ms
+step:69/1490 train_time:2202ms step_avg:31.92ms
+step:70/1490 train_time:2237ms step_avg:31.95ms
+step:71/1490 train_time:2266ms step_avg:31.91ms
+step:72/1490 train_time:2300ms step_avg:31.94ms
+step:73/1490 train_time:2328ms step_avg:31.89ms
+step:74/1490 train_time:2363ms step_avg:31.93ms
+step:75/1490 train_time:2392ms step_avg:31.89ms
+step:76/1490 train_time:2426ms step_avg:31.92ms
+step:77/1490 train_time:2455ms step_avg:31.88ms
+step:78/1490 train_time:2490ms step_avg:31.93ms
+step:79/1490 train_time:2519ms step_avg:31.89ms
+step:80/1490 train_time:2553ms step_avg:31.91ms
+step:81/1490 train_time:2582ms step_avg:31.87ms
+step:82/1490 train_time:2616ms step_avg:31.91ms
+step:83/1490 train_time:2645ms step_avg:31.86ms
+step:84/1490 train_time:2679ms step_avg:31.90ms
+step:85/1490 train_time:2708ms step_avg:31.85ms
+step:86/1490 train_time:2742ms step_avg:31.89ms
+step:87/1490 train_time:2770ms step_avg:31.84ms
+step:88/1490 train_time:2805ms step_avg:31.87ms
+step:89/1490 train_time:2833ms step_avg:31.83ms
+step:90/1490 train_time:2867ms step_avg:31.86ms
+step:91/1490 train_time:2896ms step_avg:31.82ms
+step:92/1490 train_time:2930ms step_avg:31.85ms
+step:93/1490 train_time:2959ms step_avg:31.82ms
+step:94/1490 train_time:2994ms step_avg:31.85ms
+step:95/1490 train_time:3022ms step_avg:31.81ms
+step:96/1490 train_time:3056ms step_avg:31.83ms
+step:97/1490 train_time:3085ms step_avg:31.80ms
+step:98/1490 train_time:3119ms step_avg:31.83ms
+step:99/1490 train_time:3147ms step_avg:31.79ms
+step:100/1490 train_time:3182ms step_avg:31.82ms
+step:101/1490 train_time:3211ms step_avg:31.79ms
+step:102/1490 train_time:3245ms step_avg:31.82ms
+step:103/1490 train_time:3274ms step_avg:31.78ms
+step:104/1490 train_time:3309ms step_avg:31.81ms
+step:105/1490 train_time:3337ms step_avg:31.78ms
+step:106/1490 train_time:3371ms step_avg:31.81ms
+step:107/1490 train_time:3400ms step_avg:31.77ms
+step:108/1490 train_time:3434ms step_avg:31.80ms
+step:109/1490 train_time:3463ms step_avg:31.77ms
+step:110/1490 train_time:3497ms step_avg:31.80ms
+step:111/1490 train_time:3526ms step_avg:31.77ms
+step:112/1490 train_time:3560ms step_avg:31.79ms
+step:113/1490 train_time:3589ms step_avg:31.76ms
+step:114/1490 train_time:3624ms step_avg:31.79ms
+step:115/1490 train_time:3652ms step_avg:31.76ms
+step:116/1490 train_time:3686ms step_avg:31.78ms
+step:117/1490 train_time:3715ms step_avg:31.75ms
+step:118/1490 train_time:3749ms step_avg:31.77ms
+step:119/1490 train_time:3778ms step_avg:31.74ms
+step:120/1490 train_time:3812ms step_avg:31.77ms
+step:121/1490 train_time:3841ms step_avg:31.74ms
+step:122/1490 train_time:3875ms step_avg:31.76ms
+step:123/1490 train_time:3903ms step_avg:31.73ms
+step:124/1490 train_time:3937ms step_avg:31.75ms
+step:125/1490 train_time:3966ms step_avg:31.73ms
+step:126/1490 train_time:4000ms step_avg:31.75ms
+step:127/1490 train_time:4028ms step_avg:31.72ms
+step:128/1490 train_time:4063ms step_avg:31.74ms
+step:129/1490 train_time:4091ms step_avg:31.72ms
+step:130/1490 train_time:4126ms step_avg:31.74ms
+step:131/1490 train_time:4154ms step_avg:31.71ms
+step:132/1490 train_time:4188ms step_avg:31.73ms
+step:133/1490 train_time:4217ms step_avg:31.70ms
+step:134/1490 train_time:4251ms step_avg:31.73ms
+step:135/1490 train_time:4280ms step_avg:31.70ms
+step:136/1490 train_time:4314ms step_avg:31.72ms
+step:137/1490 train_time:4343ms step_avg:31.70ms
+step:138/1490 train_time:4377ms step_avg:31.72ms
+step:139/1490 train_time:4406ms step_avg:31.70ms
+step:140/1490 train_time:4440ms step_avg:31.72ms
+step:141/1490 train_time:4469ms step_avg:31.69ms
+step:142/1490 train_time:4503ms step_avg:31.71ms
+step:143/1490 train_time:4532ms step_avg:31.69ms
+step:144/1490 train_time:4566ms step_avg:31.71ms
+step:145/1490 train_time:4595ms step_avg:31.69ms
+step:146/1490 train_time:4629ms step_avg:31.71ms
+step:147/1490 train_time:4658ms step_avg:31.69ms
+step:148/1490 train_time:4693ms step_avg:31.71ms
+step:149/1490 train_time:4722ms step_avg:31.69ms
+step:150/1490 train_time:4756ms step_avg:31.71ms
+step:151/1490 train_time:4784ms step_avg:31.68ms
+step:152/1490 train_time:4818ms step_avg:31.70ms
+step:153/1490 train_time:4847ms step_avg:31.68ms
+step:154/1490 train_time:4881ms step_avg:31.69ms
+step:155/1490 train_time:4910ms step_avg:31.67ms
+step:156/1490 train_time:4944ms step_avg:31.69ms
+step:157/1490 train_time:4972ms step_avg:31.67ms
+step:158/1490 train_time:5007ms step_avg:31.69ms
+step:159/1490 train_time:5035ms step_avg:31.67ms
+step:160/1490 train_time:5070ms step_avg:31.68ms
+step:161/1490 train_time:5098ms step_avg:31.67ms
+step:162/1490 train_time:5133ms step_avg:31.68ms
+step:163/1490 train_time:5161ms step_avg:31.66ms
+step:164/1490 train_time:5196ms step_avg:31.68ms
+step:165/1490 train_time:5224ms step_avg:31.66ms
+step:166/1490 train_time:5258ms step_avg:31.68ms
+step:167/1490 train_time:5287ms step_avg:31.66ms
+step:168/1490 train_time:5321ms step_avg:31.67ms
+step:169/1490 train_time:5349ms step_avg:31.65ms
+step:170/1490 train_time:5385ms step_avg:31.68ms
+step:171/1490 train_time:5413ms step_avg:31.66ms
+step:172/1490 train_time:5448ms step_avg:31.67ms
+step:173/1490 train_time:5476ms step_avg:31.65ms
+step:174/1490 train_time:5511ms step_avg:31.67ms
+step:175/1490 train_time:5539ms step_avg:31.65ms
+step:176/1490 train_time:5574ms step_avg:31.67ms
+step:177/1490 train_time:5603ms step_avg:31.65ms
+step:178/1490 train_time:5637ms step_avg:31.67ms
+step:179/1490 train_time:5665ms step_avg:31.65ms
+step:180/1490 train_time:5700ms step_avg:31.67ms
+step:181/1490 train_time:5728ms step_avg:31.65ms
+step:182/1490 train_time:5763ms step_avg:31.66ms
+step:183/1490 train_time:5791ms step_avg:31.64ms
+step:184/1490 train_time:5825ms step_avg:31.66ms
+step:185/1490 train_time:5854ms step_avg:31.64ms
+step:186/1490 train_time:5889ms step_avg:31.66ms
+step:187/1490 train_time:5917ms step_avg:31.64ms
+step:188/1490 train_time:5952ms step_avg:31.66ms
+step:189/1490 train_time:5980ms step_avg:31.64ms
+step:190/1490 train_time:6015ms step_avg:31.66ms
+step:191/1490 train_time:6043ms step_avg:31.64ms
+step:192/1490 train_time:6078ms step_avg:31.66ms
+step:193/1490 train_time:6106ms step_avg:31.64ms
+step:194/1490 train_time:6140ms step_avg:31.65ms
+step:195/1490 train_time:6169ms step_avg:31.64ms
+step:196/1490 train_time:6204ms step_avg:31.65ms
+step:197/1490 train_time:6233ms step_avg:31.64ms
+step:198/1490 train_time:6267ms step_avg:31.65ms
+step:199/1490 train_time:6295ms step_avg:31.63ms
+step:200/1490 train_time:6330ms step_avg:31.65ms
+step:201/1490 train_time:6359ms step_avg:31.63ms
+step:202/1490 train_time:6393ms step_avg:31.65ms
+step:203/1490 train_time:6422ms step_avg:31.63ms
+step:204/1490 train_time:6456ms step_avg:31.65ms
+step:205/1490 train_time:6485ms step_avg:31.63ms
+step:206/1490 train_time:6519ms step_avg:31.65ms
+step:207/1490 train_time:6547ms step_avg:31.63ms
+step:208/1490 train_time:6582ms step_avg:31.64ms
+step:209/1490 train_time:6611ms step_avg:31.63ms
+step:210/1490 train_time:6645ms step_avg:31.64ms
+step:211/1490 train_time:6673ms step_avg:31.63ms
+step:212/1490 train_time:6708ms step_avg:31.64ms
+step:213/1490 train_time:6736ms step_avg:31.63ms
+step:214/1490 train_time:6771ms step_avg:31.64ms
+step:215/1490 train_time:6799ms step_avg:31.62ms
+step:216/1490 train_time:6833ms step_avg:31.64ms
+step:217/1490 train_time:6862ms step_avg:31.62ms
+step:218/1490 train_time:6897ms step_avg:31.64ms
+step:219/1490 train_time:6925ms step_avg:31.62ms
+step:220/1490 train_time:6960ms step_avg:31.63ms
+step:221/1490 train_time:6988ms step_avg:31.62ms
+step:222/1490 train_time:7022ms step_avg:31.63ms
+step:223/1490 train_time:7051ms step_avg:31.62ms
+step:224/1490 train_time:7085ms step_avg:31.63ms
+step:225/1490 train_time:7113ms step_avg:31.61ms
+step:226/1490 train_time:7147ms step_avg:31.63ms
+step:227/1490 train_time:7176ms step_avg:31.61ms
+step:228/1490 train_time:7211ms step_avg:31.63ms
+step:229/1490 train_time:7239ms step_avg:31.61ms
+step:230/1490 train_time:7274ms step_avg:31.63ms
+step:231/1490 train_time:7302ms step_avg:31.61ms
+step:232/1490 train_time:7336ms step_avg:31.62ms
+step:233/1490 train_time:7365ms step_avg:31.61ms
+step:234/1490 train_time:7400ms step_avg:31.62ms
+step:235/1490 train_time:7428ms step_avg:31.61ms
+step:236/1490 train_time:7462ms step_avg:31.62ms
+step:237/1490 train_time:7491ms step_avg:31.61ms
+step:238/1490 train_time:7526ms step_avg:31.62ms
+step:239/1490 train_time:7554ms step_avg:31.61ms
+step:240/1490 train_time:7588ms step_avg:31.62ms
+step:241/1490 train_time:7617ms step_avg:31.61ms
+step:242/1490 train_time:7651ms step_avg:31.62ms
+step:243/1490 train_time:7680ms step_avg:31.60ms
+step:244/1490 train_time:7714ms step_avg:31.62ms
+step:245/1490 train_time:7743ms step_avg:31.60ms
+step:246/1490 train_time:7777ms step_avg:31.61ms
+step:247/1490 train_time:7806ms step_avg:31.60ms
+step:248/1490 train_time:7840ms step_avg:31.61ms
+step:249/1490 train_time:7868ms step_avg:31.60ms
+step:250/1490 train_time:7903ms step_avg:31.61ms
+step:250/1490 val_loss:4.5249 train_time:7946ms step_avg:31.78ms
+step:251/1490 train_time:7962ms step_avg:31.72ms
+step:252/1490 train_time:7979ms step_avg:31.66ms
+step:253/1490 train_time:7996ms step_avg:31.61ms
+step:254/1490 train_time:8032ms step_avg:31.62ms
+step:255/1490 train_time:8063ms step_avg:31.62ms
+step:256/1490 train_time:8098ms step_avg:31.63ms
+step:257/1490 train_time:8127ms step_avg:31.62ms
+step:258/1490 train_time:8162ms step_avg:31.63ms
+step:259/1490 train_time:8190ms step_avg:31.62ms
+step:260/1490 train_time:8225ms step_avg:31.64ms
+step:261/1490 train_time:8254ms step_avg:31.63ms
+step:262/1490 train_time:8288ms step_avg:31.63ms
+step:263/1490 train_time:8317ms step_avg:31.62ms
+step:264/1490 train_time:8351ms step_avg:31.63ms
+step:265/1490 train_time:8379ms step_avg:31.62ms
+step:266/1490 train_time:8413ms step_avg:31.63ms
+step:267/1490 train_time:8441ms step_avg:31.61ms
+step:268/1490 train_time:8475ms step_avg:31.62ms
+step:269/1490 train_time:8503ms step_avg:31.61ms
+step:270/1490 train_time:8538ms step_avg:31.62ms
+step:271/1490 train_time:8566ms step_avg:31.61ms
+step:272/1490 train_time:8600ms step_avg:31.62ms
+step:273/1490 train_time:8628ms step_avg:31.61ms
+step:274/1490 train_time:8663ms step_avg:31.62ms
+step:275/1490 train_time:8691ms step_avg:31.60ms
+step:276/1490 train_time:8725ms step_avg:31.61ms
+step:277/1490 train_time:8753ms step_avg:31.60ms
+step:278/1490 train_time:8787ms step_avg:31.61ms
+step:279/1490 train_time:8815ms step_avg:31.60ms
+step:280/1490 train_time:8849ms step_avg:31.60ms
+step:281/1490 train_time:8878ms step_avg:31.59ms
+step:282/1490 train_time:8912ms step_avg:31.60ms
+step:283/1490 train_time:8941ms step_avg:31.59ms
+step:284/1490 train_time:8975ms step_avg:31.60ms
+step:285/1490 train_time:9004ms step_avg:31.59ms
+step:286/1490 train_time:9040ms step_avg:31.61ms
+step:287/1490 train_time:9069ms step_avg:31.60ms
+step:288/1490 train_time:9104ms step_avg:31.61ms
+step:289/1490 train_time:9132ms step_avg:31.60ms
+step:290/1490 train_time:9167ms step_avg:31.61ms
+step:291/1490 train_time:9196ms step_avg:31.60ms
+step:292/1490 train_time:9230ms step_avg:31.61ms
+step:293/1490 train_time:9259ms step_avg:31.60ms
+step:294/1490 train_time:9294ms step_avg:31.61ms
+step:295/1490 train_time:9322ms step_avg:31.60ms
+step:296/1490 train_time:9356ms step_avg:31.61ms
+step:297/1490 train_time:9384ms step_avg:31.60ms
+step:298/1490 train_time:9418ms step_avg:31.61ms
+step:299/1490 train_time:9447ms step_avg:31.59ms
+step:300/1490 train_time:9481ms step_avg:31.60ms
+step:301/1490 train_time:9509ms step_avg:31.59ms
+step:302/1490 train_time:9543ms step_avg:31.60ms
+step:303/1490 train_time:9571ms step_avg:31.59ms
+step:304/1490 train_time:9606ms step_avg:31.60ms
+step:305/1490 train_time:9634ms step_avg:31.59ms
+step:306/1490 train_time:9669ms step_avg:31.60ms
+step:307/1490 train_time:9697ms step_avg:31.59ms
+step:308/1490 train_time:9732ms step_avg:31.60ms
+step:309/1490 train_time:9760ms step_avg:31.59ms
+step:310/1490 train_time:9794ms step_avg:31.59ms
+step:311/1490 train_time:9822ms step_avg:31.58ms
+step:312/1490 train_time:9857ms step_avg:31.59ms
+step:313/1490 train_time:9885ms step_avg:31.58ms
+step:314/1490 train_time:9919ms step_avg:31.59ms
+step:315/1490 train_time:9948ms step_avg:31.58ms
+step:316/1490 train_time:9983ms step_avg:31.59ms
+step:317/1490 train_time:10011ms step_avg:31.58ms
+step:318/1490 train_time:10046ms step_avg:31.59ms
+step:319/1490 train_time:10074ms step_avg:31.58ms
+step:320/1490 train_time:10110ms step_avg:31.59ms
+step:321/1490 train_time:10138ms step_avg:31.58ms
+step:322/1490 train_time:10173ms step_avg:31.59ms
+step:323/1490 train_time:10201ms step_avg:31.58ms
+step:324/1490 train_time:10236ms step_avg:31.59ms
+step:325/1490 train_time:10264ms step_avg:31.58ms
+step:326/1490 train_time:10298ms step_avg:31.59ms
+step:327/1490 train_time:10327ms step_avg:31.58ms
+step:328/1490 train_time:10362ms step_avg:31.59ms
+step:329/1490 train_time:10390ms step_avg:31.58ms
+step:330/1490 train_time:10425ms step_avg:31.59ms
+step:331/1490 train_time:10453ms step_avg:31.58ms
+step:332/1490 train_time:10487ms step_avg:31.59ms
+step:333/1490 train_time:10515ms step_avg:31.58ms
+step:334/1490 train_time:10550ms step_avg:31.59ms
+step:335/1490 train_time:10578ms step_avg:31.58ms
+step:336/1490 train_time:10613ms step_avg:31.59ms
+step:337/1490 train_time:10641ms step_avg:31.58ms
+step:338/1490 train_time:10675ms step_avg:31.58ms
+step:339/1490 train_time:10703ms step_avg:31.57ms
+step:340/1490 train_time:10738ms step_avg:31.58ms
+step:341/1490 train_time:10766ms step_avg:31.57ms
+step:342/1490 train_time:10800ms step_avg:31.58ms
+step:343/1490 train_time:10829ms step_avg:31.57ms
+step:344/1490 train_time:10863ms step_avg:31.58ms
+step:345/1490 train_time:10892ms step_avg:31.57ms
+step:346/1490 train_time:10926ms step_avg:31.58ms
+step:347/1490 train_time:10954ms step_avg:31.57ms
+step:348/1490 train_time:10989ms step_avg:31.58ms
+step:349/1490 train_time:11017ms step_avg:31.57ms
+step:350/1490 train_time:11053ms step_avg:31.58ms
+step:351/1490 train_time:11081ms step_avg:31.57ms
+step:352/1490 train_time:11115ms step_avg:31.58ms
+step:353/1490 train_time:11144ms step_avg:31.57ms
+step:354/1490 train_time:11178ms step_avg:31.58ms
+step:355/1490 train_time:11206ms step_avg:31.57ms
+step:356/1490 train_time:11241ms step_avg:31.58ms
+step:357/1490 train_time:11269ms step_avg:31.57ms
+step:358/1490 train_time:11304ms step_avg:31.58ms
+step:359/1490 train_time:11332ms step_avg:31.57ms
+step:360/1490 train_time:11367ms step_avg:31.57ms
+step:361/1490 train_time:11395ms step_avg:31.57ms
+step:362/1490 train_time:11430ms step_avg:31.58ms
+step:363/1490 train_time:11459ms step_avg:31.57ms
+step:364/1490 train_time:11493ms step_avg:31.57ms
+step:365/1490 train_time:11521ms step_avg:31.57ms
+step:366/1490 train_time:11555ms step_avg:31.57ms
+step:367/1490 train_time:11584ms step_avg:31.56ms
+step:368/1490 train_time:11617ms step_avg:31.57ms
+step:369/1490 train_time:11646ms step_avg:31.56ms
+step:370/1490 train_time:11680ms step_avg:31.57ms
+step:371/1490 train_time:11708ms step_avg:31.56ms
+step:372/1490 train_time:11743ms step_avg:31.57ms
+step:373/1490 train_time:11771ms step_avg:31.56ms
+step:374/1490 train_time:11805ms step_avg:31.56ms
+step:375/1490 train_time:11833ms step_avg:31.56ms
+step:376/1490 train_time:11868ms step_avg:31.56ms
+step:377/1490 train_time:11896ms step_avg:31.55ms
+step:378/1490 train_time:11931ms step_avg:31.56ms
+step:379/1490 train_time:11959ms step_avg:31.56ms
+step:380/1490 train_time:11994ms step_avg:31.56ms
+step:381/1490 train_time:12022ms step_avg:31.55ms
+step:382/1490 train_time:12056ms step_avg:31.56ms
+step:383/1490 train_time:12084ms step_avg:31.55ms
+step:384/1490 train_time:12119ms step_avg:31.56ms
+step:385/1490 train_time:12147ms step_avg:31.55ms
+step:386/1490 train_time:12182ms step_avg:31.56ms
+step:387/1490 train_time:12210ms step_avg:31.55ms
+step:388/1490 train_time:12245ms step_avg:31.56ms
+step:389/1490 train_time:12273ms step_avg:31.55ms
+step:390/1490 train_time:12308ms step_avg:31.56ms
+step:391/1490 train_time:12337ms step_avg:31.55ms
+step:392/1490 train_time:12371ms step_avg:31.56ms
+step:393/1490 train_time:12400ms step_avg:31.55ms
+step:394/1490 train_time:12434ms step_avg:31.56ms
+step:395/1490 train_time:12463ms step_avg:31.55ms
+step:396/1490 train_time:12497ms step_avg:31.56ms
+step:397/1490 train_time:12525ms step_avg:31.55ms
+step:398/1490 train_time:12559ms step_avg:31.56ms
+step:399/1490 train_time:12587ms step_avg:31.55ms
+step:400/1490 train_time:12622ms step_avg:31.56ms
+step:401/1490 train_time:12650ms step_avg:31.55ms
+step:402/1490 train_time:12685ms step_avg:31.55ms
+step:403/1490 train_time:12713ms step_avg:31.55ms
+step:404/1490 train_time:12747ms step_avg:31.55ms
+step:405/1490 train_time:12775ms step_avg:31.54ms
+step:406/1490 train_time:12810ms step_avg:31.55ms
+step:407/1490 train_time:12838ms step_avg:31.54ms
+step:408/1490 train_time:12873ms step_avg:31.55ms
+step:409/1490 train_time:12901ms step_avg:31.54ms
+step:410/1490 train_time:12936ms step_avg:31.55ms
+step:411/1490 train_time:12964ms step_avg:31.54ms
+step:412/1490 train_time:12998ms step_avg:31.55ms
+step:413/1490 train_time:13026ms step_avg:31.54ms
+step:414/1490 train_time:13061ms step_avg:31.55ms
+step:415/1490 train_time:13089ms step_avg:31.54ms
+step:416/1490 train_time:13124ms step_avg:31.55ms
+step:417/1490 train_time:13152ms step_avg:31.54ms
+step:418/1490 train_time:13186ms step_avg:31.55ms
+step:419/1490 train_time:13214ms step_avg:31.54ms
+step:420/1490 train_time:13249ms step_avg:31.55ms
+step:421/1490 train_time:13277ms step_avg:31.54ms
+step:422/1490 train_time:13312ms step_avg:31.54ms
+step:423/1490 train_time:13340ms step_avg:31.54ms
+step:424/1490 train_time:13374ms step_avg:31.54ms
+step:425/1490 train_time:13403ms step_avg:31.54ms
+step:426/1490 train_time:13437ms step_avg:31.54ms
+step:427/1490 train_time:13466ms step_avg:31.54ms
+step:428/1490 train_time:13500ms step_avg:31.54ms
+step:429/1490 train_time:13529ms step_avg:31.54ms
+step:430/1490 train_time:13564ms step_avg:31.54ms
+step:431/1490 train_time:13592ms step_avg:31.54ms
+step:432/1490 train_time:13626ms step_avg:31.54ms
+step:433/1490 train_time:13655ms step_avg:31.54ms
+step:434/1490 train_time:13689ms step_avg:31.54ms
+step:435/1490 train_time:13717ms step_avg:31.53ms
+step:436/1490 train_time:13752ms step_avg:31.54ms
+step:437/1490 train_time:13781ms step_avg:31.53ms
+step:438/1490 train_time:13815ms step_avg:31.54ms
+step:439/1490 train_time:13844ms step_avg:31.53ms
+step:440/1490 train_time:13878ms step_avg:31.54ms
+step:441/1490 train_time:13906ms step_avg:31.53ms
+step:442/1490 train_time:13940ms step_avg:31.54ms
+step:443/1490 train_time:13969ms step_avg:31.53ms
+step:444/1490 train_time:14004ms step_avg:31.54ms
+step:445/1490 train_time:14032ms step_avg:31.53ms
+step:446/1490 train_time:14067ms step_avg:31.54ms
+step:447/1490 train_time:14095ms step_avg:31.53ms
+step:448/1490 train_time:14130ms step_avg:31.54ms
+step:449/1490 train_time:14158ms step_avg:31.53ms
+step:450/1490 train_time:14193ms step_avg:31.54ms
+step:451/1490 train_time:14221ms step_avg:31.53ms
+step:452/1490 train_time:14255ms step_avg:31.54ms
+step:453/1490 train_time:14284ms step_avg:31.53ms
+step:454/1490 train_time:14318ms step_avg:31.54ms
+step:455/1490 train_time:14346ms step_avg:31.53ms
+step:456/1490 train_time:14381ms step_avg:31.54ms
+step:457/1490 train_time:14409ms step_avg:31.53ms
+step:458/1490 train_time:14444ms step_avg:31.54ms
+step:459/1490 train_time:14472ms step_avg:31.53ms
+step:460/1490 train_time:14507ms step_avg:31.54ms
+step:461/1490 train_time:14535ms step_avg:31.53ms
+step:462/1490 train_time:14570ms step_avg:31.54ms
+step:463/1490 train_time:14598ms step_avg:31.53ms
+step:464/1490 train_time:14633ms step_avg:31.54ms
+step:465/1490 train_time:14661ms step_avg:31.53ms
+step:466/1490 train_time:14695ms step_avg:31.54ms
+step:467/1490 train_time:14724ms step_avg:31.53ms
+step:468/1490 train_time:14758ms step_avg:31.53ms
+step:469/1490 train_time:14787ms step_avg:31.53ms
+step:470/1490 train_time:14821ms step_avg:31.53ms
+step:471/1490 train_time:14849ms step_avg:31.53ms
+step:472/1490 train_time:14884ms step_avg:31.53ms
+step:473/1490 train_time:14912ms step_avg:31.53ms
+step:474/1490 train_time:14947ms step_avg:31.53ms
+step:475/1490 train_time:14975ms step_avg:31.53ms
+step:476/1490 train_time:15009ms step_avg:31.53ms
+step:477/1490 train_time:15037ms step_avg:31.53ms
+step:478/1490 train_time:15072ms step_avg:31.53ms
+step:479/1490 train_time:15100ms step_avg:31.52ms
+step:480/1490 train_time:15134ms step_avg:31.53ms
+step:481/1490 train_time:15163ms step_avg:31.52ms
+step:482/1490 train_time:15197ms step_avg:31.53ms
+step:483/1490 train_time:15225ms step_avg:31.52ms
+step:484/1490 train_time:15262ms step_avg:31.53ms
+step:485/1490 train_time:15314ms step_avg:31.57ms
+step:486/1490 train_time:15373ms step_avg:31.63ms
+step:487/1490 train_time:15428ms step_avg:31.68ms
+step:488/1490 train_time:15487ms step_avg:31.74ms
+step:489/1490 train_time:15542ms step_avg:31.78ms
+step:490/1490 train_time:15602ms step_avg:31.84ms
+step:491/1490 train_time:15656ms step_avg:31.89ms
+step:492/1490 train_time:15715ms step_avg:31.94ms
+step:493/1490 train_time:15769ms step_avg:31.99ms
+step:494/1490 train_time:15829ms step_avg:32.04ms
+step:495/1490 train_time:15883ms step_avg:32.09ms
+step:496/1490 train_time:15943ms step_avg:32.14ms
+step:497/1490 train_time:15998ms step_avg:32.19ms
+step:498/1490 train_time:16059ms step_avg:32.25ms
+step:499/1490 train_time:16114ms step_avg:32.29ms
+step:500/1490 train_time:16173ms step_avg:32.35ms
+step:500/1490 val_loss:4.2298 train_time:16245ms step_avg:32.49ms
+step:501/1490 train_time:16262ms step_avg:32.46ms
+step:502/1490 train_time:16288ms step_avg:32.45ms
+step:503/1490 train_time:16345ms step_avg:32.50ms
+step:504/1490 train_time:16407ms step_avg:32.55ms
+step:505/1490 train_time:16462ms step_avg:32.60ms
+step:506/1490 train_time:16522ms step_avg:32.65ms
+step:507/1490 train_time:16577ms step_avg:32.70ms
+step:508/1490 train_time:16636ms step_avg:32.75ms
+step:509/1490 train_time:16690ms step_avg:32.79ms
+step:510/1490 train_time:16749ms step_avg:32.84ms
+step:511/1490 train_time:16803ms step_avg:32.88ms
+step:512/1490 train_time:16861ms step_avg:32.93ms
+step:513/1490 train_time:16914ms step_avg:32.97ms
+step:514/1490 train_time:16974ms step_avg:33.02ms
+step:515/1490 train_time:17027ms step_avg:33.06ms
+step:516/1490 train_time:17087ms step_avg:33.11ms
+step:517/1490 train_time:17141ms step_avg:33.15ms
+step:518/1490 train_time:17200ms step_avg:33.21ms
+step:519/1490 train_time:17255ms step_avg:33.25ms
+step:520/1490 train_time:17315ms step_avg:33.30ms
+step:521/1490 train_time:17372ms step_avg:33.34ms
+step:522/1490 train_time:17431ms step_avg:33.39ms
+step:523/1490 train_time:17486ms step_avg:33.43ms
+step:524/1490 train_time:17547ms step_avg:33.49ms
+step:525/1490 train_time:17601ms step_avg:33.53ms
+step:526/1490 train_time:17661ms step_avg:33.58ms
+step:527/1490 train_time:17715ms step_avg:33.61ms
+step:528/1490 train_time:17775ms step_avg:33.66ms
+step:529/1490 train_time:17829ms step_avg:33.70ms
+step:530/1490 train_time:17888ms step_avg:33.75ms
+step:531/1490 train_time:17942ms step_avg:33.79ms
+step:532/1490 train_time:18000ms step_avg:33.83ms
+step:533/1490 train_time:18054ms step_avg:33.87ms
+step:534/1490 train_time:18113ms step_avg:33.92ms
+step:535/1490 train_time:18168ms step_avg:33.96ms
+step:536/1490 train_time:18228ms step_avg:34.01ms
+step:537/1490 train_time:18283ms step_avg:34.05ms
+step:538/1490 train_time:18343ms step_avg:34.10ms
+step:539/1490 train_time:18398ms step_avg:34.13ms
+step:540/1490 train_time:18458ms step_avg:34.18ms
+step:541/1490 train_time:18512ms step_avg:34.22ms
+step:542/1490 train_time:18572ms step_avg:34.27ms
+step:543/1490 train_time:18627ms step_avg:34.30ms
+step:544/1490 train_time:18687ms step_avg:34.35ms
+step:545/1490 train_time:18740ms step_avg:34.39ms
+step:546/1490 train_time:18799ms step_avg:34.43ms
+step:547/1490 train_time:18853ms step_avg:34.47ms
+step:548/1490 train_time:18912ms step_avg:34.51ms
+step:549/1490 train_time:18966ms step_avg:34.55ms
+step:550/1490 train_time:19026ms step_avg:34.59ms
+step:551/1490 train_time:19081ms step_avg:34.63ms
+step:552/1490 train_time:19140ms step_avg:34.67ms
+step:553/1490 train_time:19194ms step_avg:34.71ms
+step:554/1490 train_time:19254ms step_avg:34.75ms
+step:555/1490 train_time:19310ms step_avg:34.79ms
+step:556/1490 train_time:19370ms step_avg:34.84ms
+step:557/1490 train_time:19425ms step_avg:34.87ms
+step:558/1490 train_time:19485ms step_avg:34.92ms
+step:559/1490 train_time:19539ms step_avg:34.95ms
+step:560/1490 train_time:19599ms step_avg:35.00ms
+step:561/1490 train_time:19654ms step_avg:35.03ms
+step:562/1490 train_time:19714ms step_avg:35.08ms
+step:563/1490 train_time:19769ms step_avg:35.11ms
+step:564/1490 train_time:19828ms step_avg:35.16ms
+step:565/1490 train_time:19881ms step_avg:35.19ms
+step:566/1490 train_time:19941ms step_avg:35.23ms
+step:567/1490 train_time:19994ms step_avg:35.26ms
+step:568/1490 train_time:20053ms step_avg:35.30ms
+step:569/1490 train_time:20107ms step_avg:35.34ms
+step:570/1490 train_time:20168ms step_avg:35.38ms
+step:571/1490 train_time:20222ms step_avg:35.42ms
+step:572/1490 train_time:20283ms step_avg:35.46ms
+step:573/1490 train_time:20336ms step_avg:35.49ms
+step:574/1490 train_time:20396ms step_avg:35.53ms
+step:575/1490 train_time:20451ms step_avg:35.57ms
+step:576/1490 train_time:20511ms step_avg:35.61ms
+step:577/1490 train_time:20566ms step_avg:35.64ms
+step:578/1490 train_time:20627ms step_avg:35.69ms
+step:579/1490 train_time:20681ms step_avg:35.72ms
+step:580/1490 train_time:20741ms step_avg:35.76ms
+step:581/1490 train_time:20794ms step_avg:35.79ms
+step:582/1490 train_time:20854ms step_avg:35.83ms
+step:583/1490 train_time:20908ms step_avg:35.86ms
+step:584/1490 train_time:20968ms step_avg:35.90ms
+step:585/1490 train_time:21022ms step_avg:35.93ms
+step:586/1490 train_time:21081ms step_avg:35.97ms
+step:587/1490 train_time:21134ms step_avg:36.00ms
+step:588/1490 train_time:21195ms step_avg:36.05ms
+step:589/1490 train_time:21249ms step_avg:36.08ms
+step:590/1490 train_time:21309ms step_avg:36.12ms
+step:591/1490 train_time:21364ms step_avg:36.15ms
+step:592/1490 train_time:21423ms step_avg:36.19ms
+step:593/1490 train_time:21478ms step_avg:36.22ms
+step:594/1490 train_time:21538ms step_avg:36.26ms
+step:595/1490 train_time:21592ms step_avg:36.29ms
+step:596/1490 train_time:21651ms step_avg:36.33ms
+step:597/1490 train_time:21707ms step_avg:36.36ms
+step:598/1490 train_time:21767ms step_avg:36.40ms
+step:599/1490 train_time:21821ms step_avg:36.43ms
+step:600/1490 train_time:21880ms step_avg:36.47ms
+step:601/1490 train_time:21934ms step_avg:36.50ms
+step:602/1490 train_time:21994ms step_avg:36.53ms
+step:603/1490 train_time:22047ms step_avg:36.56ms
+step:604/1490 train_time:22107ms step_avg:36.60ms
+step:605/1490 train_time:22161ms step_avg:36.63ms
+step:606/1490 train_time:22221ms step_avg:36.67ms
+step:607/1490 train_time:22275ms step_avg:36.70ms
+step:608/1490 train_time:22335ms step_avg:36.74ms
+step:609/1490 train_time:22391ms step_avg:36.77ms
+step:610/1490 train_time:22450ms step_avg:36.80ms
+step:611/1490 train_time:22504ms step_avg:36.83ms
+step:612/1490 train_time:22566ms step_avg:36.87ms
+step:613/1490 train_time:22620ms step_avg:36.90ms
+step:614/1490 train_time:22680ms step_avg:36.94ms
+step:615/1490 train_time:22733ms step_avg:36.96ms
+step:616/1490 train_time:22793ms step_avg:37.00ms
+step:617/1490 train_time:22848ms step_avg:37.03ms
+step:618/1490 train_time:22908ms step_avg:37.07ms
+step:619/1490 train_time:22961ms step_avg:37.09ms
+step:620/1490 train_time:23021ms step_avg:37.13ms
+step:621/1490 train_time:23075ms step_avg:37.16ms
+step:622/1490 train_time:23135ms step_avg:37.19ms
+step:623/1490 train_time:23189ms step_avg:37.22ms
+step:624/1490 train_time:23249ms step_avg:37.26ms
+step:625/1490 train_time:23303ms step_avg:37.28ms
+step:626/1490 train_time:23363ms step_avg:37.32ms
+step:627/1490 train_time:23417ms step_avg:37.35ms
+step:628/1490 train_time:23477ms step_avg:37.38ms
+step:629/1490 train_time:23532ms step_avg:37.41ms
+step:630/1490 train_time:23592ms step_avg:37.45ms
+step:631/1490 train_time:23646ms step_avg:37.47ms
+step:632/1490 train_time:23706ms step_avg:37.51ms
+step:633/1490 train_time:23761ms step_avg:37.54ms
+step:634/1490 train_time:23821ms step_avg:37.57ms
+step:635/1490 train_time:23875ms step_avg:37.60ms
+step:636/1490 train_time:23934ms step_avg:37.63ms
+step:637/1490 train_time:23988ms step_avg:37.66ms
+step:638/1490 train_time:24049ms step_avg:37.69ms
+step:639/1490 train_time:24103ms step_avg:37.72ms
+step:640/1490 train_time:24162ms step_avg:37.75ms
+step:641/1490 train_time:24216ms step_avg:37.78ms
+step:642/1490 train_time:24277ms step_avg:37.82ms
+step:643/1490 train_time:24331ms step_avg:37.84ms
+step:644/1490 train_time:24391ms step_avg:37.87ms
+step:645/1490 train_time:24445ms step_avg:37.90ms
+step:646/1490 train_time:24505ms step_avg:37.93ms
+step:647/1490 train_time:24561ms step_avg:37.96ms
+step:648/1490 train_time:24621ms step_avg:37.99ms
+step:649/1490 train_time:24675ms step_avg:38.02ms
+step:650/1490 train_time:24734ms step_avg:38.05ms
+step:651/1490 train_time:24788ms step_avg:38.08ms
+step:652/1490 train_time:24848ms step_avg:38.11ms
+step:653/1490 train_time:24903ms step_avg:38.14ms
+step:654/1490 train_time:24962ms step_avg:38.17ms
+step:655/1490 train_time:25016ms step_avg:38.19ms
+step:656/1490 train_time:25076ms step_avg:38.23ms
+step:657/1490 train_time:25131ms step_avg:38.25ms
+step:658/1490 train_time:25191ms step_avg:38.28ms
+step:659/1490 train_time:25245ms step_avg:38.31ms
+step:660/1490 train_time:25306ms step_avg:38.34ms
+step:661/1490 train_time:25360ms step_avg:38.37ms
+step:662/1490 train_time:25419ms step_avg:38.40ms
+step:663/1490 train_time:25474ms step_avg:38.42ms
+step:664/1490 train_time:25533ms step_avg:38.45ms
+step:665/1490 train_time:25587ms step_avg:38.48ms
+step:666/1490 train_time:25647ms step_avg:38.51ms
+step:667/1490 train_time:25703ms step_avg:38.53ms
+step:668/1490 train_time:25762ms step_avg:38.57ms
+step:669/1490 train_time:25816ms step_avg:38.59ms
+step:670/1490 train_time:25876ms step_avg:38.62ms
+step:671/1490 train_time:25930ms step_avg:38.64ms
+step:672/1490 train_time:25989ms step_avg:38.67ms
+step:673/1490 train_time:26044ms step_avg:38.70ms
+step:674/1490 train_time:26104ms step_avg:38.73ms
+step:675/1490 train_time:26158ms step_avg:38.75ms
+step:676/1490 train_time:26218ms step_avg:38.78ms
+step:677/1490 train_time:26272ms step_avg:38.81ms
+step:678/1490 train_time:26331ms step_avg:38.84ms
+step:679/1490 train_time:26385ms step_avg:38.86ms
+step:680/1490 train_time:26446ms step_avg:38.89ms
+step:681/1490 train_time:26500ms step_avg:38.91ms
+step:682/1490 train_time:26560ms step_avg:38.94ms
+step:683/1490 train_time:26614ms step_avg:38.97ms
+step:684/1490 train_time:26674ms step_avg:39.00ms
+step:685/1490 train_time:26729ms step_avg:39.02ms
+step:686/1490 train_time:26788ms step_avg:39.05ms
+step:687/1490 train_time:26842ms step_avg:39.07ms
+step:688/1490 train_time:26902ms step_avg:39.10ms
+step:689/1490 train_time:26957ms step_avg:39.13ms
+step:690/1490 train_time:27016ms step_avg:39.15ms
+step:691/1490 train_time:27071ms step_avg:39.18ms
+step:692/1490 train_time:27131ms step_avg:39.21ms
+step:693/1490 train_time:27186ms step_avg:39.23ms
+step:694/1490 train_time:27246ms step_avg:39.26ms
+step:695/1490 train_time:27300ms step_avg:39.28ms
+step:696/1490 train_time:27359ms step_avg:39.31ms
+step:697/1490 train_time:27413ms step_avg:39.33ms
+step:698/1490 train_time:27474ms step_avg:39.36ms
+step:699/1490 train_time:27528ms step_avg:39.38ms
+step:700/1490 train_time:27588ms step_avg:39.41ms
+step:701/1490 train_time:27642ms step_avg:39.43ms
+step:702/1490 train_time:27701ms step_avg:39.46ms
+step:703/1490 train_time:27755ms step_avg:39.48ms
+step:704/1490 train_time:27815ms step_avg:39.51ms
+step:705/1490 train_time:27870ms step_avg:39.53ms
+step:706/1490 train_time:27929ms step_avg:39.56ms
+step:707/1490 train_time:27983ms step_avg:39.58ms
+step:708/1490 train_time:28043ms step_avg:39.61ms
+step:709/1490 train_time:28097ms step_avg:39.63ms
+step:710/1490 train_time:28156ms step_avg:39.66ms
+step:711/1490 train_time:28211ms step_avg:39.68ms
+step:712/1490 train_time:28271ms step_avg:39.71ms
+step:713/1490 train_time:28324ms step_avg:39.73ms
+step:714/1490 train_time:28384ms step_avg:39.75ms
+step:715/1490 train_time:28439ms step_avg:39.78ms
+step:716/1490 train_time:28499ms step_avg:39.80ms
+step:717/1490 train_time:28553ms step_avg:39.82ms
+step:718/1490 train_time:28612ms step_avg:39.85ms
+step:719/1490 train_time:28667ms step_avg:39.87ms
+step:720/1490 train_time:28727ms step_avg:39.90ms
+step:721/1490 train_time:28781ms step_avg:39.92ms
+step:722/1490 train_time:28841ms step_avg:39.95ms
+step:723/1490 train_time:28895ms step_avg:39.96ms
+step:724/1490 train_time:28955ms step_avg:39.99ms
+step:725/1490 train_time:29008ms step_avg:40.01ms
+step:726/1490 train_time:29069ms step_avg:40.04ms
+step:727/1490 train_time:29123ms step_avg:40.06ms
+step:728/1490 train_time:29184ms step_avg:40.09ms
+step:729/1490 train_time:29238ms step_avg:40.11ms
+step:730/1490 train_time:29298ms step_avg:40.13ms
+step:731/1490 train_time:29353ms step_avg:40.15ms
+step:732/1490 train_time:29413ms step_avg:40.18ms
+step:733/1490 train_time:29468ms step_avg:40.20ms
+step:734/1490 train_time:29528ms step_avg:40.23ms
+step:735/1490 train_time:29583ms step_avg:40.25ms
+step:736/1490 train_time:29643ms step_avg:40.28ms
+step:737/1490 train_time:29697ms step_avg:40.29ms
+step:738/1490 train_time:29757ms step_avg:40.32ms
+step:739/1490 train_time:29811ms step_avg:40.34ms
+step:740/1490 train_time:29871ms step_avg:40.37ms
+step:741/1490 train_time:29925ms step_avg:40.38ms
+step:742/1490 train_time:29985ms step_avg:40.41ms
+step:743/1490 train_time:30040ms step_avg:40.43ms
+step:744/1490 train_time:30100ms step_avg:40.46ms
+step:745/1490 train_time:30154ms step_avg:40.48ms
+step:746/1490 train_time:30213ms step_avg:40.50ms
+step:747/1490 train_time:30268ms step_avg:40.52ms
+step:748/1490 train_time:30328ms step_avg:40.55ms
+step:749/1490 train_time:30383ms step_avg:40.56ms
+step:750/1490 train_time:30442ms step_avg:40.59ms
+step:750/1490 val_loss:3.8069 train_time:30516ms step_avg:40.69ms
+step:751/1490 train_time:30535ms step_avg:40.66ms
+step:752/1490 train_time:30559ms step_avg:40.64ms
+step:753/1490 train_time:30615ms step_avg:40.66ms
+step:754/1490 train_time:30677ms step_avg:40.69ms
+step:755/1490 train_time:30732ms step_avg:40.70ms
+step:756/1490 train_time:30793ms step_avg:40.73ms
+step:757/1490 train_time:30847ms step_avg:40.75ms
+step:758/1490 train_time:30907ms step_avg:40.77ms
+step:759/1490 train_time:30961ms step_avg:40.79ms
+step:760/1490 train_time:31019ms step_avg:40.82ms
+step:761/1490 train_time:31073ms step_avg:40.83ms
+step:762/1490 train_time:31133ms step_avg:40.86ms
+step:763/1490 train_time:31186ms step_avg:40.87ms
+step:764/1490 train_time:31245ms step_avg:40.90ms
+step:765/1490 train_time:31299ms step_avg:40.91ms
+step:766/1490 train_time:31358ms step_avg:40.94ms
+step:767/1490 train_time:31411ms step_avg:40.95ms
+step:768/1490 train_time:31471ms step_avg:40.98ms
+step:769/1490 train_time:31527ms step_avg:41.00ms
+step:770/1490 train_time:31589ms step_avg:41.02ms
+step:771/1490 train_time:31644ms step_avg:41.04ms
+step:772/1490 train_time:31705ms step_avg:41.07ms
+step:773/1490 train_time:31762ms step_avg:41.09ms
+step:774/1490 train_time:31822ms step_avg:41.11ms
+step:775/1490 train_time:31876ms step_avg:41.13ms
+step:776/1490 train_time:31935ms step_avg:41.15ms
+step:777/1490 train_time:31990ms step_avg:41.17ms
+step:778/1490 train_time:32050ms step_avg:41.19ms
+step:779/1490 train_time:32103ms step_avg:41.21ms
+step:780/1490 train_time:32163ms step_avg:41.24ms
+step:781/1490 train_time:32217ms step_avg:41.25ms
+step:782/1490 train_time:32276ms step_avg:41.27ms
+step:783/1490 train_time:32330ms step_avg:41.29ms
+step:784/1490 train_time:32389ms step_avg:41.31ms
+step:785/1490 train_time:32443ms step_avg:41.33ms
+step:786/1490 train_time:32503ms step_avg:41.35ms
+step:787/1490 train_time:32558ms step_avg:41.37ms
+step:788/1490 train_time:32619ms step_avg:41.39ms
+step:789/1490 train_time:32674ms step_avg:41.41ms
+step:790/1490 train_time:32735ms step_avg:41.44ms
+step:791/1490 train_time:32790ms step_avg:41.45ms
+step:792/1490 train_time:32849ms step_avg:41.48ms
+step:793/1490 train_time:32903ms step_avg:41.49ms
+step:794/1490 train_time:32963ms step_avg:41.52ms
+step:795/1490 train_time:33018ms step_avg:41.53ms
+step:796/1490 train_time:33077ms step_avg:41.55ms
+step:797/1490 train_time:33131ms step_avg:41.57ms
+step:798/1490 train_time:33191ms step_avg:41.59ms
+step:799/1490 train_time:33245ms step_avg:41.61ms
+step:800/1490 train_time:33304ms step_avg:41.63ms
+step:801/1490 train_time:33358ms step_avg:41.65ms
+step:802/1490 train_time:33417ms step_avg:41.67ms
+step:803/1490 train_time:33471ms step_avg:41.68ms
+step:804/1490 train_time:33532ms step_avg:41.71ms
+step:805/1490 train_time:33587ms step_avg:41.72ms
+step:806/1490 train_time:33648ms step_avg:41.75ms
+step:807/1490 train_time:33702ms step_avg:41.76ms
+step:808/1490 train_time:33762ms step_avg:41.78ms
+step:809/1490 train_time:33816ms step_avg:41.80ms
+step:810/1490 train_time:33876ms step_avg:41.82ms
+step:811/1490 train_time:33931ms step_avg:41.84ms
+step:812/1490 train_time:33990ms step_avg:41.86ms
+step:813/1490 train_time:34044ms step_avg:41.87ms
+step:814/1490 train_time:34104ms step_avg:41.90ms
+step:815/1490 train_time:34158ms step_avg:41.91ms
+step:816/1490 train_time:34217ms step_avg:41.93ms
+step:817/1490 train_time:34272ms step_avg:41.95ms
+step:818/1490 train_time:34331ms step_avg:41.97ms
+step:819/1490 train_time:34385ms step_avg:41.98ms
+step:820/1490 train_time:34445ms step_avg:42.01ms
+step:821/1490 train_time:34500ms step_avg:42.02ms
+step:822/1490 train_time:34560ms step_avg:42.04ms
+step:823/1490 train_time:34614ms step_avg:42.06ms
+step:824/1490 train_time:34674ms step_avg:42.08ms
+step:825/1490 train_time:34728ms step_avg:42.09ms
+step:826/1490 train_time:34790ms step_avg:42.12ms
+step:827/1490 train_time:34844ms step_avg:42.13ms
+step:828/1490 train_time:34903ms step_avg:42.15ms
+step:829/1490 train_time:34958ms step_avg:42.17ms
+step:830/1490 train_time:35017ms step_avg:42.19ms
+step:831/1490 train_time:35071ms step_avg:42.20ms
+step:832/1490 train_time:35131ms step_avg:42.22ms
+step:833/1490 train_time:35186ms step_avg:42.24ms
+step:834/1490 train_time:35246ms step_avg:42.26ms
+step:835/1490 train_time:35301ms step_avg:42.28ms
+step:836/1490 train_time:35360ms step_avg:42.30ms
+step:837/1490 train_time:35414ms step_avg:42.31ms
+step:838/1490 train_time:35473ms step_avg:42.33ms
+step:839/1490 train_time:35528ms step_avg:42.35ms
+step:840/1490 train_time:35589ms step_avg:42.37ms
+step:841/1490 train_time:35643ms step_avg:42.38ms
+step:842/1490 train_time:35704ms step_avg:42.40ms
+step:843/1490 train_time:35758ms step_avg:42.42ms
+step:844/1490 train_time:35818ms step_avg:42.44ms
+step:845/1490 train_time:35872ms step_avg:42.45ms
+step:846/1490 train_time:35932ms step_avg:42.47ms
+step:847/1490 train_time:35986ms step_avg:42.49ms
+step:848/1490 train_time:36047ms step_avg:42.51ms
+step:849/1490 train_time:36101ms step_avg:42.52ms
+step:850/1490 train_time:36161ms step_avg:42.54ms
+step:851/1490 train_time:36215ms step_avg:42.56ms
+step:852/1490 train_time:36276ms step_avg:42.58ms
+step:853/1490 train_time:36330ms step_avg:42.59ms
+step:854/1490 train_time:36390ms step_avg:42.61ms
+step:855/1490 train_time:36444ms step_avg:42.62ms
+step:856/1490 train_time:36503ms step_avg:42.64ms
+step:857/1490 train_time:36558ms step_avg:42.66ms
+step:858/1490 train_time:36617ms step_avg:42.68ms
+step:859/1490 train_time:36671ms step_avg:42.69ms
+step:860/1490 train_time:36731ms step_avg:42.71ms
+step:861/1490 train_time:36785ms step_avg:42.72ms
+step:862/1490 train_time:36846ms step_avg:42.75ms
+step:863/1490 train_time:36901ms step_avg:42.76ms
+step:864/1490 train_time:36961ms step_avg:42.78ms
+step:865/1490 train_time:37014ms step_avg:42.79ms
+step:866/1490 train_time:37074ms step_avg:42.81ms
+step:867/1490 train_time:37128ms step_avg:42.82ms
+step:868/1490 train_time:37189ms step_avg:42.84ms
+step:869/1490 train_time:37243ms step_avg:42.86ms
+step:870/1490 train_time:37303ms step_avg:42.88ms
+step:871/1490 train_time:37357ms step_avg:42.89ms
+step:872/1490 train_time:37417ms step_avg:42.91ms
+step:873/1490 train_time:37472ms step_avg:42.92ms
+step:874/1490 train_time:37531ms step_avg:42.94ms
+step:875/1490 train_time:37585ms step_avg:42.95ms
+step:876/1490 train_time:37645ms step_avg:42.97ms
+step:877/1490 train_time:37699ms step_avg:42.99ms
+step:878/1490 train_time:37759ms step_avg:43.01ms
+step:879/1490 train_time:37814ms step_avg:43.02ms
+step:880/1490 train_time:37873ms step_avg:43.04ms
+step:881/1490 train_time:37928ms step_avg:43.05ms
+step:882/1490 train_time:37989ms step_avg:43.07ms
+step:883/1490 train_time:38042ms step_avg:43.08ms
+step:884/1490 train_time:38103ms step_avg:43.10ms
+step:885/1490 train_time:38157ms step_avg:43.12ms
+step:886/1490 train_time:38217ms step_avg:43.13ms
+step:887/1490 train_time:38271ms step_avg:43.15ms
+step:888/1490 train_time:38331ms step_avg:43.17ms
+step:889/1490 train_time:38386ms step_avg:43.18ms
+step:890/1490 train_time:38446ms step_avg:43.20ms
+step:891/1490 train_time:38500ms step_avg:43.21ms
+step:892/1490 train_time:38560ms step_avg:43.23ms
+step:893/1490 train_time:38614ms step_avg:43.24ms
+step:894/1490 train_time:38674ms step_avg:43.26ms
+step:895/1490 train_time:38728ms step_avg:43.27ms
+step:896/1490 train_time:38790ms step_avg:43.29ms
+step:897/1490 train_time:38844ms step_avg:43.30ms
+step:898/1490 train_time:38904ms step_avg:43.32ms
+step:899/1490 train_time:38958ms step_avg:43.33ms
+step:900/1490 train_time:39017ms step_avg:43.35ms
+step:901/1490 train_time:39071ms step_avg:43.36ms
+step:902/1490 train_time:39132ms step_avg:43.38ms
+step:903/1490 train_time:39186ms step_avg:43.40ms
+step:904/1490 train_time:39245ms step_avg:43.41ms
+step:905/1490 train_time:39300ms step_avg:43.43ms
+step:906/1490 train_time:39359ms step_avg:43.44ms
+step:907/1490 train_time:39413ms step_avg:43.45ms
+step:908/1490 train_time:39473ms step_avg:43.47ms
+step:909/1490 train_time:39527ms step_avg:43.48ms
+step:910/1490 train_time:39587ms step_avg:43.50ms
+step:911/1490 train_time:39641ms step_avg:43.51ms
+step:912/1490 train_time:39701ms step_avg:43.53ms
+step:913/1490 train_time:39755ms step_avg:43.54ms
+step:914/1490 train_time:39815ms step_avg:43.56ms
+step:915/1490 train_time:39870ms step_avg:43.57ms
+step:916/1490 train_time:39930ms step_avg:43.59ms
+step:917/1490 train_time:39984ms step_avg:43.60ms
+step:918/1490 train_time:40044ms step_avg:43.62ms
+step:919/1490 train_time:40099ms step_avg:43.63ms
+step:920/1490 train_time:40157ms step_avg:43.65ms
+step:921/1490 train_time:40211ms step_avg:43.66ms
+step:922/1490 train_time:40271ms step_avg:43.68ms
+step:923/1490 train_time:40325ms step_avg:43.69ms
+step:924/1490 train_time:40385ms step_avg:43.71ms
+step:925/1490 train_time:40440ms step_avg:43.72ms
+step:926/1490 train_time:40500ms step_avg:43.74ms
+step:927/1490 train_time:40553ms step_avg:43.75ms
+step:928/1490 train_time:40612ms step_avg:43.76ms
+step:929/1490 train_time:40666ms step_avg:43.77ms
+step:930/1490 train_time:40726ms step_avg:43.79ms
+step:931/1490 train_time:40780ms step_avg:43.80ms
+step:932/1490 train_time:40841ms step_avg:43.82ms
+step:933/1490 train_time:40895ms step_avg:43.83ms
+step:934/1490 train_time:40955ms step_avg:43.85ms
+step:935/1490 train_time:41010ms step_avg:43.86ms
+step:936/1490 train_time:41069ms step_avg:43.88ms
+step:937/1490 train_time:41123ms step_avg:43.89ms
+step:938/1490 train_time:41183ms step_avg:43.91ms
+step:939/1490 train_time:41236ms step_avg:43.92ms
+step:940/1490 train_time:41297ms step_avg:43.93ms
+step:941/1490 train_time:41351ms step_avg:43.94ms
+step:942/1490 train_time:41411ms step_avg:43.96ms
+step:943/1490 train_time:41465ms step_avg:43.97ms
+step:944/1490 train_time:41526ms step_avg:43.99ms
+step:945/1490 train_time:41580ms step_avg:44.00ms
+step:946/1490 train_time:41639ms step_avg:44.02ms
+step:947/1490 train_time:41694ms step_avg:44.03ms
+step:948/1490 train_time:41754ms step_avg:44.04ms
+step:949/1490 train_time:41808ms step_avg:44.05ms
+step:950/1490 train_time:41868ms step_avg:44.07ms
+step:951/1490 train_time:41921ms step_avg:44.08ms
+step:952/1490 train_time:41981ms step_avg:44.10ms
+step:953/1490 train_time:42035ms step_avg:44.11ms
+step:954/1490 train_time:42096ms step_avg:44.13ms
+step:955/1490 train_time:42150ms step_avg:44.14ms
+step:956/1490 train_time:42210ms step_avg:44.15ms
+step:957/1490 train_time:42263ms step_avg:44.16ms
+step:958/1490 train_time:42323ms step_avg:44.18ms
+step:959/1490 train_time:42378ms step_avg:44.19ms
+step:960/1490 train_time:42437ms step_avg:44.21ms
+step:961/1490 train_time:42492ms step_avg:44.22ms
+step:962/1490 train_time:42551ms step_avg:44.23ms
+step:963/1490 train_time:42606ms step_avg:44.24ms
+step:964/1490 train_time:42667ms step_avg:44.26ms
+step:965/1490 train_time:42721ms step_avg:44.27ms
+step:966/1490 train_time:42781ms step_avg:44.29ms
+step:967/1490 train_time:42835ms step_avg:44.30ms
+step:968/1490 train_time:42899ms step_avg:44.32ms
+step:969/1490 train_time:42978ms step_avg:44.35ms
+step:970/1490 train_time:43064ms step_avg:44.40ms
+step:971/1490 train_time:43145ms step_avg:44.43ms
+step:972/1490 train_time:43231ms step_avg:44.48ms
+step:973/1490 train_time:43311ms step_avg:44.51ms
+step:974/1490 train_time:43397ms step_avg:44.56ms
+step:975/1490 train_time:43477ms step_avg:44.59ms
+step:976/1490 train_time:43564ms step_avg:44.64ms
+step:977/1490 train_time:43647ms step_avg:44.67ms
+step:978/1490 train_time:43734ms step_avg:44.72ms
+step:979/1490 train_time:43815ms step_avg:44.76ms
+step:980/1490 train_time:43901ms step_avg:44.80ms
+step:981/1490 train_time:43981ms step_avg:44.83ms
+step:982/1490 train_time:44067ms step_avg:44.88ms
+step:983/1490 train_time:44149ms step_avg:44.91ms
+step:984/1490 train_time:44236ms step_avg:44.96ms
+step:985/1490 train_time:44317ms step_avg:44.99ms
+step:986/1490 train_time:44403ms step_avg:45.03ms
+step:987/1490 train_time:44484ms step_avg:45.07ms
+step:988/1490 train_time:44571ms step_avg:45.11ms
+step:989/1490 train_time:44652ms step_avg:45.15ms
+step:990/1490 train_time:44739ms step_avg:45.19ms
+step:991/1490 train_time:44819ms step_avg:45.23ms
+step:992/1490 train_time:44906ms step_avg:45.27ms
+step:993/1490 train_time:44986ms step_avg:45.30ms
+step:994/1490 train_time:45071ms step_avg:45.34ms
+step:995/1490 train_time:45154ms step_avg:45.38ms
+step:996/1490 train_time:45240ms step_avg:45.42ms
+step:997/1490 train_time:45322ms step_avg:45.46ms
+step:998/1490 train_time:45408ms step_avg:45.50ms
+step:999/1490 train_time:45487ms step_avg:45.53ms
+step:1000/1490 train_time:45574ms step_avg:45.57ms
+step:1000/1490 val_loss:3.5143 train_time:45677ms step_avg:45.68ms
+step:1001/1490 train_time:45694ms step_avg:45.65ms
+step:1002/1490 train_time:45745ms step_avg:45.65ms
+step:1003/1490 train_time:45832ms step_avg:45.69ms
+step:1004/1490 train_time:45920ms step_avg:45.74ms
+step:1005/1490 train_time:46001ms step_avg:45.77ms
+step:1006/1490 train_time:46085ms step_avg:45.81ms
+step:1007/1490 train_time:46165ms step_avg:45.84ms
+step:1008/1490 train_time:46251ms step_avg:45.88ms
+step:1009/1490 train_time:46332ms step_avg:45.92ms
+step:1010/1490 train_time:46418ms step_avg:45.96ms
+step:1011/1490 train_time:46498ms step_avg:45.99ms
+step:1012/1490 train_time:46583ms step_avg:46.03ms
+step:1013/1490 train_time:46665ms step_avg:46.07ms
+step:1014/1490 train_time:46754ms step_avg:46.11ms
+step:1015/1490 train_time:46838ms step_avg:46.15ms
+step:1016/1490 train_time:46925ms step_avg:46.19ms
+step:1017/1490 train_time:47005ms step_avg:46.22ms
+step:1018/1490 train_time:47092ms step_avg:46.26ms
+step:1019/1490 train_time:47172ms step_avg:46.29ms
+step:1020/1490 train_time:47258ms step_avg:46.33ms
+step:1021/1490 train_time:47337ms step_avg:46.36ms
+step:1022/1490 train_time:47423ms step_avg:46.40ms
+step:1023/1490 train_time:47502ms step_avg:46.43ms
+step:1024/1490 train_time:47588ms step_avg:46.47ms
+step:1025/1490 train_time:47670ms step_avg:46.51ms
+step:1026/1490 train_time:47757ms step_avg:46.55ms
+step:1027/1490 train_time:47841ms step_avg:46.58ms
+step:1028/1490 train_time:47927ms step_avg:46.62ms
+step:1029/1490 train_time:48008ms step_avg:46.66ms
+step:1030/1490 train_time:48093ms step_avg:46.69ms
+step:1031/1490 train_time:48174ms step_avg:46.73ms
+step:1032/1490 train_time:48260ms step_avg:46.76ms
+step:1033/1490 train_time:48340ms step_avg:46.80ms
+step:1034/1490 train_time:48425ms step_avg:46.83ms
+step:1035/1490 train_time:48504ms step_avg:46.86ms
+step:1036/1490 train_time:48592ms step_avg:46.90ms
+step:1037/1490 train_time:48673ms step_avg:46.94ms
+step:1038/1490 train_time:48761ms step_avg:46.98ms
+step:1039/1490 train_time:48844ms step_avg:47.01ms
+step:1040/1490 train_time:48932ms step_avg:47.05ms
+step:1041/1490 train_time:49011ms step_avg:47.08ms
+step:1042/1490 train_time:49098ms step_avg:47.12ms
+step:1043/1490 train_time:49179ms step_avg:47.15ms
+step:1044/1490 train_time:49264ms step_avg:47.19ms
+step:1045/1490 train_time:49344ms step_avg:47.22ms
+step:1046/1490 train_time:49431ms step_avg:47.26ms
+step:1047/1490 train_time:49511ms step_avg:47.29ms
+step:1048/1490 train_time:49597ms step_avg:47.33ms
+step:1049/1490 train_time:49678ms step_avg:47.36ms
+step:1050/1490 train_time:49767ms step_avg:47.40ms
+step:1051/1490 train_time:49850ms step_avg:47.43ms
+step:1052/1490 train_time:49936ms step_avg:47.47ms
+step:1053/1490 train_time:50016ms step_avg:47.50ms
+step:1054/1490 train_time:50102ms step_avg:47.53ms
+step:1055/1490 train_time:50183ms step_avg:47.57ms
+step:1056/1490 train_time:50270ms step_avg:47.60ms
+step:1057/1490 train_time:50350ms step_avg:47.64ms
+step:1058/1490 train_time:50436ms step_avg:47.67ms
+step:1059/1490 train_time:50517ms step_avg:47.70ms
+step:1060/1490 train_time:50603ms step_avg:47.74ms
+step:1061/1490 train_time:50684ms step_avg:47.77ms
+step:1062/1490 train_time:50771ms step_avg:47.81ms
+step:1063/1490 train_time:50852ms step_avg:47.84ms
+step:1064/1490 train_time:50939ms step_avg:47.87ms
+step:1065/1490 train_time:51020ms step_avg:47.91ms
+step:1066/1490 train_time:51105ms step_avg:47.94ms
+step:1067/1490 train_time:51185ms step_avg:47.97ms
+step:1068/1490 train_time:51273ms step_avg:48.01ms
+step:1069/1490 train_time:51354ms step_avg:48.04ms
+step:1070/1490 train_time:51440ms step_avg:48.08ms
+step:1071/1490 train_time:51522ms step_avg:48.11ms
+step:1072/1490 train_time:51608ms step_avg:48.14ms
+step:1073/1490 train_time:51689ms step_avg:48.17ms
+step:1074/1490 train_time:51776ms step_avg:48.21ms
+step:1075/1490 train_time:51857ms step_avg:48.24ms
+step:1076/1490 train_time:51942ms step_avg:48.27ms
+step:1077/1490 train_time:52023ms step_avg:48.30ms
+step:1078/1490 train_time:52110ms step_avg:48.34ms
+step:1079/1490 train_time:52191ms step_avg:48.37ms
+step:1080/1490 train_time:52277ms step_avg:48.40ms
+step:1081/1490 train_time:52358ms step_avg:48.44ms
+step:1082/1490 train_time:52444ms step_avg:48.47ms
+step:1083/1490 train_time:52526ms step_avg:48.50ms
+step:1084/1490 train_time:52612ms step_avg:48.54ms
+step:1085/1490 train_time:52693ms step_avg:48.57ms
+step:1086/1490 train_time:52781ms step_avg:48.60ms
+step:1087/1490 train_time:52862ms step_avg:48.63ms
+step:1088/1490 train_time:52949ms step_avg:48.67ms
+step:1089/1490 train_time:53030ms step_avg:48.70ms
+step:1090/1490 train_time:53116ms step_avg:48.73ms
+step:1091/1490 train_time:53196ms step_avg:48.76ms
+step:1092/1490 train_time:53283ms step_avg:48.79ms
+step:1093/1490 train_time:53364ms step_avg:48.82ms
+step:1094/1490 train_time:53451ms step_avg:48.86ms
+step:1095/1490 train_time:53532ms step_avg:48.89ms
+step:1096/1490 train_time:53617ms step_avg:48.92ms
+step:1097/1490 train_time:53698ms step_avg:48.95ms
+step:1098/1490 train_time:53784ms step_avg:48.98ms
+step:1099/1490 train_time:53866ms step_avg:49.01ms
+step:1100/1490 train_time:53953ms step_avg:49.05ms
+step:1101/1490 train_time:54034ms step_avg:49.08ms
+step:1102/1490 train_time:54120ms step_avg:49.11ms
+step:1103/1490 train_time:54201ms step_avg:49.14ms
+step:1104/1490 train_time:54288ms step_avg:49.17ms
+step:1105/1490 train_time:54369ms step_avg:49.20ms
+step:1106/1490 train_time:54454ms step_avg:49.24ms
+step:1107/1490 train_time:54535ms step_avg:49.26ms
+step:1108/1490 train_time:54623ms step_avg:49.30ms
+step:1109/1490 train_time:54704ms step_avg:49.33ms
+step:1110/1490 train_time:54789ms step_avg:49.36ms
+step:1111/1490 train_time:54870ms step_avg:49.39ms
+step:1112/1490 train_time:54956ms step_avg:49.42ms
+step:1113/1490 train_time:55038ms step_avg:49.45ms
+step:1114/1490 train_time:55125ms step_avg:49.48ms
+step:1115/1490 train_time:55205ms step_avg:49.51ms
+step:1116/1490 train_time:55291ms step_avg:49.54ms
+step:1117/1490 train_time:55372ms step_avg:49.57ms
+step:1118/1490 train_time:55459ms step_avg:49.61ms
+step:1119/1490 train_time:55540ms step_avg:49.63ms
+step:1120/1490 train_time:55627ms step_avg:49.67ms
+step:1121/1490 train_time:55707ms step_avg:49.69ms
+step:1122/1490 train_time:55793ms step_avg:49.73ms
+step:1123/1490 train_time:55875ms step_avg:49.75ms
+step:1124/1490 train_time:55962ms step_avg:49.79ms
+step:1125/1490 train_time:56043ms step_avg:49.82ms
+step:1126/1490 train_time:56131ms step_avg:49.85ms
+step:1127/1490 train_time:56210ms step_avg:49.88ms
+step:1128/1490 train_time:56295ms step_avg:49.91ms
+step:1129/1490 train_time:56377ms step_avg:49.94ms
+step:1130/1490 train_time:56463ms step_avg:49.97ms
+step:1131/1490 train_time:56544ms step_avg:49.99ms
+step:1132/1490 train_time:56631ms step_avg:50.03ms
+step:1133/1490 train_time:56711ms step_avg:50.05ms
+step:1134/1490 train_time:56797ms step_avg:50.09ms
+step:1135/1490 train_time:56879ms step_avg:50.11ms
+step:1136/1490 train_time:56967ms step_avg:50.15ms
+step:1137/1490 train_time:57050ms step_avg:50.18ms
+step:1138/1490 train_time:57136ms step_avg:50.21ms
+step:1139/1490 train_time:57217ms step_avg:50.23ms
+step:1140/1490 train_time:57302ms step_avg:50.26ms
+step:1141/1490 train_time:57383ms step_avg:50.29ms
+step:1142/1490 train_time:57471ms step_avg:50.33ms
+step:1143/1490 train_time:57552ms step_avg:50.35ms
+step:1144/1490 train_time:57638ms step_avg:50.38ms
+step:1145/1490 train_time:57719ms step_avg:50.41ms
+step:1146/1490 train_time:57804ms step_avg:50.44ms
+step:1147/1490 train_time:57885ms step_avg:50.47ms
+step:1148/1490 train_time:57973ms step_avg:50.50ms
+step:1149/1490 train_time:58055ms step_avg:50.53ms
+step:1150/1490 train_time:58141ms step_avg:50.56ms
+step:1151/1490 train_time:58221ms step_avg:50.58ms
+step:1152/1490 train_time:58307ms step_avg:50.61ms
+step:1153/1490 train_time:58389ms step_avg:50.64ms
+step:1154/1490 train_time:58475ms step_avg:50.67ms
+step:1155/1490 train_time:58556ms step_avg:50.70ms
+step:1156/1490 train_time:58643ms step_avg:50.73ms
+step:1157/1490 train_time:58723ms step_avg:50.75ms
+step:1158/1490 train_time:58809ms step_avg:50.78ms
+step:1159/1490 train_time:58889ms step_avg:50.81ms
+step:1160/1490 train_time:58976ms step_avg:50.84ms
+step:1161/1490 train_time:59057ms step_avg:50.87ms
+step:1162/1490 train_time:59144ms step_avg:50.90ms
+step:1163/1490 train_time:59227ms step_avg:50.93ms
+step:1164/1490 train_time:59312ms step_avg:50.96ms
+step:1165/1490 train_time:59393ms step_avg:50.98ms
+step:1166/1490 train_time:59481ms step_avg:51.01ms
+step:1167/1490 train_time:59561ms step_avg:51.04ms
+step:1168/1490 train_time:59648ms step_avg:51.07ms
+step:1169/1490 train_time:59729ms step_avg:51.09ms
+step:1170/1490 train_time:59815ms step_avg:51.12ms
+step:1171/1490 train_time:59895ms step_avg:51.15ms
+step:1172/1490 train_time:59982ms step_avg:51.18ms
+step:1173/1490 train_time:60063ms step_avg:51.20ms
+step:1174/1490 train_time:60150ms step_avg:51.24ms
+step:1175/1490 train_time:60231ms step_avg:51.26ms
+step:1176/1490 train_time:60317ms step_avg:51.29ms
+step:1177/1490 train_time:60397ms step_avg:51.31ms
+step:1178/1490 train_time:60483ms step_avg:51.34ms
+step:1179/1490 train_time:60566ms step_avg:51.37ms
+step:1180/1490 train_time:60651ms step_avg:51.40ms
+step:1181/1490 train_time:60733ms step_avg:51.42ms
+step:1182/1490 train_time:60819ms step_avg:51.45ms
+step:1183/1490 train_time:60899ms step_avg:51.48ms
+step:1184/1490 train_time:60985ms step_avg:51.51ms
+step:1185/1490 train_time:61067ms step_avg:51.53ms
+step:1186/1490 train_time:61155ms step_avg:51.56ms
+step:1187/1490 train_time:61237ms step_avg:51.59ms
+step:1188/1490 train_time:61323ms step_avg:51.62ms
+step:1189/1490 train_time:61403ms step_avg:51.64ms
+step:1190/1490 train_time:61489ms step_avg:51.67ms
+step:1191/1490 train_time:61571ms step_avg:51.70ms
+step:1192/1490 train_time:61658ms step_avg:51.73ms
+step:1193/1490 train_time:61739ms step_avg:51.75ms
+step:1194/1490 train_time:61825ms step_avg:51.78ms
+step:1195/1490 train_time:61906ms step_avg:51.80ms
+step:1196/1490 train_time:61992ms step_avg:51.83ms
+step:1197/1490 train_time:62073ms step_avg:51.86ms
+step:1198/1490 train_time:62160ms step_avg:51.89ms
+step:1199/1490 train_time:62240ms step_avg:51.91ms
+step:1200/1490 train_time:62329ms step_avg:51.94ms
+step:1201/1490 train_time:62410ms step_avg:51.96ms
+step:1202/1490 train_time:62495ms step_avg:51.99ms
+step:1203/1490 train_time:62577ms step_avg:52.02ms
+step:1204/1490 train_time:62664ms step_avg:52.05ms
+step:1205/1490 train_time:62745ms step_avg:52.07ms
+step:1206/1490 train_time:62833ms step_avg:52.10ms
+step:1207/1490 train_time:62913ms step_avg:52.12ms
+step:1208/1490 train_time:62999ms step_avg:52.15ms
+step:1209/1490 train_time:63080ms step_avg:52.18ms
+step:1210/1490 train_time:63165ms step_avg:52.20ms
+step:1211/1490 train_time:63246ms step_avg:52.23ms
+step:1212/1490 train_time:63332ms step_avg:52.25ms
+step:1213/1490 train_time:63412ms step_avg:52.28ms
+step:1214/1490 train_time:63499ms step_avg:52.31ms
+step:1215/1490 train_time:63580ms step_avg:52.33ms
+step:1216/1490 train_time:63669ms step_avg:52.36ms
+step:1217/1490 train_time:63750ms step_avg:52.38ms
+step:1218/1490 train_time:63835ms step_avg:52.41ms
+step:1219/1490 train_time:63916ms step_avg:52.43ms
+step:1220/1490 train_time:64002ms step_avg:52.46ms
+step:1221/1490 train_time:64083ms step_avg:52.48ms
+step:1222/1490 train_time:64169ms step_avg:52.51ms
+step:1223/1490 train_time:64251ms step_avg:52.54ms
+step:1224/1490 train_time:64337ms step_avg:52.56ms
+step:1225/1490 train_time:64418ms step_avg:52.59ms
+step:1226/1490 train_time:64504ms step_avg:52.61ms
+step:1227/1490 train_time:64585ms step_avg:52.64ms
+step:1228/1490 train_time:64673ms step_avg:52.67ms
+step:1229/1490 train_time:64755ms step_avg:52.69ms
+step:1230/1490 train_time:64841ms step_avg:52.72ms
+step:1231/1490 train_time:64922ms step_avg:52.74ms
+step:1232/1490 train_time:65008ms step_avg:52.77ms
+step:1233/1490 train_time:65089ms step_avg:52.79ms
+step:1234/1490 train_time:65175ms step_avg:52.82ms
+step:1235/1490 train_time:65255ms step_avg:52.84ms
+step:1236/1490 train_time:65343ms step_avg:52.87ms
+step:1237/1490 train_time:65422ms step_avg:52.89ms
+step:1238/1490 train_time:65509ms step_avg:52.92ms
+step:1239/1490 train_time:65590ms step_avg:52.94ms
+step:1240/1490 train_time:65677ms step_avg:52.97ms
+step:1241/1490 train_time:65758ms step_avg:52.99ms
+step:1242/1490 train_time:65845ms step_avg:53.02ms
+step:1243/1490 train_time:65925ms step_avg:53.04ms
+step:1244/1490 train_time:66011ms step_avg:53.06ms
+step:1245/1490 train_time:66092ms step_avg:53.09ms
+step:1246/1490 train_time:66178ms step_avg:53.11ms
+step:1247/1490 train_time:66259ms step_avg:53.13ms
+step:1248/1490 train_time:66346ms step_avg:53.16ms
+step:1249/1490 train_time:66427ms step_avg:53.18ms
+step:1250/1490 train_time:66512ms step_avg:53.21ms
+step:1250/1490 val_loss:3.3704 train_time:66616ms step_avg:53.29ms
+step:1251/1490 train_time:66634ms step_avg:53.26ms
+step:1252/1490 train_time:66684ms step_avg:53.26ms
+step:1253/1490 train_time:66768ms step_avg:53.29ms
+step:1254/1490 train_time:66857ms step_avg:53.32ms
+step:1255/1490 train_time:66938ms step_avg:53.34ms
+step:1256/1490 train_time:67024ms step_avg:53.36ms
+step:1257/1490 train_time:67103ms step_avg:53.38ms
+step:1258/1490 train_time:67189ms step_avg:53.41ms
+step:1259/1490 train_time:67269ms step_avg:53.43ms
+step:1260/1490 train_time:67353ms step_avg:53.45ms
+step:1261/1490 train_time:67432ms step_avg:53.47ms
+step:1262/1490 train_time:67518ms step_avg:53.50ms
+step:1263/1490 train_time:67602ms step_avg:53.53ms
+step:1264/1490 train_time:67689ms step_avg:53.55ms
+step:1265/1490 train_time:67773ms step_avg:53.58ms
+step:1266/1490 train_time:67860ms step_avg:53.60ms
+step:1267/1490 train_time:67942ms step_avg:53.62ms
+step:1268/1490 train_time:68028ms step_avg:53.65ms
+step:1269/1490 train_time:68108ms step_avg:53.67ms
+step:1270/1490 train_time:68193ms step_avg:53.70ms
+step:1271/1490 train_time:68274ms step_avg:53.72ms
+step:1272/1490 train_time:68361ms step_avg:53.74ms
+step:1273/1490 train_time:68440ms step_avg:53.76ms
+step:1274/1490 train_time:68526ms step_avg:53.79ms
+step:1275/1490 train_time:68607ms step_avg:53.81ms
+step:1276/1490 train_time:68696ms step_avg:53.84ms
+step:1277/1490 train_time:68780ms step_avg:53.86ms
+step:1278/1490 train_time:68868ms step_avg:53.89ms
+step:1279/1490 train_time:68950ms step_avg:53.91ms
+step:1280/1490 train_time:69036ms step_avg:53.93ms
+step:1281/1490 train_time:69115ms step_avg:53.95ms
+step:1282/1490 train_time:69203ms step_avg:53.98ms
+step:1283/1490 train_time:69282ms step_avg:54.00ms
+step:1284/1490 train_time:69367ms step_avg:54.02ms
+step:1285/1490 train_time:69448ms step_avg:54.05ms
+step:1286/1490 train_time:69535ms step_avg:54.07ms
+step:1287/1490 train_time:69616ms step_avg:54.09ms
+step:1288/1490 train_time:69705ms step_avg:54.12ms
+step:1289/1490 train_time:69788ms step_avg:54.14ms
+step:1290/1490 train_time:69874ms step_avg:54.17ms
+step:1291/1490 train_time:69957ms step_avg:54.19ms
+step:1292/1490 train_time:70043ms step_avg:54.21ms
+step:1293/1490 train_time:70123ms step_avg:54.23ms
+step:1294/1490 train_time:70209ms step_avg:54.26ms
+step:1295/1490 train_time:70290ms step_avg:54.28ms
+step:1296/1490 train_time:70375ms step_avg:54.30ms
+step:1297/1490 train_time:70456ms step_avg:54.32ms
+step:1298/1490 train_time:70543ms step_avg:54.35ms
+step:1299/1490 train_time:70623ms step_avg:54.37ms
+step:1300/1490 train_time:70709ms step_avg:54.39ms
+step:1301/1490 train_time:70792ms step_avg:54.41ms
+step:1302/1490 train_time:70879ms step_avg:54.44ms
+step:1303/1490 train_time:70960ms step_avg:54.46ms
+step:1304/1490 train_time:71047ms step_avg:54.48ms
+step:1305/1490 train_time:71127ms step_avg:54.50ms
+step:1306/1490 train_time:71213ms step_avg:54.53ms
+step:1307/1490 train_time:71294ms step_avg:54.55ms
+step:1308/1490 train_time:71381ms step_avg:54.57ms
+step:1309/1490 train_time:71461ms step_avg:54.59ms
+step:1310/1490 train_time:71546ms step_avg:54.62ms
+step:1311/1490 train_time:71628ms step_avg:54.64ms
+step:1312/1490 train_time:71714ms step_avg:54.66ms
+step:1313/1490 train_time:71795ms step_avg:54.68ms
+step:1314/1490 train_time:71882ms step_avg:54.70ms
+step:1315/1490 train_time:71963ms step_avg:54.72ms
+step:1316/1490 train_time:72050ms step_avg:54.75ms
+step:1317/1490 train_time:72132ms step_avg:54.77ms
+step:1318/1490 train_time:72218ms step_avg:54.79ms
+step:1319/1490 train_time:72299ms step_avg:54.81ms
+step:1320/1490 train_time:72386ms step_avg:54.84ms
+step:1321/1490 train_time:72466ms step_avg:54.86ms
+step:1322/1490 train_time:72552ms step_avg:54.88ms
+step:1323/1490 train_time:72633ms step_avg:54.90ms
+step:1324/1490 train_time:72720ms step_avg:54.92ms
+step:1325/1490 train_time:72802ms step_avg:54.94ms
+step:1326/1490 train_time:72887ms step_avg:54.97ms
+step:1327/1490 train_time:72970ms step_avg:54.99ms
+step:1328/1490 train_time:73056ms step_avg:55.01ms
+step:1329/1490 train_time:73137ms step_avg:55.03ms
+step:1330/1490 train_time:73223ms step_avg:55.05ms
+step:1331/1490 train_time:73303ms step_avg:55.07ms
+step:1332/1490 train_time:73389ms step_avg:55.10ms
+step:1333/1490 train_time:73472ms step_avg:55.12ms
+step:1334/1490 train_time:73559ms step_avg:55.14ms
+step:1335/1490 train_time:73640ms step_avg:55.16ms
+step:1336/1490 train_time:73726ms step_avg:55.18ms
+step:1337/1490 train_time:73807ms step_avg:55.20ms
+step:1338/1490 train_time:73895ms step_avg:55.23ms
+step:1339/1490 train_time:73976ms step_avg:55.25ms
+step:1340/1490 train_time:74063ms step_avg:55.27ms
+step:1341/1490 train_time:74144ms step_avg:55.29ms
+step:1342/1490 train_time:74230ms step_avg:55.31ms
+step:1343/1490 train_time:74311ms step_avg:55.33ms
+step:1344/1490 train_time:74396ms step_avg:55.35ms
+step:1345/1490 train_time:74477ms step_avg:55.37ms
+step:1346/1490 train_time:74564ms step_avg:55.40ms
+step:1347/1490 train_time:74645ms step_avg:55.42ms
+step:1348/1490 train_time:74731ms step_avg:55.44ms
+step:1349/1490 train_time:74811ms step_avg:55.46ms
+step:1350/1490 train_time:74898ms step_avg:55.48ms
+step:1351/1490 train_time:74978ms step_avg:55.50ms
+step:1352/1490 train_time:75065ms step_avg:55.52ms
+step:1353/1490 train_time:75146ms step_avg:55.54ms
+step:1354/1490 train_time:75232ms step_avg:55.56ms
+step:1355/1490 train_time:75314ms step_avg:55.58ms
+step:1356/1490 train_time:75400ms step_avg:55.60ms
+step:1357/1490 train_time:75480ms step_avg:55.62ms
+step:1358/1490 train_time:75566ms step_avg:55.64ms
+step:1359/1490 train_time:75647ms step_avg:55.66ms
+step:1360/1490 train_time:75733ms step_avg:55.69ms
+step:1361/1490 train_time:75813ms step_avg:55.70ms
+step:1362/1490 train_time:75899ms step_avg:55.73ms
+step:1363/1490 train_time:75981ms step_avg:55.75ms
+step:1364/1490 train_time:76067ms step_avg:55.77ms
+step:1365/1490 train_time:76148ms step_avg:55.79ms
+step:1366/1490 train_time:76236ms step_avg:55.81ms
+step:1367/1490 train_time:76316ms step_avg:55.83ms
+step:1368/1490 train_time:76402ms step_avg:55.85ms
+step:1369/1490 train_time:76482ms step_avg:55.87ms
+step:1370/1490 train_time:76570ms step_avg:55.89ms
+step:1371/1490 train_time:76651ms step_avg:55.91ms
+step:1372/1490 train_time:76738ms step_avg:55.93ms
+step:1373/1490 train_time:76819ms step_avg:55.95ms
+step:1374/1490 train_time:76904ms step_avg:55.97ms
+step:1375/1490 train_time:76986ms step_avg:55.99ms
+step:1376/1490 train_time:77074ms step_avg:56.01ms
+step:1377/1490 train_time:77154ms step_avg:56.03ms
+step:1378/1490 train_time:77241ms step_avg:56.05ms
+step:1379/1490 train_time:77321ms step_avg:56.07ms
+step:1380/1490 train_time:77407ms step_avg:56.09ms
+step:1381/1490 train_time:77487ms step_avg:56.11ms
+step:1382/1490 train_time:77574ms step_avg:56.13ms
+step:1383/1490 train_time:77656ms step_avg:56.15ms
+step:1384/1490 train_time:77742ms step_avg:56.17ms
+step:1385/1490 train_time:77823ms step_avg:56.19ms
+step:1386/1490 train_time:77908ms step_avg:56.21ms
+step:1387/1490 train_time:77991ms step_avg:56.23ms
+step:1388/1490 train_time:78079ms step_avg:56.25ms
+step:1389/1490 train_time:78159ms step_avg:56.27ms
+step:1390/1490 train_time:78246ms step_avg:56.29ms
+step:1391/1490 train_time:78326ms step_avg:56.31ms
+step:1392/1490 train_time:78412ms step_avg:56.33ms
+step:1393/1490 train_time:78492ms step_avg:56.35ms
+step:1394/1490 train_time:78580ms step_avg:56.37ms
+step:1395/1490 train_time:78661ms step_avg:56.39ms
+step:1396/1490 train_time:78746ms step_avg:56.41ms
+step:1397/1490 train_time:78828ms step_avg:56.43ms
+step:1398/1490 train_time:78914ms step_avg:56.45ms
+step:1399/1490 train_time:78995ms step_avg:56.47ms
+step:1400/1490 train_time:79082ms step_avg:56.49ms
+step:1401/1490 train_time:79164ms step_avg:56.51ms
+step:1402/1490 train_time:79251ms step_avg:56.53ms
+step:1403/1490 train_time:79332ms step_avg:56.54ms
+step:1404/1490 train_time:79418ms step_avg:56.57ms
+step:1405/1490 train_time:79499ms step_avg:56.58ms
+step:1406/1490 train_time:79585ms step_avg:56.60ms
+step:1407/1490 train_time:79665ms step_avg:56.62ms
+step:1408/1490 train_time:79752ms step_avg:56.64ms
+step:1409/1490 train_time:79832ms step_avg:56.66ms
+step:1410/1490 train_time:79919ms step_avg:56.68ms
+step:1411/1490 train_time:80000ms step_avg:56.70ms
+step:1412/1490 train_time:80087ms step_avg:56.72ms
+step:1413/1490 train_time:80168ms step_avg:56.74ms
+step:1414/1490 train_time:80255ms step_avg:56.76ms
+step:1415/1490 train_time:80338ms step_avg:56.78ms
+step:1416/1490 train_time:80424ms step_avg:56.80ms
+step:1417/1490 train_time:80505ms step_avg:56.81ms
+step:1418/1490 train_time:80591ms step_avg:56.83ms
+step:1419/1490 train_time:80671ms step_avg:56.85ms
+step:1420/1490 train_time:80759ms step_avg:56.87ms
+step:1421/1490 train_time:80840ms step_avg:56.89ms
+step:1422/1490 train_time:80926ms step_avg:56.91ms
+step:1423/1490 train_time:81007ms step_avg:56.93ms
+step:1424/1490 train_time:81094ms step_avg:56.95ms
+step:1425/1490 train_time:81176ms step_avg:56.97ms
+step:1426/1490 train_time:81262ms step_avg:56.99ms
+step:1427/1490 train_time:81342ms step_avg:57.00ms
+step:1428/1490 train_time:81429ms step_avg:57.02ms
+step:1429/1490 train_time:81510ms step_avg:57.04ms
+step:1430/1490 train_time:81595ms step_avg:57.06ms
+step:1431/1490 train_time:81678ms step_avg:57.08ms
+step:1432/1490 train_time:81763ms step_avg:57.10ms
+step:1433/1490 train_time:81843ms step_avg:57.11ms
+step:1434/1490 train_time:81930ms step_avg:57.13ms
+step:1435/1490 train_time:82011ms step_avg:57.15ms
+step:1436/1490 train_time:82099ms step_avg:57.17ms
+step:1437/1490 train_time:82179ms step_avg:57.19ms
+step:1438/1490 train_time:82266ms step_avg:57.21ms
+step:1439/1490 train_time:82347ms step_avg:57.23ms
+step:1440/1490 train_time:82433ms step_avg:57.25ms
+step:1441/1490 train_time:82513ms step_avg:57.26ms
+step:1442/1490 train_time:82600ms step_avg:57.28ms
+step:1443/1490 train_time:82682ms step_avg:57.30ms
+step:1444/1490 train_time:82767ms step_avg:57.32ms
+step:1445/1490 train_time:82849ms step_avg:57.33ms
+step:1446/1490 train_time:82935ms step_avg:57.35ms
+step:1447/1490 train_time:83015ms step_avg:57.37ms
+step:1448/1490 train_time:83102ms step_avg:57.39ms
+step:1449/1490 train_time:83183ms step_avg:57.41ms
+step:1450/1490 train_time:83270ms step_avg:57.43ms
+step:1451/1490 train_time:83356ms step_avg:57.45ms
+step:1452/1490 train_time:83443ms step_avg:57.47ms
+step:1453/1490 train_time:83523ms step_avg:57.48ms
+step:1454/1490 train_time:83610ms step_avg:57.50ms
+step:1455/1490 train_time:83692ms step_avg:57.52ms
+step:1456/1490 train_time:83778ms step_avg:57.54ms
+step:1457/1490 train_time:83861ms step_avg:57.56ms
+step:1458/1490 train_time:83948ms step_avg:57.58ms
+step:1459/1490 train_time:84030ms step_avg:57.59ms
+step:1460/1490 train_time:84117ms step_avg:57.61ms
+step:1461/1490 train_time:84199ms step_avg:57.63ms
+step:1462/1490 train_time:84284ms step_avg:57.65ms
+step:1463/1490 train_time:84367ms step_avg:57.67ms
+step:1464/1490 train_time:84454ms step_avg:57.69ms
+step:1465/1490 train_time:84535ms step_avg:57.70ms
+step:1466/1490 train_time:84621ms step_avg:57.72ms
+step:1467/1490 train_time:84702ms step_avg:57.74ms
+step:1468/1490 train_time:84789ms step_avg:57.76ms
+step:1469/1490 train_time:84871ms step_avg:57.77ms
+step:1470/1490 train_time:84958ms step_avg:57.79ms
+step:1471/1490 train_time:85038ms step_avg:57.81ms
+step:1472/1490 train_time:85124ms step_avg:57.83ms
+step:1473/1490 train_time:85206ms step_avg:57.85ms
+step:1474/1490 train_time:85293ms step_avg:57.86ms
+step:1475/1490 train_time:85375ms step_avg:57.88ms
+step:1476/1490 train_time:85462ms step_avg:57.90ms
+step:1477/1490 train_time:85542ms step_avg:57.92ms
+step:1478/1490 train_time:85628ms step_avg:57.94ms
+step:1479/1490 train_time:85710ms step_avg:57.95ms
+step:1480/1490 train_time:85797ms step_avg:57.97ms
+step:1481/1490 train_time:85879ms step_avg:57.99ms
+step:1482/1490 train_time:85965ms step_avg:58.01ms
+step:1483/1490 train_time:86047ms step_avg:58.02ms
+step:1484/1490 train_time:86134ms step_avg:58.04ms
+step:1485/1490 train_time:86216ms step_avg:58.06ms
+step:1486/1490 train_time:86304ms step_avg:58.08ms
+step:1487/1490 train_time:86387ms step_avg:58.09ms
+step:1488/1490 train_time:86473ms step_avg:58.11ms
+step:1489/1490 train_time:86554ms step_avg:58.13ms
+step:1490/1490 train_time:86641ms step_avg:58.15ms
+step:1490/1490 val_loss:3.2773 train_time:86743ms step_avg:58.22ms
+peak memory allocated: 31296 MiB reserved: 47142 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/baseline/2026-03-22_18-25-54_time-185_secs_baseline_9e0803.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/baseline/2026-03-22_18-25-54_time-185_secs_baseline_9e0803.txt
@@ -1,0 +1,4456 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 18:26:09 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   36C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            133W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   41C    P0            124W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1380667      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1380668      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1380669      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1380670      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1380671      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1380672      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1380673      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1380674      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8323 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:69ms step_avg:68.55ms
+step:2/1490 train_time:90ms step_avg:44.75ms
+step:3/1490 train_time:106ms step_avg:35.38ms
+step:4/1490 train_time:139ms step_avg:34.76ms
+step:5/1490 train_time:166ms step_avg:33.28ms
+step:6/1490 train_time:201ms step_avg:33.51ms
+step:7/1490 train_time:228ms step_avg:32.62ms
+step:8/1490 train_time:263ms step_avg:32.87ms
+step:9/1490 train_time:290ms step_avg:32.27ms
+step:10/1490 train_time:325ms step_avg:32.51ms
+step:11/1490 train_time:353ms step_avg:32.10ms
+step:12/1490 train_time:388ms step_avg:32.32ms
+step:13/1490 train_time:416ms step_avg:31.98ms
+step:14/1490 train_time:450ms step_avg:32.15ms
+step:15/1490 train_time:478ms step_avg:31.90ms
+step:16/1490 train_time:513ms step_avg:32.06ms
+step:17/1490 train_time:542ms step_avg:31.90ms
+step:18/1490 train_time:576ms step_avg:32.01ms
+step:19/1490 train_time:604ms step_avg:31.78ms
+step:20/1490 train_time:638ms step_avg:31.91ms
+step:21/1490 train_time:667ms step_avg:31.76ms
+step:22/1490 train_time:701ms step_avg:31.88ms
+step:23/1490 train_time:729ms step_avg:31.72ms
+step:24/1490 train_time:764ms step_avg:31.84ms
+step:25/1490 train_time:792ms step_avg:31.70ms
+step:26/1490 train_time:827ms step_avg:31.81ms
+step:27/1490 train_time:855ms step_avg:31.67ms
+step:28/1490 train_time:890ms step_avg:31.78ms
+step:29/1490 train_time:918ms step_avg:31.66ms
+step:30/1490 train_time:953ms step_avg:31.77ms
+step:31/1490 train_time:982ms step_avg:31.69ms
+step:32/1490 train_time:1018ms step_avg:31.81ms
+step:33/1490 train_time:1048ms step_avg:31.75ms
+step:34/1490 train_time:1083ms step_avg:31.86ms
+step:35/1490 train_time:1112ms step_avg:31.78ms
+step:36/1490 train_time:1147ms step_avg:31.86ms
+step:37/1490 train_time:1176ms step_avg:31.77ms
+step:38/1490 train_time:1210ms step_avg:31.84ms
+step:39/1490 train_time:1238ms step_avg:31.75ms
+step:40/1490 train_time:1273ms step_avg:31.82ms
+step:41/1490 train_time:1302ms step_avg:31.75ms
+step:42/1490 train_time:1336ms step_avg:31.81ms
+step:43/1490 train_time:1365ms step_avg:31.73ms
+step:44/1490 train_time:1399ms step_avg:31.78ms
+step:45/1490 train_time:1427ms step_avg:31.71ms
+step:46/1490 train_time:1462ms step_avg:31.77ms
+step:47/1490 train_time:1490ms step_avg:31.70ms
+step:48/1490 train_time:1524ms step_avg:31.75ms
+step:49/1490 train_time:1553ms step_avg:31.69ms
+step:50/1490 train_time:1588ms step_avg:31.75ms
+step:51/1490 train_time:1616ms step_avg:31.69ms
+step:52/1490 train_time:1651ms step_avg:31.74ms
+step:53/1490 train_time:1679ms step_avg:31.68ms
+step:54/1490 train_time:1714ms step_avg:31.73ms
+step:55/1490 train_time:1743ms step_avg:31.68ms
+step:56/1490 train_time:1777ms step_avg:31.74ms
+step:57/1490 train_time:1805ms step_avg:31.67ms
+step:58/1490 train_time:1839ms step_avg:31.71ms
+step:59/1490 train_time:1868ms step_avg:31.66ms
+step:60/1490 train_time:1902ms step_avg:31.70ms
+step:61/1490 train_time:1931ms step_avg:31.65ms
+step:62/1490 train_time:1965ms step_avg:31.70ms
+step:63/1490 train_time:1994ms step_avg:31.66ms
+step:64/1490 train_time:2029ms step_avg:31.71ms
+step:65/1490 train_time:2058ms step_avg:31.66ms
+step:66/1490 train_time:2093ms step_avg:31.71ms
+step:67/1490 train_time:2121ms step_avg:31.66ms
+step:68/1490 train_time:2156ms step_avg:31.70ms
+step:69/1490 train_time:2184ms step_avg:31.65ms
+step:70/1490 train_time:2219ms step_avg:31.70ms
+step:71/1490 train_time:2248ms step_avg:31.66ms
+step:72/1490 train_time:2283ms step_avg:31.70ms
+step:73/1490 train_time:2311ms step_avg:31.66ms
+step:74/1490 train_time:2346ms step_avg:31.70ms
+step:75/1490 train_time:2374ms step_avg:31.65ms
+step:76/1490 train_time:2408ms step_avg:31.69ms
+step:77/1490 train_time:2436ms step_avg:31.64ms
+step:78/1490 train_time:2471ms step_avg:31.68ms
+step:79/1490 train_time:2500ms step_avg:31.64ms
+step:80/1490 train_time:2534ms step_avg:31.68ms
+step:81/1490 train_time:2563ms step_avg:31.64ms
+step:82/1490 train_time:2597ms step_avg:31.67ms
+step:83/1490 train_time:2626ms step_avg:31.63ms
+step:84/1490 train_time:2660ms step_avg:31.66ms
+step:85/1490 train_time:2689ms step_avg:31.63ms
+step:86/1490 train_time:2723ms step_avg:31.66ms
+step:87/1490 train_time:2751ms step_avg:31.63ms
+step:88/1490 train_time:2786ms step_avg:31.66ms
+step:89/1490 train_time:2814ms step_avg:31.62ms
+step:90/1490 train_time:2849ms step_avg:31.65ms
+step:91/1490 train_time:2877ms step_avg:31.61ms
+step:92/1490 train_time:2912ms step_avg:31.65ms
+step:93/1490 train_time:2940ms step_avg:31.61ms
+step:94/1490 train_time:2975ms step_avg:31.65ms
+step:95/1490 train_time:3004ms step_avg:31.62ms
+step:96/1490 train_time:3038ms step_avg:31.65ms
+step:97/1490 train_time:3067ms step_avg:31.62ms
+step:98/1490 train_time:3101ms step_avg:31.64ms
+step:99/1490 train_time:3129ms step_avg:31.61ms
+step:100/1490 train_time:3164ms step_avg:31.64ms
+step:101/1490 train_time:3193ms step_avg:31.62ms
+step:102/1490 train_time:3228ms step_avg:31.65ms
+step:103/1490 train_time:3257ms step_avg:31.62ms
+step:104/1490 train_time:3292ms step_avg:31.65ms
+step:105/1490 train_time:3321ms step_avg:31.63ms
+step:106/1490 train_time:3355ms step_avg:31.65ms
+step:107/1490 train_time:3384ms step_avg:31.63ms
+step:108/1490 train_time:3418ms step_avg:31.65ms
+step:109/1490 train_time:3447ms step_avg:31.62ms
+step:110/1490 train_time:3482ms step_avg:31.65ms
+step:111/1490 train_time:3510ms step_avg:31.63ms
+step:112/1490 train_time:3545ms step_avg:31.65ms
+step:113/1490 train_time:3573ms step_avg:31.62ms
+step:114/1490 train_time:3608ms step_avg:31.65ms
+step:115/1490 train_time:3636ms step_avg:31.62ms
+step:116/1490 train_time:3671ms step_avg:31.64ms
+step:117/1490 train_time:3699ms step_avg:31.62ms
+step:118/1490 train_time:3733ms step_avg:31.64ms
+step:119/1490 train_time:3762ms step_avg:31.61ms
+step:120/1490 train_time:3796ms step_avg:31.64ms
+step:121/1490 train_time:3825ms step_avg:31.61ms
+step:122/1490 train_time:3859ms step_avg:31.63ms
+step:123/1490 train_time:3887ms step_avg:31.60ms
+step:124/1490 train_time:3921ms step_avg:31.62ms
+step:125/1490 train_time:3951ms step_avg:31.61ms
+step:126/1490 train_time:3985ms step_avg:31.63ms
+step:127/1490 train_time:4014ms step_avg:31.60ms
+step:128/1490 train_time:4049ms step_avg:31.63ms
+step:129/1490 train_time:4077ms step_avg:31.60ms
+step:130/1490 train_time:4112ms step_avg:31.63ms
+step:131/1490 train_time:4141ms step_avg:31.61ms
+step:132/1490 train_time:4175ms step_avg:31.63ms
+step:133/1490 train_time:4204ms step_avg:31.61ms
+step:134/1490 train_time:4238ms step_avg:31.63ms
+step:135/1490 train_time:4267ms step_avg:31.61ms
+step:136/1490 train_time:4301ms step_avg:31.63ms
+step:137/1490 train_time:4329ms step_avg:31.60ms
+step:138/1490 train_time:4364ms step_avg:31.62ms
+step:139/1490 train_time:4392ms step_avg:31.60ms
+step:140/1490 train_time:4427ms step_avg:31.62ms
+step:141/1490 train_time:4455ms step_avg:31.60ms
+step:142/1490 train_time:4490ms step_avg:31.62ms
+step:143/1490 train_time:4518ms step_avg:31.59ms
+step:144/1490 train_time:4553ms step_avg:31.62ms
+step:145/1490 train_time:4582ms step_avg:31.60ms
+step:146/1490 train_time:4616ms step_avg:31.62ms
+step:147/1490 train_time:4644ms step_avg:31.59ms
+step:148/1490 train_time:4679ms step_avg:31.62ms
+step:149/1490 train_time:4708ms step_avg:31.60ms
+step:150/1490 train_time:4742ms step_avg:31.62ms
+step:151/1490 train_time:4771ms step_avg:31.59ms
+step:152/1490 train_time:4805ms step_avg:31.61ms
+step:153/1490 train_time:4833ms step_avg:31.59ms
+step:154/1490 train_time:4868ms step_avg:31.61ms
+step:155/1490 train_time:4896ms step_avg:31.59ms
+step:156/1490 train_time:4931ms step_avg:31.61ms
+step:157/1490 train_time:4959ms step_avg:31.59ms
+step:158/1490 train_time:4994ms step_avg:31.61ms
+step:159/1490 train_time:5023ms step_avg:31.59ms
+step:160/1490 train_time:5057ms step_avg:31.61ms
+step:161/1490 train_time:5086ms step_avg:31.59ms
+step:162/1490 train_time:5120ms step_avg:31.60ms
+step:163/1490 train_time:5148ms step_avg:31.59ms
+step:164/1490 train_time:5183ms step_avg:31.60ms
+step:165/1490 train_time:5212ms step_avg:31.59ms
+step:166/1490 train_time:5247ms step_avg:31.61ms
+step:167/1490 train_time:5275ms step_avg:31.59ms
+step:168/1490 train_time:5310ms step_avg:31.61ms
+step:169/1490 train_time:5338ms step_avg:31.58ms
+step:170/1490 train_time:5373ms step_avg:31.60ms
+step:171/1490 train_time:5401ms step_avg:31.59ms
+step:172/1490 train_time:5435ms step_avg:31.60ms
+step:173/1490 train_time:5464ms step_avg:31.58ms
+step:174/1490 train_time:5499ms step_avg:31.60ms
+step:175/1490 train_time:5527ms step_avg:31.58ms
+step:176/1490 train_time:5561ms step_avg:31.60ms
+step:177/1490 train_time:5590ms step_avg:31.58ms
+step:178/1490 train_time:5625ms step_avg:31.60ms
+step:179/1490 train_time:5653ms step_avg:31.58ms
+step:180/1490 train_time:5688ms step_avg:31.60ms
+step:181/1490 train_time:5716ms step_avg:31.58ms
+step:182/1490 train_time:5750ms step_avg:31.59ms
+step:183/1490 train_time:5779ms step_avg:31.58ms
+step:184/1490 train_time:5813ms step_avg:31.59ms
+step:185/1490 train_time:5842ms step_avg:31.58ms
+step:186/1490 train_time:5877ms step_avg:31.59ms
+step:187/1490 train_time:5905ms step_avg:31.58ms
+step:188/1490 train_time:5940ms step_avg:31.59ms
+step:189/1490 train_time:5968ms step_avg:31.58ms
+step:190/1490 train_time:6002ms step_avg:31.59ms
+step:191/1490 train_time:6030ms step_avg:31.57ms
+step:192/1490 train_time:6065ms step_avg:31.59ms
+step:193/1490 train_time:6094ms step_avg:31.57ms
+step:194/1490 train_time:6128ms step_avg:31.59ms
+step:195/1490 train_time:6156ms step_avg:31.57ms
+step:196/1490 train_time:6191ms step_avg:31.59ms
+step:197/1490 train_time:6219ms step_avg:31.57ms
+step:198/1490 train_time:6254ms step_avg:31.58ms
+step:199/1490 train_time:6282ms step_avg:31.57ms
+step:200/1490 train_time:6317ms step_avg:31.58ms
+step:201/1490 train_time:6345ms step_avg:31.57ms
+step:202/1490 train_time:6380ms step_avg:31.58ms
+step:203/1490 train_time:6409ms step_avg:31.57ms
+step:204/1490 train_time:6443ms step_avg:31.58ms
+step:205/1490 train_time:6472ms step_avg:31.57ms
+step:206/1490 train_time:6506ms step_avg:31.58ms
+step:207/1490 train_time:6534ms step_avg:31.57ms
+step:208/1490 train_time:6569ms step_avg:31.58ms
+step:209/1490 train_time:6597ms step_avg:31.57ms
+step:210/1490 train_time:6631ms step_avg:31.58ms
+step:211/1490 train_time:6660ms step_avg:31.56ms
+step:212/1490 train_time:6694ms step_avg:31.58ms
+step:213/1490 train_time:6723ms step_avg:31.56ms
+step:214/1490 train_time:6757ms step_avg:31.58ms
+step:215/1490 train_time:6786ms step_avg:31.56ms
+step:216/1490 train_time:6820ms step_avg:31.57ms
+step:217/1490 train_time:6848ms step_avg:31.56ms
+step:218/1490 train_time:6883ms step_avg:31.57ms
+step:219/1490 train_time:6911ms step_avg:31.56ms
+step:220/1490 train_time:6946ms step_avg:31.57ms
+step:221/1490 train_time:6974ms step_avg:31.56ms
+step:222/1490 train_time:7008ms step_avg:31.57ms
+step:223/1490 train_time:7036ms step_avg:31.55ms
+step:224/1490 train_time:7071ms step_avg:31.57ms
+step:225/1490 train_time:7100ms step_avg:31.55ms
+step:226/1490 train_time:7134ms step_avg:31.57ms
+step:227/1490 train_time:7163ms step_avg:31.55ms
+step:228/1490 train_time:7197ms step_avg:31.57ms
+step:229/1490 train_time:7225ms step_avg:31.55ms
+step:230/1490 train_time:7260ms step_avg:31.56ms
+step:231/1490 train_time:7288ms step_avg:31.55ms
+step:232/1490 train_time:7323ms step_avg:31.56ms
+step:233/1490 train_time:7351ms step_avg:31.55ms
+step:234/1490 train_time:7386ms step_avg:31.56ms
+step:235/1490 train_time:7414ms step_avg:31.55ms
+step:236/1490 train_time:7448ms step_avg:31.56ms
+step:237/1490 train_time:7477ms step_avg:31.55ms
+step:238/1490 train_time:7511ms step_avg:31.56ms
+step:239/1490 train_time:7539ms step_avg:31.55ms
+step:240/1490 train_time:7574ms step_avg:31.56ms
+step:241/1490 train_time:7602ms step_avg:31.54ms
+step:242/1490 train_time:7636ms step_avg:31.56ms
+step:243/1490 train_time:7665ms step_avg:31.54ms
+step:244/1490 train_time:7699ms step_avg:31.55ms
+step:245/1490 train_time:7727ms step_avg:31.54ms
+step:246/1490 train_time:7762ms step_avg:31.55ms
+step:247/1490 train_time:7790ms step_avg:31.54ms
+step:248/1490 train_time:7825ms step_avg:31.55ms
+step:249/1490 train_time:7853ms step_avg:31.54ms
+step:250/1490 train_time:7888ms step_avg:31.55ms
+step:250/1490 val_loss:4.5215 train_time:7931ms step_avg:31.72ms
+step:251/1490 train_time:7946ms step_avg:31.66ms
+step:252/1490 train_time:7964ms step_avg:31.60ms
+step:253/1490 train_time:7982ms step_avg:31.55ms
+step:254/1490 train_time:8017ms step_avg:31.56ms
+step:255/1490 train_time:8047ms step_avg:31.56ms
+step:256/1490 train_time:8081ms step_avg:31.57ms
+step:257/1490 train_time:8110ms step_avg:31.56ms
+step:258/1490 train_time:8144ms step_avg:31.57ms
+step:259/1490 train_time:8173ms step_avg:31.56ms
+step:260/1490 train_time:8208ms step_avg:31.57ms
+step:261/1490 train_time:8236ms step_avg:31.56ms
+step:262/1490 train_time:8270ms step_avg:31.57ms
+step:263/1490 train_time:8298ms step_avg:31.55ms
+step:264/1490 train_time:8335ms step_avg:31.57ms
+step:265/1490 train_time:8361ms step_avg:31.55ms
+step:266/1490 train_time:8395ms step_avg:31.56ms
+step:267/1490 train_time:8423ms step_avg:31.55ms
+step:268/1490 train_time:8457ms step_avg:31.56ms
+step:269/1490 train_time:8485ms step_avg:31.54ms
+step:270/1490 train_time:8520ms step_avg:31.55ms
+step:271/1490 train_time:8548ms step_avg:31.54ms
+step:272/1490 train_time:8582ms step_avg:31.55ms
+step:273/1490 train_time:8610ms step_avg:31.54ms
+step:274/1490 train_time:8644ms step_avg:31.55ms
+step:275/1490 train_time:8672ms step_avg:31.53ms
+step:276/1490 train_time:8706ms step_avg:31.54ms
+step:277/1490 train_time:8734ms step_avg:31.53ms
+step:278/1490 train_time:8769ms step_avg:31.54ms
+step:279/1490 train_time:8796ms step_avg:31.53ms
+step:280/1490 train_time:8831ms step_avg:31.54ms
+step:281/1490 train_time:8859ms step_avg:31.53ms
+step:282/1490 train_time:8895ms step_avg:31.54ms
+step:283/1490 train_time:8924ms step_avg:31.53ms
+step:284/1490 train_time:8959ms step_avg:31.54ms
+step:285/1490 train_time:8988ms step_avg:31.54ms
+step:286/1490 train_time:9022ms step_avg:31.55ms
+step:287/1490 train_time:9051ms step_avg:31.54ms
+step:288/1490 train_time:9087ms step_avg:31.55ms
+step:289/1490 train_time:9115ms step_avg:31.54ms
+step:290/1490 train_time:9150ms step_avg:31.55ms
+step:291/1490 train_time:9178ms step_avg:31.54ms
+step:292/1490 train_time:9213ms step_avg:31.55ms
+step:293/1490 train_time:9241ms step_avg:31.54ms
+step:294/1490 train_time:9276ms step_avg:31.55ms
+step:295/1490 train_time:9304ms step_avg:31.54ms
+step:296/1490 train_time:9338ms step_avg:31.55ms
+step:297/1490 train_time:9366ms step_avg:31.54ms
+step:298/1490 train_time:9401ms step_avg:31.55ms
+step:299/1490 train_time:9429ms step_avg:31.53ms
+step:300/1490 train_time:9463ms step_avg:31.54ms
+step:301/1490 train_time:9491ms step_avg:31.53ms
+step:302/1490 train_time:9525ms step_avg:31.54ms
+step:303/1490 train_time:9554ms step_avg:31.53ms
+step:304/1490 train_time:9588ms step_avg:31.54ms
+step:305/1490 train_time:9616ms step_avg:31.53ms
+step:306/1490 train_time:9650ms step_avg:31.54ms
+step:307/1490 train_time:9678ms step_avg:31.53ms
+step:308/1490 train_time:9713ms step_avg:31.54ms
+step:309/1490 train_time:9741ms step_avg:31.52ms
+step:310/1490 train_time:9775ms step_avg:31.53ms
+step:311/1490 train_time:9804ms step_avg:31.52ms
+step:312/1490 train_time:9838ms step_avg:31.53ms
+step:313/1490 train_time:9866ms step_avg:31.52ms
+step:314/1490 train_time:9901ms step_avg:31.53ms
+step:315/1490 train_time:9930ms step_avg:31.52ms
+step:316/1490 train_time:9964ms step_avg:31.53ms
+step:317/1490 train_time:9993ms step_avg:31.52ms
+step:318/1490 train_time:10028ms step_avg:31.53ms
+step:319/1490 train_time:10056ms step_avg:31.52ms
+step:320/1490 train_time:10091ms step_avg:31.53ms
+step:321/1490 train_time:10119ms step_avg:31.52ms
+step:322/1490 train_time:10154ms step_avg:31.53ms
+step:323/1490 train_time:10183ms step_avg:31.53ms
+step:324/1490 train_time:10217ms step_avg:31.53ms
+step:325/1490 train_time:10246ms step_avg:31.52ms
+step:326/1490 train_time:10280ms step_avg:31.53ms
+step:327/1490 train_time:10309ms step_avg:31.52ms
+step:328/1490 train_time:10343ms step_avg:31.53ms
+step:329/1490 train_time:10372ms step_avg:31.52ms
+step:330/1490 train_time:10406ms step_avg:31.53ms
+step:331/1490 train_time:10434ms step_avg:31.52ms
+step:332/1490 train_time:10469ms step_avg:31.53ms
+step:333/1490 train_time:10497ms step_avg:31.52ms
+step:334/1490 train_time:10531ms step_avg:31.53ms
+step:335/1490 train_time:10559ms step_avg:31.52ms
+step:336/1490 train_time:10594ms step_avg:31.53ms
+step:337/1490 train_time:10622ms step_avg:31.52ms
+step:338/1490 train_time:10657ms step_avg:31.53ms
+step:339/1490 train_time:10685ms step_avg:31.52ms
+step:340/1490 train_time:10719ms step_avg:31.53ms
+step:341/1490 train_time:10747ms step_avg:31.52ms
+step:342/1490 train_time:10781ms step_avg:31.52ms
+step:343/1490 train_time:10809ms step_avg:31.51ms
+step:344/1490 train_time:10844ms step_avg:31.52ms
+step:345/1490 train_time:10872ms step_avg:31.51ms
+step:346/1490 train_time:10906ms step_avg:31.52ms
+step:347/1490 train_time:10935ms step_avg:31.51ms
+step:348/1490 train_time:10970ms step_avg:31.52ms
+step:349/1490 train_time:10998ms step_avg:31.51ms
+step:350/1490 train_time:11033ms step_avg:31.52ms
+step:351/1490 train_time:11061ms step_avg:31.51ms
+step:352/1490 train_time:11096ms step_avg:31.52ms
+step:353/1490 train_time:11124ms step_avg:31.51ms
+step:354/1490 train_time:11159ms step_avg:31.52ms
+step:355/1490 train_time:11187ms step_avg:31.51ms
+step:356/1490 train_time:11221ms step_avg:31.52ms
+step:357/1490 train_time:11250ms step_avg:31.51ms
+step:358/1490 train_time:11284ms step_avg:31.52ms
+step:359/1490 train_time:11312ms step_avg:31.51ms
+step:360/1490 train_time:11347ms step_avg:31.52ms
+step:361/1490 train_time:11375ms step_avg:31.51ms
+step:362/1490 train_time:11409ms step_avg:31.52ms
+step:363/1490 train_time:11438ms step_avg:31.51ms
+step:364/1490 train_time:11472ms step_avg:31.52ms
+step:365/1490 train_time:11500ms step_avg:31.51ms
+step:366/1490 train_time:11535ms step_avg:31.52ms
+step:367/1490 train_time:11563ms step_avg:31.51ms
+step:368/1490 train_time:11598ms step_avg:31.51ms
+step:369/1490 train_time:11626ms step_avg:31.51ms
+step:370/1490 train_time:11660ms step_avg:31.51ms
+step:371/1490 train_time:11689ms step_avg:31.51ms
+step:372/1490 train_time:11723ms step_avg:31.51ms
+step:373/1490 train_time:11752ms step_avg:31.51ms
+step:374/1490 train_time:11786ms step_avg:31.51ms
+step:375/1490 train_time:11814ms step_avg:31.50ms
+step:376/1490 train_time:11849ms step_avg:31.51ms
+step:377/1490 train_time:11876ms step_avg:31.50ms
+step:378/1490 train_time:11911ms step_avg:31.51ms
+step:379/1490 train_time:11939ms step_avg:31.50ms
+step:380/1490 train_time:11974ms step_avg:31.51ms
+step:381/1490 train_time:12003ms step_avg:31.50ms
+step:382/1490 train_time:12037ms step_avg:31.51ms
+step:383/1490 train_time:12066ms step_avg:31.50ms
+step:384/1490 train_time:12100ms step_avg:31.51ms
+step:385/1490 train_time:12129ms step_avg:31.50ms
+step:386/1490 train_time:12163ms step_avg:31.51ms
+step:387/1490 train_time:12191ms step_avg:31.50ms
+step:388/1490 train_time:12226ms step_avg:31.51ms
+step:389/1490 train_time:12254ms step_avg:31.50ms
+step:390/1490 train_time:12289ms step_avg:31.51ms
+step:391/1490 train_time:12318ms step_avg:31.50ms
+step:392/1490 train_time:12352ms step_avg:31.51ms
+step:393/1490 train_time:12380ms step_avg:31.50ms
+step:394/1490 train_time:12415ms step_avg:31.51ms
+step:395/1490 train_time:12443ms step_avg:31.50ms
+step:396/1490 train_time:12478ms step_avg:31.51ms
+step:397/1490 train_time:12506ms step_avg:31.50ms
+step:398/1490 train_time:12541ms step_avg:31.51ms
+step:399/1490 train_time:12569ms step_avg:31.50ms
+step:400/1490 train_time:12603ms step_avg:31.51ms
+step:401/1490 train_time:12631ms step_avg:31.50ms
+step:402/1490 train_time:12665ms step_avg:31.51ms
+step:403/1490 train_time:12694ms step_avg:31.50ms
+step:404/1490 train_time:12729ms step_avg:31.51ms
+step:405/1490 train_time:12757ms step_avg:31.50ms
+step:406/1490 train_time:12791ms step_avg:31.51ms
+step:407/1490 train_time:12819ms step_avg:31.50ms
+step:408/1490 train_time:12854ms step_avg:31.51ms
+step:409/1490 train_time:12882ms step_avg:31.50ms
+step:410/1490 train_time:12917ms step_avg:31.50ms
+step:411/1490 train_time:12945ms step_avg:31.50ms
+step:412/1490 train_time:12980ms step_avg:31.50ms
+step:413/1490 train_time:13008ms step_avg:31.50ms
+step:414/1490 train_time:13042ms step_avg:31.50ms
+step:415/1490 train_time:13070ms step_avg:31.49ms
+step:416/1490 train_time:13105ms step_avg:31.50ms
+step:417/1490 train_time:13134ms step_avg:31.50ms
+step:418/1490 train_time:13168ms step_avg:31.50ms
+step:419/1490 train_time:13197ms step_avg:31.50ms
+step:420/1490 train_time:13231ms step_avg:31.50ms
+step:421/1490 train_time:13259ms step_avg:31.50ms
+step:422/1490 train_time:13294ms step_avg:31.50ms
+step:423/1490 train_time:13323ms step_avg:31.50ms
+step:424/1490 train_time:13357ms step_avg:31.50ms
+step:425/1490 train_time:13386ms step_avg:31.50ms
+step:426/1490 train_time:13421ms step_avg:31.50ms
+step:427/1490 train_time:13449ms step_avg:31.50ms
+step:428/1490 train_time:13483ms step_avg:31.50ms
+step:429/1490 train_time:13511ms step_avg:31.49ms
+step:430/1490 train_time:13546ms step_avg:31.50ms
+step:431/1490 train_time:13574ms step_avg:31.49ms
+step:432/1490 train_time:13609ms step_avg:31.50ms
+step:433/1490 train_time:13637ms step_avg:31.49ms
+step:434/1490 train_time:13671ms step_avg:31.50ms
+step:435/1490 train_time:13700ms step_avg:31.49ms
+step:436/1490 train_time:13735ms step_avg:31.50ms
+step:437/1490 train_time:13763ms step_avg:31.49ms
+step:438/1490 train_time:13798ms step_avg:31.50ms
+step:439/1490 train_time:13826ms step_avg:31.49ms
+step:440/1490 train_time:13860ms step_avg:31.50ms
+step:441/1490 train_time:13889ms step_avg:31.49ms
+step:442/1490 train_time:13923ms step_avg:31.50ms
+step:443/1490 train_time:13951ms step_avg:31.49ms
+step:444/1490 train_time:13985ms step_avg:31.50ms
+step:445/1490 train_time:14014ms step_avg:31.49ms
+step:446/1490 train_time:14049ms step_avg:31.50ms
+step:447/1490 train_time:14077ms step_avg:31.49ms
+step:448/1490 train_time:14111ms step_avg:31.50ms
+step:449/1490 train_time:14139ms step_avg:31.49ms
+step:450/1490 train_time:14174ms step_avg:31.50ms
+step:451/1490 train_time:14202ms step_avg:31.49ms
+step:452/1490 train_time:14236ms step_avg:31.50ms
+step:453/1490 train_time:14265ms step_avg:31.49ms
+step:454/1490 train_time:14299ms step_avg:31.50ms
+step:455/1490 train_time:14328ms step_avg:31.49ms
+step:456/1490 train_time:14362ms step_avg:31.50ms
+step:457/1490 train_time:14391ms step_avg:31.49ms
+step:458/1490 train_time:14425ms step_avg:31.50ms
+step:459/1490 train_time:14454ms step_avg:31.49ms
+step:460/1490 train_time:14488ms step_avg:31.50ms
+step:461/1490 train_time:14516ms step_avg:31.49ms
+step:462/1490 train_time:14551ms step_avg:31.50ms
+step:463/1490 train_time:14579ms step_avg:31.49ms
+step:464/1490 train_time:14614ms step_avg:31.50ms
+step:465/1490 train_time:14642ms step_avg:31.49ms
+step:466/1490 train_time:14676ms step_avg:31.49ms
+step:467/1490 train_time:14705ms step_avg:31.49ms
+step:468/1490 train_time:14739ms step_avg:31.49ms
+step:469/1490 train_time:14767ms step_avg:31.49ms
+step:470/1490 train_time:14801ms step_avg:31.49ms
+step:471/1490 train_time:14829ms step_avg:31.49ms
+step:472/1490 train_time:14864ms step_avg:31.49ms
+step:473/1490 train_time:14892ms step_avg:31.48ms
+step:474/1490 train_time:14927ms step_avg:31.49ms
+step:475/1490 train_time:14955ms step_avg:31.48ms
+step:476/1490 train_time:14989ms step_avg:31.49ms
+step:477/1490 train_time:15017ms step_avg:31.48ms
+step:478/1490 train_time:15052ms step_avg:31.49ms
+step:479/1490 train_time:15080ms step_avg:31.48ms
+step:480/1490 train_time:15115ms step_avg:31.49ms
+step:481/1490 train_time:15143ms step_avg:31.48ms
+step:482/1490 train_time:15178ms step_avg:31.49ms
+step:483/1490 train_time:15206ms step_avg:31.48ms
+step:484/1490 train_time:15243ms step_avg:31.49ms
+step:485/1490 train_time:15295ms step_avg:31.54ms
+step:486/1490 train_time:15354ms step_avg:31.59ms
+step:487/1490 train_time:15408ms step_avg:31.64ms
+step:488/1490 train_time:15469ms step_avg:31.70ms
+step:489/1490 train_time:15523ms step_avg:31.74ms
+step:490/1490 train_time:15583ms step_avg:31.80ms
+step:491/1490 train_time:15637ms step_avg:31.85ms
+step:492/1490 train_time:15696ms step_avg:31.90ms
+step:493/1490 train_time:15751ms step_avg:31.95ms
+step:494/1490 train_time:15812ms step_avg:32.01ms
+step:495/1490 train_time:15866ms step_avg:32.05ms
+step:496/1490 train_time:15925ms step_avg:32.11ms
+step:497/1490 train_time:15979ms step_avg:32.15ms
+step:498/1490 train_time:16039ms step_avg:32.21ms
+step:499/1490 train_time:16094ms step_avg:32.25ms
+step:500/1490 train_time:16154ms step_avg:32.31ms
+step:500/1490 val_loss:4.2375 train_time:16226ms step_avg:32.45ms
+step:501/1490 train_time:16245ms step_avg:32.43ms
+step:502/1490 train_time:16269ms step_avg:32.41ms
+step:503/1490 train_time:16325ms step_avg:32.45ms
+step:504/1490 train_time:16386ms step_avg:32.51ms
+step:505/1490 train_time:16440ms step_avg:32.55ms
+step:506/1490 train_time:16500ms step_avg:32.61ms
+step:507/1490 train_time:16555ms step_avg:32.65ms
+step:508/1490 train_time:16615ms step_avg:32.71ms
+step:509/1490 train_time:16669ms step_avg:32.75ms
+step:510/1490 train_time:16728ms step_avg:32.80ms
+step:511/1490 train_time:16782ms step_avg:32.84ms
+step:512/1490 train_time:16841ms step_avg:32.89ms
+step:513/1490 train_time:16895ms step_avg:32.93ms
+step:514/1490 train_time:16954ms step_avg:32.98ms
+step:515/1490 train_time:17008ms step_avg:33.02ms
+step:516/1490 train_time:17068ms step_avg:33.08ms
+step:517/1490 train_time:17123ms step_avg:33.12ms
+step:518/1490 train_time:17184ms step_avg:33.17ms
+step:519/1490 train_time:17239ms step_avg:33.22ms
+step:520/1490 train_time:17300ms step_avg:33.27ms
+step:521/1490 train_time:17356ms step_avg:33.31ms
+step:522/1490 train_time:17416ms step_avg:33.36ms
+step:523/1490 train_time:17471ms step_avg:33.40ms
+step:524/1490 train_time:17529ms step_avg:33.45ms
+step:525/1490 train_time:17584ms step_avg:33.49ms
+step:526/1490 train_time:17644ms step_avg:33.54ms
+step:527/1490 train_time:17699ms step_avg:33.58ms
+step:528/1490 train_time:17758ms step_avg:33.63ms
+step:529/1490 train_time:17811ms step_avg:33.67ms
+step:530/1490 train_time:17871ms step_avg:33.72ms
+step:531/1490 train_time:17924ms step_avg:33.76ms
+step:532/1490 train_time:17983ms step_avg:33.80ms
+step:533/1490 train_time:18037ms step_avg:33.84ms
+step:534/1490 train_time:18098ms step_avg:33.89ms
+step:535/1490 train_time:18153ms step_avg:33.93ms
+step:536/1490 train_time:18213ms step_avg:33.98ms
+step:537/1490 train_time:18268ms step_avg:34.02ms
+step:538/1490 train_time:18328ms step_avg:34.07ms
+step:539/1490 train_time:18383ms step_avg:34.11ms
+step:540/1490 train_time:18443ms step_avg:34.15ms
+step:541/1490 train_time:18498ms step_avg:34.19ms
+step:542/1490 train_time:18558ms step_avg:34.24ms
+step:543/1490 train_time:18612ms step_avg:34.28ms
+step:544/1490 train_time:18671ms step_avg:34.32ms
+step:545/1490 train_time:18725ms step_avg:34.36ms
+step:546/1490 train_time:18784ms step_avg:34.40ms
+step:547/1490 train_time:18838ms step_avg:34.44ms
+step:548/1490 train_time:18898ms step_avg:34.49ms
+step:549/1490 train_time:18952ms step_avg:34.52ms
+step:550/1490 train_time:19010ms step_avg:34.56ms
+step:551/1490 train_time:19065ms step_avg:34.60ms
+step:552/1490 train_time:19125ms step_avg:34.65ms
+step:553/1490 train_time:19179ms step_avg:34.68ms
+step:554/1490 train_time:19240ms step_avg:34.73ms
+step:555/1490 train_time:19295ms step_avg:34.77ms
+step:556/1490 train_time:19355ms step_avg:34.81ms
+step:557/1490 train_time:19408ms step_avg:34.84ms
+step:558/1490 train_time:19469ms step_avg:34.89ms
+step:559/1490 train_time:19524ms step_avg:34.93ms
+step:560/1490 train_time:19583ms step_avg:34.97ms
+step:561/1490 train_time:19636ms step_avg:35.00ms
+step:562/1490 train_time:19696ms step_avg:35.05ms
+step:563/1490 train_time:19749ms step_avg:35.08ms
+step:564/1490 train_time:19808ms step_avg:35.12ms
+step:565/1490 train_time:19863ms step_avg:35.16ms
+step:566/1490 train_time:19923ms step_avg:35.20ms
+step:567/1490 train_time:19976ms step_avg:35.23ms
+step:568/1490 train_time:20036ms step_avg:35.28ms
+step:569/1490 train_time:20090ms step_avg:35.31ms
+step:570/1490 train_time:20150ms step_avg:35.35ms
+step:571/1490 train_time:20205ms step_avg:35.39ms
+step:572/1490 train_time:20266ms step_avg:35.43ms
+step:573/1490 train_time:20320ms step_avg:35.46ms
+step:574/1490 train_time:20380ms step_avg:35.51ms
+step:575/1490 train_time:20435ms step_avg:35.54ms
+step:576/1490 train_time:20495ms step_avg:35.58ms
+step:577/1490 train_time:20549ms step_avg:35.61ms
+step:578/1490 train_time:20609ms step_avg:35.66ms
+step:579/1490 train_time:20664ms step_avg:35.69ms
+step:580/1490 train_time:20723ms step_avg:35.73ms
+step:581/1490 train_time:20777ms step_avg:35.76ms
+step:582/1490 train_time:20836ms step_avg:35.80ms
+step:583/1490 train_time:20890ms step_avg:35.83ms
+step:584/1490 train_time:20949ms step_avg:35.87ms
+step:585/1490 train_time:21003ms step_avg:35.90ms
+step:586/1490 train_time:21063ms step_avg:35.94ms
+step:587/1490 train_time:21117ms step_avg:35.97ms
+step:588/1490 train_time:21177ms step_avg:36.02ms
+step:589/1490 train_time:21231ms step_avg:36.05ms
+step:590/1490 train_time:21291ms step_avg:36.09ms
+step:591/1490 train_time:21345ms step_avg:36.12ms
+step:592/1490 train_time:21405ms step_avg:36.16ms
+step:593/1490 train_time:21460ms step_avg:36.19ms
+step:594/1490 train_time:21521ms step_avg:36.23ms
+step:595/1490 train_time:21575ms step_avg:36.26ms
+step:596/1490 train_time:21634ms step_avg:36.30ms
+step:597/1490 train_time:21689ms step_avg:36.33ms
+step:598/1490 train_time:21749ms step_avg:36.37ms
+step:599/1490 train_time:21804ms step_avg:36.40ms
+step:600/1490 train_time:21863ms step_avg:36.44ms
+step:601/1490 train_time:21917ms step_avg:36.47ms
+step:602/1490 train_time:21976ms step_avg:36.51ms
+step:603/1490 train_time:22030ms step_avg:36.53ms
+step:604/1490 train_time:22090ms step_avg:36.57ms
+step:605/1490 train_time:22145ms step_avg:36.60ms
+step:606/1490 train_time:22205ms step_avg:36.64ms
+step:607/1490 train_time:22260ms step_avg:36.67ms
+step:608/1490 train_time:22320ms step_avg:36.71ms
+step:609/1490 train_time:22374ms step_avg:36.74ms
+step:610/1490 train_time:22434ms step_avg:36.78ms
+step:611/1490 train_time:22489ms step_avg:36.81ms
+step:612/1490 train_time:22548ms step_avg:36.84ms
+step:613/1490 train_time:22602ms step_avg:36.87ms
+step:614/1490 train_time:22663ms step_avg:36.91ms
+step:615/1490 train_time:22717ms step_avg:36.94ms
+step:616/1490 train_time:22776ms step_avg:36.97ms
+step:617/1490 train_time:22832ms step_avg:37.00ms
+step:618/1490 train_time:22890ms step_avg:37.04ms
+step:619/1490 train_time:22945ms step_avg:37.07ms
+step:620/1490 train_time:23005ms step_avg:37.10ms
+step:621/1490 train_time:23059ms step_avg:37.13ms
+step:622/1490 train_time:23119ms step_avg:37.17ms
+step:623/1490 train_time:23174ms step_avg:37.20ms
+step:624/1490 train_time:23233ms step_avg:37.23ms
+step:625/1490 train_time:23287ms step_avg:37.26ms
+step:626/1490 train_time:23347ms step_avg:37.30ms
+step:627/1490 train_time:23402ms step_avg:37.32ms
+step:628/1490 train_time:23462ms step_avg:37.36ms
+step:629/1490 train_time:23516ms step_avg:37.39ms
+step:630/1490 train_time:23576ms step_avg:37.42ms
+step:631/1490 train_time:23631ms step_avg:37.45ms
+step:632/1490 train_time:23690ms step_avg:37.48ms
+step:633/1490 train_time:23745ms step_avg:37.51ms
+step:634/1490 train_time:23805ms step_avg:37.55ms
+step:635/1490 train_time:23859ms step_avg:37.57ms
+step:636/1490 train_time:23920ms step_avg:37.61ms
+step:637/1490 train_time:23974ms step_avg:37.64ms
+step:638/1490 train_time:24034ms step_avg:37.67ms
+step:639/1490 train_time:24087ms step_avg:37.70ms
+step:640/1490 train_time:24148ms step_avg:37.73ms
+step:641/1490 train_time:24203ms step_avg:37.76ms
+step:642/1490 train_time:24263ms step_avg:37.79ms
+step:643/1490 train_time:24317ms step_avg:37.82ms
+step:644/1490 train_time:24377ms step_avg:37.85ms
+step:645/1490 train_time:24432ms step_avg:37.88ms
+step:646/1490 train_time:24491ms step_avg:37.91ms
+step:647/1490 train_time:24546ms step_avg:37.94ms
+step:648/1490 train_time:24606ms step_avg:37.97ms
+step:649/1490 train_time:24661ms step_avg:38.00ms
+step:650/1490 train_time:24721ms step_avg:38.03ms
+step:651/1490 train_time:24774ms step_avg:38.06ms
+step:652/1490 train_time:24834ms step_avg:38.09ms
+step:653/1490 train_time:24889ms step_avg:38.11ms
+step:654/1490 train_time:24949ms step_avg:38.15ms
+step:655/1490 train_time:25004ms step_avg:38.17ms
+step:656/1490 train_time:25063ms step_avg:38.21ms
+step:657/1490 train_time:25117ms step_avg:38.23ms
+step:658/1490 train_time:25177ms step_avg:38.26ms
+step:659/1490 train_time:25232ms step_avg:38.29ms
+step:660/1490 train_time:25292ms step_avg:38.32ms
+step:661/1490 train_time:25346ms step_avg:38.35ms
+step:662/1490 train_time:25405ms step_avg:38.38ms
+step:663/1490 train_time:25460ms step_avg:38.40ms
+step:664/1490 train_time:25520ms step_avg:38.43ms
+step:665/1490 train_time:25575ms step_avg:38.46ms
+step:666/1490 train_time:25634ms step_avg:38.49ms
+step:667/1490 train_time:25688ms step_avg:38.51ms
+step:668/1490 train_time:25748ms step_avg:38.54ms
+step:669/1490 train_time:25803ms step_avg:38.57ms
+step:670/1490 train_time:25863ms step_avg:38.60ms
+step:671/1490 train_time:25916ms step_avg:38.62ms
+step:672/1490 train_time:25976ms step_avg:38.66ms
+step:673/1490 train_time:26031ms step_avg:38.68ms
+step:674/1490 train_time:26090ms step_avg:38.71ms
+step:675/1490 train_time:26144ms step_avg:38.73ms
+step:676/1490 train_time:26204ms step_avg:38.76ms
+step:677/1490 train_time:26259ms step_avg:38.79ms
+step:678/1490 train_time:26319ms step_avg:38.82ms
+step:679/1490 train_time:26373ms step_avg:38.84ms
+step:680/1490 train_time:26432ms step_avg:38.87ms
+step:681/1490 train_time:26487ms step_avg:38.89ms
+step:682/1490 train_time:26547ms step_avg:38.93ms
+step:683/1490 train_time:26601ms step_avg:38.95ms
+step:684/1490 train_time:26662ms step_avg:38.98ms
+step:685/1490 train_time:26716ms step_avg:39.00ms
+step:686/1490 train_time:26776ms step_avg:39.03ms
+step:687/1490 train_time:26832ms step_avg:39.06ms
+step:688/1490 train_time:26891ms step_avg:39.09ms
+step:689/1490 train_time:26946ms step_avg:39.11ms
+step:690/1490 train_time:27005ms step_avg:39.14ms
+step:691/1490 train_time:27060ms step_avg:39.16ms
+step:692/1490 train_time:27120ms step_avg:39.19ms
+step:693/1490 train_time:27175ms step_avg:39.21ms
+step:694/1490 train_time:27234ms step_avg:39.24ms
+step:695/1490 train_time:27288ms step_avg:39.26ms
+step:696/1490 train_time:27348ms step_avg:39.29ms
+step:697/1490 train_time:27402ms step_avg:39.31ms
+step:698/1490 train_time:27462ms step_avg:39.34ms
+step:699/1490 train_time:27516ms step_avg:39.37ms
+step:700/1490 train_time:27576ms step_avg:39.39ms
+step:701/1490 train_time:27630ms step_avg:39.41ms
+step:702/1490 train_time:27689ms step_avg:39.44ms
+step:703/1490 train_time:27744ms step_avg:39.46ms
+step:704/1490 train_time:27803ms step_avg:39.49ms
+step:705/1490 train_time:27858ms step_avg:39.51ms
+step:706/1490 train_time:27918ms step_avg:39.54ms
+step:707/1490 train_time:27972ms step_avg:39.56ms
+step:708/1490 train_time:28032ms step_avg:39.59ms
+step:709/1490 train_time:28085ms step_avg:39.61ms
+step:710/1490 train_time:28145ms step_avg:39.64ms
+step:711/1490 train_time:28199ms step_avg:39.66ms
+step:712/1490 train_time:28260ms step_avg:39.69ms
+step:713/1490 train_time:28315ms step_avg:39.71ms
+step:714/1490 train_time:28375ms step_avg:39.74ms
+step:715/1490 train_time:28428ms step_avg:39.76ms
+step:716/1490 train_time:28489ms step_avg:39.79ms
+step:717/1490 train_time:28544ms step_avg:39.81ms
+step:718/1490 train_time:28603ms step_avg:39.84ms
+step:719/1490 train_time:28657ms step_avg:39.86ms
+step:720/1490 train_time:28717ms step_avg:39.88ms
+step:721/1490 train_time:28771ms step_avg:39.90ms
+step:722/1490 train_time:28831ms step_avg:39.93ms
+step:723/1490 train_time:28885ms step_avg:39.95ms
+step:724/1490 train_time:28944ms step_avg:39.98ms
+step:725/1490 train_time:28998ms step_avg:40.00ms
+step:726/1490 train_time:29059ms step_avg:40.03ms
+step:727/1490 train_time:29113ms step_avg:40.05ms
+step:728/1490 train_time:29173ms step_avg:40.07ms
+step:729/1490 train_time:29227ms step_avg:40.09ms
+step:730/1490 train_time:29287ms step_avg:40.12ms
+step:731/1490 train_time:29341ms step_avg:40.14ms
+step:732/1490 train_time:29401ms step_avg:40.16ms
+step:733/1490 train_time:29455ms step_avg:40.18ms
+step:734/1490 train_time:29515ms step_avg:40.21ms
+step:735/1490 train_time:29569ms step_avg:40.23ms
+step:736/1490 train_time:29629ms step_avg:40.26ms
+step:737/1490 train_time:29683ms step_avg:40.28ms
+step:738/1490 train_time:29743ms step_avg:40.30ms
+step:739/1490 train_time:29797ms step_avg:40.32ms
+step:740/1490 train_time:29858ms step_avg:40.35ms
+step:741/1490 train_time:29912ms step_avg:40.37ms
+step:742/1490 train_time:29972ms step_avg:40.39ms
+step:743/1490 train_time:30026ms step_avg:40.41ms
+step:744/1490 train_time:30086ms step_avg:40.44ms
+step:745/1490 train_time:30141ms step_avg:40.46ms
+step:746/1490 train_time:30200ms step_avg:40.48ms
+step:747/1490 train_time:30254ms step_avg:40.50ms
+step:748/1490 train_time:30314ms step_avg:40.53ms
+step:749/1490 train_time:30367ms step_avg:40.54ms
+step:750/1490 train_time:30427ms step_avg:40.57ms
+step:750/1490 val_loss:3.8056 train_time:30500ms step_avg:40.67ms
+step:751/1490 train_time:30516ms step_avg:40.63ms
+step:752/1490 train_time:30542ms step_avg:40.61ms
+step:753/1490 train_time:30601ms step_avg:40.64ms
+step:754/1490 train_time:30664ms step_avg:40.67ms
+step:755/1490 train_time:30719ms step_avg:40.69ms
+step:756/1490 train_time:30779ms step_avg:40.71ms
+step:757/1490 train_time:30832ms step_avg:40.73ms
+step:758/1490 train_time:30893ms step_avg:40.76ms
+step:759/1490 train_time:30946ms step_avg:40.77ms
+step:760/1490 train_time:31005ms step_avg:40.80ms
+step:761/1490 train_time:31059ms step_avg:40.81ms
+step:762/1490 train_time:31118ms step_avg:40.84ms
+step:763/1490 train_time:31172ms step_avg:40.85ms
+step:764/1490 train_time:31230ms step_avg:40.88ms
+step:765/1490 train_time:31284ms step_avg:40.89ms
+step:766/1490 train_time:31343ms step_avg:40.92ms
+step:767/1490 train_time:31397ms step_avg:40.93ms
+step:768/1490 train_time:31457ms step_avg:40.96ms
+step:769/1490 train_time:31513ms step_avg:40.98ms
+step:770/1490 train_time:31573ms step_avg:41.00ms
+step:771/1490 train_time:31629ms step_avg:41.02ms
+step:772/1490 train_time:31691ms step_avg:41.05ms
+step:773/1490 train_time:31745ms step_avg:41.07ms
+step:774/1490 train_time:31805ms step_avg:41.09ms
+step:775/1490 train_time:31860ms step_avg:41.11ms
+step:776/1490 train_time:31919ms step_avg:41.13ms
+step:777/1490 train_time:31973ms step_avg:41.15ms
+step:778/1490 train_time:32032ms step_avg:41.17ms
+step:779/1490 train_time:32086ms step_avg:41.19ms
+step:780/1490 train_time:32145ms step_avg:41.21ms
+step:781/1490 train_time:32199ms step_avg:41.23ms
+step:782/1490 train_time:32258ms step_avg:41.25ms
+step:783/1490 train_time:32311ms step_avg:41.27ms
+step:784/1490 train_time:32371ms step_avg:41.29ms
+step:785/1490 train_time:32426ms step_avg:41.31ms
+step:786/1490 train_time:32487ms step_avg:41.33ms
+step:787/1490 train_time:32542ms step_avg:41.35ms
+step:788/1490 train_time:32603ms step_avg:41.37ms
+step:789/1490 train_time:32658ms step_avg:41.39ms
+step:790/1490 train_time:32719ms step_avg:41.42ms
+step:791/1490 train_time:32773ms step_avg:41.43ms
+step:792/1490 train_time:32834ms step_avg:41.46ms
+step:793/1490 train_time:32889ms step_avg:41.47ms
+step:794/1490 train_time:32948ms step_avg:41.50ms
+step:795/1490 train_time:33002ms step_avg:41.51ms
+step:796/1490 train_time:33062ms step_avg:41.53ms
+step:797/1490 train_time:33116ms step_avg:41.55ms
+step:798/1490 train_time:33175ms step_avg:41.57ms
+step:799/1490 train_time:33230ms step_avg:41.59ms
+step:800/1490 train_time:33290ms step_avg:41.61ms
+step:801/1490 train_time:33344ms step_avg:41.63ms
+step:802/1490 train_time:33404ms step_avg:41.65ms
+step:803/1490 train_time:33460ms step_avg:41.67ms
+step:804/1490 train_time:33519ms step_avg:41.69ms
+step:805/1490 train_time:33572ms step_avg:41.70ms
+step:806/1490 train_time:33633ms step_avg:41.73ms
+step:807/1490 train_time:33689ms step_avg:41.75ms
+step:808/1490 train_time:33749ms step_avg:41.77ms
+step:809/1490 train_time:33803ms step_avg:41.78ms
+step:810/1490 train_time:33863ms step_avg:41.81ms
+step:811/1490 train_time:33918ms step_avg:41.82ms
+step:812/1490 train_time:33976ms step_avg:41.84ms
+step:813/1490 train_time:34031ms step_avg:41.86ms
+step:814/1490 train_time:34090ms step_avg:41.88ms
+step:815/1490 train_time:34143ms step_avg:41.89ms
+step:816/1490 train_time:34203ms step_avg:41.91ms
+step:817/1490 train_time:34257ms step_avg:41.93ms
+step:818/1490 train_time:34317ms step_avg:41.95ms
+step:819/1490 train_time:34372ms step_avg:41.97ms
+step:820/1490 train_time:34431ms step_avg:41.99ms
+step:821/1490 train_time:34485ms step_avg:42.00ms
+step:822/1490 train_time:34546ms step_avg:42.03ms
+step:823/1490 train_time:34600ms step_avg:42.04ms
+step:824/1490 train_time:34660ms step_avg:42.06ms
+step:825/1490 train_time:34715ms step_avg:42.08ms
+step:826/1490 train_time:34776ms step_avg:42.10ms
+step:827/1490 train_time:34830ms step_avg:42.12ms
+step:828/1490 train_time:34890ms step_avg:42.14ms
+step:829/1490 train_time:34945ms step_avg:42.15ms
+step:830/1490 train_time:35005ms step_avg:42.17ms
+step:831/1490 train_time:35059ms step_avg:42.19ms
+step:832/1490 train_time:35118ms step_avg:42.21ms
+step:833/1490 train_time:35171ms step_avg:42.22ms
+step:834/1490 train_time:35231ms step_avg:42.24ms
+step:835/1490 train_time:35286ms step_avg:42.26ms
+step:836/1490 train_time:35345ms step_avg:42.28ms
+step:837/1490 train_time:35399ms step_avg:42.29ms
+step:838/1490 train_time:35459ms step_avg:42.31ms
+step:839/1490 train_time:35512ms step_avg:42.33ms
+step:840/1490 train_time:35572ms step_avg:42.35ms
+step:841/1490 train_time:35628ms step_avg:42.36ms
+step:842/1490 train_time:35688ms step_avg:42.39ms
+step:843/1490 train_time:35742ms step_avg:42.40ms
+step:844/1490 train_time:35803ms step_avg:42.42ms
+step:845/1490 train_time:35857ms step_avg:42.43ms
+step:846/1490 train_time:35916ms step_avg:42.45ms
+step:847/1490 train_time:35970ms step_avg:42.47ms
+step:848/1490 train_time:36030ms step_avg:42.49ms
+step:849/1490 train_time:36084ms step_avg:42.50ms
+step:850/1490 train_time:36144ms step_avg:42.52ms
+step:851/1490 train_time:36198ms step_avg:42.54ms
+step:852/1490 train_time:36257ms step_avg:42.55ms
+step:853/1490 train_time:36311ms step_avg:42.57ms
+step:854/1490 train_time:36371ms step_avg:42.59ms
+step:855/1490 train_time:36425ms step_avg:42.60ms
+step:856/1490 train_time:36486ms step_avg:42.62ms
+step:857/1490 train_time:36540ms step_avg:42.64ms
+step:858/1490 train_time:36600ms step_avg:42.66ms
+step:859/1490 train_time:36655ms step_avg:42.67ms
+step:860/1490 train_time:36715ms step_avg:42.69ms
+step:861/1490 train_time:36770ms step_avg:42.71ms
+step:862/1490 train_time:36831ms step_avg:42.73ms
+step:863/1490 train_time:36885ms step_avg:42.74ms
+step:864/1490 train_time:36945ms step_avg:42.76ms
+step:865/1490 train_time:36999ms step_avg:42.77ms
+step:866/1490 train_time:37058ms step_avg:42.79ms
+step:867/1490 train_time:37112ms step_avg:42.81ms
+step:868/1490 train_time:37171ms step_avg:42.82ms
+step:869/1490 train_time:37226ms step_avg:42.84ms
+step:870/1490 train_time:37286ms step_avg:42.86ms
+step:871/1490 train_time:37341ms step_avg:42.87ms
+step:872/1490 train_time:37400ms step_avg:42.89ms
+step:873/1490 train_time:37454ms step_avg:42.90ms
+step:874/1490 train_time:37515ms step_avg:42.92ms
+step:875/1490 train_time:37569ms step_avg:42.94ms
+step:876/1490 train_time:37629ms step_avg:42.96ms
+step:877/1490 train_time:37683ms step_avg:42.97ms
+step:878/1490 train_time:37744ms step_avg:42.99ms
+step:879/1490 train_time:37799ms step_avg:43.00ms
+step:880/1490 train_time:37859ms step_avg:43.02ms
+step:881/1490 train_time:37913ms step_avg:43.03ms
+step:882/1490 train_time:37973ms step_avg:43.05ms
+step:883/1490 train_time:38026ms step_avg:43.07ms
+step:884/1490 train_time:38086ms step_avg:43.08ms
+step:885/1490 train_time:38140ms step_avg:43.10ms
+step:886/1490 train_time:38200ms step_avg:43.11ms
+step:887/1490 train_time:38254ms step_avg:43.13ms
+step:888/1490 train_time:38315ms step_avg:43.15ms
+step:889/1490 train_time:38369ms step_avg:43.16ms
+step:890/1490 train_time:38429ms step_avg:43.18ms
+step:891/1490 train_time:38484ms step_avg:43.19ms
+step:892/1490 train_time:38544ms step_avg:43.21ms
+step:893/1490 train_time:38598ms step_avg:43.22ms
+step:894/1490 train_time:38658ms step_avg:43.24ms
+step:895/1490 train_time:38711ms step_avg:43.25ms
+step:896/1490 train_time:38771ms step_avg:43.27ms
+step:897/1490 train_time:38826ms step_avg:43.28ms
+step:898/1490 train_time:38886ms step_avg:43.30ms
+step:899/1490 train_time:38940ms step_avg:43.31ms
+step:900/1490 train_time:38999ms step_avg:43.33ms
+step:901/1490 train_time:39053ms step_avg:43.34ms
+step:902/1490 train_time:39113ms step_avg:43.36ms
+step:903/1490 train_time:39168ms step_avg:43.38ms
+step:904/1490 train_time:39227ms step_avg:43.39ms
+step:905/1490 train_time:39282ms step_avg:43.41ms
+step:906/1490 train_time:39342ms step_avg:43.42ms
+step:907/1490 train_time:39395ms step_avg:43.43ms
+step:908/1490 train_time:39455ms step_avg:43.45ms
+step:909/1490 train_time:39509ms step_avg:43.46ms
+step:910/1490 train_time:39569ms step_avg:43.48ms
+step:911/1490 train_time:39623ms step_avg:43.49ms
+step:912/1490 train_time:39684ms step_avg:43.51ms
+step:913/1490 train_time:39739ms step_avg:43.53ms
+step:914/1490 train_time:39799ms step_avg:43.54ms
+step:915/1490 train_time:39853ms step_avg:43.55ms
+step:916/1490 train_time:39913ms step_avg:43.57ms
+step:917/1490 train_time:39967ms step_avg:43.58ms
+step:918/1490 train_time:40027ms step_avg:43.60ms
+step:919/1490 train_time:40081ms step_avg:43.61ms
+step:920/1490 train_time:40141ms step_avg:43.63ms
+step:921/1490 train_time:40195ms step_avg:43.64ms
+step:922/1490 train_time:40255ms step_avg:43.66ms
+step:923/1490 train_time:40310ms step_avg:43.67ms
+step:924/1490 train_time:40369ms step_avg:43.69ms
+step:925/1490 train_time:40423ms step_avg:43.70ms
+step:926/1490 train_time:40483ms step_avg:43.72ms
+step:927/1490 train_time:40537ms step_avg:43.73ms
+step:928/1490 train_time:40598ms step_avg:43.75ms
+step:929/1490 train_time:40652ms step_avg:43.76ms
+step:930/1490 train_time:40712ms step_avg:43.78ms
+step:931/1490 train_time:40766ms step_avg:43.79ms
+step:932/1490 train_time:40826ms step_avg:43.80ms
+step:933/1490 train_time:40881ms step_avg:43.82ms
+step:934/1490 train_time:40940ms step_avg:43.83ms
+step:935/1490 train_time:40995ms step_avg:43.84ms
+step:936/1490 train_time:41054ms step_avg:43.86ms
+step:937/1490 train_time:41108ms step_avg:43.87ms
+step:938/1490 train_time:41168ms step_avg:43.89ms
+step:939/1490 train_time:41222ms step_avg:43.90ms
+step:940/1490 train_time:41282ms step_avg:43.92ms
+step:941/1490 train_time:41336ms step_avg:43.93ms
+step:942/1490 train_time:41395ms step_avg:43.94ms
+step:943/1490 train_time:41449ms step_avg:43.95ms
+step:944/1490 train_time:41508ms step_avg:43.97ms
+step:945/1490 train_time:41563ms step_avg:43.98ms
+step:946/1490 train_time:41624ms step_avg:44.00ms
+step:947/1490 train_time:41678ms step_avg:44.01ms
+step:948/1490 train_time:41738ms step_avg:44.03ms
+step:949/1490 train_time:41793ms step_avg:44.04ms
+step:950/1490 train_time:41852ms step_avg:44.05ms
+step:951/1490 train_time:41906ms step_avg:44.07ms
+step:952/1490 train_time:41966ms step_avg:44.08ms
+step:953/1490 train_time:42020ms step_avg:44.09ms
+step:954/1490 train_time:42081ms step_avg:44.11ms
+step:955/1490 train_time:42136ms step_avg:44.12ms
+step:956/1490 train_time:42196ms step_avg:44.14ms
+step:957/1490 train_time:42250ms step_avg:44.15ms
+step:958/1490 train_time:42309ms step_avg:44.16ms
+step:959/1490 train_time:42363ms step_avg:44.17ms
+step:960/1490 train_time:42424ms step_avg:44.19ms
+step:961/1490 train_time:42478ms step_avg:44.20ms
+step:962/1490 train_time:42537ms step_avg:44.22ms
+step:963/1490 train_time:42592ms step_avg:44.23ms
+step:964/1490 train_time:42651ms step_avg:44.24ms
+step:965/1490 train_time:42706ms step_avg:44.25ms
+step:966/1490 train_time:42766ms step_avg:44.27ms
+step:967/1490 train_time:42819ms step_avg:44.28ms
+step:968/1490 train_time:42883ms step_avg:44.30ms
+step:969/1490 train_time:42962ms step_avg:44.34ms
+step:970/1490 train_time:43050ms step_avg:44.38ms
+step:971/1490 train_time:43132ms step_avg:44.42ms
+step:972/1490 train_time:43218ms step_avg:44.46ms
+step:973/1490 train_time:43299ms step_avg:44.50ms
+step:974/1490 train_time:43385ms step_avg:44.54ms
+step:975/1490 train_time:43466ms step_avg:44.58ms
+step:976/1490 train_time:43553ms step_avg:44.62ms
+step:977/1490 train_time:43633ms step_avg:44.66ms
+step:978/1490 train_time:43719ms step_avg:44.70ms
+step:979/1490 train_time:43801ms step_avg:44.74ms
+step:980/1490 train_time:43888ms step_avg:44.78ms
+step:981/1490 train_time:43967ms step_avg:44.82ms
+step:982/1490 train_time:44055ms step_avg:44.86ms
+step:983/1490 train_time:44136ms step_avg:44.90ms
+step:984/1490 train_time:44221ms step_avg:44.94ms
+step:985/1490 train_time:44302ms step_avg:44.98ms
+step:986/1490 train_time:44388ms step_avg:45.02ms
+step:987/1490 train_time:44469ms step_avg:45.05ms
+step:988/1490 train_time:44556ms step_avg:45.10ms
+step:989/1490 train_time:44635ms step_avg:45.13ms
+step:990/1490 train_time:44722ms step_avg:45.17ms
+step:991/1490 train_time:44805ms step_avg:45.21ms
+step:992/1490 train_time:44891ms step_avg:45.25ms
+step:993/1490 train_time:44972ms step_avg:45.29ms
+step:994/1490 train_time:45057ms step_avg:45.33ms
+step:995/1490 train_time:45138ms step_avg:45.37ms
+step:996/1490 train_time:45226ms step_avg:45.41ms
+step:997/1490 train_time:45307ms step_avg:45.44ms
+step:998/1490 train_time:45392ms step_avg:45.48ms
+step:999/1490 train_time:45473ms step_avg:45.52ms
+step:1000/1490 train_time:45559ms step_avg:45.56ms
+step:1000/1490 val_loss:3.5186 train_time:45663ms step_avg:45.66ms
+step:1001/1490 train_time:45682ms step_avg:45.64ms
+step:1002/1490 train_time:45733ms step_avg:45.64ms
+step:1003/1490 train_time:45817ms step_avg:45.68ms
+step:1004/1490 train_time:45902ms step_avg:45.72ms
+step:1005/1490 train_time:45985ms step_avg:45.76ms
+step:1006/1490 train_time:46069ms step_avg:45.79ms
+step:1007/1490 train_time:46149ms step_avg:45.83ms
+step:1008/1490 train_time:46234ms step_avg:45.87ms
+step:1009/1490 train_time:46314ms step_avg:45.90ms
+step:1010/1490 train_time:46398ms step_avg:45.94ms
+step:1011/1490 train_time:46479ms step_avg:45.97ms
+step:1012/1490 train_time:46566ms step_avg:46.01ms
+step:1013/1490 train_time:46649ms step_avg:46.05ms
+step:1014/1490 train_time:46737ms step_avg:46.09ms
+step:1015/1490 train_time:46818ms step_avg:46.13ms
+step:1016/1490 train_time:46906ms step_avg:46.17ms
+step:1017/1490 train_time:46986ms step_avg:46.20ms
+step:1018/1490 train_time:47073ms step_avg:46.24ms
+step:1019/1490 train_time:47154ms step_avg:46.27ms
+step:1020/1490 train_time:47240ms step_avg:46.31ms
+step:1021/1490 train_time:47320ms step_avg:46.35ms
+step:1022/1490 train_time:47404ms step_avg:46.38ms
+step:1023/1490 train_time:47484ms step_avg:46.42ms
+step:1024/1490 train_time:47572ms step_avg:46.46ms
+step:1025/1490 train_time:47653ms step_avg:46.49ms
+step:1026/1490 train_time:47740ms step_avg:46.53ms
+step:1027/1490 train_time:47823ms step_avg:46.57ms
+step:1028/1490 train_time:47908ms step_avg:46.60ms
+step:1029/1490 train_time:47989ms step_avg:46.64ms
+step:1030/1490 train_time:48075ms step_avg:46.67ms
+step:1031/1490 train_time:48156ms step_avg:46.71ms
+step:1032/1490 train_time:48241ms step_avg:46.75ms
+step:1033/1490 train_time:48321ms step_avg:46.78ms
+step:1034/1490 train_time:48406ms step_avg:46.81ms
+step:1035/1490 train_time:48486ms step_avg:46.85ms
+step:1036/1490 train_time:48574ms step_avg:46.89ms
+step:1037/1490 train_time:48654ms step_avg:46.92ms
+step:1038/1490 train_time:48741ms step_avg:46.96ms
+step:1039/1490 train_time:48824ms step_avg:46.99ms
+step:1040/1490 train_time:48912ms step_avg:47.03ms
+step:1041/1490 train_time:48992ms step_avg:47.06ms
+step:1042/1490 train_time:49078ms step_avg:47.10ms
+step:1043/1490 train_time:49160ms step_avg:47.13ms
+step:1044/1490 train_time:49246ms step_avg:47.17ms
+step:1045/1490 train_time:49327ms step_avg:47.20ms
+step:1046/1490 train_time:49412ms step_avg:47.24ms
+step:1047/1490 train_time:49492ms step_avg:47.27ms
+step:1048/1490 train_time:49579ms step_avg:47.31ms
+step:1049/1490 train_time:49660ms step_avg:47.34ms
+step:1050/1490 train_time:49748ms step_avg:47.38ms
+step:1051/1490 train_time:49831ms step_avg:47.41ms
+step:1052/1490 train_time:49917ms step_avg:47.45ms
+step:1053/1490 train_time:49997ms step_avg:47.48ms
+step:1054/1490 train_time:50084ms step_avg:47.52ms
+step:1055/1490 train_time:50165ms step_avg:47.55ms
+step:1056/1490 train_time:50251ms step_avg:47.59ms
+step:1057/1490 train_time:50331ms step_avg:47.62ms
+step:1058/1490 train_time:50417ms step_avg:47.65ms
+step:1059/1490 train_time:50499ms step_avg:47.69ms
+step:1060/1490 train_time:50585ms step_avg:47.72ms
+step:1061/1490 train_time:50665ms step_avg:47.75ms
+step:1062/1490 train_time:50753ms step_avg:47.79ms
+step:1063/1490 train_time:50834ms step_avg:47.82ms
+step:1064/1490 train_time:50921ms step_avg:47.86ms
+step:1065/1490 train_time:51002ms step_avg:47.89ms
+step:1066/1490 train_time:51088ms step_avg:47.92ms
+step:1067/1490 train_time:51170ms step_avg:47.96ms
+step:1068/1490 train_time:51257ms step_avg:47.99ms
+step:1069/1490 train_time:51339ms step_avg:48.03ms
+step:1070/1490 train_time:51425ms step_avg:48.06ms
+step:1071/1490 train_time:51506ms step_avg:48.09ms
+step:1072/1490 train_time:51590ms step_avg:48.13ms
+step:1073/1490 train_time:51672ms step_avg:48.16ms
+step:1074/1490 train_time:51758ms step_avg:48.19ms
+step:1075/1490 train_time:51840ms step_avg:48.22ms
+step:1076/1490 train_time:51927ms step_avg:48.26ms
+step:1077/1490 train_time:52007ms step_avg:48.29ms
+step:1078/1490 train_time:52093ms step_avg:48.32ms
+step:1079/1490 train_time:52173ms step_avg:48.35ms
+step:1080/1490 train_time:52261ms step_avg:48.39ms
+step:1081/1490 train_time:52343ms step_avg:48.42ms
+step:1082/1490 train_time:52430ms step_avg:48.46ms
+step:1083/1490 train_time:52510ms step_avg:48.49ms
+step:1084/1490 train_time:52596ms step_avg:48.52ms
+step:1085/1490 train_time:52678ms step_avg:48.55ms
+step:1086/1490 train_time:52764ms step_avg:48.59ms
+step:1087/1490 train_time:52845ms step_avg:48.62ms
+step:1088/1490 train_time:52932ms step_avg:48.65ms
+step:1089/1490 train_time:53012ms step_avg:48.68ms
+step:1090/1490 train_time:53098ms step_avg:48.71ms
+step:1091/1490 train_time:53179ms step_avg:48.74ms
+step:1092/1490 train_time:53266ms step_avg:48.78ms
+step:1093/1490 train_time:53347ms step_avg:48.81ms
+step:1094/1490 train_time:53433ms step_avg:48.84ms
+step:1095/1490 train_time:53514ms step_avg:48.87ms
+step:1096/1490 train_time:53600ms step_avg:48.90ms
+step:1097/1490 train_time:53681ms step_avg:48.93ms
+step:1098/1490 train_time:53767ms step_avg:48.97ms
+step:1099/1490 train_time:53848ms step_avg:49.00ms
+step:1100/1490 train_time:53935ms step_avg:49.03ms
+step:1101/1490 train_time:54015ms step_avg:49.06ms
+step:1102/1490 train_time:54101ms step_avg:49.09ms
+step:1103/1490 train_time:54183ms step_avg:49.12ms
+step:1104/1490 train_time:54269ms step_avg:49.16ms
+step:1105/1490 train_time:54350ms step_avg:49.19ms
+step:1106/1490 train_time:54437ms step_avg:49.22ms
+step:1107/1490 train_time:54516ms step_avg:49.25ms
+step:1108/1490 train_time:54602ms step_avg:49.28ms
+step:1109/1490 train_time:54684ms step_avg:49.31ms
+step:1110/1490 train_time:54771ms step_avg:49.34ms
+step:1111/1490 train_time:54852ms step_avg:49.37ms
+step:1112/1490 train_time:54938ms step_avg:49.41ms
+step:1113/1490 train_time:55019ms step_avg:49.43ms
+step:1114/1490 train_time:55104ms step_avg:49.46ms
+step:1115/1490 train_time:55185ms step_avg:49.49ms
+step:1116/1490 train_time:55273ms step_avg:49.53ms
+step:1117/1490 train_time:55354ms step_avg:49.56ms
+step:1118/1490 train_time:55440ms step_avg:49.59ms
+step:1119/1490 train_time:55521ms step_avg:49.62ms
+step:1120/1490 train_time:55606ms step_avg:49.65ms
+step:1121/1490 train_time:55687ms step_avg:49.68ms
+step:1122/1490 train_time:55775ms step_avg:49.71ms
+step:1123/1490 train_time:55857ms step_avg:49.74ms
+step:1124/1490 train_time:55943ms step_avg:49.77ms
+step:1125/1490 train_time:56023ms step_avg:49.80ms
+step:1126/1490 train_time:56110ms step_avg:49.83ms
+step:1127/1490 train_time:56191ms step_avg:49.86ms
+step:1128/1490 train_time:56277ms step_avg:49.89ms
+step:1129/1490 train_time:56359ms step_avg:49.92ms
+step:1130/1490 train_time:56445ms step_avg:49.95ms
+step:1131/1490 train_time:56526ms step_avg:49.98ms
+step:1132/1490 train_time:56612ms step_avg:50.01ms
+step:1133/1490 train_time:56692ms step_avg:50.04ms
+step:1134/1490 train_time:56779ms step_avg:50.07ms
+step:1135/1490 train_time:56860ms step_avg:50.10ms
+step:1136/1490 train_time:56947ms step_avg:50.13ms
+step:1137/1490 train_time:57028ms step_avg:50.16ms
+step:1138/1490 train_time:57114ms step_avg:50.19ms
+step:1139/1490 train_time:57195ms step_avg:50.22ms
+step:1140/1490 train_time:57282ms step_avg:50.25ms
+step:1141/1490 train_time:57365ms step_avg:50.28ms
+step:1142/1490 train_time:57449ms step_avg:50.31ms
+step:1143/1490 train_time:57531ms step_avg:50.33ms
+step:1144/1490 train_time:57617ms step_avg:50.36ms
+step:1145/1490 train_time:57697ms step_avg:50.39ms
+step:1146/1490 train_time:57783ms step_avg:50.42ms
+step:1147/1490 train_time:57864ms step_avg:50.45ms
+step:1148/1490 train_time:57951ms step_avg:50.48ms
+step:1149/1490 train_time:58032ms step_avg:50.51ms
+step:1150/1490 train_time:58118ms step_avg:50.54ms
+step:1151/1490 train_time:58198ms step_avg:50.56ms
+step:1152/1490 train_time:58285ms step_avg:50.59ms
+step:1153/1490 train_time:58364ms step_avg:50.62ms
+step:1154/1490 train_time:58452ms step_avg:50.65ms
+step:1155/1490 train_time:58534ms step_avg:50.68ms
+step:1156/1490 train_time:58620ms step_avg:50.71ms
+step:1157/1490 train_time:58701ms step_avg:50.74ms
+step:1158/1490 train_time:58786ms step_avg:50.77ms
+step:1159/1490 train_time:58868ms step_avg:50.79ms
+step:1160/1490 train_time:58954ms step_avg:50.82ms
+step:1161/1490 train_time:59035ms step_avg:50.85ms
+step:1162/1490 train_time:59121ms step_avg:50.88ms
+step:1163/1490 train_time:59202ms step_avg:50.90ms
+step:1164/1490 train_time:59288ms step_avg:50.93ms
+step:1165/1490 train_time:59370ms step_avg:50.96ms
+step:1166/1490 train_time:59458ms step_avg:50.99ms
+step:1167/1490 train_time:59538ms step_avg:51.02ms
+step:1168/1490 train_time:59624ms step_avg:51.05ms
+step:1169/1490 train_time:59704ms step_avg:51.07ms
+step:1170/1490 train_time:59790ms step_avg:51.10ms
+step:1171/1490 train_time:59873ms step_avg:51.13ms
+step:1172/1490 train_time:59959ms step_avg:51.16ms
+step:1173/1490 train_time:60039ms step_avg:51.18ms
+step:1174/1490 train_time:60126ms step_avg:51.21ms
+step:1175/1490 train_time:60206ms step_avg:51.24ms
+step:1176/1490 train_time:60292ms step_avg:51.27ms
+step:1177/1490 train_time:60373ms step_avg:51.29ms
+step:1178/1490 train_time:60460ms step_avg:51.32ms
+step:1179/1490 train_time:60542ms step_avg:51.35ms
+step:1180/1490 train_time:60628ms step_avg:51.38ms
+step:1181/1490 train_time:60707ms step_avg:51.40ms
+step:1182/1490 train_time:60794ms step_avg:51.43ms
+step:1183/1490 train_time:60875ms step_avg:51.46ms
+step:1184/1490 train_time:60962ms step_avg:51.49ms
+step:1185/1490 train_time:61044ms step_avg:51.51ms
+step:1186/1490 train_time:61131ms step_avg:51.54ms
+step:1187/1490 train_time:61211ms step_avg:51.57ms
+step:1188/1490 train_time:61298ms step_avg:51.60ms
+step:1189/1490 train_time:61379ms step_avg:51.62ms
+step:1190/1490 train_time:61465ms step_avg:51.65ms
+step:1191/1490 train_time:61546ms step_avg:51.68ms
+step:1192/1490 train_time:61633ms step_avg:51.71ms
+step:1193/1490 train_time:61714ms step_avg:51.73ms
+step:1194/1490 train_time:61799ms step_avg:51.76ms
+step:1195/1490 train_time:61881ms step_avg:51.78ms
+step:1196/1490 train_time:61967ms step_avg:51.81ms
+step:1197/1490 train_time:62048ms step_avg:51.84ms
+step:1198/1490 train_time:62136ms step_avg:51.87ms
+step:1199/1490 train_time:62216ms step_avg:51.89ms
+step:1200/1490 train_time:62302ms step_avg:51.92ms
+step:1201/1490 train_time:62383ms step_avg:51.94ms
+step:1202/1490 train_time:62471ms step_avg:51.97ms
+step:1203/1490 train_time:62552ms step_avg:52.00ms
+step:1204/1490 train_time:62638ms step_avg:52.03ms
+step:1205/1490 train_time:62720ms step_avg:52.05ms
+step:1206/1490 train_time:62807ms step_avg:52.08ms
+step:1207/1490 train_time:62889ms step_avg:52.10ms
+step:1208/1490 train_time:62975ms step_avg:52.13ms
+step:1209/1490 train_time:63055ms step_avg:52.15ms
+step:1210/1490 train_time:63141ms step_avg:52.18ms
+step:1211/1490 train_time:63222ms step_avg:52.21ms
+step:1212/1490 train_time:63307ms step_avg:52.23ms
+step:1213/1490 train_time:63388ms step_avg:52.26ms
+step:1214/1490 train_time:63475ms step_avg:52.29ms
+step:1215/1490 train_time:63557ms step_avg:52.31ms
+step:1216/1490 train_time:63643ms step_avg:52.34ms
+step:1217/1490 train_time:63724ms step_avg:52.36ms
+step:1218/1490 train_time:63810ms step_avg:52.39ms
+step:1219/1490 train_time:63891ms step_avg:52.41ms
+step:1220/1490 train_time:63978ms step_avg:52.44ms
+step:1221/1490 train_time:64059ms step_avg:52.46ms
+step:1222/1490 train_time:64145ms step_avg:52.49ms
+step:1223/1490 train_time:64227ms step_avg:52.52ms
+step:1224/1490 train_time:64313ms step_avg:52.54ms
+step:1225/1490 train_time:64392ms step_avg:52.57ms
+step:1226/1490 train_time:64479ms step_avg:52.59ms
+step:1227/1490 train_time:64560ms step_avg:52.62ms
+step:1228/1490 train_time:64645ms step_avg:52.64ms
+step:1229/1490 train_time:64727ms step_avg:52.67ms
+step:1230/1490 train_time:64813ms step_avg:52.69ms
+step:1231/1490 train_time:64894ms step_avg:52.72ms
+step:1232/1490 train_time:64980ms step_avg:52.74ms
+step:1233/1490 train_time:65062ms step_avg:52.77ms
+step:1234/1490 train_time:65148ms step_avg:52.79ms
+step:1235/1490 train_time:65229ms step_avg:52.82ms
+step:1236/1490 train_time:65314ms step_avg:52.84ms
+step:1237/1490 train_time:65395ms step_avg:52.87ms
+step:1238/1490 train_time:65482ms step_avg:52.89ms
+step:1239/1490 train_time:65562ms step_avg:52.92ms
+step:1240/1490 train_time:65649ms step_avg:52.94ms
+step:1241/1490 train_time:65732ms step_avg:52.97ms
+step:1242/1490 train_time:65817ms step_avg:52.99ms
+step:1243/1490 train_time:65896ms step_avg:53.01ms
+step:1244/1490 train_time:65983ms step_avg:53.04ms
+step:1245/1490 train_time:66066ms step_avg:53.06ms
+step:1246/1490 train_time:66153ms step_avg:53.09ms
+step:1247/1490 train_time:66234ms step_avg:53.11ms
+step:1248/1490 train_time:66319ms step_avg:53.14ms
+step:1249/1490 train_time:66400ms step_avg:53.16ms
+step:1250/1490 train_time:66486ms step_avg:53.19ms
+step:1250/1490 val_loss:3.3729 train_time:66590ms step_avg:53.27ms
+step:1251/1490 train_time:66607ms step_avg:53.24ms
+step:1252/1490 train_time:66659ms step_avg:53.24ms
+step:1253/1490 train_time:66743ms step_avg:53.27ms
+step:1254/1490 train_time:66831ms step_avg:53.29ms
+step:1255/1490 train_time:66911ms step_avg:53.32ms
+step:1256/1490 train_time:66998ms step_avg:53.34ms
+step:1257/1490 train_time:67079ms step_avg:53.36ms
+step:1258/1490 train_time:67164ms step_avg:53.39ms
+step:1259/1490 train_time:67244ms step_avg:53.41ms
+step:1260/1490 train_time:67328ms step_avg:53.43ms
+step:1261/1490 train_time:67407ms step_avg:53.45ms
+step:1262/1490 train_time:67494ms step_avg:53.48ms
+step:1263/1490 train_time:67576ms step_avg:53.50ms
+step:1264/1490 train_time:67665ms step_avg:53.53ms
+step:1265/1490 train_time:67750ms step_avg:53.56ms
+step:1266/1490 train_time:67838ms step_avg:53.58ms
+step:1267/1490 train_time:67919ms step_avg:53.61ms
+step:1268/1490 train_time:68005ms step_avg:53.63ms
+step:1269/1490 train_time:68085ms step_avg:53.65ms
+step:1270/1490 train_time:68171ms step_avg:53.68ms
+step:1271/1490 train_time:68250ms step_avg:53.70ms
+step:1272/1490 train_time:68335ms step_avg:53.72ms
+step:1273/1490 train_time:68415ms step_avg:53.74ms
+step:1274/1490 train_time:68501ms step_avg:53.77ms
+step:1275/1490 train_time:68583ms step_avg:53.79ms
+step:1276/1490 train_time:68671ms step_avg:53.82ms
+step:1277/1490 train_time:68753ms step_avg:53.84ms
+step:1278/1490 train_time:68839ms step_avg:53.86ms
+step:1279/1490 train_time:68922ms step_avg:53.89ms
+step:1280/1490 train_time:69007ms step_avg:53.91ms
+step:1281/1490 train_time:69088ms step_avg:53.93ms
+step:1282/1490 train_time:69174ms step_avg:53.96ms
+step:1283/1490 train_time:69255ms step_avg:53.98ms
+step:1284/1490 train_time:69340ms step_avg:54.00ms
+step:1285/1490 train_time:69421ms step_avg:54.02ms
+step:1286/1490 train_time:69509ms step_avg:54.05ms
+step:1287/1490 train_time:69590ms step_avg:54.07ms
+step:1288/1490 train_time:69679ms step_avg:54.10ms
+step:1289/1490 train_time:69761ms step_avg:54.12ms
+step:1290/1490 train_time:69848ms step_avg:54.15ms
+step:1291/1490 train_time:69929ms step_avg:54.17ms
+step:1292/1490 train_time:70014ms step_avg:54.19ms
+step:1293/1490 train_time:70095ms step_avg:54.21ms
+step:1294/1490 train_time:70182ms step_avg:54.24ms
+step:1295/1490 train_time:70263ms step_avg:54.26ms
+step:1296/1490 train_time:70347ms step_avg:54.28ms
+step:1297/1490 train_time:70427ms step_avg:54.30ms
+step:1298/1490 train_time:70516ms step_avg:54.33ms
+step:1299/1490 train_time:70597ms step_avg:54.35ms
+step:1300/1490 train_time:70683ms step_avg:54.37ms
+step:1301/1490 train_time:70766ms step_avg:54.39ms
+step:1302/1490 train_time:70854ms step_avg:54.42ms
+step:1303/1490 train_time:70935ms step_avg:54.44ms
+step:1304/1490 train_time:71020ms step_avg:54.46ms
+step:1305/1490 train_time:71101ms step_avg:54.48ms
+step:1306/1490 train_time:71186ms step_avg:54.51ms
+step:1307/1490 train_time:71266ms step_avg:54.53ms
+step:1308/1490 train_time:71353ms step_avg:54.55ms
+step:1309/1490 train_time:71433ms step_avg:54.57ms
+step:1310/1490 train_time:71519ms step_avg:54.59ms
+step:1311/1490 train_time:71601ms step_avg:54.62ms
+step:1312/1490 train_time:71687ms step_avg:54.64ms
+step:1313/1490 train_time:71768ms step_avg:54.66ms
+step:1314/1490 train_time:71856ms step_avg:54.68ms
+step:1315/1490 train_time:71936ms step_avg:54.70ms
+step:1316/1490 train_time:72021ms step_avg:54.73ms
+step:1317/1490 train_time:72102ms step_avg:54.75ms
+step:1318/1490 train_time:72188ms step_avg:54.77ms
+step:1319/1490 train_time:72269ms step_avg:54.79ms
+step:1320/1490 train_time:72355ms step_avg:54.81ms
+step:1321/1490 train_time:72434ms step_avg:54.83ms
+step:1322/1490 train_time:72520ms step_avg:54.86ms
+step:1323/1490 train_time:72602ms step_avg:54.88ms
+step:1324/1490 train_time:72689ms step_avg:54.90ms
+step:1325/1490 train_time:72772ms step_avg:54.92ms
+step:1326/1490 train_time:72858ms step_avg:54.95ms
+step:1327/1490 train_time:72939ms step_avg:54.97ms
+step:1328/1490 train_time:73025ms step_avg:54.99ms
+step:1329/1490 train_time:73106ms step_avg:55.01ms
+step:1330/1490 train_time:73192ms step_avg:55.03ms
+step:1331/1490 train_time:73274ms step_avg:55.05ms
+step:1332/1490 train_time:73359ms step_avg:55.07ms
+step:1333/1490 train_time:73440ms step_avg:55.09ms
+step:1334/1490 train_time:73526ms step_avg:55.12ms
+step:1335/1490 train_time:73606ms step_avg:55.14ms
+step:1336/1490 train_time:73694ms step_avg:55.16ms
+step:1337/1490 train_time:73775ms step_avg:55.18ms
+step:1338/1490 train_time:73861ms step_avg:55.20ms
+step:1339/1490 train_time:73941ms step_avg:55.22ms
+step:1340/1490 train_time:74027ms step_avg:55.24ms
+step:1341/1490 train_time:74108ms step_avg:55.26ms
+step:1342/1490 train_time:74195ms step_avg:55.29ms
+step:1343/1490 train_time:74276ms step_avg:55.31ms
+step:1344/1490 train_time:74362ms step_avg:55.33ms
+step:1345/1490 train_time:74444ms step_avg:55.35ms
+step:1346/1490 train_time:74530ms step_avg:55.37ms
+step:1347/1490 train_time:74611ms step_avg:55.39ms
+step:1348/1490 train_time:74697ms step_avg:55.41ms
+step:1349/1490 train_time:74779ms step_avg:55.43ms
+step:1350/1490 train_time:74865ms step_avg:55.46ms
+step:1351/1490 train_time:74945ms step_avg:55.47ms
+step:1352/1490 train_time:75032ms step_avg:55.50ms
+step:1353/1490 train_time:75113ms step_avg:55.52ms
+step:1354/1490 train_time:75199ms step_avg:55.54ms
+step:1355/1490 train_time:75280ms step_avg:55.56ms
+step:1356/1490 train_time:75366ms step_avg:55.58ms
+step:1357/1490 train_time:75447ms step_avg:55.60ms
+step:1358/1490 train_time:75532ms step_avg:55.62ms
+step:1359/1490 train_time:75613ms step_avg:55.64ms
+step:1360/1490 train_time:75699ms step_avg:55.66ms
+step:1361/1490 train_time:75780ms step_avg:55.68ms
+step:1362/1490 train_time:75868ms step_avg:55.70ms
+step:1363/1490 train_time:75951ms step_avg:55.72ms
+step:1364/1490 train_time:76036ms step_avg:55.74ms
+step:1365/1490 train_time:76117ms step_avg:55.76ms
+step:1366/1490 train_time:76203ms step_avg:55.79ms
+step:1367/1490 train_time:76285ms step_avg:55.80ms
+step:1368/1490 train_time:76370ms step_avg:55.83ms
+step:1369/1490 train_time:76451ms step_avg:55.84ms
+step:1370/1490 train_time:76538ms step_avg:55.87ms
+step:1371/1490 train_time:76618ms step_avg:55.89ms
+step:1372/1490 train_time:76705ms step_avg:55.91ms
+step:1373/1490 train_time:76786ms step_avg:55.93ms
+step:1374/1490 train_time:76873ms step_avg:55.95ms
+step:1375/1490 train_time:76955ms step_avg:55.97ms
+step:1376/1490 train_time:77040ms step_avg:55.99ms
+step:1377/1490 train_time:77121ms step_avg:56.01ms
+step:1378/1490 train_time:77208ms step_avg:56.03ms
+step:1379/1490 train_time:77289ms step_avg:56.05ms
+step:1380/1490 train_time:77375ms step_avg:56.07ms
+step:1381/1490 train_time:77454ms step_avg:56.09ms
+step:1382/1490 train_time:77540ms step_avg:56.11ms
+step:1383/1490 train_time:77622ms step_avg:56.13ms
+step:1384/1490 train_time:77709ms step_avg:56.15ms
+step:1385/1490 train_time:77790ms step_avg:56.17ms
+step:1386/1490 train_time:77878ms step_avg:56.19ms
+step:1387/1490 train_time:77959ms step_avg:56.21ms
+step:1388/1490 train_time:78045ms step_avg:56.23ms
+step:1389/1490 train_time:78125ms step_avg:56.25ms
+step:1390/1490 train_time:78211ms step_avg:56.27ms
+step:1391/1490 train_time:78293ms step_avg:56.29ms
+step:1392/1490 train_time:78379ms step_avg:56.31ms
+step:1393/1490 train_time:78461ms step_avg:56.33ms
+step:1394/1490 train_time:78547ms step_avg:56.35ms
+step:1395/1490 train_time:78627ms step_avg:56.36ms
+step:1396/1490 train_time:78714ms step_avg:56.39ms
+step:1397/1490 train_time:78794ms step_avg:56.40ms
+step:1398/1490 train_time:78880ms step_avg:56.42ms
+step:1399/1490 train_time:78960ms step_avg:56.44ms
+step:1400/1490 train_time:79046ms step_avg:56.46ms
+step:1401/1490 train_time:79128ms step_avg:56.48ms
+step:1402/1490 train_time:79214ms step_avg:56.50ms
+step:1403/1490 train_time:79294ms step_avg:56.52ms
+step:1404/1490 train_time:79380ms step_avg:56.54ms
+step:1405/1490 train_time:79462ms step_avg:56.56ms
+step:1406/1490 train_time:79549ms step_avg:56.58ms
+step:1407/1490 train_time:79628ms step_avg:56.59ms
+step:1408/1490 train_time:79716ms step_avg:56.62ms
+step:1409/1490 train_time:79797ms step_avg:56.63ms
+step:1410/1490 train_time:79883ms step_avg:56.65ms
+step:1411/1490 train_time:79965ms step_avg:56.67ms
+step:1412/1490 train_time:80052ms step_avg:56.69ms
+step:1413/1490 train_time:80133ms step_avg:56.71ms
+step:1414/1490 train_time:80219ms step_avg:56.73ms
+step:1415/1490 train_time:80301ms step_avg:56.75ms
+step:1416/1490 train_time:80387ms step_avg:56.77ms
+step:1417/1490 train_time:80468ms step_avg:56.79ms
+step:1418/1490 train_time:80555ms step_avg:56.81ms
+step:1419/1490 train_time:80635ms step_avg:56.83ms
+step:1420/1490 train_time:80720ms step_avg:56.84ms
+step:1421/1490 train_time:80801ms step_avg:56.86ms
+step:1422/1490 train_time:80888ms step_avg:56.88ms
+step:1423/1490 train_time:80970ms step_avg:56.90ms
+step:1424/1490 train_time:81057ms step_avg:56.92ms
+step:1425/1490 train_time:81137ms step_avg:56.94ms
+step:1426/1490 train_time:81223ms step_avg:56.96ms
+step:1427/1490 train_time:81305ms step_avg:56.98ms
+step:1428/1490 train_time:81392ms step_avg:57.00ms
+step:1429/1490 train_time:81473ms step_avg:57.01ms
+step:1430/1490 train_time:81559ms step_avg:57.03ms
+step:1431/1490 train_time:81639ms step_avg:57.05ms
+step:1432/1490 train_time:81726ms step_avg:57.07ms
+step:1433/1490 train_time:81806ms step_avg:57.09ms
+step:1434/1490 train_time:81894ms step_avg:57.11ms
+step:1435/1490 train_time:81975ms step_avg:57.13ms
+step:1436/1490 train_time:82062ms step_avg:57.15ms
+step:1437/1490 train_time:82142ms step_avg:57.16ms
+step:1438/1490 train_time:82228ms step_avg:57.18ms
+step:1439/1490 train_time:82309ms step_avg:57.20ms
+step:1440/1490 train_time:82396ms step_avg:57.22ms
+step:1441/1490 train_time:82476ms step_avg:57.24ms
+step:1442/1490 train_time:82563ms step_avg:57.26ms
+step:1443/1490 train_time:82642ms step_avg:57.27ms
+step:1444/1490 train_time:82729ms step_avg:57.29ms
+step:1445/1490 train_time:82810ms step_avg:57.31ms
+step:1446/1490 train_time:82896ms step_avg:57.33ms
+step:1447/1490 train_time:82977ms step_avg:57.34ms
+step:1448/1490 train_time:83064ms step_avg:57.36ms
+step:1449/1490 train_time:83145ms step_avg:57.38ms
+step:1450/1490 train_time:83230ms step_avg:57.40ms
+step:1451/1490 train_time:83316ms step_avg:57.42ms
+step:1452/1490 train_time:83403ms step_avg:57.44ms
+step:1453/1490 train_time:83485ms step_avg:57.46ms
+step:1454/1490 train_time:83572ms step_avg:57.48ms
+step:1455/1490 train_time:83655ms step_avg:57.49ms
+step:1456/1490 train_time:83741ms step_avg:57.51ms
+step:1457/1490 train_time:83822ms step_avg:57.53ms
+step:1458/1490 train_time:83907ms step_avg:57.55ms
+step:1459/1490 train_time:83989ms step_avg:57.57ms
+step:1460/1490 train_time:84076ms step_avg:57.59ms
+step:1461/1490 train_time:84156ms step_avg:57.60ms
+step:1462/1490 train_time:84242ms step_avg:57.62ms
+step:1463/1490 train_time:84324ms step_avg:57.64ms
+step:1464/1490 train_time:84412ms step_avg:57.66ms
+step:1465/1490 train_time:84494ms step_avg:57.68ms
+step:1466/1490 train_time:84581ms step_avg:57.70ms
+step:1467/1490 train_time:84663ms step_avg:57.71ms
+step:1468/1490 train_time:84751ms step_avg:57.73ms
+step:1469/1490 train_time:84832ms step_avg:57.75ms
+step:1470/1490 train_time:84918ms step_avg:57.77ms
+step:1471/1490 train_time:84999ms step_avg:57.78ms
+step:1472/1490 train_time:85085ms step_avg:57.80ms
+step:1473/1490 train_time:85166ms step_avg:57.82ms
+step:1474/1490 train_time:85253ms step_avg:57.84ms
+step:1475/1490 train_time:85334ms step_avg:57.85ms
+step:1476/1490 train_time:85421ms step_avg:57.87ms
+step:1477/1490 train_time:85503ms step_avg:57.89ms
+step:1478/1490 train_time:85590ms step_avg:57.91ms
+step:1479/1490 train_time:85671ms step_avg:57.93ms
+step:1480/1490 train_time:85759ms step_avg:57.95ms
+step:1481/1490 train_time:85839ms step_avg:57.96ms
+step:1482/1490 train_time:85925ms step_avg:57.98ms
+step:1483/1490 train_time:86006ms step_avg:57.99ms
+step:1484/1490 train_time:86094ms step_avg:58.01ms
+step:1485/1490 train_time:86175ms step_avg:58.03ms
+step:1486/1490 train_time:86262ms step_avg:58.05ms
+step:1487/1490 train_time:86342ms step_avg:58.06ms
+step:1488/1490 train_time:86429ms step_avg:58.08ms
+step:1489/1490 train_time:86510ms step_avg:58.10ms
+step:1490/1490 train_time:86598ms step_avg:58.12ms
+step:1490/1490 val_loss:3.2800 train_time:86702ms step_avg:58.19ms
+peak memory allocated: 31277 MiB reserved: 47142 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/baseline/2026-03-22_18-29-01_time-187_secs_baseline_28bdb2.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/baseline/2026-03-22_18-29-01_time-187_secs_baseline_28bdb2.txt
@@ -1,0 +1,4456 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 18:29:16 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   36C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            132W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   41C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1395770      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1395771      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1395772      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1395773      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1395774      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1395775      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1395776      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1395777      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8316 train_time:0ms step_avg:0.04ms
+step:1/1490 train_time:92ms step_avg:91.77ms
+step:2/1490 train_time:117ms step_avg:58.62ms
+step:3/1490 train_time:134ms step_avg:44.72ms
+step:4/1490 train_time:164ms step_avg:41.09ms
+step:5/1490 train_time:192ms step_avg:38.39ms
+step:6/1490 train_time:227ms step_avg:37.79ms
+step:7/1490 train_time:254ms step_avg:36.35ms
+step:8/1490 train_time:289ms step_avg:36.11ms
+step:9/1490 train_time:317ms step_avg:35.22ms
+step:10/1490 train_time:352ms step_avg:35.15ms
+step:11/1490 train_time:380ms step_avg:34.50ms
+step:12/1490 train_time:414ms step_avg:34.49ms
+step:13/1490 train_time:442ms step_avg:34.01ms
+step:14/1490 train_time:477ms step_avg:34.04ms
+step:15/1490 train_time:505ms step_avg:33.64ms
+step:16/1490 train_time:539ms step_avg:33.69ms
+step:17/1490 train_time:568ms step_avg:33.39ms
+step:18/1490 train_time:602ms step_avg:33.43ms
+step:19/1490 train_time:630ms step_avg:33.16ms
+step:20/1490 train_time:664ms step_avg:33.22ms
+step:21/1490 train_time:692ms step_avg:32.97ms
+step:22/1490 train_time:727ms step_avg:33.03ms
+step:23/1490 train_time:755ms step_avg:32.83ms
+step:24/1490 train_time:789ms step_avg:32.88ms
+step:25/1490 train_time:818ms step_avg:32.71ms
+step:26/1490 train_time:852ms step_avg:32.77ms
+step:27/1490 train_time:880ms step_avg:32.61ms
+step:28/1490 train_time:915ms step_avg:32.67ms
+step:29/1490 train_time:943ms step_avg:32.51ms
+step:30/1490 train_time:978ms step_avg:32.61ms
+step:31/1490 train_time:1008ms step_avg:32.51ms
+step:32/1490 train_time:1043ms step_avg:32.60ms
+step:33/1490 train_time:1073ms step_avg:32.52ms
+step:34/1490 train_time:1108ms step_avg:32.58ms
+step:35/1490 train_time:1137ms step_avg:32.48ms
+step:36/1490 train_time:1171ms step_avg:32.54ms
+step:37/1490 train_time:1200ms step_avg:32.43ms
+step:38/1490 train_time:1234ms step_avg:32.48ms
+step:39/1490 train_time:1263ms step_avg:32.38ms
+step:40/1490 train_time:1299ms step_avg:32.47ms
+step:41/1490 train_time:1326ms step_avg:32.35ms
+step:42/1490 train_time:1361ms step_avg:32.40ms
+step:43/1490 train_time:1389ms step_avg:32.31ms
+step:44/1490 train_time:1424ms step_avg:32.36ms
+step:45/1490 train_time:1452ms step_avg:32.27ms
+step:46/1490 train_time:1486ms step_avg:32.31ms
+step:47/1490 train_time:1515ms step_avg:32.23ms
+step:48/1490 train_time:1549ms step_avg:32.28ms
+step:49/1490 train_time:1578ms step_avg:32.19ms
+step:50/1490 train_time:1612ms step_avg:32.24ms
+step:51/1490 train_time:1640ms step_avg:32.16ms
+step:52/1490 train_time:1675ms step_avg:32.20ms
+step:53/1490 train_time:1703ms step_avg:32.13ms
+step:54/1490 train_time:1737ms step_avg:32.17ms
+step:55/1490 train_time:1766ms step_avg:32.10ms
+step:56/1490 train_time:1800ms step_avg:32.15ms
+step:57/1490 train_time:1828ms step_avg:32.08ms
+step:58/1490 train_time:1863ms step_avg:32.12ms
+step:59/1490 train_time:1891ms step_avg:32.06ms
+step:60/1490 train_time:1926ms step_avg:32.09ms
+step:61/1490 train_time:1955ms step_avg:32.04ms
+step:62/1490 train_time:1989ms step_avg:32.08ms
+step:63/1490 train_time:2018ms step_avg:32.03ms
+step:64/1490 train_time:2053ms step_avg:32.08ms
+step:65/1490 train_time:2082ms step_avg:32.03ms
+step:66/1490 train_time:2117ms step_avg:32.07ms
+step:67/1490 train_time:2146ms step_avg:32.02ms
+step:68/1490 train_time:2180ms step_avg:32.06ms
+step:69/1490 train_time:2209ms step_avg:32.01ms
+step:70/1490 train_time:2244ms step_avg:32.05ms
+step:71/1490 train_time:2272ms step_avg:32.01ms
+step:72/1490 train_time:2307ms step_avg:32.04ms
+step:73/1490 train_time:2335ms step_avg:31.99ms
+step:74/1490 train_time:2369ms step_avg:32.02ms
+step:75/1490 train_time:2398ms step_avg:31.97ms
+step:76/1490 train_time:2432ms step_avg:32.00ms
+step:77/1490 train_time:2461ms step_avg:31.96ms
+step:78/1490 train_time:2496ms step_avg:31.99ms
+step:79/1490 train_time:2524ms step_avg:31.95ms
+step:80/1490 train_time:2559ms step_avg:31.98ms
+step:81/1490 train_time:2588ms step_avg:31.95ms
+step:82/1490 train_time:2622ms step_avg:31.98ms
+step:83/1490 train_time:2650ms step_avg:31.93ms
+step:84/1490 train_time:2684ms step_avg:31.96ms
+step:85/1490 train_time:2713ms step_avg:31.92ms
+step:86/1490 train_time:2747ms step_avg:31.95ms
+step:87/1490 train_time:2776ms step_avg:31.91ms
+step:88/1490 train_time:2810ms step_avg:31.94ms
+step:89/1490 train_time:2839ms step_avg:31.90ms
+step:90/1490 train_time:2875ms step_avg:31.94ms
+step:91/1490 train_time:2902ms step_avg:31.89ms
+step:92/1490 train_time:2937ms step_avg:31.93ms
+step:93/1490 train_time:2966ms step_avg:31.89ms
+step:94/1490 train_time:3001ms step_avg:31.92ms
+step:95/1490 train_time:3030ms step_avg:31.89ms
+step:96/1490 train_time:3064ms step_avg:31.92ms
+step:97/1490 train_time:3093ms step_avg:31.89ms
+step:98/1490 train_time:3127ms step_avg:31.91ms
+step:99/1490 train_time:3156ms step_avg:31.88ms
+step:100/1490 train_time:3191ms step_avg:31.91ms
+step:101/1490 train_time:3220ms step_avg:31.88ms
+step:102/1490 train_time:3255ms step_avg:31.91ms
+step:103/1490 train_time:3283ms step_avg:31.87ms
+step:104/1490 train_time:3318ms step_avg:31.91ms
+step:105/1490 train_time:3347ms step_avg:31.88ms
+step:106/1490 train_time:3381ms step_avg:31.90ms
+step:107/1490 train_time:3410ms step_avg:31.87ms
+step:108/1490 train_time:3444ms step_avg:31.89ms
+step:109/1490 train_time:3473ms step_avg:31.86ms
+step:110/1490 train_time:3507ms step_avg:31.88ms
+step:111/1490 train_time:3536ms step_avg:31.86ms
+step:112/1490 train_time:3571ms step_avg:31.88ms
+step:113/1490 train_time:3599ms step_avg:31.85ms
+step:114/1490 train_time:3634ms step_avg:31.88ms
+step:115/1490 train_time:3662ms step_avg:31.84ms
+step:116/1490 train_time:3696ms step_avg:31.87ms
+step:117/1490 train_time:3725ms step_avg:31.84ms
+step:118/1490 train_time:3759ms step_avg:31.86ms
+step:119/1490 train_time:3788ms step_avg:31.83ms
+step:120/1490 train_time:3823ms step_avg:31.86ms
+step:121/1490 train_time:3851ms step_avg:31.83ms
+step:122/1490 train_time:3885ms step_avg:31.85ms
+step:123/1490 train_time:3914ms step_avg:31.82ms
+step:124/1490 train_time:3949ms step_avg:31.84ms
+step:125/1490 train_time:3977ms step_avg:31.82ms
+step:126/1490 train_time:4012ms step_avg:31.84ms
+step:127/1490 train_time:4040ms step_avg:31.81ms
+step:128/1490 train_time:4076ms step_avg:31.85ms
+step:129/1490 train_time:4103ms step_avg:31.81ms
+step:130/1490 train_time:4139ms step_avg:31.84ms
+step:131/1490 train_time:4167ms step_avg:31.81ms
+step:132/1490 train_time:4202ms step_avg:31.83ms
+step:133/1490 train_time:4230ms step_avg:31.81ms
+step:134/1490 train_time:4265ms step_avg:31.83ms
+step:135/1490 train_time:4293ms step_avg:31.80ms
+step:136/1490 train_time:4328ms step_avg:31.82ms
+step:137/1490 train_time:4357ms step_avg:31.81ms
+step:138/1490 train_time:4392ms step_avg:31.83ms
+step:139/1490 train_time:4420ms step_avg:31.80ms
+step:140/1490 train_time:4455ms step_avg:31.82ms
+step:141/1490 train_time:4484ms step_avg:31.80ms
+step:142/1490 train_time:4519ms step_avg:31.82ms
+step:143/1490 train_time:4548ms step_avg:31.80ms
+step:144/1490 train_time:4582ms step_avg:31.82ms
+step:145/1490 train_time:4611ms step_avg:31.80ms
+step:146/1490 train_time:4645ms step_avg:31.82ms
+step:147/1490 train_time:4674ms step_avg:31.79ms
+step:148/1490 train_time:4708ms step_avg:31.81ms
+step:149/1490 train_time:4736ms step_avg:31.79ms
+step:150/1490 train_time:4770ms step_avg:31.80ms
+step:151/1490 train_time:4798ms step_avg:31.78ms
+step:152/1490 train_time:4833ms step_avg:31.80ms
+step:153/1490 train_time:4862ms step_avg:31.78ms
+step:154/1490 train_time:4897ms step_avg:31.80ms
+step:155/1490 train_time:4925ms step_avg:31.78ms
+step:156/1490 train_time:4960ms step_avg:31.80ms
+step:157/1490 train_time:4988ms step_avg:31.77ms
+step:158/1490 train_time:5023ms step_avg:31.79ms
+step:159/1490 train_time:5051ms step_avg:31.77ms
+step:160/1490 train_time:5086ms step_avg:31.79ms
+step:161/1490 train_time:5115ms step_avg:31.77ms
+step:162/1490 train_time:5149ms step_avg:31.78ms
+step:163/1490 train_time:5177ms step_avg:31.76ms
+step:164/1490 train_time:5212ms step_avg:31.78ms
+step:165/1490 train_time:5241ms step_avg:31.76ms
+step:166/1490 train_time:5276ms step_avg:31.78ms
+step:167/1490 train_time:5304ms step_avg:31.76ms
+step:168/1490 train_time:5338ms step_avg:31.78ms
+step:169/1490 train_time:5367ms step_avg:31.76ms
+step:170/1490 train_time:5402ms step_avg:31.78ms
+step:171/1490 train_time:5431ms step_avg:31.76ms
+step:172/1490 train_time:5465ms step_avg:31.77ms
+step:173/1490 train_time:5495ms step_avg:31.76ms
+step:174/1490 train_time:5529ms step_avg:31.78ms
+step:175/1490 train_time:5558ms step_avg:31.76ms
+step:176/1490 train_time:5592ms step_avg:31.77ms
+step:177/1490 train_time:5621ms step_avg:31.75ms
+step:178/1490 train_time:5655ms step_avg:31.77ms
+step:179/1490 train_time:5683ms step_avg:31.75ms
+step:180/1490 train_time:5718ms step_avg:31.77ms
+step:181/1490 train_time:5746ms step_avg:31.75ms
+step:182/1490 train_time:5781ms step_avg:31.76ms
+step:183/1490 train_time:5809ms step_avg:31.74ms
+step:184/1490 train_time:5843ms step_avg:31.76ms
+step:185/1490 train_time:5871ms step_avg:31.74ms
+step:186/1490 train_time:5906ms step_avg:31.75ms
+step:187/1490 train_time:5934ms step_avg:31.73ms
+step:188/1490 train_time:5969ms step_avg:31.75ms
+step:189/1490 train_time:5997ms step_avg:31.73ms
+step:190/1490 train_time:6032ms step_avg:31.75ms
+step:191/1490 train_time:6061ms step_avg:31.73ms
+step:192/1490 train_time:6095ms step_avg:31.75ms
+step:193/1490 train_time:6123ms step_avg:31.73ms
+step:194/1490 train_time:6158ms step_avg:31.74ms
+step:195/1490 train_time:6186ms step_avg:31.72ms
+step:196/1490 train_time:6221ms step_avg:31.74ms
+step:197/1490 train_time:6249ms step_avg:31.72ms
+step:198/1490 train_time:6284ms step_avg:31.74ms
+step:199/1490 train_time:6312ms step_avg:31.72ms
+step:200/1490 train_time:6346ms step_avg:31.73ms
+step:201/1490 train_time:6374ms step_avg:31.71ms
+step:202/1490 train_time:6409ms step_avg:31.73ms
+step:203/1490 train_time:6438ms step_avg:31.71ms
+step:204/1490 train_time:6472ms step_avg:31.73ms
+step:205/1490 train_time:6501ms step_avg:31.71ms
+step:206/1490 train_time:6536ms step_avg:31.73ms
+step:207/1490 train_time:6564ms step_avg:31.71ms
+step:208/1490 train_time:6599ms step_avg:31.72ms
+step:209/1490 train_time:6627ms step_avg:31.71ms
+step:210/1490 train_time:6661ms step_avg:31.72ms
+step:211/1490 train_time:6690ms step_avg:31.71ms
+step:212/1490 train_time:6725ms step_avg:31.72ms
+step:213/1490 train_time:6753ms step_avg:31.70ms
+step:214/1490 train_time:6787ms step_avg:31.72ms
+step:215/1490 train_time:6816ms step_avg:31.70ms
+step:216/1490 train_time:6850ms step_avg:31.71ms
+step:217/1490 train_time:6879ms step_avg:31.70ms
+step:218/1490 train_time:6914ms step_avg:31.71ms
+step:219/1490 train_time:6942ms step_avg:31.70ms
+step:220/1490 train_time:6977ms step_avg:31.71ms
+step:221/1490 train_time:7006ms step_avg:31.70ms
+step:222/1490 train_time:7040ms step_avg:31.71ms
+step:223/1490 train_time:7069ms step_avg:31.70ms
+step:224/1490 train_time:7103ms step_avg:31.71ms
+step:225/1490 train_time:7131ms step_avg:31.69ms
+step:226/1490 train_time:7165ms step_avg:31.71ms
+step:227/1490 train_time:7194ms step_avg:31.69ms
+step:228/1490 train_time:7229ms step_avg:31.71ms
+step:229/1490 train_time:7258ms step_avg:31.69ms
+step:230/1490 train_time:7293ms step_avg:31.71ms
+step:231/1490 train_time:7320ms step_avg:31.69ms
+step:232/1490 train_time:7355ms step_avg:31.70ms
+step:233/1490 train_time:7384ms step_avg:31.69ms
+step:234/1490 train_time:7419ms step_avg:31.71ms
+step:235/1490 train_time:7448ms step_avg:31.69ms
+step:236/1490 train_time:7482ms step_avg:31.70ms
+step:237/1490 train_time:7510ms step_avg:31.69ms
+step:238/1490 train_time:7545ms step_avg:31.70ms
+step:239/1490 train_time:7573ms step_avg:31.69ms
+step:240/1490 train_time:7607ms step_avg:31.70ms
+step:241/1490 train_time:7636ms step_avg:31.68ms
+step:242/1490 train_time:7670ms step_avg:31.70ms
+step:243/1490 train_time:7699ms step_avg:31.68ms
+step:244/1490 train_time:7734ms step_avg:31.69ms
+step:245/1490 train_time:7762ms step_avg:31.68ms
+step:246/1490 train_time:7796ms step_avg:31.69ms
+step:247/1490 train_time:7824ms step_avg:31.68ms
+step:248/1490 train_time:7859ms step_avg:31.69ms
+step:249/1490 train_time:7888ms step_avg:31.68ms
+step:250/1490 train_time:7923ms step_avg:31.69ms
+step:250/1490 val_loss:4.4979 train_time:7966ms step_avg:31.86ms
+step:251/1490 train_time:7984ms step_avg:31.81ms
+step:252/1490 train_time:8001ms step_avg:31.75ms
+step:253/1490 train_time:8016ms step_avg:31.68ms
+step:254/1490 train_time:8052ms step_avg:31.70ms
+step:255/1490 train_time:8082ms step_avg:31.69ms
+step:256/1490 train_time:8118ms step_avg:31.71ms
+step:257/1490 train_time:8147ms step_avg:31.70ms
+step:258/1490 train_time:8182ms step_avg:31.71ms
+step:259/1490 train_time:8211ms step_avg:31.70ms
+step:260/1490 train_time:8246ms step_avg:31.71ms
+step:261/1490 train_time:8274ms step_avg:31.70ms
+step:262/1490 train_time:8309ms step_avg:31.71ms
+step:263/1490 train_time:8337ms step_avg:31.70ms
+step:264/1490 train_time:8371ms step_avg:31.71ms
+step:265/1490 train_time:8399ms step_avg:31.70ms
+step:266/1490 train_time:8434ms step_avg:31.71ms
+step:267/1490 train_time:8462ms step_avg:31.69ms
+step:268/1490 train_time:8496ms step_avg:31.70ms
+step:269/1490 train_time:8525ms step_avg:31.69ms
+step:270/1490 train_time:8559ms step_avg:31.70ms
+step:271/1490 train_time:8587ms step_avg:31.69ms
+step:272/1490 train_time:8622ms step_avg:31.70ms
+step:273/1490 train_time:8650ms step_avg:31.68ms
+step:274/1490 train_time:8684ms step_avg:31.69ms
+step:275/1490 train_time:8712ms step_avg:31.68ms
+step:276/1490 train_time:8746ms step_avg:31.69ms
+step:277/1490 train_time:8774ms step_avg:31.68ms
+step:278/1490 train_time:8809ms step_avg:31.69ms
+step:279/1490 train_time:8837ms step_avg:31.67ms
+step:280/1490 train_time:8871ms step_avg:31.68ms
+step:281/1490 train_time:8899ms step_avg:31.67ms
+step:282/1490 train_time:8934ms step_avg:31.68ms
+step:283/1490 train_time:8963ms step_avg:31.67ms
+step:284/1490 train_time:8997ms step_avg:31.68ms
+step:285/1490 train_time:9026ms step_avg:31.67ms
+step:286/1490 train_time:9061ms step_avg:31.68ms
+step:287/1490 train_time:9091ms step_avg:31.67ms
+step:288/1490 train_time:9125ms step_avg:31.69ms
+step:289/1490 train_time:9154ms step_avg:31.68ms
+step:290/1490 train_time:9189ms step_avg:31.69ms
+step:291/1490 train_time:9217ms step_avg:31.67ms
+step:292/1490 train_time:9252ms step_avg:31.68ms
+step:293/1490 train_time:9280ms step_avg:31.67ms
+step:294/1490 train_time:9315ms step_avg:31.68ms
+step:295/1490 train_time:9343ms step_avg:31.67ms
+step:296/1490 train_time:9378ms step_avg:31.68ms
+step:297/1490 train_time:9406ms step_avg:31.67ms
+step:298/1490 train_time:9441ms step_avg:31.68ms
+step:299/1490 train_time:9469ms step_avg:31.67ms
+step:300/1490 train_time:9503ms step_avg:31.68ms
+step:301/1490 train_time:9531ms step_avg:31.67ms
+step:302/1490 train_time:9566ms step_avg:31.67ms
+step:303/1490 train_time:9594ms step_avg:31.66ms
+step:304/1490 train_time:9628ms step_avg:31.67ms
+step:305/1490 train_time:9657ms step_avg:31.66ms
+step:306/1490 train_time:9691ms step_avg:31.67ms
+step:307/1490 train_time:9719ms step_avg:31.66ms
+step:308/1490 train_time:9754ms step_avg:31.67ms
+step:309/1490 train_time:9782ms step_avg:31.66ms
+step:310/1490 train_time:9816ms step_avg:31.66ms
+step:311/1490 train_time:9844ms step_avg:31.65ms
+step:312/1490 train_time:9878ms step_avg:31.66ms
+step:313/1490 train_time:9907ms step_avg:31.65ms
+step:314/1490 train_time:9941ms step_avg:31.66ms
+step:315/1490 train_time:9969ms step_avg:31.65ms
+step:316/1490 train_time:10004ms step_avg:31.66ms
+step:317/1490 train_time:10032ms step_avg:31.65ms
+step:318/1490 train_time:10067ms step_avg:31.66ms
+step:319/1490 train_time:10096ms step_avg:31.65ms
+step:320/1490 train_time:10131ms step_avg:31.66ms
+step:321/1490 train_time:10159ms step_avg:31.65ms
+step:322/1490 train_time:10194ms step_avg:31.66ms
+step:323/1490 train_time:10223ms step_avg:31.65ms
+step:324/1490 train_time:10257ms step_avg:31.66ms
+step:325/1490 train_time:10286ms step_avg:31.65ms
+step:326/1490 train_time:10320ms step_avg:31.66ms
+step:327/1490 train_time:10349ms step_avg:31.65ms
+step:328/1490 train_time:10383ms step_avg:31.65ms
+step:329/1490 train_time:10411ms step_avg:31.65ms
+step:330/1490 train_time:10445ms step_avg:31.65ms
+step:331/1490 train_time:10474ms step_avg:31.64ms
+step:332/1490 train_time:10508ms step_avg:31.65ms
+step:333/1490 train_time:10536ms step_avg:31.64ms
+step:334/1490 train_time:10570ms step_avg:31.65ms
+step:335/1490 train_time:10599ms step_avg:31.64ms
+step:336/1490 train_time:10634ms step_avg:31.65ms
+step:337/1490 train_time:10662ms step_avg:31.64ms
+step:338/1490 train_time:10696ms step_avg:31.65ms
+step:339/1490 train_time:10725ms step_avg:31.64ms
+step:340/1490 train_time:10759ms step_avg:31.65ms
+step:341/1490 train_time:10788ms step_avg:31.64ms
+step:342/1490 train_time:10822ms step_avg:31.64ms
+step:343/1490 train_time:10850ms step_avg:31.63ms
+step:344/1490 train_time:10884ms step_avg:31.64ms
+step:345/1490 train_time:10913ms step_avg:31.63ms
+step:346/1490 train_time:10947ms step_avg:31.64ms
+step:347/1490 train_time:10975ms step_avg:31.63ms
+step:348/1490 train_time:11010ms step_avg:31.64ms
+step:349/1490 train_time:11038ms step_avg:31.63ms
+step:350/1490 train_time:11073ms step_avg:31.64ms
+step:351/1490 train_time:11101ms step_avg:31.63ms
+step:352/1490 train_time:11136ms step_avg:31.64ms
+step:353/1490 train_time:11164ms step_avg:31.63ms
+step:354/1490 train_time:11199ms step_avg:31.63ms
+step:355/1490 train_time:11227ms step_avg:31.63ms
+step:356/1490 train_time:11263ms step_avg:31.64ms
+step:357/1490 train_time:11291ms step_avg:31.63ms
+step:358/1490 train_time:11325ms step_avg:31.63ms
+step:359/1490 train_time:11353ms step_avg:31.62ms
+step:360/1490 train_time:11388ms step_avg:31.63ms
+step:361/1490 train_time:11417ms step_avg:31.62ms
+step:362/1490 train_time:11451ms step_avg:31.63ms
+step:363/1490 train_time:11480ms step_avg:31.62ms
+step:364/1490 train_time:11514ms step_avg:31.63ms
+step:365/1490 train_time:11542ms step_avg:31.62ms
+step:366/1490 train_time:11576ms step_avg:31.63ms
+step:367/1490 train_time:11605ms step_avg:31.62ms
+step:368/1490 train_time:11639ms step_avg:31.63ms
+step:369/1490 train_time:11668ms step_avg:31.62ms
+step:370/1490 train_time:11702ms step_avg:31.63ms
+step:371/1490 train_time:11731ms step_avg:31.62ms
+step:372/1490 train_time:11765ms step_avg:31.63ms
+step:373/1490 train_time:11793ms step_avg:31.62ms
+step:374/1490 train_time:11828ms step_avg:31.62ms
+step:375/1490 train_time:11856ms step_avg:31.62ms
+step:376/1490 train_time:11890ms step_avg:31.62ms
+step:377/1490 train_time:11918ms step_avg:31.61ms
+step:378/1490 train_time:11953ms step_avg:31.62ms
+step:379/1490 train_time:11981ms step_avg:31.61ms
+step:380/1490 train_time:12016ms step_avg:31.62ms
+step:381/1490 train_time:12044ms step_avg:31.61ms
+step:382/1490 train_time:12079ms step_avg:31.62ms
+step:383/1490 train_time:12107ms step_avg:31.61ms
+step:384/1490 train_time:12142ms step_avg:31.62ms
+step:385/1490 train_time:12170ms step_avg:31.61ms
+step:386/1490 train_time:12204ms step_avg:31.62ms
+step:387/1490 train_time:12232ms step_avg:31.61ms
+step:388/1490 train_time:12266ms step_avg:31.61ms
+step:389/1490 train_time:12296ms step_avg:31.61ms
+step:390/1490 train_time:12330ms step_avg:31.62ms
+step:391/1490 train_time:12358ms step_avg:31.61ms
+step:392/1490 train_time:12393ms step_avg:31.61ms
+step:393/1490 train_time:12421ms step_avg:31.61ms
+step:394/1490 train_time:12456ms step_avg:31.61ms
+step:395/1490 train_time:12484ms step_avg:31.61ms
+step:396/1490 train_time:12519ms step_avg:31.61ms
+step:397/1490 train_time:12547ms step_avg:31.60ms
+step:398/1490 train_time:12581ms step_avg:31.61ms
+step:399/1490 train_time:12609ms step_avg:31.60ms
+step:400/1490 train_time:12643ms step_avg:31.61ms
+step:401/1490 train_time:12672ms step_avg:31.60ms
+step:402/1490 train_time:12706ms step_avg:31.61ms
+step:403/1490 train_time:12735ms step_avg:31.60ms
+step:404/1490 train_time:12769ms step_avg:31.61ms
+step:405/1490 train_time:12797ms step_avg:31.60ms
+step:406/1490 train_time:12832ms step_avg:31.61ms
+step:407/1490 train_time:12860ms step_avg:31.60ms
+step:408/1490 train_time:12894ms step_avg:31.60ms
+step:409/1490 train_time:12923ms step_avg:31.60ms
+step:410/1490 train_time:12958ms step_avg:31.60ms
+step:411/1490 train_time:12986ms step_avg:31.60ms
+step:412/1490 train_time:13021ms step_avg:31.60ms
+step:413/1490 train_time:13049ms step_avg:31.60ms
+step:414/1490 train_time:13083ms step_avg:31.60ms
+step:415/1490 train_time:13111ms step_avg:31.59ms
+step:416/1490 train_time:13146ms step_avg:31.60ms
+step:417/1490 train_time:13174ms step_avg:31.59ms
+step:418/1490 train_time:13209ms step_avg:31.60ms
+step:419/1490 train_time:13237ms step_avg:31.59ms
+step:420/1490 train_time:13272ms step_avg:31.60ms
+step:421/1490 train_time:13300ms step_avg:31.59ms
+step:422/1490 train_time:13335ms step_avg:31.60ms
+step:423/1490 train_time:13363ms step_avg:31.59ms
+step:424/1490 train_time:13397ms step_avg:31.60ms
+step:425/1490 train_time:13426ms step_avg:31.59ms
+step:426/1490 train_time:13460ms step_avg:31.60ms
+step:427/1490 train_time:13489ms step_avg:31.59ms
+step:428/1490 train_time:13523ms step_avg:31.60ms
+step:429/1490 train_time:13551ms step_avg:31.59ms
+step:430/1490 train_time:13585ms step_avg:31.59ms
+step:431/1490 train_time:13614ms step_avg:31.59ms
+step:432/1490 train_time:13648ms step_avg:31.59ms
+step:433/1490 train_time:13677ms step_avg:31.59ms
+step:434/1490 train_time:13711ms step_avg:31.59ms
+step:435/1490 train_time:13739ms step_avg:31.58ms
+step:436/1490 train_time:13774ms step_avg:31.59ms
+step:437/1490 train_time:13803ms step_avg:31.59ms
+step:438/1490 train_time:13838ms step_avg:31.59ms
+step:439/1490 train_time:13866ms step_avg:31.59ms
+step:440/1490 train_time:13900ms step_avg:31.59ms
+step:441/1490 train_time:13929ms step_avg:31.58ms
+step:442/1490 train_time:13963ms step_avg:31.59ms
+step:443/1490 train_time:13991ms step_avg:31.58ms
+step:444/1490 train_time:14026ms step_avg:31.59ms
+step:445/1490 train_time:14054ms step_avg:31.58ms
+step:446/1490 train_time:14088ms step_avg:31.59ms
+step:447/1490 train_time:14117ms step_avg:31.58ms
+step:448/1490 train_time:14152ms step_avg:31.59ms
+step:449/1490 train_time:14180ms step_avg:31.58ms
+step:450/1490 train_time:14215ms step_avg:31.59ms
+step:451/1490 train_time:14243ms step_avg:31.58ms
+step:452/1490 train_time:14277ms step_avg:31.59ms
+step:453/1490 train_time:14305ms step_avg:31.58ms
+step:454/1490 train_time:14340ms step_avg:31.58ms
+step:455/1490 train_time:14368ms step_avg:31.58ms
+step:456/1490 train_time:14402ms step_avg:31.58ms
+step:457/1490 train_time:14431ms step_avg:31.58ms
+step:458/1490 train_time:14465ms step_avg:31.58ms
+step:459/1490 train_time:14494ms step_avg:31.58ms
+step:460/1490 train_time:14528ms step_avg:31.58ms
+step:461/1490 train_time:14556ms step_avg:31.58ms
+step:462/1490 train_time:14591ms step_avg:31.58ms
+step:463/1490 train_time:14619ms step_avg:31.57ms
+step:464/1490 train_time:14654ms step_avg:31.58ms
+step:465/1490 train_time:14682ms step_avg:31.58ms
+step:466/1490 train_time:14717ms step_avg:31.58ms
+step:467/1490 train_time:14745ms step_avg:31.57ms
+step:468/1490 train_time:14780ms step_avg:31.58ms
+step:469/1490 train_time:14808ms step_avg:31.57ms
+step:470/1490 train_time:14842ms step_avg:31.58ms
+step:471/1490 train_time:14871ms step_avg:31.57ms
+step:472/1490 train_time:14905ms step_avg:31.58ms
+step:473/1490 train_time:14934ms step_avg:31.57ms
+step:474/1490 train_time:14968ms step_avg:31.58ms
+step:475/1490 train_time:14997ms step_avg:31.57ms
+step:476/1490 train_time:15031ms step_avg:31.58ms
+step:477/1490 train_time:15060ms step_avg:31.57ms
+step:478/1490 train_time:15094ms step_avg:31.58ms
+step:479/1490 train_time:15122ms step_avg:31.57ms
+step:480/1490 train_time:15157ms step_avg:31.58ms
+step:481/1490 train_time:15186ms step_avg:31.57ms
+step:482/1490 train_time:15220ms step_avg:31.58ms
+step:483/1490 train_time:15248ms step_avg:31.57ms
+step:484/1490 train_time:15285ms step_avg:31.58ms
+step:485/1490 train_time:15337ms step_avg:31.62ms
+step:486/1490 train_time:15395ms step_avg:31.68ms
+step:487/1490 train_time:15450ms step_avg:31.72ms
+step:488/1490 train_time:15509ms step_avg:31.78ms
+step:489/1490 train_time:15564ms step_avg:31.83ms
+step:490/1490 train_time:15624ms step_avg:31.89ms
+step:491/1490 train_time:15679ms step_avg:31.93ms
+step:492/1490 train_time:15739ms step_avg:31.99ms
+step:493/1490 train_time:15793ms step_avg:32.03ms
+step:494/1490 train_time:15854ms step_avg:32.09ms
+step:495/1490 train_time:15907ms step_avg:32.14ms
+step:496/1490 train_time:15968ms step_avg:32.19ms
+step:497/1490 train_time:16022ms step_avg:32.24ms
+step:498/1490 train_time:16083ms step_avg:32.30ms
+step:499/1490 train_time:16138ms step_avg:32.34ms
+step:500/1490 train_time:16198ms step_avg:32.40ms
+step:500/1490 val_loss:4.2155 train_time:16270ms step_avg:32.54ms
+step:501/1490 train_time:16286ms step_avg:32.51ms
+step:502/1490 train_time:16313ms step_avg:32.50ms
+step:503/1490 train_time:16369ms step_avg:32.54ms
+step:504/1490 train_time:16434ms step_avg:32.61ms
+step:505/1490 train_time:16491ms step_avg:32.65ms
+step:506/1490 train_time:16551ms step_avg:32.71ms
+step:507/1490 train_time:16606ms step_avg:32.75ms
+step:508/1490 train_time:16666ms step_avg:32.81ms
+step:509/1490 train_time:16720ms step_avg:32.85ms
+step:510/1490 train_time:16778ms step_avg:32.90ms
+step:511/1490 train_time:16832ms step_avg:32.94ms
+step:512/1490 train_time:16891ms step_avg:32.99ms
+step:513/1490 train_time:16945ms step_avg:33.03ms
+step:514/1490 train_time:17004ms step_avg:33.08ms
+step:515/1490 train_time:17057ms step_avg:33.12ms
+step:516/1490 train_time:17116ms step_avg:33.17ms
+step:517/1490 train_time:17170ms step_avg:33.21ms
+step:518/1490 train_time:17231ms step_avg:33.26ms
+step:519/1490 train_time:17287ms step_avg:33.31ms
+step:520/1490 train_time:17349ms step_avg:33.36ms
+step:521/1490 train_time:17404ms step_avg:33.40ms
+step:522/1490 train_time:17464ms step_avg:33.46ms
+step:523/1490 train_time:17519ms step_avg:33.50ms
+step:524/1490 train_time:17578ms step_avg:33.55ms
+step:525/1490 train_time:17634ms step_avg:33.59ms
+step:526/1490 train_time:17694ms step_avg:33.64ms
+step:527/1490 train_time:17748ms step_avg:33.68ms
+step:528/1490 train_time:17808ms step_avg:33.73ms
+step:529/1490 train_time:17863ms step_avg:33.77ms
+step:530/1490 train_time:17922ms step_avg:33.81ms
+step:531/1490 train_time:17975ms step_avg:33.85ms
+step:532/1490 train_time:18035ms step_avg:33.90ms
+step:533/1490 train_time:18089ms step_avg:33.94ms
+step:534/1490 train_time:18148ms step_avg:33.99ms
+step:535/1490 train_time:18202ms step_avg:34.02ms
+step:536/1490 train_time:18263ms step_avg:34.07ms
+step:537/1490 train_time:18317ms step_avg:34.11ms
+step:538/1490 train_time:18377ms step_avg:34.16ms
+step:539/1490 train_time:18432ms step_avg:34.20ms
+step:540/1490 train_time:18493ms step_avg:34.25ms
+step:541/1490 train_time:18547ms step_avg:34.28ms
+step:542/1490 train_time:18609ms step_avg:34.33ms
+step:543/1490 train_time:18663ms step_avg:34.37ms
+step:544/1490 train_time:18722ms step_avg:34.42ms
+step:545/1490 train_time:18777ms step_avg:34.45ms
+step:546/1490 train_time:18838ms step_avg:34.50ms
+step:547/1490 train_time:18892ms step_avg:34.54ms
+step:548/1490 train_time:18951ms step_avg:34.58ms
+step:549/1490 train_time:19005ms step_avg:34.62ms
+step:550/1490 train_time:19064ms step_avg:34.66ms
+step:551/1490 train_time:19118ms step_avg:34.70ms
+step:552/1490 train_time:19178ms step_avg:34.74ms
+step:553/1490 train_time:19233ms step_avg:34.78ms
+step:554/1490 train_time:19293ms step_avg:34.83ms
+step:555/1490 train_time:19347ms step_avg:34.86ms
+step:556/1490 train_time:19408ms step_avg:34.91ms
+step:557/1490 train_time:19463ms step_avg:34.94ms
+step:558/1490 train_time:19523ms step_avg:34.99ms
+step:559/1490 train_time:19577ms step_avg:35.02ms
+step:560/1490 train_time:19638ms step_avg:35.07ms
+step:561/1490 train_time:19692ms step_avg:35.10ms
+step:562/1490 train_time:19752ms step_avg:35.15ms
+step:563/1490 train_time:19807ms step_avg:35.18ms
+step:564/1490 train_time:19867ms step_avg:35.23ms
+step:565/1490 train_time:19921ms step_avg:35.26ms
+step:566/1490 train_time:19979ms step_avg:35.30ms
+step:567/1490 train_time:20033ms step_avg:35.33ms
+step:568/1490 train_time:20093ms step_avg:35.37ms
+step:569/1490 train_time:20146ms step_avg:35.41ms
+step:570/1490 train_time:20207ms step_avg:35.45ms
+step:571/1490 train_time:20261ms step_avg:35.48ms
+step:572/1490 train_time:20321ms step_avg:35.53ms
+step:573/1490 train_time:20375ms step_avg:35.56ms
+step:574/1490 train_time:20435ms step_avg:35.60ms
+step:575/1490 train_time:20490ms step_avg:35.64ms
+step:576/1490 train_time:20551ms step_avg:35.68ms
+step:577/1490 train_time:20605ms step_avg:35.71ms
+step:578/1490 train_time:20665ms step_avg:35.75ms
+step:579/1490 train_time:20719ms step_avg:35.78ms
+step:580/1490 train_time:20779ms step_avg:35.83ms
+step:581/1490 train_time:20834ms step_avg:35.86ms
+step:582/1490 train_time:20894ms step_avg:35.90ms
+step:583/1490 train_time:20947ms step_avg:35.93ms
+step:584/1490 train_time:21007ms step_avg:35.97ms
+step:585/1490 train_time:21062ms step_avg:36.00ms
+step:586/1490 train_time:21121ms step_avg:36.04ms
+step:587/1490 train_time:21176ms step_avg:36.07ms
+step:588/1490 train_time:21235ms step_avg:36.11ms
+step:589/1490 train_time:21289ms step_avg:36.14ms
+step:590/1490 train_time:21350ms step_avg:36.19ms
+step:591/1490 train_time:21404ms step_avg:36.22ms
+step:592/1490 train_time:21465ms step_avg:36.26ms
+step:593/1490 train_time:21518ms step_avg:36.29ms
+step:594/1490 train_time:21578ms step_avg:36.33ms
+step:595/1490 train_time:21632ms step_avg:36.36ms
+step:596/1490 train_time:21693ms step_avg:36.40ms
+step:597/1490 train_time:21747ms step_avg:36.43ms
+step:598/1490 train_time:21807ms step_avg:36.47ms
+step:599/1490 train_time:21863ms step_avg:36.50ms
+step:600/1490 train_time:21922ms step_avg:36.54ms
+step:601/1490 train_time:21976ms step_avg:36.57ms
+step:602/1490 train_time:22036ms step_avg:36.60ms
+step:603/1490 train_time:22090ms step_avg:36.63ms
+step:604/1490 train_time:22150ms step_avg:36.67ms
+step:605/1490 train_time:22204ms step_avg:36.70ms
+step:606/1490 train_time:22263ms step_avg:36.74ms
+step:607/1490 train_time:22317ms step_avg:36.77ms
+step:608/1490 train_time:22377ms step_avg:36.80ms
+step:609/1490 train_time:22431ms step_avg:36.83ms
+step:610/1490 train_time:22492ms step_avg:36.87ms
+step:611/1490 train_time:22546ms step_avg:36.90ms
+step:612/1490 train_time:22605ms step_avg:36.94ms
+step:613/1490 train_time:22659ms step_avg:36.96ms
+step:614/1490 train_time:22719ms step_avg:37.00ms
+step:615/1490 train_time:22773ms step_avg:37.03ms
+step:616/1490 train_time:22833ms step_avg:37.07ms
+step:617/1490 train_time:22888ms step_avg:37.10ms
+step:618/1490 train_time:22948ms step_avg:37.13ms
+step:619/1490 train_time:23002ms step_avg:37.16ms
+step:620/1490 train_time:23061ms step_avg:37.20ms
+step:621/1490 train_time:23115ms step_avg:37.22ms
+step:622/1490 train_time:23176ms step_avg:37.26ms
+step:623/1490 train_time:23231ms step_avg:37.29ms
+step:624/1490 train_time:23292ms step_avg:37.33ms
+step:625/1490 train_time:23345ms step_avg:37.35ms
+step:626/1490 train_time:23405ms step_avg:37.39ms
+step:627/1490 train_time:23460ms step_avg:37.42ms
+step:628/1490 train_time:23519ms step_avg:37.45ms
+step:629/1490 train_time:23574ms step_avg:37.48ms
+step:630/1490 train_time:23633ms step_avg:37.51ms
+step:631/1490 train_time:23689ms step_avg:37.54ms
+step:632/1490 train_time:23748ms step_avg:37.58ms
+step:633/1490 train_time:23802ms step_avg:37.60ms
+step:634/1490 train_time:23861ms step_avg:37.64ms
+step:635/1490 train_time:23916ms step_avg:37.66ms
+step:636/1490 train_time:23976ms step_avg:37.70ms
+step:637/1490 train_time:24031ms step_avg:37.72ms
+step:638/1490 train_time:24091ms step_avg:37.76ms
+step:639/1490 train_time:24145ms step_avg:37.78ms
+step:640/1490 train_time:24204ms step_avg:37.82ms
+step:641/1490 train_time:24258ms step_avg:37.84ms
+step:642/1490 train_time:24319ms step_avg:37.88ms
+step:643/1490 train_time:24373ms step_avg:37.91ms
+step:644/1490 train_time:24434ms step_avg:37.94ms
+step:645/1490 train_time:24488ms step_avg:37.97ms
+step:646/1490 train_time:24548ms step_avg:38.00ms
+step:647/1490 train_time:24602ms step_avg:38.03ms
+step:648/1490 train_time:24662ms step_avg:38.06ms
+step:649/1490 train_time:24717ms step_avg:38.08ms
+step:650/1490 train_time:24777ms step_avg:38.12ms
+step:651/1490 train_time:24831ms step_avg:38.14ms
+step:652/1490 train_time:24892ms step_avg:38.18ms
+step:653/1490 train_time:24945ms step_avg:38.20ms
+step:654/1490 train_time:25005ms step_avg:38.23ms
+step:655/1490 train_time:25060ms step_avg:38.26ms
+step:656/1490 train_time:25119ms step_avg:38.29ms
+step:657/1490 train_time:25174ms step_avg:38.32ms
+step:658/1490 train_time:25233ms step_avg:38.35ms
+step:659/1490 train_time:25287ms step_avg:38.37ms
+step:660/1490 train_time:25348ms step_avg:38.41ms
+step:661/1490 train_time:25402ms step_avg:38.43ms
+step:662/1490 train_time:25462ms step_avg:38.46ms
+step:663/1490 train_time:25517ms step_avg:38.49ms
+step:664/1490 train_time:25576ms step_avg:38.52ms
+step:665/1490 train_time:25631ms step_avg:38.54ms
+step:666/1490 train_time:25691ms step_avg:38.57ms
+step:667/1490 train_time:25745ms step_avg:38.60ms
+step:668/1490 train_time:25804ms step_avg:38.63ms
+step:669/1490 train_time:25857ms step_avg:38.65ms
+step:670/1490 train_time:25918ms step_avg:38.68ms
+step:671/1490 train_time:25972ms step_avg:38.71ms
+step:672/1490 train_time:26032ms step_avg:38.74ms
+step:673/1490 train_time:26086ms step_avg:38.76ms
+step:674/1490 train_time:26146ms step_avg:38.79ms
+step:675/1490 train_time:26199ms step_avg:38.81ms
+step:676/1490 train_time:26261ms step_avg:38.85ms
+step:677/1490 train_time:26315ms step_avg:38.87ms
+step:678/1490 train_time:26374ms step_avg:38.90ms
+step:679/1490 train_time:26430ms step_avg:38.92ms
+step:680/1490 train_time:26489ms step_avg:38.96ms
+step:681/1490 train_time:26543ms step_avg:38.98ms
+step:682/1490 train_time:26604ms step_avg:39.01ms
+step:683/1490 train_time:26659ms step_avg:39.03ms
+step:684/1490 train_time:26719ms step_avg:39.06ms
+step:685/1490 train_time:26774ms step_avg:39.09ms
+step:686/1490 train_time:26833ms step_avg:39.12ms
+step:687/1490 train_time:26887ms step_avg:39.14ms
+step:688/1490 train_time:26947ms step_avg:39.17ms
+step:689/1490 train_time:27002ms step_avg:39.19ms
+step:690/1490 train_time:27061ms step_avg:39.22ms
+step:691/1490 train_time:27115ms step_avg:39.24ms
+step:692/1490 train_time:27174ms step_avg:39.27ms
+step:693/1490 train_time:27229ms step_avg:39.29ms
+step:694/1490 train_time:27290ms step_avg:39.32ms
+step:695/1490 train_time:27344ms step_avg:39.34ms
+step:696/1490 train_time:27403ms step_avg:39.37ms
+step:697/1490 train_time:27457ms step_avg:39.39ms
+step:698/1490 train_time:27517ms step_avg:39.42ms
+step:699/1490 train_time:27572ms step_avg:39.44ms
+step:700/1490 train_time:27632ms step_avg:39.47ms
+step:701/1490 train_time:27687ms step_avg:39.50ms
+step:702/1490 train_time:27748ms step_avg:39.53ms
+step:703/1490 train_time:27802ms step_avg:39.55ms
+step:704/1490 train_time:27861ms step_avg:39.58ms
+step:705/1490 train_time:27915ms step_avg:39.60ms
+step:706/1490 train_time:27976ms step_avg:39.63ms
+step:707/1490 train_time:28030ms step_avg:39.65ms
+step:708/1490 train_time:28090ms step_avg:39.67ms
+step:709/1490 train_time:28143ms step_avg:39.69ms
+step:710/1490 train_time:28203ms step_avg:39.72ms
+step:711/1490 train_time:28259ms step_avg:39.75ms
+step:712/1490 train_time:28319ms step_avg:39.77ms
+step:713/1490 train_time:28374ms step_avg:39.79ms
+step:714/1490 train_time:28434ms step_avg:39.82ms
+step:715/1490 train_time:28488ms step_avg:39.84ms
+step:716/1490 train_time:28548ms step_avg:39.87ms
+step:717/1490 train_time:28602ms step_avg:39.89ms
+step:718/1490 train_time:28662ms step_avg:39.92ms
+step:719/1490 train_time:28716ms step_avg:39.94ms
+step:720/1490 train_time:28775ms step_avg:39.97ms
+step:721/1490 train_time:28829ms step_avg:39.98ms
+step:722/1490 train_time:28890ms step_avg:40.01ms
+step:723/1490 train_time:28943ms step_avg:40.03ms
+step:724/1490 train_time:29004ms step_avg:40.06ms
+step:725/1490 train_time:29058ms step_avg:40.08ms
+step:726/1490 train_time:29118ms step_avg:40.11ms
+step:727/1490 train_time:29173ms step_avg:40.13ms
+step:728/1490 train_time:29233ms step_avg:40.16ms
+step:729/1490 train_time:29288ms step_avg:40.18ms
+step:730/1490 train_time:29348ms step_avg:40.20ms
+step:731/1490 train_time:29402ms step_avg:40.22ms
+step:732/1490 train_time:29462ms step_avg:40.25ms
+step:733/1490 train_time:29516ms step_avg:40.27ms
+step:734/1490 train_time:29577ms step_avg:40.30ms
+step:735/1490 train_time:29631ms step_avg:40.31ms
+step:736/1490 train_time:29692ms step_avg:40.34ms
+step:737/1490 train_time:29746ms step_avg:40.36ms
+step:738/1490 train_time:29806ms step_avg:40.39ms
+step:739/1490 train_time:29860ms step_avg:40.41ms
+step:740/1490 train_time:29920ms step_avg:40.43ms
+step:741/1490 train_time:29974ms step_avg:40.45ms
+step:742/1490 train_time:30035ms step_avg:40.48ms
+step:743/1490 train_time:30089ms step_avg:40.50ms
+step:744/1490 train_time:30149ms step_avg:40.52ms
+step:745/1490 train_time:30203ms step_avg:40.54ms
+step:746/1490 train_time:30263ms step_avg:40.57ms
+step:747/1490 train_time:30317ms step_avg:40.59ms
+step:748/1490 train_time:30376ms step_avg:40.61ms
+step:749/1490 train_time:30432ms step_avg:40.63ms
+step:750/1490 train_time:30492ms step_avg:40.66ms
+step:750/1490 val_loss:3.8092 train_time:30564ms step_avg:40.75ms
+step:751/1490 train_time:30580ms step_avg:40.72ms
+step:752/1490 train_time:30607ms step_avg:40.70ms
+step:753/1490 train_time:30665ms step_avg:40.72ms
+step:754/1490 train_time:30728ms step_avg:40.75ms
+step:755/1490 train_time:30784ms step_avg:40.77ms
+step:756/1490 train_time:30845ms step_avg:40.80ms
+step:757/1490 train_time:30899ms step_avg:40.82ms
+step:758/1490 train_time:30958ms step_avg:40.84ms
+step:759/1490 train_time:31013ms step_avg:40.86ms
+step:760/1490 train_time:31072ms step_avg:40.88ms
+step:761/1490 train_time:31125ms step_avg:40.90ms
+step:762/1490 train_time:31185ms step_avg:40.92ms
+step:763/1490 train_time:31238ms step_avg:40.94ms
+step:764/1490 train_time:31297ms step_avg:40.96ms
+step:765/1490 train_time:31351ms step_avg:40.98ms
+step:766/1490 train_time:31410ms step_avg:41.01ms
+step:767/1490 train_time:31464ms step_avg:41.02ms
+step:768/1490 train_time:31524ms step_avg:41.05ms
+step:769/1490 train_time:31581ms step_avg:41.07ms
+step:770/1490 train_time:31642ms step_avg:41.09ms
+step:771/1490 train_time:31697ms step_avg:41.11ms
+step:772/1490 train_time:31760ms step_avg:41.14ms
+step:773/1490 train_time:31815ms step_avg:41.16ms
+step:774/1490 train_time:31875ms step_avg:41.18ms
+step:775/1490 train_time:31930ms step_avg:41.20ms
+step:776/1490 train_time:31989ms step_avg:41.22ms
+step:777/1490 train_time:32043ms step_avg:41.24ms
+step:778/1490 train_time:32102ms step_avg:41.26ms
+step:779/1490 train_time:32156ms step_avg:41.28ms
+step:780/1490 train_time:32216ms step_avg:41.30ms
+step:781/1490 train_time:32269ms step_avg:41.32ms
+step:782/1490 train_time:32329ms step_avg:41.34ms
+step:783/1490 train_time:32383ms step_avg:41.36ms
+step:784/1490 train_time:32442ms step_avg:41.38ms
+step:785/1490 train_time:32495ms step_avg:41.40ms
+step:786/1490 train_time:32556ms step_avg:41.42ms
+step:787/1490 train_time:32612ms step_avg:41.44ms
+step:788/1490 train_time:32672ms step_avg:41.46ms
+step:789/1490 train_time:32727ms step_avg:41.48ms
+step:790/1490 train_time:32788ms step_avg:41.50ms
+step:791/1490 train_time:32842ms step_avg:41.52ms
+step:792/1490 train_time:32902ms step_avg:41.54ms
+step:793/1490 train_time:32956ms step_avg:41.56ms
+step:794/1490 train_time:33017ms step_avg:41.58ms
+step:795/1490 train_time:33071ms step_avg:41.60ms
+step:796/1490 train_time:33131ms step_avg:41.62ms
+step:797/1490 train_time:33184ms step_avg:41.64ms
+step:798/1490 train_time:33244ms step_avg:41.66ms
+step:799/1490 train_time:33298ms step_avg:41.67ms
+step:800/1490 train_time:33357ms step_avg:41.70ms
+step:801/1490 train_time:33412ms step_avg:41.71ms
+step:802/1490 train_time:33472ms step_avg:41.74ms
+step:803/1490 train_time:33526ms step_avg:41.75ms
+step:804/1490 train_time:33588ms step_avg:41.78ms
+step:805/1490 train_time:33642ms step_avg:41.79ms
+step:806/1490 train_time:33702ms step_avg:41.81ms
+step:807/1490 train_time:33757ms step_avg:41.83ms
+step:808/1490 train_time:33817ms step_avg:41.85ms
+step:809/1490 train_time:33873ms step_avg:41.87ms
+step:810/1490 train_time:33933ms step_avg:41.89ms
+step:811/1490 train_time:33986ms step_avg:41.91ms
+step:812/1490 train_time:34047ms step_avg:41.93ms
+step:813/1490 train_time:34102ms step_avg:41.95ms
+step:814/1490 train_time:34161ms step_avg:41.97ms
+step:815/1490 train_time:34214ms step_avg:41.98ms
+step:816/1490 train_time:34273ms step_avg:42.00ms
+step:817/1490 train_time:34327ms step_avg:42.02ms
+step:818/1490 train_time:34388ms step_avg:42.04ms
+step:819/1490 train_time:34441ms step_avg:42.05ms
+step:820/1490 train_time:34501ms step_avg:42.07ms
+step:821/1490 train_time:34556ms step_avg:42.09ms
+step:822/1490 train_time:34618ms step_avg:42.11ms
+step:823/1490 train_time:34672ms step_avg:42.13ms
+step:824/1490 train_time:34733ms step_avg:42.15ms
+step:825/1490 train_time:34788ms step_avg:42.17ms
+step:826/1490 train_time:34848ms step_avg:42.19ms
+step:827/1490 train_time:34903ms step_avg:42.20ms
+step:828/1490 train_time:34962ms step_avg:42.22ms
+step:829/1490 train_time:35016ms step_avg:42.24ms
+step:830/1490 train_time:35076ms step_avg:42.26ms
+step:831/1490 train_time:35130ms step_avg:42.27ms
+step:832/1490 train_time:35190ms step_avg:42.30ms
+step:833/1490 train_time:35243ms step_avg:42.31ms
+step:834/1490 train_time:35303ms step_avg:42.33ms
+step:835/1490 train_time:35357ms step_avg:42.34ms
+step:836/1490 train_time:35418ms step_avg:42.37ms
+step:837/1490 train_time:35472ms step_avg:42.38ms
+step:838/1490 train_time:35532ms step_avg:42.40ms
+step:839/1490 train_time:35587ms step_avg:42.42ms
+step:840/1490 train_time:35648ms step_avg:42.44ms
+step:841/1490 train_time:35703ms step_avg:42.45ms
+step:842/1490 train_time:35762ms step_avg:42.47ms
+step:843/1490 train_time:35816ms step_avg:42.49ms
+step:844/1490 train_time:35876ms step_avg:42.51ms
+step:845/1490 train_time:35930ms step_avg:42.52ms
+step:846/1490 train_time:35990ms step_avg:42.54ms
+step:847/1490 train_time:36045ms step_avg:42.56ms
+step:848/1490 train_time:36105ms step_avg:42.58ms
+step:849/1490 train_time:36160ms step_avg:42.59ms
+step:850/1490 train_time:36220ms step_avg:42.61ms
+step:851/1490 train_time:36273ms step_avg:42.62ms
+step:852/1490 train_time:36332ms step_avg:42.64ms
+step:853/1490 train_time:36387ms step_avg:42.66ms
+step:854/1490 train_time:36448ms step_avg:42.68ms
+step:855/1490 train_time:36502ms step_avg:42.69ms
+step:856/1490 train_time:36561ms step_avg:42.71ms
+step:857/1490 train_time:36616ms step_avg:42.73ms
+step:858/1490 train_time:36676ms step_avg:42.75ms
+step:859/1490 train_time:36730ms step_avg:42.76ms
+step:860/1490 train_time:36790ms step_avg:42.78ms
+step:861/1490 train_time:36844ms step_avg:42.79ms
+step:862/1490 train_time:36904ms step_avg:42.81ms
+step:863/1490 train_time:36958ms step_avg:42.83ms
+step:864/1490 train_time:37018ms step_avg:42.85ms
+step:865/1490 train_time:37073ms step_avg:42.86ms
+step:866/1490 train_time:37132ms step_avg:42.88ms
+step:867/1490 train_time:37187ms step_avg:42.89ms
+step:868/1490 train_time:37247ms step_avg:42.91ms
+step:869/1490 train_time:37302ms step_avg:42.92ms
+step:870/1490 train_time:37361ms step_avg:42.94ms
+step:871/1490 train_time:37415ms step_avg:42.96ms
+step:872/1490 train_time:37475ms step_avg:42.98ms
+step:873/1490 train_time:37530ms step_avg:42.99ms
+step:874/1490 train_time:37590ms step_avg:43.01ms
+step:875/1490 train_time:37644ms step_avg:43.02ms
+step:876/1490 train_time:37704ms step_avg:43.04ms
+step:877/1490 train_time:37758ms step_avg:43.05ms
+step:878/1490 train_time:37818ms step_avg:43.07ms
+step:879/1490 train_time:37872ms step_avg:43.09ms
+step:880/1490 train_time:37932ms step_avg:43.10ms
+step:881/1490 train_time:37987ms step_avg:43.12ms
+step:882/1490 train_time:38047ms step_avg:43.14ms
+step:883/1490 train_time:38101ms step_avg:43.15ms
+step:884/1490 train_time:38160ms step_avg:43.17ms
+step:885/1490 train_time:38215ms step_avg:43.18ms
+step:886/1490 train_time:38274ms step_avg:43.20ms
+step:887/1490 train_time:38329ms step_avg:43.21ms
+step:888/1490 train_time:38388ms step_avg:43.23ms
+step:889/1490 train_time:38442ms step_avg:43.24ms
+step:890/1490 train_time:38503ms step_avg:43.26ms
+step:891/1490 train_time:38557ms step_avg:43.27ms
+step:892/1490 train_time:38617ms step_avg:43.29ms
+step:893/1490 train_time:38672ms step_avg:43.31ms
+step:894/1490 train_time:38731ms step_avg:43.32ms
+step:895/1490 train_time:38785ms step_avg:43.34ms
+step:896/1490 train_time:38846ms step_avg:43.35ms
+step:897/1490 train_time:38900ms step_avg:43.37ms
+step:898/1490 train_time:38960ms step_avg:43.39ms
+step:899/1490 train_time:39015ms step_avg:43.40ms
+step:900/1490 train_time:39075ms step_avg:43.42ms
+step:901/1490 train_time:39129ms step_avg:43.43ms
+step:902/1490 train_time:39189ms step_avg:43.45ms
+step:903/1490 train_time:39243ms step_avg:43.46ms
+step:904/1490 train_time:39302ms step_avg:43.48ms
+step:905/1490 train_time:39356ms step_avg:43.49ms
+step:906/1490 train_time:39417ms step_avg:43.51ms
+step:907/1490 train_time:39472ms step_avg:43.52ms
+step:908/1490 train_time:39532ms step_avg:43.54ms
+step:909/1490 train_time:39587ms step_avg:43.55ms
+step:910/1490 train_time:39646ms step_avg:43.57ms
+step:911/1490 train_time:39701ms step_avg:43.58ms
+step:912/1490 train_time:39760ms step_avg:43.60ms
+step:913/1490 train_time:39815ms step_avg:43.61ms
+step:914/1490 train_time:39875ms step_avg:43.63ms
+step:915/1490 train_time:39929ms step_avg:43.64ms
+step:916/1490 train_time:39989ms step_avg:43.66ms
+step:917/1490 train_time:40044ms step_avg:43.67ms
+step:918/1490 train_time:40104ms step_avg:43.69ms
+step:919/1490 train_time:40158ms step_avg:43.70ms
+step:920/1490 train_time:40218ms step_avg:43.71ms
+step:921/1490 train_time:40272ms step_avg:43.73ms
+step:922/1490 train_time:40332ms step_avg:43.74ms
+step:923/1490 train_time:40386ms step_avg:43.75ms
+step:924/1490 train_time:40446ms step_avg:43.77ms
+step:925/1490 train_time:40500ms step_avg:43.78ms
+step:926/1490 train_time:40560ms step_avg:43.80ms
+step:927/1490 train_time:40615ms step_avg:43.81ms
+step:928/1490 train_time:40675ms step_avg:43.83ms
+step:929/1490 train_time:40729ms step_avg:43.84ms
+step:930/1490 train_time:40789ms step_avg:43.86ms
+step:931/1490 train_time:40843ms step_avg:43.87ms
+step:932/1490 train_time:40904ms step_avg:43.89ms
+step:933/1490 train_time:40958ms step_avg:43.90ms
+step:934/1490 train_time:41017ms step_avg:43.92ms
+step:935/1490 train_time:41072ms step_avg:43.93ms
+step:936/1490 train_time:41132ms step_avg:43.94ms
+step:937/1490 train_time:41185ms step_avg:43.95ms
+step:938/1490 train_time:41246ms step_avg:43.97ms
+step:939/1490 train_time:41299ms step_avg:43.98ms
+step:940/1490 train_time:41359ms step_avg:44.00ms
+step:941/1490 train_time:41414ms step_avg:44.01ms
+step:942/1490 train_time:41473ms step_avg:44.03ms
+step:943/1490 train_time:41528ms step_avg:44.04ms
+step:944/1490 train_time:41588ms step_avg:44.05ms
+step:945/1490 train_time:41643ms step_avg:44.07ms
+step:946/1490 train_time:41702ms step_avg:44.08ms
+step:947/1490 train_time:41756ms step_avg:44.09ms
+step:948/1490 train_time:41817ms step_avg:44.11ms
+step:949/1490 train_time:41871ms step_avg:44.12ms
+step:950/1490 train_time:41931ms step_avg:44.14ms
+step:951/1490 train_time:41985ms step_avg:44.15ms
+step:952/1490 train_time:42045ms step_avg:44.16ms
+step:953/1490 train_time:42099ms step_avg:44.17ms
+step:954/1490 train_time:42158ms step_avg:44.19ms
+step:955/1490 train_time:42213ms step_avg:44.20ms
+step:956/1490 train_time:42272ms step_avg:44.22ms
+step:957/1490 train_time:42326ms step_avg:44.23ms
+step:958/1490 train_time:42387ms step_avg:44.25ms
+step:959/1490 train_time:42441ms step_avg:44.26ms
+step:960/1490 train_time:42501ms step_avg:44.27ms
+step:961/1490 train_time:42555ms step_avg:44.28ms
+step:962/1490 train_time:42615ms step_avg:44.30ms
+step:963/1490 train_time:42669ms step_avg:44.31ms
+step:964/1490 train_time:42730ms step_avg:44.33ms
+step:965/1490 train_time:42784ms step_avg:44.34ms
+step:966/1490 train_time:42843ms step_avg:44.35ms
+step:967/1490 train_time:42897ms step_avg:44.36ms
+step:968/1490 train_time:42961ms step_avg:44.38ms
+step:969/1490 train_time:43039ms step_avg:44.42ms
+step:970/1490 train_time:43126ms step_avg:44.46ms
+step:971/1490 train_time:43207ms step_avg:44.50ms
+step:972/1490 train_time:43293ms step_avg:44.54ms
+step:973/1490 train_time:43374ms step_avg:44.58ms
+step:974/1490 train_time:43460ms step_avg:44.62ms
+step:975/1490 train_time:43543ms step_avg:44.66ms
+step:976/1490 train_time:43629ms step_avg:44.70ms
+step:977/1490 train_time:43709ms step_avg:44.74ms
+step:978/1490 train_time:43796ms step_avg:44.78ms
+step:979/1490 train_time:43876ms step_avg:44.82ms
+step:980/1490 train_time:43962ms step_avg:44.86ms
+step:981/1490 train_time:44045ms step_avg:44.90ms
+step:982/1490 train_time:44132ms step_avg:44.94ms
+step:983/1490 train_time:44211ms step_avg:44.98ms
+step:984/1490 train_time:44297ms step_avg:45.02ms
+step:985/1490 train_time:44377ms step_avg:45.05ms
+step:986/1490 train_time:44464ms step_avg:45.10ms
+step:987/1490 train_time:44546ms step_avg:45.13ms
+step:988/1490 train_time:44632ms step_avg:45.17ms
+step:989/1490 train_time:44713ms step_avg:45.21ms
+step:990/1490 train_time:44799ms step_avg:45.25ms
+step:991/1490 train_time:44881ms step_avg:45.29ms
+step:992/1490 train_time:44967ms step_avg:45.33ms
+step:993/1490 train_time:45049ms step_avg:45.37ms
+step:994/1490 train_time:45136ms step_avg:45.41ms
+step:995/1490 train_time:45217ms step_avg:45.44ms
+step:996/1490 train_time:45303ms step_avg:45.48ms
+step:997/1490 train_time:45383ms step_avg:45.52ms
+step:998/1490 train_time:45468ms step_avg:45.56ms
+step:999/1490 train_time:45551ms step_avg:45.60ms
+step:1000/1490 train_time:45639ms step_avg:45.64ms
+step:1000/1490 val_loss:3.5174 train_time:45741ms step_avg:45.74ms
+step:1001/1490 train_time:45759ms step_avg:45.71ms
+step:1002/1490 train_time:45807ms step_avg:45.72ms
+step:1003/1490 train_time:45892ms step_avg:45.75ms
+step:1004/1490 train_time:45981ms step_avg:45.80ms
+step:1005/1490 train_time:46062ms step_avg:45.83ms
+step:1006/1490 train_time:46149ms step_avg:45.87ms
+step:1007/1490 train_time:46229ms step_avg:45.91ms
+step:1008/1490 train_time:46314ms step_avg:45.95ms
+step:1009/1490 train_time:46394ms step_avg:45.98ms
+step:1010/1490 train_time:46479ms step_avg:46.02ms
+step:1011/1490 train_time:46558ms step_avg:46.05ms
+step:1012/1490 train_time:46644ms step_avg:46.09ms
+step:1013/1490 train_time:46726ms step_avg:46.13ms
+step:1014/1490 train_time:46815ms step_avg:46.17ms
+step:1015/1490 train_time:46897ms step_avg:46.20ms
+step:1016/1490 train_time:46987ms step_avg:46.25ms
+step:1017/1490 train_time:47069ms step_avg:46.28ms
+step:1018/1490 train_time:47154ms step_avg:46.32ms
+step:1019/1490 train_time:47234ms step_avg:46.35ms
+step:1020/1490 train_time:47319ms step_avg:46.39ms
+step:1021/1490 train_time:47399ms step_avg:46.42ms
+step:1022/1490 train_time:47484ms step_avg:46.46ms
+step:1023/1490 train_time:47564ms step_avg:46.49ms
+step:1024/1490 train_time:47649ms step_avg:46.53ms
+step:1025/1490 train_time:47729ms step_avg:46.57ms
+step:1026/1490 train_time:47817ms step_avg:46.61ms
+step:1027/1490 train_time:47900ms step_avg:46.64ms
+step:1028/1490 train_time:47988ms step_avg:46.68ms
+step:1029/1490 train_time:48069ms step_avg:46.71ms
+step:1030/1490 train_time:48155ms step_avg:46.75ms
+step:1031/1490 train_time:48236ms step_avg:46.79ms
+step:1032/1490 train_time:48322ms step_avg:46.82ms
+step:1033/1490 train_time:48403ms step_avg:46.86ms
+step:1034/1490 train_time:48488ms step_avg:46.89ms
+step:1035/1490 train_time:48569ms step_avg:46.93ms
+step:1036/1490 train_time:48655ms step_avg:46.96ms
+step:1037/1490 train_time:48736ms step_avg:47.00ms
+step:1038/1490 train_time:48823ms step_avg:47.04ms
+step:1039/1490 train_time:48905ms step_avg:47.07ms
+step:1040/1490 train_time:48991ms step_avg:47.11ms
+step:1041/1490 train_time:49073ms step_avg:47.14ms
+step:1042/1490 train_time:49161ms step_avg:47.18ms
+step:1043/1490 train_time:49241ms step_avg:47.21ms
+step:1044/1490 train_time:49327ms step_avg:47.25ms
+step:1045/1490 train_time:49407ms step_avg:47.28ms
+step:1046/1490 train_time:49492ms step_avg:47.32ms
+step:1047/1490 train_time:49574ms step_avg:47.35ms
+step:1048/1490 train_time:49660ms step_avg:47.39ms
+step:1049/1490 train_time:49741ms step_avg:47.42ms
+step:1050/1490 train_time:49827ms step_avg:47.45ms
+step:1051/1490 train_time:49907ms step_avg:47.49ms
+step:1052/1490 train_time:49994ms step_avg:47.52ms
+step:1053/1490 train_time:50077ms step_avg:47.56ms
+step:1054/1490 train_time:50164ms step_avg:47.59ms
+step:1055/1490 train_time:50245ms step_avg:47.63ms
+step:1056/1490 train_time:50330ms step_avg:47.66ms
+step:1057/1490 train_time:50411ms step_avg:47.69ms
+step:1058/1490 train_time:50496ms step_avg:47.73ms
+step:1059/1490 train_time:50578ms step_avg:47.76ms
+step:1060/1490 train_time:50663ms step_avg:47.80ms
+step:1061/1490 train_time:50745ms step_avg:47.83ms
+step:1062/1490 train_time:50831ms step_avg:47.86ms
+step:1063/1490 train_time:50912ms step_avg:47.89ms
+step:1064/1490 train_time:50999ms step_avg:47.93ms
+step:1065/1490 train_time:51082ms step_avg:47.96ms
+step:1066/1490 train_time:51167ms step_avg:48.00ms
+step:1067/1490 train_time:51250ms step_avg:48.03ms
+step:1068/1490 train_time:51336ms step_avg:48.07ms
+step:1069/1490 train_time:51416ms step_avg:48.10ms
+step:1070/1490 train_time:51501ms step_avg:48.13ms
+step:1071/1490 train_time:51584ms step_avg:48.16ms
+step:1072/1490 train_time:51669ms step_avg:48.20ms
+step:1073/1490 train_time:51750ms step_avg:48.23ms
+step:1074/1490 train_time:51837ms step_avg:48.27ms
+step:1075/1490 train_time:51918ms step_avg:48.30ms
+step:1076/1490 train_time:52005ms step_avg:48.33ms
+step:1077/1490 train_time:52087ms step_avg:48.36ms
+step:1078/1490 train_time:52174ms step_avg:48.40ms
+step:1079/1490 train_time:52254ms step_avg:48.43ms
+step:1080/1490 train_time:52341ms step_avg:48.46ms
+step:1081/1490 train_time:52420ms step_avg:48.49ms
+step:1082/1490 train_time:52504ms step_avg:48.53ms
+step:1083/1490 train_time:52585ms step_avg:48.55ms
+step:1084/1490 train_time:52672ms step_avg:48.59ms
+step:1085/1490 train_time:52753ms step_avg:48.62ms
+step:1086/1490 train_time:52840ms step_avg:48.66ms
+step:1087/1490 train_time:52921ms step_avg:48.69ms
+step:1088/1490 train_time:53006ms step_avg:48.72ms
+step:1089/1490 train_time:53088ms step_avg:48.75ms
+step:1090/1490 train_time:53175ms step_avg:48.78ms
+step:1091/1490 train_time:53256ms step_avg:48.81ms
+step:1092/1490 train_time:53343ms step_avg:48.85ms
+step:1093/1490 train_time:53423ms step_avg:48.88ms
+step:1094/1490 train_time:53508ms step_avg:48.91ms
+step:1095/1490 train_time:53590ms step_avg:48.94ms
+step:1096/1490 train_time:53676ms step_avg:48.97ms
+step:1097/1490 train_time:53758ms step_avg:49.00ms
+step:1098/1490 train_time:53844ms step_avg:49.04ms
+step:1099/1490 train_time:53924ms step_avg:49.07ms
+step:1100/1490 train_time:54011ms step_avg:49.10ms
+step:1101/1490 train_time:54094ms step_avg:49.13ms
+step:1102/1490 train_time:54181ms step_avg:49.17ms
+step:1103/1490 train_time:54262ms step_avg:49.19ms
+step:1104/1490 train_time:54347ms step_avg:49.23ms
+step:1105/1490 train_time:54428ms step_avg:49.26ms
+step:1106/1490 train_time:54513ms step_avg:49.29ms
+step:1107/1490 train_time:54595ms step_avg:49.32ms
+step:1108/1490 train_time:54683ms step_avg:49.35ms
+step:1109/1490 train_time:54764ms step_avg:49.38ms
+step:1110/1490 train_time:54851ms step_avg:49.42ms
+step:1111/1490 train_time:54931ms step_avg:49.44ms
+step:1112/1490 train_time:55017ms step_avg:49.48ms
+step:1113/1490 train_time:55100ms step_avg:49.51ms
+step:1114/1490 train_time:55186ms step_avg:49.54ms
+step:1115/1490 train_time:55267ms step_avg:49.57ms
+step:1116/1490 train_time:55353ms step_avg:49.60ms
+step:1117/1490 train_time:55433ms step_avg:49.63ms
+step:1118/1490 train_time:55518ms step_avg:49.66ms
+step:1119/1490 train_time:55599ms step_avg:49.69ms
+step:1120/1490 train_time:55685ms step_avg:49.72ms
+step:1121/1490 train_time:55766ms step_avg:49.75ms
+step:1122/1490 train_time:55852ms step_avg:49.78ms
+step:1123/1490 train_time:55934ms step_avg:49.81ms
+step:1124/1490 train_time:56020ms step_avg:49.84ms
+step:1125/1490 train_time:56100ms step_avg:49.87ms
+step:1126/1490 train_time:56188ms step_avg:49.90ms
+step:1127/1490 train_time:56269ms step_avg:49.93ms
+step:1128/1490 train_time:56355ms step_avg:49.96ms
+step:1129/1490 train_time:56436ms step_avg:49.99ms
+step:1130/1490 train_time:56521ms step_avg:50.02ms
+step:1131/1490 train_time:56603ms step_avg:50.05ms
+step:1132/1490 train_time:56689ms step_avg:50.08ms
+step:1133/1490 train_time:56770ms step_avg:50.11ms
+step:1134/1490 train_time:56857ms step_avg:50.14ms
+step:1135/1490 train_time:56938ms step_avg:50.17ms
+step:1136/1490 train_time:57024ms step_avg:50.20ms
+step:1137/1490 train_time:57104ms step_avg:50.22ms
+step:1138/1490 train_time:57191ms step_avg:50.26ms
+step:1139/1490 train_time:57272ms step_avg:50.28ms
+step:1140/1490 train_time:57358ms step_avg:50.31ms
+step:1141/1490 train_time:57438ms step_avg:50.34ms
+step:1142/1490 train_time:57523ms step_avg:50.37ms
+step:1143/1490 train_time:57605ms step_avg:50.40ms
+step:1144/1490 train_time:57691ms step_avg:50.43ms
+step:1145/1490 train_time:57773ms step_avg:50.46ms
+step:1146/1490 train_time:57860ms step_avg:50.49ms
+step:1147/1490 train_time:57941ms step_avg:50.52ms
+step:1148/1490 train_time:58027ms step_avg:50.55ms
+step:1149/1490 train_time:58108ms step_avg:50.57ms
+step:1150/1490 train_time:58195ms step_avg:50.60ms
+step:1151/1490 train_time:58276ms step_avg:50.63ms
+step:1152/1490 train_time:58363ms step_avg:50.66ms
+step:1153/1490 train_time:58444ms step_avg:50.69ms
+step:1154/1490 train_time:58530ms step_avg:50.72ms
+step:1155/1490 train_time:58611ms step_avg:50.75ms
+step:1156/1490 train_time:58697ms step_avg:50.78ms
+step:1157/1490 train_time:58777ms step_avg:50.80ms
+step:1158/1490 train_time:58863ms step_avg:50.83ms
+step:1159/1490 train_time:58945ms step_avg:50.86ms
+step:1160/1490 train_time:59030ms step_avg:50.89ms
+step:1161/1490 train_time:59111ms step_avg:50.91ms
+step:1162/1490 train_time:59198ms step_avg:50.94ms
+step:1163/1490 train_time:59279ms step_avg:50.97ms
+step:1164/1490 train_time:59366ms step_avg:51.00ms
+step:1165/1490 train_time:59449ms step_avg:51.03ms
+step:1166/1490 train_time:59536ms step_avg:51.06ms
+step:1167/1490 train_time:59618ms step_avg:51.09ms
+step:1168/1490 train_time:59705ms step_avg:51.12ms
+step:1169/1490 train_time:59785ms step_avg:51.14ms
+step:1170/1490 train_time:59871ms step_avg:51.17ms
+step:1171/1490 train_time:59954ms step_avg:51.20ms
+step:1172/1490 train_time:60040ms step_avg:51.23ms
+step:1173/1490 train_time:60121ms step_avg:51.25ms
+step:1174/1490 train_time:60207ms step_avg:51.28ms
+step:1175/1490 train_time:60289ms step_avg:51.31ms
+step:1176/1490 train_time:60376ms step_avg:51.34ms
+step:1177/1490 train_time:60457ms step_avg:51.37ms
+step:1178/1490 train_time:60544ms step_avg:51.40ms
+step:1179/1490 train_time:60623ms step_avg:51.42ms
+step:1180/1490 train_time:60711ms step_avg:51.45ms
+step:1181/1490 train_time:60791ms step_avg:51.47ms
+step:1182/1490 train_time:60877ms step_avg:51.50ms
+step:1183/1490 train_time:60959ms step_avg:51.53ms
+step:1184/1490 train_time:61046ms step_avg:51.56ms
+step:1185/1490 train_time:61125ms step_avg:51.58ms
+step:1186/1490 train_time:61212ms step_avg:51.61ms
+step:1187/1490 train_time:61295ms step_avg:51.64ms
+step:1188/1490 train_time:61381ms step_avg:51.67ms
+step:1189/1490 train_time:61464ms step_avg:51.69ms
+step:1190/1490 train_time:61550ms step_avg:51.72ms
+step:1191/1490 train_time:61631ms step_avg:51.75ms
+step:1192/1490 train_time:61716ms step_avg:51.78ms
+step:1193/1490 train_time:61797ms step_avg:51.80ms
+step:1194/1490 train_time:61883ms step_avg:51.83ms
+step:1195/1490 train_time:61964ms step_avg:51.85ms
+step:1196/1490 train_time:62051ms step_avg:51.88ms
+step:1197/1490 train_time:62134ms step_avg:51.91ms
+step:1198/1490 train_time:62219ms step_avg:51.94ms
+step:1199/1490 train_time:62300ms step_avg:51.96ms
+step:1200/1490 train_time:62388ms step_avg:51.99ms
+step:1201/1490 train_time:62469ms step_avg:52.01ms
+step:1202/1490 train_time:62556ms step_avg:52.04ms
+step:1203/1490 train_time:62636ms step_avg:52.07ms
+step:1204/1490 train_time:62724ms step_avg:52.10ms
+step:1205/1490 train_time:62805ms step_avg:52.12ms
+step:1206/1490 train_time:62891ms step_avg:52.15ms
+step:1207/1490 train_time:62972ms step_avg:52.17ms
+step:1208/1490 train_time:63060ms step_avg:52.20ms
+step:1209/1490 train_time:63141ms step_avg:52.23ms
+step:1210/1490 train_time:63227ms step_avg:52.25ms
+step:1211/1490 train_time:63309ms step_avg:52.28ms
+step:1212/1490 train_time:63394ms step_avg:52.31ms
+step:1213/1490 train_time:63476ms step_avg:52.33ms
+step:1214/1490 train_time:63562ms step_avg:52.36ms
+step:1215/1490 train_time:63642ms step_avg:52.38ms
+step:1216/1490 train_time:63728ms step_avg:52.41ms
+step:1217/1490 train_time:63809ms step_avg:52.43ms
+step:1218/1490 train_time:63895ms step_avg:52.46ms
+step:1219/1490 train_time:63977ms step_avg:52.48ms
+step:1220/1490 train_time:64063ms step_avg:52.51ms
+step:1221/1490 train_time:64144ms step_avg:52.53ms
+step:1222/1490 train_time:64230ms step_avg:52.56ms
+step:1223/1490 train_time:64312ms step_avg:52.59ms
+step:1224/1490 train_time:64399ms step_avg:52.61ms
+step:1225/1490 train_time:64479ms step_avg:52.64ms
+step:1226/1490 train_time:64565ms step_avg:52.66ms
+step:1227/1490 train_time:64645ms step_avg:52.69ms
+step:1228/1490 train_time:64730ms step_avg:52.71ms
+step:1229/1490 train_time:64812ms step_avg:52.74ms
+step:1230/1490 train_time:64897ms step_avg:52.76ms
+step:1231/1490 train_time:64978ms step_avg:52.78ms
+step:1232/1490 train_time:65065ms step_avg:52.81ms
+step:1233/1490 train_time:65145ms step_avg:52.83ms
+step:1234/1490 train_time:65231ms step_avg:52.86ms
+step:1235/1490 train_time:65311ms step_avg:52.88ms
+step:1236/1490 train_time:65398ms step_avg:52.91ms
+step:1237/1490 train_time:65480ms step_avg:52.93ms
+step:1238/1490 train_time:65566ms step_avg:52.96ms
+step:1239/1490 train_time:65646ms step_avg:52.98ms
+step:1240/1490 train_time:65732ms step_avg:53.01ms
+step:1241/1490 train_time:65813ms step_avg:53.03ms
+step:1242/1490 train_time:65900ms step_avg:53.06ms
+step:1243/1490 train_time:65982ms step_avg:53.08ms
+step:1244/1490 train_time:66069ms step_avg:53.11ms
+step:1245/1490 train_time:66149ms step_avg:53.13ms
+step:1246/1490 train_time:66236ms step_avg:53.16ms
+step:1247/1490 train_time:66316ms step_avg:53.18ms
+step:1248/1490 train_time:66404ms step_avg:53.21ms
+step:1249/1490 train_time:66484ms step_avg:53.23ms
+step:1250/1490 train_time:66571ms step_avg:53.26ms
+step:1250/1490 val_loss:3.3716 train_time:66674ms step_avg:53.34ms
+step:1251/1490 train_time:66691ms step_avg:53.31ms
+step:1252/1490 train_time:66742ms step_avg:53.31ms
+step:1253/1490 train_time:66827ms step_avg:53.33ms
+step:1254/1490 train_time:66915ms step_avg:53.36ms
+step:1255/1490 train_time:66995ms step_avg:53.38ms
+step:1256/1490 train_time:67081ms step_avg:53.41ms
+step:1257/1490 train_time:67162ms step_avg:53.43ms
+step:1258/1490 train_time:67247ms step_avg:53.46ms
+step:1259/1490 train_time:67325ms step_avg:53.48ms
+step:1260/1490 train_time:67410ms step_avg:53.50ms
+step:1261/1490 train_time:67490ms step_avg:53.52ms
+step:1262/1490 train_time:67576ms step_avg:53.55ms
+step:1263/1490 train_time:67659ms step_avg:53.57ms
+step:1264/1490 train_time:67748ms step_avg:53.60ms
+step:1265/1490 train_time:67830ms step_avg:53.62ms
+step:1266/1490 train_time:67917ms step_avg:53.65ms
+step:1267/1490 train_time:68000ms step_avg:53.67ms
+step:1268/1490 train_time:68086ms step_avg:53.70ms
+step:1269/1490 train_time:68167ms step_avg:53.72ms
+step:1270/1490 train_time:68253ms step_avg:53.74ms
+step:1271/1490 train_time:68332ms step_avg:53.76ms
+step:1272/1490 train_time:68416ms step_avg:53.79ms
+step:1273/1490 train_time:68496ms step_avg:53.81ms
+step:1274/1490 train_time:68582ms step_avg:53.83ms
+step:1275/1490 train_time:68665ms step_avg:53.86ms
+step:1276/1490 train_time:68754ms step_avg:53.88ms
+step:1277/1490 train_time:68835ms step_avg:53.90ms
+step:1278/1490 train_time:68921ms step_avg:53.93ms
+step:1279/1490 train_time:69003ms step_avg:53.95ms
+step:1280/1490 train_time:69090ms step_avg:53.98ms
+step:1281/1490 train_time:69172ms step_avg:54.00ms
+step:1282/1490 train_time:69258ms step_avg:54.02ms
+step:1283/1490 train_time:69338ms step_avg:54.04ms
+step:1284/1490 train_time:69423ms step_avg:54.07ms
+step:1285/1490 train_time:69502ms step_avg:54.09ms
+step:1286/1490 train_time:69589ms step_avg:54.11ms
+step:1287/1490 train_time:69672ms step_avg:54.14ms
+step:1288/1490 train_time:69761ms step_avg:54.16ms
+step:1289/1490 train_time:69844ms step_avg:54.18ms
+step:1290/1490 train_time:69929ms step_avg:54.21ms
+step:1291/1490 train_time:70010ms step_avg:54.23ms
+step:1292/1490 train_time:70098ms step_avg:54.26ms
+step:1293/1490 train_time:70180ms step_avg:54.28ms
+step:1294/1490 train_time:70266ms step_avg:54.30ms
+step:1295/1490 train_time:70346ms step_avg:54.32ms
+step:1296/1490 train_time:70431ms step_avg:54.34ms
+step:1297/1490 train_time:70511ms step_avg:54.36ms
+step:1298/1490 train_time:70599ms step_avg:54.39ms
+step:1299/1490 train_time:70681ms step_avg:54.41ms
+step:1300/1490 train_time:70767ms step_avg:54.44ms
+step:1301/1490 train_time:70850ms step_avg:54.46ms
+step:1302/1490 train_time:70936ms step_avg:54.48ms
+step:1303/1490 train_time:71017ms step_avg:54.50ms
+step:1304/1490 train_time:71103ms step_avg:54.53ms
+step:1305/1490 train_time:71183ms step_avg:54.55ms
+step:1306/1490 train_time:71269ms step_avg:54.57ms
+step:1307/1490 train_time:71352ms step_avg:54.59ms
+step:1308/1490 train_time:71437ms step_avg:54.62ms
+step:1309/1490 train_time:71518ms step_avg:54.64ms
+step:1310/1490 train_time:71605ms step_avg:54.66ms
+step:1311/1490 train_time:71687ms step_avg:54.68ms
+step:1312/1490 train_time:71775ms step_avg:54.71ms
+step:1313/1490 train_time:71855ms step_avg:54.73ms
+step:1314/1490 train_time:71941ms step_avg:54.75ms
+step:1315/1490 train_time:72023ms step_avg:54.77ms
+step:1316/1490 train_time:72112ms step_avg:54.80ms
+step:1317/1490 train_time:72192ms step_avg:54.82ms
+step:1318/1490 train_time:72278ms step_avg:54.84ms
+step:1319/1490 train_time:72360ms step_avg:54.86ms
+step:1320/1490 train_time:72446ms step_avg:54.88ms
+step:1321/1490 train_time:72526ms step_avg:54.90ms
+step:1322/1490 train_time:72613ms step_avg:54.93ms
+step:1323/1490 train_time:72694ms step_avg:54.95ms
+step:1324/1490 train_time:72782ms step_avg:54.97ms
+step:1325/1490 train_time:72863ms step_avg:54.99ms
+step:1326/1490 train_time:72950ms step_avg:55.02ms
+step:1327/1490 train_time:73031ms step_avg:55.03ms
+step:1328/1490 train_time:73118ms step_avg:55.06ms
+step:1329/1490 train_time:73199ms step_avg:55.08ms
+step:1330/1490 train_time:73286ms step_avg:55.10ms
+step:1331/1490 train_time:73366ms step_avg:55.12ms
+step:1332/1490 train_time:73452ms step_avg:55.14ms
+step:1333/1490 train_time:73533ms step_avg:55.16ms
+step:1334/1490 train_time:73618ms step_avg:55.19ms
+step:1335/1490 train_time:73701ms step_avg:55.21ms
+step:1336/1490 train_time:73787ms step_avg:55.23ms
+step:1337/1490 train_time:73868ms step_avg:55.25ms
+step:1338/1490 train_time:73956ms step_avg:55.27ms
+step:1339/1490 train_time:74036ms step_avg:55.29ms
+step:1340/1490 train_time:74121ms step_avg:55.31ms
+step:1341/1490 train_time:74202ms step_avg:55.33ms
+step:1342/1490 train_time:74290ms step_avg:55.36ms
+step:1343/1490 train_time:74370ms step_avg:55.38ms
+step:1344/1490 train_time:74456ms step_avg:55.40ms
+step:1345/1490 train_time:74537ms step_avg:55.42ms
+step:1346/1490 train_time:74623ms step_avg:55.44ms
+step:1347/1490 train_time:74704ms step_avg:55.46ms
+step:1348/1490 train_time:74793ms step_avg:55.48ms
+step:1349/1490 train_time:74874ms step_avg:55.50ms
+step:1350/1490 train_time:74960ms step_avg:55.53ms
+step:1351/1490 train_time:75041ms step_avg:55.54ms
+step:1352/1490 train_time:75127ms step_avg:55.57ms
+step:1353/1490 train_time:75207ms step_avg:55.59ms
+step:1354/1490 train_time:75295ms step_avg:55.61ms
+step:1355/1490 train_time:75376ms step_avg:55.63ms
+step:1356/1490 train_time:75462ms step_avg:55.65ms
+step:1357/1490 train_time:75543ms step_avg:55.67ms
+step:1358/1490 train_time:75628ms step_avg:55.69ms
+step:1359/1490 train_time:75708ms step_avg:55.71ms
+step:1360/1490 train_time:75795ms step_avg:55.73ms
+step:1361/1490 train_time:75876ms step_avg:55.75ms
+step:1362/1490 train_time:75962ms step_avg:55.77ms
+step:1363/1490 train_time:76045ms step_avg:55.79ms
+step:1364/1490 train_time:76131ms step_avg:55.81ms
+step:1365/1490 train_time:76212ms step_avg:55.83ms
+step:1366/1490 train_time:76298ms step_avg:55.86ms
+step:1367/1490 train_time:76380ms step_avg:55.87ms
+step:1368/1490 train_time:76466ms step_avg:55.90ms
+step:1369/1490 train_time:76548ms step_avg:55.92ms
+step:1370/1490 train_time:76635ms step_avg:55.94ms
+step:1371/1490 train_time:76715ms step_avg:55.96ms
+step:1372/1490 train_time:76802ms step_avg:55.98ms
+step:1373/1490 train_time:76883ms step_avg:56.00ms
+step:1374/1490 train_time:76969ms step_avg:56.02ms
+step:1375/1490 train_time:77050ms step_avg:56.04ms
+step:1376/1490 train_time:77136ms step_avg:56.06ms
+step:1377/1490 train_time:77217ms step_avg:56.08ms
+step:1378/1490 train_time:77303ms step_avg:56.10ms
+step:1379/1490 train_time:77384ms step_avg:56.12ms
+step:1380/1490 train_time:77472ms step_avg:56.14ms
+step:1381/1490 train_time:77554ms step_avg:56.16ms
+step:1382/1490 train_time:77639ms step_avg:56.18ms
+step:1383/1490 train_time:77720ms step_avg:56.20ms
+step:1384/1490 train_time:77807ms step_avg:56.22ms
+step:1385/1490 train_time:77888ms step_avg:56.24ms
+step:1386/1490 train_time:77975ms step_avg:56.26ms
+step:1387/1490 train_time:78056ms step_avg:56.28ms
+step:1388/1490 train_time:78143ms step_avg:56.30ms
+step:1389/1490 train_time:78225ms step_avg:56.32ms
+step:1390/1490 train_time:78312ms step_avg:56.34ms
+step:1391/1490 train_time:78393ms step_avg:56.36ms
+step:1392/1490 train_time:78481ms step_avg:56.38ms
+step:1393/1490 train_time:78563ms step_avg:56.40ms
+step:1394/1490 train_time:78650ms step_avg:56.42ms
+step:1395/1490 train_time:78731ms step_avg:56.44ms
+step:1396/1490 train_time:78817ms step_avg:56.46ms
+step:1397/1490 train_time:78898ms step_avg:56.48ms
+step:1398/1490 train_time:78984ms step_avg:56.50ms
+step:1399/1490 train_time:79065ms step_avg:56.52ms
+step:1400/1490 train_time:79152ms step_avg:56.54ms
+step:1401/1490 train_time:79232ms step_avg:56.55ms
+step:1402/1490 train_time:79318ms step_avg:56.58ms
+step:1403/1490 train_time:79400ms step_avg:56.59ms
+step:1404/1490 train_time:79488ms step_avg:56.62ms
+step:1405/1490 train_time:79568ms step_avg:56.63ms
+step:1406/1490 train_time:79655ms step_avg:56.65ms
+step:1407/1490 train_time:79736ms step_avg:56.67ms
+step:1408/1490 train_time:79822ms step_avg:56.69ms
+step:1409/1490 train_time:79905ms step_avg:56.71ms
+step:1410/1490 train_time:79992ms step_avg:56.73ms
+step:1411/1490 train_time:80073ms step_avg:56.75ms
+step:1412/1490 train_time:80159ms step_avg:56.77ms
+step:1413/1490 train_time:80239ms step_avg:56.79ms
+step:1414/1490 train_time:80325ms step_avg:56.81ms
+step:1415/1490 train_time:80406ms step_avg:56.82ms
+step:1416/1490 train_time:80493ms step_avg:56.85ms
+step:1417/1490 train_time:80573ms step_avg:56.86ms
+step:1418/1490 train_time:80659ms step_avg:56.88ms
+step:1419/1490 train_time:80741ms step_avg:56.90ms
+step:1420/1490 train_time:80827ms step_avg:56.92ms
+step:1421/1490 train_time:80907ms step_avg:56.94ms
+step:1422/1490 train_time:80994ms step_avg:56.96ms
+step:1423/1490 train_time:81076ms step_avg:56.98ms
+step:1424/1490 train_time:81162ms step_avg:57.00ms
+step:1425/1490 train_time:81245ms step_avg:57.01ms
+step:1426/1490 train_time:81330ms step_avg:57.03ms
+step:1427/1490 train_time:81411ms step_avg:57.05ms
+step:1428/1490 train_time:81498ms step_avg:57.07ms
+step:1429/1490 train_time:81578ms step_avg:57.09ms
+step:1430/1490 train_time:81665ms step_avg:57.11ms
+step:1431/1490 train_time:81747ms step_avg:57.13ms
+step:1432/1490 train_time:81834ms step_avg:57.15ms
+step:1433/1490 train_time:81916ms step_avg:57.16ms
+step:1434/1490 train_time:82003ms step_avg:57.18ms
+step:1435/1490 train_time:82084ms step_avg:57.20ms
+step:1436/1490 train_time:82172ms step_avg:57.22ms
+step:1437/1490 train_time:82253ms step_avg:57.24ms
+step:1438/1490 train_time:82339ms step_avg:57.26ms
+step:1439/1490 train_time:82420ms step_avg:57.28ms
+step:1440/1490 train_time:82506ms step_avg:57.30ms
+step:1441/1490 train_time:82589ms step_avg:57.31ms
+step:1442/1490 train_time:82675ms step_avg:57.33ms
+step:1443/1490 train_time:82756ms step_avg:57.35ms
+step:1444/1490 train_time:82842ms step_avg:57.37ms
+step:1445/1490 train_time:82923ms step_avg:57.39ms
+step:1446/1490 train_time:83011ms step_avg:57.41ms
+step:1447/1490 train_time:83092ms step_avg:57.42ms
+step:1448/1490 train_time:83179ms step_avg:57.44ms
+step:1449/1490 train_time:83261ms step_avg:57.46ms
+step:1450/1490 train_time:83347ms step_avg:57.48ms
+step:1451/1490 train_time:83431ms step_avg:57.50ms
+step:1452/1490 train_time:83520ms step_avg:57.52ms
+step:1453/1490 train_time:83601ms step_avg:57.54ms
+step:1454/1490 train_time:83688ms step_avg:57.56ms
+step:1455/1490 train_time:83770ms step_avg:57.57ms
+step:1456/1490 train_time:83858ms step_avg:57.59ms
+step:1457/1490 train_time:83938ms step_avg:57.61ms
+step:1458/1490 train_time:84025ms step_avg:57.63ms
+step:1459/1490 train_time:84106ms step_avg:57.65ms
+step:1460/1490 train_time:84196ms step_avg:57.67ms
+step:1461/1490 train_time:84277ms step_avg:57.68ms
+step:1462/1490 train_time:84363ms step_avg:57.70ms
+step:1463/1490 train_time:84444ms step_avg:57.72ms
+step:1464/1490 train_time:84531ms step_avg:57.74ms
+step:1465/1490 train_time:84613ms step_avg:57.76ms
+step:1466/1490 train_time:84700ms step_avg:57.78ms
+step:1467/1490 train_time:84782ms step_avg:57.79ms
+step:1468/1490 train_time:84868ms step_avg:57.81ms
+step:1469/1490 train_time:84949ms step_avg:57.83ms
+step:1470/1490 train_time:85035ms step_avg:57.85ms
+step:1471/1490 train_time:85116ms step_avg:57.86ms
+step:1472/1490 train_time:85204ms step_avg:57.88ms
+step:1473/1490 train_time:85285ms step_avg:57.90ms
+step:1474/1490 train_time:85370ms step_avg:57.92ms
+step:1475/1490 train_time:85453ms step_avg:57.93ms
+step:1476/1490 train_time:85539ms step_avg:57.95ms
+step:1477/1490 train_time:85620ms step_avg:57.97ms
+step:1478/1490 train_time:85708ms step_avg:57.99ms
+step:1479/1490 train_time:85788ms step_avg:58.00ms
+step:1480/1490 train_time:85875ms step_avg:58.02ms
+step:1481/1490 train_time:85957ms step_avg:58.04ms
+step:1482/1490 train_time:86043ms step_avg:58.06ms
+step:1483/1490 train_time:86125ms step_avg:58.07ms
+step:1484/1490 train_time:86211ms step_avg:58.09ms
+step:1485/1490 train_time:86294ms step_avg:58.11ms
+step:1486/1490 train_time:86381ms step_avg:58.13ms
+step:1487/1490 train_time:86462ms step_avg:58.15ms
+step:1488/1490 train_time:86549ms step_avg:58.16ms
+step:1489/1490 train_time:86630ms step_avg:58.18ms
+step:1490/1490 train_time:86716ms step_avg:58.20ms
+step:1490/1490 val_loss:3.2781 train_time:86821ms step_avg:58.27ms
+peak memory allocated: 31296 MiB reserved: 47022 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/baseline/2026-03-22_19-55-03_time-186_secs_baseline_9b69dd.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/baseline/2026-03-22_19-55-03_time-186_secs_baseline_9b69dd.txt
@@ -1,0 +1,4456 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 19:55:18 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   32C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   31C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   29C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   31C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   31C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   29C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   31C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   28C    P0            114W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1767108      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1767109      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1767110      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1767111      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1767112      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1767113      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1767114      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1767115      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8315 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:73ms step_avg:73.31ms
+step:2/1490 train_time:102ms step_avg:51.10ms
+step:3/1490 train_time:119ms step_avg:39.67ms
+step:4/1490 train_time:146ms step_avg:36.38ms
+step:5/1490 train_time:172ms step_avg:34.45ms
+step:6/1490 train_time:207ms step_avg:34.54ms
+step:7/1490 train_time:235ms step_avg:33.50ms
+step:8/1490 train_time:269ms step_avg:33.62ms
+step:9/1490 train_time:296ms step_avg:32.94ms
+step:10/1490 train_time:331ms step_avg:33.07ms
+step:11/1490 train_time:359ms step_avg:32.63ms
+step:12/1490 train_time:393ms step_avg:32.78ms
+step:13/1490 train_time:422ms step_avg:32.45ms
+step:14/1490 train_time:456ms step_avg:32.58ms
+step:15/1490 train_time:484ms step_avg:32.28ms
+step:16/1490 train_time:518ms step_avg:32.40ms
+step:17/1490 train_time:547ms step_avg:32.17ms
+step:18/1490 train_time:581ms step_avg:32.26ms
+step:19/1490 train_time:609ms step_avg:32.07ms
+step:20/1490 train_time:644ms step_avg:32.19ms
+step:21/1490 train_time:672ms step_avg:32.01ms
+step:22/1490 train_time:707ms step_avg:32.13ms
+step:23/1490 train_time:735ms step_avg:31.95ms
+step:24/1490 train_time:769ms step_avg:32.06ms
+step:25/1490 train_time:797ms step_avg:31.90ms
+step:26/1490 train_time:832ms step_avg:32.00ms
+step:27/1490 train_time:860ms step_avg:31.87ms
+step:28/1490 train_time:895ms step_avg:31.96ms
+step:29/1490 train_time:923ms step_avg:31.83ms
+step:30/1490 train_time:957ms step_avg:31.92ms
+step:31/1490 train_time:986ms step_avg:31.81ms
+step:32/1490 train_time:1021ms step_avg:31.91ms
+step:33/1490 train_time:1051ms step_avg:31.84ms
+step:34/1490 train_time:1086ms step_avg:31.94ms
+step:35/1490 train_time:1115ms step_avg:31.85ms
+step:36/1490 train_time:1150ms step_avg:31.94ms
+step:37/1490 train_time:1179ms step_avg:31.85ms
+step:38/1490 train_time:1213ms step_avg:31.93ms
+step:39/1490 train_time:1242ms step_avg:31.84ms
+step:40/1490 train_time:1276ms step_avg:31.90ms
+step:41/1490 train_time:1305ms step_avg:31.82ms
+step:42/1490 train_time:1339ms step_avg:31.88ms
+step:43/1490 train_time:1367ms step_avg:31.80ms
+step:44/1490 train_time:1402ms step_avg:31.86ms
+step:45/1490 train_time:1431ms step_avg:31.79ms
+step:46/1490 train_time:1466ms step_avg:31.86ms
+step:47/1490 train_time:1494ms step_avg:31.78ms
+step:48/1490 train_time:1528ms step_avg:31.84ms
+step:49/1490 train_time:1557ms step_avg:31.77ms
+step:50/1490 train_time:1591ms step_avg:31.82ms
+step:51/1490 train_time:1619ms step_avg:31.75ms
+step:52/1490 train_time:1654ms step_avg:31.80ms
+step:53/1490 train_time:1682ms step_avg:31.73ms
+step:54/1490 train_time:1716ms step_avg:31.78ms
+step:55/1490 train_time:1744ms step_avg:31.72ms
+step:56/1490 train_time:1778ms step_avg:31.76ms
+step:57/1490 train_time:1807ms step_avg:31.70ms
+step:58/1490 train_time:1841ms step_avg:31.75ms
+step:59/1490 train_time:1870ms step_avg:31.69ms
+step:60/1490 train_time:1904ms step_avg:31.74ms
+step:61/1490 train_time:1933ms step_avg:31.68ms
+step:62/1490 train_time:1968ms step_avg:31.74ms
+step:63/1490 train_time:1996ms step_avg:31.68ms
+step:64/1490 train_time:2031ms step_avg:31.73ms
+step:65/1490 train_time:2059ms step_avg:31.68ms
+step:66/1490 train_time:2094ms step_avg:31.72ms
+step:67/1490 train_time:2123ms step_avg:31.68ms
+step:68/1490 train_time:2157ms step_avg:31.72ms
+step:69/1490 train_time:2186ms step_avg:31.68ms
+step:70/1490 train_time:2220ms step_avg:31.71ms
+step:71/1490 train_time:2249ms step_avg:31.67ms
+step:72/1490 train_time:2283ms step_avg:31.71ms
+step:73/1490 train_time:2312ms step_avg:31.67ms
+step:74/1490 train_time:2346ms step_avg:31.71ms
+step:75/1490 train_time:2375ms step_avg:31.66ms
+step:76/1490 train_time:2409ms step_avg:31.70ms
+step:77/1490 train_time:2437ms step_avg:31.65ms
+step:78/1490 train_time:2472ms step_avg:31.69ms
+step:79/1490 train_time:2500ms step_avg:31.65ms
+step:80/1490 train_time:2535ms step_avg:31.68ms
+step:81/1490 train_time:2563ms step_avg:31.65ms
+step:82/1490 train_time:2598ms step_avg:31.68ms
+step:83/1490 train_time:2626ms step_avg:31.64ms
+step:84/1490 train_time:2660ms step_avg:31.67ms
+step:85/1490 train_time:2689ms step_avg:31.64ms
+step:86/1490 train_time:2724ms step_avg:31.67ms
+step:87/1490 train_time:2752ms step_avg:31.63ms
+step:88/1490 train_time:2787ms step_avg:31.67ms
+step:89/1490 train_time:2815ms step_avg:31.63ms
+step:90/1490 train_time:2850ms step_avg:31.67ms
+step:91/1490 train_time:2878ms step_avg:31.63ms
+step:92/1490 train_time:2913ms step_avg:31.66ms
+step:93/1490 train_time:2942ms step_avg:31.63ms
+step:94/1490 train_time:2976ms step_avg:31.66ms
+step:95/1490 train_time:3005ms step_avg:31.63ms
+step:96/1490 train_time:3039ms step_avg:31.66ms
+step:97/1490 train_time:3068ms step_avg:31.62ms
+step:98/1490 train_time:3102ms step_avg:31.65ms
+step:99/1490 train_time:3130ms step_avg:31.62ms
+step:100/1490 train_time:3165ms step_avg:31.65ms
+step:101/1490 train_time:3193ms step_avg:31.61ms
+step:102/1490 train_time:3228ms step_avg:31.65ms
+step:103/1490 train_time:3257ms step_avg:31.62ms
+step:104/1490 train_time:3291ms step_avg:31.65ms
+step:105/1490 train_time:3320ms step_avg:31.62ms
+step:106/1490 train_time:3354ms step_avg:31.64ms
+step:107/1490 train_time:3382ms step_avg:31.61ms
+step:108/1490 train_time:3417ms step_avg:31.63ms
+step:109/1490 train_time:3445ms step_avg:31.61ms
+step:110/1490 train_time:3480ms step_avg:31.64ms
+step:111/1490 train_time:3508ms step_avg:31.61ms
+step:112/1490 train_time:3543ms step_avg:31.63ms
+step:113/1490 train_time:3571ms step_avg:31.60ms
+step:114/1490 train_time:3605ms step_avg:31.63ms
+step:115/1490 train_time:3634ms step_avg:31.60ms
+step:116/1490 train_time:3668ms step_avg:31.62ms
+step:117/1490 train_time:3696ms step_avg:31.59ms
+step:118/1490 train_time:3731ms step_avg:31.62ms
+step:119/1490 train_time:3760ms step_avg:31.59ms
+step:120/1490 train_time:3794ms step_avg:31.61ms
+step:121/1490 train_time:3822ms step_avg:31.59ms
+step:122/1490 train_time:3856ms step_avg:31.61ms
+step:123/1490 train_time:3885ms step_avg:31.58ms
+step:124/1490 train_time:3919ms step_avg:31.61ms
+step:125/1490 train_time:3948ms step_avg:31.59ms
+step:126/1490 train_time:3982ms step_avg:31.61ms
+step:127/1490 train_time:4011ms step_avg:31.58ms
+step:128/1490 train_time:4046ms step_avg:31.61ms
+step:129/1490 train_time:4074ms step_avg:31.58ms
+step:130/1490 train_time:4108ms step_avg:31.60ms
+step:131/1490 train_time:4137ms step_avg:31.58ms
+step:132/1490 train_time:4172ms step_avg:31.60ms
+step:133/1490 train_time:4200ms step_avg:31.58ms
+step:134/1490 train_time:4235ms step_avg:31.60ms
+step:135/1490 train_time:4263ms step_avg:31.58ms
+step:136/1490 train_time:4297ms step_avg:31.60ms
+step:137/1490 train_time:4326ms step_avg:31.58ms
+step:138/1490 train_time:4360ms step_avg:31.60ms
+step:139/1490 train_time:4388ms step_avg:31.57ms
+step:140/1490 train_time:4423ms step_avg:31.59ms
+step:141/1490 train_time:4451ms step_avg:31.57ms
+step:142/1490 train_time:4486ms step_avg:31.59ms
+step:143/1490 train_time:4514ms step_avg:31.57ms
+step:144/1490 train_time:4549ms step_avg:31.59ms
+step:145/1490 train_time:4577ms step_avg:31.56ms
+step:146/1490 train_time:4611ms step_avg:31.58ms
+step:147/1490 train_time:4640ms step_avg:31.56ms
+step:148/1490 train_time:4674ms step_avg:31.58ms
+step:149/1490 train_time:4703ms step_avg:31.56ms
+step:150/1490 train_time:4737ms step_avg:31.58ms
+step:151/1490 train_time:4765ms step_avg:31.56ms
+step:152/1490 train_time:4799ms step_avg:31.57ms
+step:153/1490 train_time:4828ms step_avg:31.56ms
+step:154/1490 train_time:4862ms step_avg:31.57ms
+step:155/1490 train_time:4891ms step_avg:31.55ms
+step:156/1490 train_time:4925ms step_avg:31.57ms
+step:157/1490 train_time:4953ms step_avg:31.55ms
+step:158/1490 train_time:4988ms step_avg:31.57ms
+step:159/1490 train_time:5016ms step_avg:31.55ms
+step:160/1490 train_time:5051ms step_avg:31.57ms
+step:161/1490 train_time:5079ms step_avg:31.55ms
+step:162/1490 train_time:5114ms step_avg:31.57ms
+step:163/1490 train_time:5143ms step_avg:31.55ms
+step:164/1490 train_time:5177ms step_avg:31.57ms
+step:165/1490 train_time:5205ms step_avg:31.55ms
+step:166/1490 train_time:5240ms step_avg:31.56ms
+step:167/1490 train_time:5268ms step_avg:31.55ms
+step:168/1490 train_time:5302ms step_avg:31.56ms
+step:169/1490 train_time:5331ms step_avg:31.54ms
+step:170/1490 train_time:5366ms step_avg:31.56ms
+step:171/1490 train_time:5394ms step_avg:31.54ms
+step:172/1490 train_time:5429ms step_avg:31.56ms
+step:173/1490 train_time:5457ms step_avg:31.54ms
+step:174/1490 train_time:5492ms step_avg:31.56ms
+step:175/1490 train_time:5520ms step_avg:31.54ms
+step:176/1490 train_time:5555ms step_avg:31.56ms
+step:177/1490 train_time:5583ms step_avg:31.54ms
+step:178/1490 train_time:5617ms step_avg:31.56ms
+step:179/1490 train_time:5646ms step_avg:31.54ms
+step:180/1490 train_time:5680ms step_avg:31.55ms
+step:181/1490 train_time:5708ms step_avg:31.54ms
+step:182/1490 train_time:5742ms step_avg:31.55ms
+step:183/1490 train_time:5771ms step_avg:31.53ms
+step:184/1490 train_time:5806ms step_avg:31.55ms
+step:185/1490 train_time:5834ms step_avg:31.53ms
+step:186/1490 train_time:5868ms step_avg:31.55ms
+step:187/1490 train_time:5897ms step_avg:31.53ms
+step:188/1490 train_time:5931ms step_avg:31.55ms
+step:189/1490 train_time:5960ms step_avg:31.54ms
+step:190/1490 train_time:5995ms step_avg:31.55ms
+step:191/1490 train_time:6023ms step_avg:31.54ms
+step:192/1490 train_time:6058ms step_avg:31.55ms
+step:193/1490 train_time:6086ms step_avg:31.54ms
+step:194/1490 train_time:6120ms step_avg:31.55ms
+step:195/1490 train_time:6149ms step_avg:31.53ms
+step:196/1490 train_time:6183ms step_avg:31.55ms
+step:197/1490 train_time:6211ms step_avg:31.53ms
+step:198/1490 train_time:6246ms step_avg:31.55ms
+step:199/1490 train_time:6275ms step_avg:31.53ms
+step:200/1490 train_time:6310ms step_avg:31.55ms
+step:201/1490 train_time:6338ms step_avg:31.53ms
+step:202/1490 train_time:6372ms step_avg:31.55ms
+step:203/1490 train_time:6401ms step_avg:31.53ms
+step:204/1490 train_time:6435ms step_avg:31.54ms
+step:205/1490 train_time:6464ms step_avg:31.53ms
+step:206/1490 train_time:6498ms step_avg:31.54ms
+step:207/1490 train_time:6526ms step_avg:31.53ms
+step:208/1490 train_time:6561ms step_avg:31.54ms
+step:209/1490 train_time:6589ms step_avg:31.53ms
+step:210/1490 train_time:6623ms step_avg:31.54ms
+step:211/1490 train_time:6652ms step_avg:31.52ms
+step:212/1490 train_time:6686ms step_avg:31.54ms
+step:213/1490 train_time:6715ms step_avg:31.52ms
+step:214/1490 train_time:6749ms step_avg:31.54ms
+step:215/1490 train_time:6778ms step_avg:31.52ms
+step:216/1490 train_time:6812ms step_avg:31.54ms
+step:217/1490 train_time:6840ms step_avg:31.52ms
+step:218/1490 train_time:6875ms step_avg:31.53ms
+step:219/1490 train_time:6903ms step_avg:31.52ms
+step:220/1490 train_time:6937ms step_avg:31.53ms
+step:221/1490 train_time:6966ms step_avg:31.52ms
+step:222/1490 train_time:7000ms step_avg:31.53ms
+step:223/1490 train_time:7029ms step_avg:31.52ms
+step:224/1490 train_time:7063ms step_avg:31.53ms
+step:225/1490 train_time:7091ms step_avg:31.52ms
+step:226/1490 train_time:7126ms step_avg:31.53ms
+step:227/1490 train_time:7155ms step_avg:31.52ms
+step:228/1490 train_time:7189ms step_avg:31.53ms
+step:229/1490 train_time:7217ms step_avg:31.52ms
+step:230/1490 train_time:7252ms step_avg:31.53ms
+step:231/1490 train_time:7280ms step_avg:31.52ms
+step:232/1490 train_time:7315ms step_avg:31.53ms
+step:233/1490 train_time:7343ms step_avg:31.51ms
+step:234/1490 train_time:7377ms step_avg:31.53ms
+step:235/1490 train_time:7406ms step_avg:31.51ms
+step:236/1490 train_time:7440ms step_avg:31.53ms
+step:237/1490 train_time:7469ms step_avg:31.51ms
+step:238/1490 train_time:7503ms step_avg:31.53ms
+step:239/1490 train_time:7532ms step_avg:31.51ms
+step:240/1490 train_time:7566ms step_avg:31.53ms
+step:241/1490 train_time:7594ms step_avg:31.51ms
+step:242/1490 train_time:7629ms step_avg:31.52ms
+step:243/1490 train_time:7657ms step_avg:31.51ms
+step:244/1490 train_time:7692ms step_avg:31.52ms
+step:245/1490 train_time:7720ms step_avg:31.51ms
+step:246/1490 train_time:7755ms step_avg:31.52ms
+step:247/1490 train_time:7783ms step_avg:31.51ms
+step:248/1490 train_time:7818ms step_avg:31.52ms
+step:249/1490 train_time:7846ms step_avg:31.51ms
+step:250/1490 train_time:7881ms step_avg:31.52ms
+step:250/1490 val_loss:4.5154 train_time:7924ms step_avg:31.69ms
+step:251/1490 train_time:7939ms step_avg:31.63ms
+step:252/1490 train_time:7957ms step_avg:31.57ms
+step:253/1490 train_time:7974ms step_avg:31.52ms
+step:254/1490 train_time:8009ms step_avg:31.53ms
+step:255/1490 train_time:8039ms step_avg:31.53ms
+step:256/1490 train_time:8074ms step_avg:31.54ms
+step:257/1490 train_time:8104ms step_avg:31.53ms
+step:258/1490 train_time:8139ms step_avg:31.55ms
+step:259/1490 train_time:8168ms step_avg:31.54ms
+step:260/1490 train_time:8203ms step_avg:31.55ms
+step:261/1490 train_time:8231ms step_avg:31.53ms
+step:262/1490 train_time:8265ms step_avg:31.55ms
+step:263/1490 train_time:8293ms step_avg:31.53ms
+step:264/1490 train_time:8328ms step_avg:31.55ms
+step:265/1490 train_time:8356ms step_avg:31.53ms
+step:266/1490 train_time:8391ms step_avg:31.54ms
+step:267/1490 train_time:8419ms step_avg:31.53ms
+step:268/1490 train_time:8453ms step_avg:31.54ms
+step:269/1490 train_time:8481ms step_avg:31.53ms
+step:270/1490 train_time:8515ms step_avg:31.54ms
+step:271/1490 train_time:8544ms step_avg:31.53ms
+step:272/1490 train_time:8578ms step_avg:31.54ms
+step:273/1490 train_time:8606ms step_avg:31.52ms
+step:274/1490 train_time:8640ms step_avg:31.53ms
+step:275/1490 train_time:8668ms step_avg:31.52ms
+step:276/1490 train_time:8703ms step_avg:31.53ms
+step:277/1490 train_time:8731ms step_avg:31.52ms
+step:278/1490 train_time:8765ms step_avg:31.53ms
+step:279/1490 train_time:8793ms step_avg:31.52ms
+step:280/1490 train_time:8827ms step_avg:31.53ms
+step:281/1490 train_time:8856ms step_avg:31.52ms
+step:282/1490 train_time:8891ms step_avg:31.53ms
+step:283/1490 train_time:8919ms step_avg:31.52ms
+step:284/1490 train_time:8953ms step_avg:31.53ms
+step:285/1490 train_time:8982ms step_avg:31.52ms
+step:286/1490 train_time:9017ms step_avg:31.53ms
+step:287/1490 train_time:9045ms step_avg:31.52ms
+step:288/1490 train_time:9081ms step_avg:31.53ms
+step:289/1490 train_time:9110ms step_avg:31.52ms
+step:290/1490 train_time:9145ms step_avg:31.53ms
+step:291/1490 train_time:9173ms step_avg:31.52ms
+step:292/1490 train_time:9208ms step_avg:31.53ms
+step:293/1490 train_time:9236ms step_avg:31.52ms
+step:294/1490 train_time:9271ms step_avg:31.53ms
+step:295/1490 train_time:9300ms step_avg:31.52ms
+step:296/1490 train_time:9334ms step_avg:31.53ms
+step:297/1490 train_time:9362ms step_avg:31.52ms
+step:298/1490 train_time:9397ms step_avg:31.53ms
+step:299/1490 train_time:9425ms step_avg:31.52ms
+step:300/1490 train_time:9459ms step_avg:31.53ms
+step:301/1490 train_time:9487ms step_avg:31.52ms
+step:302/1490 train_time:9522ms step_avg:31.53ms
+step:303/1490 train_time:9550ms step_avg:31.52ms
+step:304/1490 train_time:9585ms step_avg:31.53ms
+step:305/1490 train_time:9613ms step_avg:31.52ms
+step:306/1490 train_time:9648ms step_avg:31.53ms
+step:307/1490 train_time:9676ms step_avg:31.52ms
+step:308/1490 train_time:9710ms step_avg:31.53ms
+step:309/1490 train_time:9739ms step_avg:31.52ms
+step:310/1490 train_time:9773ms step_avg:31.52ms
+step:311/1490 train_time:9801ms step_avg:31.51ms
+step:312/1490 train_time:9835ms step_avg:31.52ms
+step:313/1490 train_time:9863ms step_avg:31.51ms
+step:314/1490 train_time:9898ms step_avg:31.52ms
+step:315/1490 train_time:9926ms step_avg:31.51ms
+step:316/1490 train_time:9961ms step_avg:31.52ms
+step:317/1490 train_time:9989ms step_avg:31.51ms
+step:318/1490 train_time:10024ms step_avg:31.52ms
+step:319/1490 train_time:10052ms step_avg:31.51ms
+step:320/1490 train_time:10087ms step_avg:31.52ms
+step:321/1490 train_time:10116ms step_avg:31.51ms
+step:322/1490 train_time:10150ms step_avg:31.52ms
+step:323/1490 train_time:10179ms step_avg:31.51ms
+step:324/1490 train_time:10214ms step_avg:31.52ms
+step:325/1490 train_time:10242ms step_avg:31.51ms
+step:326/1490 train_time:10276ms step_avg:31.52ms
+step:327/1490 train_time:10305ms step_avg:31.51ms
+step:328/1490 train_time:10340ms step_avg:31.52ms
+step:329/1490 train_time:10368ms step_avg:31.51ms
+step:330/1490 train_time:10403ms step_avg:31.52ms
+step:331/1490 train_time:10431ms step_avg:31.51ms
+step:332/1490 train_time:10466ms step_avg:31.52ms
+step:333/1490 train_time:10494ms step_avg:31.51ms
+step:334/1490 train_time:10529ms step_avg:31.52ms
+step:335/1490 train_time:10557ms step_avg:31.51ms
+step:336/1490 train_time:10591ms step_avg:31.52ms
+step:337/1490 train_time:10620ms step_avg:31.51ms
+step:338/1490 train_time:10654ms step_avg:31.52ms
+step:339/1490 train_time:10682ms step_avg:31.51ms
+step:340/1490 train_time:10716ms step_avg:31.52ms
+step:341/1490 train_time:10745ms step_avg:31.51ms
+step:342/1490 train_time:10779ms step_avg:31.52ms
+step:343/1490 train_time:10807ms step_avg:31.51ms
+step:344/1490 train_time:10842ms step_avg:31.52ms
+step:345/1490 train_time:10870ms step_avg:31.51ms
+step:346/1490 train_time:10904ms step_avg:31.52ms
+step:347/1490 train_time:10933ms step_avg:31.51ms
+step:348/1490 train_time:10967ms step_avg:31.52ms
+step:349/1490 train_time:10996ms step_avg:31.51ms
+step:350/1490 train_time:11031ms step_avg:31.52ms
+step:351/1490 train_time:11059ms step_avg:31.51ms
+step:352/1490 train_time:11093ms step_avg:31.52ms
+step:353/1490 train_time:11122ms step_avg:31.51ms
+step:354/1490 train_time:11156ms step_avg:31.51ms
+step:355/1490 train_time:11185ms step_avg:31.51ms
+step:356/1490 train_time:11219ms step_avg:31.51ms
+step:357/1490 train_time:11247ms step_avg:31.51ms
+step:358/1490 train_time:11282ms step_avg:31.51ms
+step:359/1490 train_time:11311ms step_avg:31.51ms
+step:360/1490 train_time:11345ms step_avg:31.51ms
+step:361/1490 train_time:11374ms step_avg:31.51ms
+step:362/1490 train_time:11408ms step_avg:31.51ms
+step:363/1490 train_time:11437ms step_avg:31.51ms
+step:364/1490 train_time:11471ms step_avg:31.51ms
+step:365/1490 train_time:11500ms step_avg:31.51ms
+step:366/1490 train_time:11534ms step_avg:31.51ms
+step:367/1490 train_time:11562ms step_avg:31.51ms
+step:368/1490 train_time:11597ms step_avg:31.51ms
+step:369/1490 train_time:11625ms step_avg:31.50ms
+step:370/1490 train_time:11659ms step_avg:31.51ms
+step:371/1490 train_time:11687ms step_avg:31.50ms
+step:372/1490 train_time:11722ms step_avg:31.51ms
+step:373/1490 train_time:11750ms step_avg:31.50ms
+step:374/1490 train_time:11785ms step_avg:31.51ms
+step:375/1490 train_time:11813ms step_avg:31.50ms
+step:376/1490 train_time:11847ms step_avg:31.51ms
+step:377/1490 train_time:11876ms step_avg:31.50ms
+step:378/1490 train_time:11910ms step_avg:31.51ms
+step:379/1490 train_time:11939ms step_avg:31.50ms
+step:380/1490 train_time:11973ms step_avg:31.51ms
+step:381/1490 train_time:12001ms step_avg:31.50ms
+step:382/1490 train_time:12036ms step_avg:31.51ms
+step:383/1490 train_time:12064ms step_avg:31.50ms
+step:384/1490 train_time:12099ms step_avg:31.51ms
+step:385/1490 train_time:12127ms step_avg:31.50ms
+step:386/1490 train_time:12162ms step_avg:31.51ms
+step:387/1490 train_time:12191ms step_avg:31.50ms
+step:388/1490 train_time:12225ms step_avg:31.51ms
+step:389/1490 train_time:12253ms step_avg:31.50ms
+step:390/1490 train_time:12288ms step_avg:31.51ms
+step:391/1490 train_time:12316ms step_avg:31.50ms
+step:392/1490 train_time:12351ms step_avg:31.51ms
+step:393/1490 train_time:12379ms step_avg:31.50ms
+step:394/1490 train_time:12414ms step_avg:31.51ms
+step:395/1490 train_time:12442ms step_avg:31.50ms
+step:396/1490 train_time:12477ms step_avg:31.51ms
+step:397/1490 train_time:12505ms step_avg:31.50ms
+step:398/1490 train_time:12540ms step_avg:31.51ms
+step:399/1490 train_time:12568ms step_avg:31.50ms
+step:400/1490 train_time:12603ms step_avg:31.51ms
+step:401/1490 train_time:12631ms step_avg:31.50ms
+step:402/1490 train_time:12666ms step_avg:31.51ms
+step:403/1490 train_time:12694ms step_avg:31.50ms
+step:404/1490 train_time:12729ms step_avg:31.51ms
+step:405/1490 train_time:12757ms step_avg:31.50ms
+step:406/1490 train_time:12791ms step_avg:31.51ms
+step:407/1490 train_time:12820ms step_avg:31.50ms
+step:408/1490 train_time:12854ms step_avg:31.51ms
+step:409/1490 train_time:12883ms step_avg:31.50ms
+step:410/1490 train_time:12917ms step_avg:31.50ms
+step:411/1490 train_time:12945ms step_avg:31.50ms
+step:412/1490 train_time:12980ms step_avg:31.50ms
+step:413/1490 train_time:13008ms step_avg:31.50ms
+step:414/1490 train_time:13043ms step_avg:31.50ms
+step:415/1490 train_time:13071ms step_avg:31.50ms
+step:416/1490 train_time:13106ms step_avg:31.50ms
+step:417/1490 train_time:13134ms step_avg:31.50ms
+step:418/1490 train_time:13168ms step_avg:31.50ms
+step:419/1490 train_time:13197ms step_avg:31.50ms
+step:420/1490 train_time:13231ms step_avg:31.50ms
+step:421/1490 train_time:13259ms step_avg:31.50ms
+step:422/1490 train_time:13294ms step_avg:31.50ms
+step:423/1490 train_time:13323ms step_avg:31.50ms
+step:424/1490 train_time:13357ms step_avg:31.50ms
+step:425/1490 train_time:13385ms step_avg:31.49ms
+step:426/1490 train_time:13420ms step_avg:31.50ms
+step:427/1490 train_time:13448ms step_avg:31.50ms
+step:428/1490 train_time:13483ms step_avg:31.50ms
+step:429/1490 train_time:13511ms step_avg:31.49ms
+step:430/1490 train_time:13546ms step_avg:31.50ms
+step:431/1490 train_time:13574ms step_avg:31.49ms
+step:432/1490 train_time:13609ms step_avg:31.50ms
+step:433/1490 train_time:13638ms step_avg:31.50ms
+step:434/1490 train_time:13672ms step_avg:31.50ms
+step:435/1490 train_time:13701ms step_avg:31.50ms
+step:436/1490 train_time:13735ms step_avg:31.50ms
+step:437/1490 train_time:13763ms step_avg:31.50ms
+step:438/1490 train_time:13797ms step_avg:31.50ms
+step:439/1490 train_time:13826ms step_avg:31.49ms
+step:440/1490 train_time:13861ms step_avg:31.50ms
+step:441/1490 train_time:13889ms step_avg:31.49ms
+step:442/1490 train_time:13924ms step_avg:31.50ms
+step:443/1490 train_time:13952ms step_avg:31.49ms
+step:444/1490 train_time:13986ms step_avg:31.50ms
+step:445/1490 train_time:14014ms step_avg:31.49ms
+step:446/1490 train_time:14049ms step_avg:31.50ms
+step:447/1490 train_time:14077ms step_avg:31.49ms
+step:448/1490 train_time:14112ms step_avg:31.50ms
+step:449/1490 train_time:14140ms step_avg:31.49ms
+step:450/1490 train_time:14174ms step_avg:31.50ms
+step:451/1490 train_time:14203ms step_avg:31.49ms
+step:452/1490 train_time:14238ms step_avg:31.50ms
+step:453/1490 train_time:14266ms step_avg:31.49ms
+step:454/1490 train_time:14301ms step_avg:31.50ms
+step:455/1490 train_time:14329ms step_avg:31.49ms
+step:456/1490 train_time:14364ms step_avg:31.50ms
+step:457/1490 train_time:14392ms step_avg:31.49ms
+step:458/1490 train_time:14427ms step_avg:31.50ms
+step:459/1490 train_time:14455ms step_avg:31.49ms
+step:460/1490 train_time:14489ms step_avg:31.50ms
+step:461/1490 train_time:14518ms step_avg:31.49ms
+step:462/1490 train_time:14552ms step_avg:31.50ms
+step:463/1490 train_time:14581ms step_avg:31.49ms
+step:464/1490 train_time:14615ms step_avg:31.50ms
+step:465/1490 train_time:14644ms step_avg:31.49ms
+step:466/1490 train_time:14679ms step_avg:31.50ms
+step:467/1490 train_time:14707ms step_avg:31.49ms
+step:468/1490 train_time:14742ms step_avg:31.50ms
+step:469/1490 train_time:14770ms step_avg:31.49ms
+step:470/1490 train_time:14805ms step_avg:31.50ms
+step:471/1490 train_time:14833ms step_avg:31.49ms
+step:472/1490 train_time:14867ms step_avg:31.50ms
+step:473/1490 train_time:14896ms step_avg:31.49ms
+step:474/1490 train_time:14930ms step_avg:31.50ms
+step:475/1490 train_time:14959ms step_avg:31.49ms
+step:476/1490 train_time:14993ms step_avg:31.50ms
+step:477/1490 train_time:15022ms step_avg:31.49ms
+step:478/1490 train_time:15056ms step_avg:31.50ms
+step:479/1490 train_time:15085ms step_avg:31.49ms
+step:480/1490 train_time:15120ms step_avg:31.50ms
+step:481/1490 train_time:15148ms step_avg:31.49ms
+step:482/1490 train_time:15182ms step_avg:31.50ms
+step:483/1490 train_time:15211ms step_avg:31.49ms
+step:484/1490 train_time:15248ms step_avg:31.50ms
+step:485/1490 train_time:15300ms step_avg:31.55ms
+step:486/1490 train_time:15359ms step_avg:31.60ms
+step:487/1490 train_time:15413ms step_avg:31.65ms
+step:488/1490 train_time:15473ms step_avg:31.71ms
+step:489/1490 train_time:15528ms step_avg:31.75ms
+step:490/1490 train_time:15588ms step_avg:31.81ms
+step:491/1490 train_time:15643ms step_avg:31.86ms
+step:492/1490 train_time:15702ms step_avg:31.91ms
+step:493/1490 train_time:15756ms step_avg:31.96ms
+step:494/1490 train_time:15816ms step_avg:32.02ms
+step:495/1490 train_time:15870ms step_avg:32.06ms
+step:496/1490 train_time:15930ms step_avg:32.12ms
+step:497/1490 train_time:15984ms step_avg:32.16ms
+step:498/1490 train_time:16044ms step_avg:32.22ms
+step:499/1490 train_time:16100ms step_avg:32.26ms
+step:500/1490 train_time:16159ms step_avg:32.32ms
+step:500/1490 val_loss:4.2296 train_time:16231ms step_avg:32.46ms
+step:501/1490 train_time:16248ms step_avg:32.43ms
+step:502/1490 train_time:16274ms step_avg:32.42ms
+step:503/1490 train_time:16331ms step_avg:32.47ms
+step:504/1490 train_time:16393ms step_avg:32.53ms
+step:505/1490 train_time:16449ms step_avg:32.57ms
+step:506/1490 train_time:16510ms step_avg:32.63ms
+step:507/1490 train_time:16565ms step_avg:32.67ms
+step:508/1490 train_time:16625ms step_avg:32.73ms
+step:509/1490 train_time:16679ms step_avg:32.77ms
+step:510/1490 train_time:16738ms step_avg:32.82ms
+step:511/1490 train_time:16792ms step_avg:32.86ms
+step:512/1490 train_time:16851ms step_avg:32.91ms
+step:513/1490 train_time:16904ms step_avg:32.95ms
+step:514/1490 train_time:16963ms step_avg:33.00ms
+step:515/1490 train_time:17016ms step_avg:33.04ms
+step:516/1490 train_time:17076ms step_avg:33.09ms
+step:517/1490 train_time:17130ms step_avg:33.13ms
+step:518/1490 train_time:17190ms step_avg:33.18ms
+step:519/1490 train_time:17245ms step_avg:33.23ms
+step:520/1490 train_time:17307ms step_avg:33.28ms
+step:521/1490 train_time:17362ms step_avg:33.32ms
+step:522/1490 train_time:17423ms step_avg:33.38ms
+step:523/1490 train_time:17478ms step_avg:33.42ms
+step:524/1490 train_time:17538ms step_avg:33.47ms
+step:525/1490 train_time:17592ms step_avg:33.51ms
+step:526/1490 train_time:17652ms step_avg:33.56ms
+step:527/1490 train_time:17706ms step_avg:33.60ms
+step:528/1490 train_time:17765ms step_avg:33.65ms
+step:529/1490 train_time:17819ms step_avg:33.68ms
+step:530/1490 train_time:17879ms step_avg:33.73ms
+step:531/1490 train_time:17933ms step_avg:33.77ms
+step:532/1490 train_time:17992ms step_avg:33.82ms
+step:533/1490 train_time:18046ms step_avg:33.86ms
+step:534/1490 train_time:18106ms step_avg:33.91ms
+step:535/1490 train_time:18160ms step_avg:33.94ms
+step:536/1490 train_time:18220ms step_avg:33.99ms
+step:537/1490 train_time:18275ms step_avg:34.03ms
+step:538/1490 train_time:18335ms step_avg:34.08ms
+step:539/1490 train_time:18391ms step_avg:34.12ms
+step:540/1490 train_time:18451ms step_avg:34.17ms
+step:541/1490 train_time:18506ms step_avg:34.21ms
+step:542/1490 train_time:18567ms step_avg:34.26ms
+step:543/1490 train_time:18622ms step_avg:34.29ms
+step:544/1490 train_time:18681ms step_avg:34.34ms
+step:545/1490 train_time:18734ms step_avg:34.38ms
+step:546/1490 train_time:18795ms step_avg:34.42ms
+step:547/1490 train_time:18849ms step_avg:34.46ms
+step:548/1490 train_time:18909ms step_avg:34.50ms
+step:549/1490 train_time:18962ms step_avg:34.54ms
+step:550/1490 train_time:19021ms step_avg:34.58ms
+step:551/1490 train_time:19075ms step_avg:34.62ms
+step:552/1490 train_time:19136ms step_avg:34.67ms
+step:553/1490 train_time:19191ms step_avg:34.70ms
+step:554/1490 train_time:19251ms step_avg:34.75ms
+step:555/1490 train_time:19305ms step_avg:34.78ms
+step:556/1490 train_time:19365ms step_avg:34.83ms
+step:557/1490 train_time:19421ms step_avg:34.87ms
+step:558/1490 train_time:19480ms step_avg:34.91ms
+step:559/1490 train_time:19534ms step_avg:34.94ms
+step:560/1490 train_time:19594ms step_avg:34.99ms
+step:561/1490 train_time:19648ms step_avg:35.02ms
+step:562/1490 train_time:19709ms step_avg:35.07ms
+step:563/1490 train_time:19764ms step_avg:35.10ms
+step:564/1490 train_time:19823ms step_avg:35.15ms
+step:565/1490 train_time:19876ms step_avg:35.18ms
+step:566/1490 train_time:19937ms step_avg:35.22ms
+step:567/1490 train_time:19991ms step_avg:35.26ms
+step:568/1490 train_time:20050ms step_avg:35.30ms
+step:569/1490 train_time:20105ms step_avg:35.33ms
+step:570/1490 train_time:20164ms step_avg:35.38ms
+step:571/1490 train_time:20217ms step_avg:35.41ms
+step:572/1490 train_time:20278ms step_avg:35.45ms
+step:573/1490 train_time:20333ms step_avg:35.48ms
+step:574/1490 train_time:20393ms step_avg:35.53ms
+step:575/1490 train_time:20448ms step_avg:35.56ms
+step:576/1490 train_time:20509ms step_avg:35.61ms
+step:577/1490 train_time:20564ms step_avg:35.64ms
+step:578/1490 train_time:20623ms step_avg:35.68ms
+step:579/1490 train_time:20677ms step_avg:35.71ms
+step:580/1490 train_time:20737ms step_avg:35.75ms
+step:581/1490 train_time:20792ms step_avg:35.79ms
+step:582/1490 train_time:20852ms step_avg:35.83ms
+step:583/1490 train_time:20906ms step_avg:35.86ms
+step:584/1490 train_time:20965ms step_avg:35.90ms
+step:585/1490 train_time:21018ms step_avg:35.93ms
+step:586/1490 train_time:21079ms step_avg:35.97ms
+step:587/1490 train_time:21133ms step_avg:36.00ms
+step:588/1490 train_time:21192ms step_avg:36.04ms
+step:589/1490 train_time:21247ms step_avg:36.07ms
+step:590/1490 train_time:21308ms step_avg:36.12ms
+step:591/1490 train_time:21363ms step_avg:36.15ms
+step:592/1490 train_time:21422ms step_avg:36.19ms
+step:593/1490 train_time:21476ms step_avg:36.22ms
+step:594/1490 train_time:21536ms step_avg:36.26ms
+step:595/1490 train_time:21590ms step_avg:36.29ms
+step:596/1490 train_time:21651ms step_avg:36.33ms
+step:597/1490 train_time:21706ms step_avg:36.36ms
+step:598/1490 train_time:21766ms step_avg:36.40ms
+step:599/1490 train_time:21821ms step_avg:36.43ms
+step:600/1490 train_time:21880ms step_avg:36.47ms
+step:601/1490 train_time:21934ms step_avg:36.50ms
+step:602/1490 train_time:21993ms step_avg:36.53ms
+step:603/1490 train_time:22046ms step_avg:36.56ms
+step:604/1490 train_time:22107ms step_avg:36.60ms
+step:605/1490 train_time:22161ms step_avg:36.63ms
+step:606/1490 train_time:22220ms step_avg:36.67ms
+step:607/1490 train_time:22275ms step_avg:36.70ms
+step:608/1490 train_time:22336ms step_avg:36.74ms
+step:609/1490 train_time:22390ms step_avg:36.76ms
+step:610/1490 train_time:22449ms step_avg:36.80ms
+step:611/1490 train_time:22503ms step_avg:36.83ms
+step:612/1490 train_time:22563ms step_avg:36.87ms
+step:613/1490 train_time:22617ms step_avg:36.90ms
+step:614/1490 train_time:22677ms step_avg:36.93ms
+step:615/1490 train_time:22733ms step_avg:36.96ms
+step:616/1490 train_time:22792ms step_avg:37.00ms
+step:617/1490 train_time:22847ms step_avg:37.03ms
+step:618/1490 train_time:22907ms step_avg:37.07ms
+step:619/1490 train_time:22961ms step_avg:37.09ms
+step:620/1490 train_time:23021ms step_avg:37.13ms
+step:621/1490 train_time:23075ms step_avg:37.16ms
+step:622/1490 train_time:23135ms step_avg:37.19ms
+step:623/1490 train_time:23189ms step_avg:37.22ms
+step:624/1490 train_time:23250ms step_avg:37.26ms
+step:625/1490 train_time:23304ms step_avg:37.29ms
+step:626/1490 train_time:23364ms step_avg:37.32ms
+step:627/1490 train_time:23419ms step_avg:37.35ms
+step:628/1490 train_time:23478ms step_avg:37.38ms
+step:629/1490 train_time:23532ms step_avg:37.41ms
+step:630/1490 train_time:23592ms step_avg:37.45ms
+step:631/1490 train_time:23646ms step_avg:37.47ms
+step:632/1490 train_time:23707ms step_avg:37.51ms
+step:633/1490 train_time:23761ms step_avg:37.54ms
+step:634/1490 train_time:23820ms step_avg:37.57ms
+step:635/1490 train_time:23874ms step_avg:37.60ms
+step:636/1490 train_time:23934ms step_avg:37.63ms
+step:637/1490 train_time:23988ms step_avg:37.66ms
+step:638/1490 train_time:24049ms step_avg:37.69ms
+step:639/1490 train_time:24102ms step_avg:37.72ms
+step:640/1490 train_time:24162ms step_avg:37.75ms
+step:641/1490 train_time:24216ms step_avg:37.78ms
+step:642/1490 train_time:24277ms step_avg:37.82ms
+step:643/1490 train_time:24332ms step_avg:37.84ms
+step:644/1490 train_time:24392ms step_avg:37.88ms
+step:645/1490 train_time:24446ms step_avg:37.90ms
+step:646/1490 train_time:24507ms step_avg:37.94ms
+step:647/1490 train_time:24561ms step_avg:37.96ms
+step:648/1490 train_time:24621ms step_avg:38.00ms
+step:649/1490 train_time:24676ms step_avg:38.02ms
+step:650/1490 train_time:24737ms step_avg:38.06ms
+step:651/1490 train_time:24792ms step_avg:38.08ms
+step:652/1490 train_time:24851ms step_avg:38.12ms
+step:653/1490 train_time:24905ms step_avg:38.14ms
+step:654/1490 train_time:24966ms step_avg:38.17ms
+step:655/1490 train_time:25020ms step_avg:38.20ms
+step:656/1490 train_time:25080ms step_avg:38.23ms
+step:657/1490 train_time:25134ms step_avg:38.26ms
+step:658/1490 train_time:25194ms step_avg:38.29ms
+step:659/1490 train_time:25249ms step_avg:38.31ms
+step:660/1490 train_time:25309ms step_avg:38.35ms
+step:661/1490 train_time:25363ms step_avg:38.37ms
+step:662/1490 train_time:25423ms step_avg:38.40ms
+step:663/1490 train_time:25477ms step_avg:38.43ms
+step:664/1490 train_time:25536ms step_avg:38.46ms
+step:665/1490 train_time:25591ms step_avg:38.48ms
+step:666/1490 train_time:25650ms step_avg:38.51ms
+step:667/1490 train_time:25705ms step_avg:38.54ms
+step:668/1490 train_time:25765ms step_avg:38.57ms
+step:669/1490 train_time:25819ms step_avg:38.59ms
+step:670/1490 train_time:25878ms step_avg:38.62ms
+step:671/1490 train_time:25933ms step_avg:38.65ms
+step:672/1490 train_time:25992ms step_avg:38.68ms
+step:673/1490 train_time:26047ms step_avg:38.70ms
+step:674/1490 train_time:26108ms step_avg:38.74ms
+step:675/1490 train_time:26162ms step_avg:38.76ms
+step:676/1490 train_time:26222ms step_avg:38.79ms
+step:677/1490 train_time:26276ms step_avg:38.81ms
+step:678/1490 train_time:26336ms step_avg:38.84ms
+step:679/1490 train_time:26391ms step_avg:38.87ms
+step:680/1490 train_time:26451ms step_avg:38.90ms
+step:681/1490 train_time:26505ms step_avg:38.92ms
+step:682/1490 train_time:26565ms step_avg:38.95ms
+step:683/1490 train_time:26620ms step_avg:38.97ms
+step:684/1490 train_time:26679ms step_avg:39.00ms
+step:685/1490 train_time:26733ms step_avg:39.03ms
+step:686/1490 train_time:26792ms step_avg:39.06ms
+step:687/1490 train_time:26847ms step_avg:39.08ms
+step:688/1490 train_time:26907ms step_avg:39.11ms
+step:689/1490 train_time:26961ms step_avg:39.13ms
+step:690/1490 train_time:27020ms step_avg:39.16ms
+step:691/1490 train_time:27075ms step_avg:39.18ms
+step:692/1490 train_time:27134ms step_avg:39.21ms
+step:693/1490 train_time:27188ms step_avg:39.23ms
+step:694/1490 train_time:27249ms step_avg:39.26ms
+step:695/1490 train_time:27303ms step_avg:39.28ms
+step:696/1490 train_time:27363ms step_avg:39.32ms
+step:697/1490 train_time:27417ms step_avg:39.34ms
+step:698/1490 train_time:27476ms step_avg:39.36ms
+step:699/1490 train_time:27531ms step_avg:39.39ms
+step:700/1490 train_time:27591ms step_avg:39.42ms
+step:701/1490 train_time:27645ms step_avg:39.44ms
+step:702/1490 train_time:27705ms step_avg:39.47ms
+step:703/1490 train_time:27759ms step_avg:39.49ms
+step:704/1490 train_time:27818ms step_avg:39.51ms
+step:705/1490 train_time:27873ms step_avg:39.54ms
+step:706/1490 train_time:27934ms step_avg:39.57ms
+step:707/1490 train_time:27988ms step_avg:39.59ms
+step:708/1490 train_time:28048ms step_avg:39.62ms
+step:709/1490 train_time:28103ms step_avg:39.64ms
+step:710/1490 train_time:28162ms step_avg:39.67ms
+step:711/1490 train_time:28216ms step_avg:39.68ms
+step:712/1490 train_time:28275ms step_avg:39.71ms
+step:713/1490 train_time:28330ms step_avg:39.73ms
+step:714/1490 train_time:28390ms step_avg:39.76ms
+step:715/1490 train_time:28444ms step_avg:39.78ms
+step:716/1490 train_time:28503ms step_avg:39.81ms
+step:717/1490 train_time:28557ms step_avg:39.83ms
+step:718/1490 train_time:28616ms step_avg:39.86ms
+step:719/1490 train_time:28672ms step_avg:39.88ms
+step:720/1490 train_time:28731ms step_avg:39.90ms
+step:721/1490 train_time:28785ms step_avg:39.92ms
+step:722/1490 train_time:28845ms step_avg:39.95ms
+step:723/1490 train_time:28899ms step_avg:39.97ms
+step:724/1490 train_time:28959ms step_avg:40.00ms
+step:725/1490 train_time:29013ms step_avg:40.02ms
+step:726/1490 train_time:29072ms step_avg:40.04ms
+step:727/1490 train_time:29128ms step_avg:40.07ms
+step:728/1490 train_time:29189ms step_avg:40.09ms
+step:729/1490 train_time:29243ms step_avg:40.11ms
+step:730/1490 train_time:29302ms step_avg:40.14ms
+step:731/1490 train_time:29356ms step_avg:40.16ms
+step:732/1490 train_time:29416ms step_avg:40.19ms
+step:733/1490 train_time:29471ms step_avg:40.21ms
+step:734/1490 train_time:29531ms step_avg:40.23ms
+step:735/1490 train_time:29585ms step_avg:40.25ms
+step:736/1490 train_time:29644ms step_avg:40.28ms
+step:737/1490 train_time:29698ms step_avg:40.30ms
+step:738/1490 train_time:29757ms step_avg:40.32ms
+step:739/1490 train_time:29811ms step_avg:40.34ms
+step:740/1490 train_time:29871ms step_avg:40.37ms
+step:741/1490 train_time:29925ms step_avg:40.38ms
+step:742/1490 train_time:29984ms step_avg:40.41ms
+step:743/1490 train_time:30038ms step_avg:40.43ms
+step:744/1490 train_time:30097ms step_avg:40.45ms
+step:745/1490 train_time:30153ms step_avg:40.47ms
+step:746/1490 train_time:30213ms step_avg:40.50ms
+step:747/1490 train_time:30268ms step_avg:40.52ms
+step:748/1490 train_time:30330ms step_avg:40.55ms
+step:749/1490 train_time:30383ms step_avg:40.57ms
+step:750/1490 train_time:30444ms step_avg:40.59ms
+step:750/1490 val_loss:3.8044 train_time:30515ms step_avg:40.69ms
+step:751/1490 train_time:30532ms step_avg:40.66ms
+step:752/1490 train_time:30558ms step_avg:40.64ms
+step:753/1490 train_time:30616ms step_avg:40.66ms
+step:754/1490 train_time:30678ms step_avg:40.69ms
+step:755/1490 train_time:30734ms step_avg:40.71ms
+step:756/1490 train_time:30794ms step_avg:40.73ms
+step:757/1490 train_time:30848ms step_avg:40.75ms
+step:758/1490 train_time:30908ms step_avg:40.78ms
+step:759/1490 train_time:30961ms step_avg:40.79ms
+step:760/1490 train_time:31021ms step_avg:40.82ms
+step:761/1490 train_time:31074ms step_avg:40.83ms
+step:762/1490 train_time:31133ms step_avg:40.86ms
+step:763/1490 train_time:31187ms step_avg:40.87ms
+step:764/1490 train_time:31246ms step_avg:40.90ms
+step:765/1490 train_time:31300ms step_avg:40.91ms
+step:766/1490 train_time:31359ms step_avg:40.94ms
+step:767/1490 train_time:31412ms step_avg:40.95ms
+step:768/1490 train_time:31471ms step_avg:40.98ms
+step:769/1490 train_time:31528ms step_avg:41.00ms
+step:770/1490 train_time:31590ms step_avg:41.03ms
+step:771/1490 train_time:31646ms step_avg:41.04ms
+step:772/1490 train_time:31706ms step_avg:41.07ms
+step:773/1490 train_time:31762ms step_avg:41.09ms
+step:774/1490 train_time:31821ms step_avg:41.11ms
+step:775/1490 train_time:31875ms step_avg:41.13ms
+step:776/1490 train_time:31934ms step_avg:41.15ms
+step:777/1490 train_time:31990ms step_avg:41.17ms
+step:778/1490 train_time:32050ms step_avg:41.20ms
+step:779/1490 train_time:32104ms step_avg:41.21ms
+step:780/1490 train_time:32163ms step_avg:41.23ms
+step:781/1490 train_time:32216ms step_avg:41.25ms
+step:782/1490 train_time:32275ms step_avg:41.27ms
+step:783/1490 train_time:32328ms step_avg:41.29ms
+step:784/1490 train_time:32388ms step_avg:41.31ms
+step:785/1490 train_time:32442ms step_avg:41.33ms
+step:786/1490 train_time:32502ms step_avg:41.35ms
+step:787/1490 train_time:32556ms step_avg:41.37ms
+step:788/1490 train_time:32616ms step_avg:41.39ms
+step:789/1490 train_time:32672ms step_avg:41.41ms
+step:790/1490 train_time:32732ms step_avg:41.43ms
+step:791/1490 train_time:32786ms step_avg:41.45ms
+step:792/1490 train_time:32846ms step_avg:41.47ms
+step:793/1490 train_time:32901ms step_avg:41.49ms
+step:794/1490 train_time:32961ms step_avg:41.51ms
+step:795/1490 train_time:33015ms step_avg:41.53ms
+step:796/1490 train_time:33074ms step_avg:41.55ms
+step:797/1490 train_time:33128ms step_avg:41.57ms
+step:798/1490 train_time:33188ms step_avg:41.59ms
+step:799/1490 train_time:33241ms step_avg:41.60ms
+step:800/1490 train_time:33301ms step_avg:41.63ms
+step:801/1490 train_time:33354ms step_avg:41.64ms
+step:802/1490 train_time:33413ms step_avg:41.66ms
+step:803/1490 train_time:33468ms step_avg:41.68ms
+step:804/1490 train_time:33528ms step_avg:41.70ms
+step:805/1490 train_time:33583ms step_avg:41.72ms
+step:806/1490 train_time:33643ms step_avg:41.74ms
+step:807/1490 train_time:33696ms step_avg:41.76ms
+step:808/1490 train_time:33757ms step_avg:41.78ms
+step:809/1490 train_time:33812ms step_avg:41.79ms
+step:810/1490 train_time:33871ms step_avg:41.82ms
+step:811/1490 train_time:33926ms step_avg:41.83ms
+step:812/1490 train_time:33986ms step_avg:41.86ms
+step:813/1490 train_time:34040ms step_avg:41.87ms
+step:814/1490 train_time:34099ms step_avg:41.89ms
+step:815/1490 train_time:34153ms step_avg:41.91ms
+step:816/1490 train_time:34212ms step_avg:41.93ms
+step:817/1490 train_time:34266ms step_avg:41.94ms
+step:818/1490 train_time:34327ms step_avg:41.96ms
+step:819/1490 train_time:34381ms step_avg:41.98ms
+step:820/1490 train_time:34440ms step_avg:42.00ms
+step:821/1490 train_time:34494ms step_avg:42.02ms
+step:822/1490 train_time:34555ms step_avg:42.04ms
+step:823/1490 train_time:34608ms step_avg:42.05ms
+step:824/1490 train_time:34669ms step_avg:42.07ms
+step:825/1490 train_time:34723ms step_avg:42.09ms
+step:826/1490 train_time:34783ms step_avg:42.11ms
+step:827/1490 train_time:34837ms step_avg:42.12ms
+step:828/1490 train_time:34897ms step_avg:42.15ms
+step:829/1490 train_time:34952ms step_avg:42.16ms
+step:830/1490 train_time:35012ms step_avg:42.18ms
+step:831/1490 train_time:35066ms step_avg:42.20ms
+step:832/1490 train_time:35125ms step_avg:42.22ms
+step:833/1490 train_time:35179ms step_avg:42.23ms
+step:834/1490 train_time:35238ms step_avg:42.25ms
+step:835/1490 train_time:35292ms step_avg:42.27ms
+step:836/1490 train_time:35352ms step_avg:42.29ms
+step:837/1490 train_time:35406ms step_avg:42.30ms
+step:838/1490 train_time:35466ms step_avg:42.32ms
+step:839/1490 train_time:35520ms step_avg:42.34ms
+step:840/1490 train_time:35579ms step_avg:42.36ms
+step:841/1490 train_time:35634ms step_avg:42.37ms
+step:842/1490 train_time:35693ms step_avg:42.39ms
+step:843/1490 train_time:35748ms step_avg:42.41ms
+step:844/1490 train_time:35809ms step_avg:42.43ms
+step:845/1490 train_time:35864ms step_avg:42.44ms
+step:846/1490 train_time:35924ms step_avg:42.46ms
+step:847/1490 train_time:35978ms step_avg:42.48ms
+step:848/1490 train_time:36037ms step_avg:42.50ms
+step:849/1490 train_time:36092ms step_avg:42.51ms
+step:850/1490 train_time:36152ms step_avg:42.53ms
+step:851/1490 train_time:36205ms step_avg:42.54ms
+step:852/1490 train_time:36265ms step_avg:42.56ms
+step:853/1490 train_time:36319ms step_avg:42.58ms
+step:854/1490 train_time:36378ms step_avg:42.60ms
+step:855/1490 train_time:36433ms step_avg:42.61ms
+step:856/1490 train_time:36492ms step_avg:42.63ms
+step:857/1490 train_time:36547ms step_avg:42.65ms
+step:858/1490 train_time:36607ms step_avg:42.67ms
+step:859/1490 train_time:36661ms step_avg:42.68ms
+step:860/1490 train_time:36721ms step_avg:42.70ms
+step:861/1490 train_time:36775ms step_avg:42.71ms
+step:862/1490 train_time:36836ms step_avg:42.73ms
+step:863/1490 train_time:36891ms step_avg:42.75ms
+step:864/1490 train_time:36951ms step_avg:42.77ms
+step:865/1490 train_time:37005ms step_avg:42.78ms
+step:866/1490 train_time:37065ms step_avg:42.80ms
+step:867/1490 train_time:37120ms step_avg:42.81ms
+step:868/1490 train_time:37178ms step_avg:42.83ms
+step:869/1490 train_time:37233ms step_avg:42.85ms
+step:870/1490 train_time:37292ms step_avg:42.86ms
+step:871/1490 train_time:37346ms step_avg:42.88ms
+step:872/1490 train_time:37406ms step_avg:42.90ms
+step:873/1490 train_time:37461ms step_avg:42.91ms
+step:874/1490 train_time:37520ms step_avg:42.93ms
+step:875/1490 train_time:37573ms step_avg:42.94ms
+step:876/1490 train_time:37632ms step_avg:42.96ms
+step:877/1490 train_time:37687ms step_avg:42.97ms
+step:878/1490 train_time:37748ms step_avg:42.99ms
+step:879/1490 train_time:37803ms step_avg:43.01ms
+step:880/1490 train_time:37863ms step_avg:43.03ms
+step:881/1490 train_time:37917ms step_avg:43.04ms
+step:882/1490 train_time:37977ms step_avg:43.06ms
+step:883/1490 train_time:38031ms step_avg:43.07ms
+step:884/1490 train_time:38091ms step_avg:43.09ms
+step:885/1490 train_time:38145ms step_avg:43.10ms
+step:886/1490 train_time:38205ms step_avg:43.12ms
+step:887/1490 train_time:38258ms step_avg:43.13ms
+step:888/1490 train_time:38317ms step_avg:43.15ms
+step:889/1490 train_time:38371ms step_avg:43.16ms
+step:890/1490 train_time:38432ms step_avg:43.18ms
+step:891/1490 train_time:38486ms step_avg:43.19ms
+step:892/1490 train_time:38546ms step_avg:43.21ms
+step:893/1490 train_time:38601ms step_avg:43.23ms
+step:894/1490 train_time:38660ms step_avg:43.24ms
+step:895/1490 train_time:38714ms step_avg:43.26ms
+step:896/1490 train_time:38774ms step_avg:43.27ms
+step:897/1490 train_time:38828ms step_avg:43.29ms
+step:898/1490 train_time:38889ms step_avg:43.31ms
+step:899/1490 train_time:38944ms step_avg:43.32ms
+step:900/1490 train_time:39003ms step_avg:43.34ms
+step:901/1490 train_time:39057ms step_avg:43.35ms
+step:902/1490 train_time:39116ms step_avg:43.37ms
+step:903/1490 train_time:39170ms step_avg:43.38ms
+step:904/1490 train_time:39229ms step_avg:43.40ms
+step:905/1490 train_time:39283ms step_avg:43.41ms
+step:906/1490 train_time:39343ms step_avg:43.43ms
+step:907/1490 train_time:39397ms step_avg:43.44ms
+step:908/1490 train_time:39457ms step_avg:43.46ms
+step:909/1490 train_time:39511ms step_avg:43.47ms
+step:910/1490 train_time:39571ms step_avg:43.48ms
+step:911/1490 train_time:39626ms step_avg:43.50ms
+step:912/1490 train_time:39686ms step_avg:43.52ms
+step:913/1490 train_time:39740ms step_avg:43.53ms
+step:914/1490 train_time:39799ms step_avg:43.54ms
+step:915/1490 train_time:39853ms step_avg:43.56ms
+step:916/1490 train_time:39913ms step_avg:43.57ms
+step:917/1490 train_time:39968ms step_avg:43.59ms
+step:918/1490 train_time:40028ms step_avg:43.60ms
+step:919/1490 train_time:40083ms step_avg:43.62ms
+step:920/1490 train_time:40143ms step_avg:43.63ms
+step:921/1490 train_time:40196ms step_avg:43.64ms
+step:922/1490 train_time:40256ms step_avg:43.66ms
+step:923/1490 train_time:40310ms step_avg:43.67ms
+step:924/1490 train_time:40370ms step_avg:43.69ms
+step:925/1490 train_time:40424ms step_avg:43.70ms
+step:926/1490 train_time:40483ms step_avg:43.72ms
+step:927/1490 train_time:40536ms step_avg:43.73ms
+step:928/1490 train_time:40596ms step_avg:43.75ms
+step:929/1490 train_time:40651ms step_avg:43.76ms
+step:930/1490 train_time:40711ms step_avg:43.78ms
+step:931/1490 train_time:40765ms step_avg:43.79ms
+step:932/1490 train_time:40825ms step_avg:43.80ms
+step:933/1490 train_time:40879ms step_avg:43.82ms
+step:934/1490 train_time:40939ms step_avg:43.83ms
+step:935/1490 train_time:40994ms step_avg:43.84ms
+step:936/1490 train_time:41054ms step_avg:43.86ms
+step:937/1490 train_time:41109ms step_avg:43.87ms
+step:938/1490 train_time:41171ms step_avg:43.89ms
+step:939/1490 train_time:41225ms step_avg:43.90ms
+step:940/1490 train_time:41284ms step_avg:43.92ms
+step:941/1490 train_time:41338ms step_avg:43.93ms
+step:942/1490 train_time:41398ms step_avg:43.95ms
+step:943/1490 train_time:41453ms step_avg:43.96ms
+step:944/1490 train_time:41512ms step_avg:43.97ms
+step:945/1490 train_time:41566ms step_avg:43.98ms
+step:946/1490 train_time:41626ms step_avg:44.00ms
+step:947/1490 train_time:41681ms step_avg:44.01ms
+step:948/1490 train_time:41741ms step_avg:44.03ms
+step:949/1490 train_time:41794ms step_avg:44.04ms
+step:950/1490 train_time:41855ms step_avg:44.06ms
+step:951/1490 train_time:41909ms step_avg:44.07ms
+step:952/1490 train_time:41969ms step_avg:44.09ms
+step:953/1490 train_time:42024ms step_avg:44.10ms
+step:954/1490 train_time:42083ms step_avg:44.11ms
+step:955/1490 train_time:42137ms step_avg:44.12ms
+step:956/1490 train_time:42197ms step_avg:44.14ms
+step:957/1490 train_time:42251ms step_avg:44.15ms
+step:958/1490 train_time:42311ms step_avg:44.17ms
+step:959/1490 train_time:42365ms step_avg:44.18ms
+step:960/1490 train_time:42425ms step_avg:44.19ms
+step:961/1490 train_time:42479ms step_avg:44.20ms
+step:962/1490 train_time:42538ms step_avg:44.22ms
+step:963/1490 train_time:42593ms step_avg:44.23ms
+step:964/1490 train_time:42653ms step_avg:44.25ms
+step:965/1490 train_time:42707ms step_avg:44.26ms
+step:966/1490 train_time:42767ms step_avg:44.27ms
+step:967/1490 train_time:42821ms step_avg:44.28ms
+step:968/1490 train_time:42883ms step_avg:44.30ms
+step:969/1490 train_time:42962ms step_avg:44.34ms
+step:970/1490 train_time:43049ms step_avg:44.38ms
+step:971/1490 train_time:43131ms step_avg:44.42ms
+step:972/1490 train_time:43217ms step_avg:44.46ms
+step:973/1490 train_time:43298ms step_avg:44.50ms
+step:974/1490 train_time:43383ms step_avg:44.54ms
+step:975/1490 train_time:43464ms step_avg:44.58ms
+step:976/1490 train_time:43550ms step_avg:44.62ms
+step:977/1490 train_time:43630ms step_avg:44.66ms
+step:978/1490 train_time:43718ms step_avg:44.70ms
+step:979/1490 train_time:43799ms step_avg:44.74ms
+step:980/1490 train_time:43884ms step_avg:44.78ms
+step:981/1490 train_time:43965ms step_avg:44.82ms
+step:982/1490 train_time:44052ms step_avg:44.86ms
+step:983/1490 train_time:44132ms step_avg:44.90ms
+step:984/1490 train_time:44218ms step_avg:44.94ms
+step:985/1490 train_time:44299ms step_avg:44.97ms
+step:986/1490 train_time:44387ms step_avg:45.02ms
+step:987/1490 train_time:44467ms step_avg:45.05ms
+step:988/1490 train_time:44552ms step_avg:45.09ms
+step:989/1490 train_time:44633ms step_avg:45.13ms
+step:990/1490 train_time:44720ms step_avg:45.17ms
+step:991/1490 train_time:44802ms step_avg:45.21ms
+step:992/1490 train_time:44889ms step_avg:45.25ms
+step:993/1490 train_time:44970ms step_avg:45.29ms
+step:994/1490 train_time:45057ms step_avg:45.33ms
+step:995/1490 train_time:45138ms step_avg:45.36ms
+step:996/1490 train_time:45223ms step_avg:45.40ms
+step:997/1490 train_time:45304ms step_avg:45.44ms
+step:998/1490 train_time:45390ms step_avg:45.48ms
+step:999/1490 train_time:45470ms step_avg:45.52ms
+step:1000/1490 train_time:45558ms step_avg:45.56ms
+step:1000/1490 val_loss:3.5168 train_time:45662ms step_avg:45.66ms
+step:1001/1490 train_time:45678ms step_avg:45.63ms
+step:1002/1490 train_time:45730ms step_avg:45.64ms
+step:1003/1490 train_time:45813ms step_avg:45.68ms
+step:1004/1490 train_time:45901ms step_avg:45.72ms
+step:1005/1490 train_time:45983ms step_avg:45.75ms
+step:1006/1490 train_time:46069ms step_avg:45.79ms
+step:1007/1490 train_time:46149ms step_avg:45.83ms
+step:1008/1490 train_time:46234ms step_avg:45.87ms
+step:1009/1490 train_time:46313ms step_avg:45.90ms
+step:1010/1490 train_time:46398ms step_avg:45.94ms
+step:1011/1490 train_time:46478ms step_avg:45.97ms
+step:1012/1490 train_time:46563ms step_avg:46.01ms
+step:1013/1490 train_time:46646ms step_avg:46.05ms
+step:1014/1490 train_time:46734ms step_avg:46.09ms
+step:1015/1490 train_time:46817ms step_avg:46.13ms
+step:1016/1490 train_time:46905ms step_avg:46.17ms
+step:1017/1490 train_time:46988ms step_avg:46.20ms
+step:1018/1490 train_time:47073ms step_avg:46.24ms
+step:1019/1490 train_time:47152ms step_avg:46.27ms
+step:1020/1490 train_time:47237ms step_avg:46.31ms
+step:1021/1490 train_time:47317ms step_avg:46.34ms
+step:1022/1490 train_time:47403ms step_avg:46.38ms
+step:1023/1490 train_time:47483ms step_avg:46.42ms
+step:1024/1490 train_time:47568ms step_avg:46.45ms
+step:1025/1490 train_time:47650ms step_avg:46.49ms
+step:1026/1490 train_time:47738ms step_avg:46.53ms
+step:1027/1490 train_time:47820ms step_avg:46.56ms
+step:1028/1490 train_time:47907ms step_avg:46.60ms
+step:1029/1490 train_time:47989ms step_avg:46.64ms
+step:1030/1490 train_time:48074ms step_avg:46.67ms
+step:1031/1490 train_time:48156ms step_avg:46.71ms
+step:1032/1490 train_time:48241ms step_avg:46.75ms
+step:1033/1490 train_time:48320ms step_avg:46.78ms
+step:1034/1490 train_time:48407ms step_avg:46.81ms
+step:1035/1490 train_time:48486ms step_avg:46.85ms
+step:1036/1490 train_time:48573ms step_avg:46.88ms
+step:1037/1490 train_time:48654ms step_avg:46.92ms
+step:1038/1490 train_time:48741ms step_avg:46.96ms
+step:1039/1490 train_time:48822ms step_avg:46.99ms
+step:1040/1490 train_time:48910ms step_avg:47.03ms
+step:1041/1490 train_time:48991ms step_avg:47.06ms
+step:1042/1490 train_time:49076ms step_avg:47.10ms
+step:1043/1490 train_time:49156ms step_avg:47.13ms
+step:1044/1490 train_time:49242ms step_avg:47.17ms
+step:1045/1490 train_time:49323ms step_avg:47.20ms
+step:1046/1490 train_time:49409ms step_avg:47.24ms
+step:1047/1490 train_time:49490ms step_avg:47.27ms
+step:1048/1490 train_time:49575ms step_avg:47.30ms
+step:1049/1490 train_time:49655ms step_avg:47.34ms
+step:1050/1490 train_time:49742ms step_avg:47.37ms
+step:1051/1490 train_time:49824ms step_avg:47.41ms
+step:1052/1490 train_time:49911ms step_avg:47.44ms
+step:1053/1490 train_time:49992ms step_avg:47.48ms
+step:1054/1490 train_time:50080ms step_avg:47.51ms
+step:1055/1490 train_time:50161ms step_avg:47.55ms
+step:1056/1490 train_time:50247ms step_avg:47.58ms
+step:1057/1490 train_time:50327ms step_avg:47.61ms
+step:1058/1490 train_time:50412ms step_avg:47.65ms
+step:1059/1490 train_time:50494ms step_avg:47.68ms
+step:1060/1490 train_time:50581ms step_avg:47.72ms
+step:1061/1490 train_time:50662ms step_avg:47.75ms
+step:1062/1490 train_time:50748ms step_avg:47.79ms
+step:1063/1490 train_time:50830ms step_avg:47.82ms
+step:1064/1490 train_time:50917ms step_avg:47.85ms
+step:1065/1490 train_time:50997ms step_avg:47.88ms
+step:1066/1490 train_time:51084ms step_avg:47.92ms
+step:1067/1490 train_time:51165ms step_avg:47.95ms
+step:1068/1490 train_time:51249ms step_avg:47.99ms
+step:1069/1490 train_time:51330ms step_avg:48.02ms
+step:1070/1490 train_time:51416ms step_avg:48.05ms
+step:1071/1490 train_time:51498ms step_avg:48.08ms
+step:1072/1490 train_time:51584ms step_avg:48.12ms
+step:1073/1490 train_time:51663ms step_avg:48.15ms
+step:1074/1490 train_time:51750ms step_avg:48.18ms
+step:1075/1490 train_time:51832ms step_avg:48.22ms
+step:1076/1490 train_time:51919ms step_avg:48.25ms
+step:1077/1490 train_time:52000ms step_avg:48.28ms
+step:1078/1490 train_time:52087ms step_avg:48.32ms
+step:1079/1490 train_time:52168ms step_avg:48.35ms
+step:1080/1490 train_time:52255ms step_avg:48.38ms
+step:1081/1490 train_time:52336ms step_avg:48.41ms
+step:1082/1490 train_time:52422ms step_avg:48.45ms
+step:1083/1490 train_time:52502ms step_avg:48.48ms
+step:1084/1490 train_time:52588ms step_avg:48.51ms
+step:1085/1490 train_time:52669ms step_avg:48.54ms
+step:1086/1490 train_time:52755ms step_avg:48.58ms
+step:1087/1490 train_time:52837ms step_avg:48.61ms
+step:1088/1490 train_time:52923ms step_avg:48.64ms
+step:1089/1490 train_time:53004ms step_avg:48.67ms
+step:1090/1490 train_time:53090ms step_avg:48.71ms
+step:1091/1490 train_time:53170ms step_avg:48.74ms
+step:1092/1490 train_time:53257ms step_avg:48.77ms
+step:1093/1490 train_time:53338ms step_avg:48.80ms
+step:1094/1490 train_time:53424ms step_avg:48.83ms
+step:1095/1490 train_time:53505ms step_avg:48.86ms
+step:1096/1490 train_time:53591ms step_avg:48.90ms
+step:1097/1490 train_time:53670ms step_avg:48.92ms
+step:1098/1490 train_time:53757ms step_avg:48.96ms
+step:1099/1490 train_time:53839ms step_avg:48.99ms
+step:1100/1490 train_time:53926ms step_avg:49.02ms
+step:1101/1490 train_time:54009ms step_avg:49.05ms
+step:1102/1490 train_time:54095ms step_avg:49.09ms
+step:1103/1490 train_time:54176ms step_avg:49.12ms
+step:1104/1490 train_time:54262ms step_avg:49.15ms
+step:1105/1490 train_time:54342ms step_avg:49.18ms
+step:1106/1490 train_time:54429ms step_avg:49.21ms
+step:1107/1490 train_time:54509ms step_avg:49.24ms
+step:1108/1490 train_time:54595ms step_avg:49.27ms
+step:1109/1490 train_time:54676ms step_avg:49.30ms
+step:1110/1490 train_time:54764ms step_avg:49.34ms
+step:1111/1490 train_time:54844ms step_avg:49.36ms
+step:1112/1490 train_time:54932ms step_avg:49.40ms
+step:1113/1490 train_time:55012ms step_avg:49.43ms
+step:1114/1490 train_time:55097ms step_avg:49.46ms
+step:1115/1490 train_time:55179ms step_avg:49.49ms
+step:1116/1490 train_time:55266ms step_avg:49.52ms
+step:1117/1490 train_time:55346ms step_avg:49.55ms
+step:1118/1490 train_time:55432ms step_avg:49.58ms
+step:1119/1490 train_time:55513ms step_avg:49.61ms
+step:1120/1490 train_time:55599ms step_avg:49.64ms
+step:1121/1490 train_time:55680ms step_avg:49.67ms
+step:1122/1490 train_time:55766ms step_avg:49.70ms
+step:1123/1490 train_time:55847ms step_avg:49.73ms
+step:1124/1490 train_time:55935ms step_avg:49.76ms
+step:1125/1490 train_time:56015ms step_avg:49.79ms
+step:1126/1490 train_time:56101ms step_avg:49.82ms
+step:1127/1490 train_time:56181ms step_avg:49.85ms
+step:1128/1490 train_time:56267ms step_avg:49.88ms
+step:1129/1490 train_time:56349ms step_avg:49.91ms
+step:1130/1490 train_time:56435ms step_avg:49.94ms
+step:1131/1490 train_time:56516ms step_avg:49.97ms
+step:1132/1490 train_time:56603ms step_avg:50.00ms
+step:1133/1490 train_time:56683ms step_avg:50.03ms
+step:1134/1490 train_time:56770ms step_avg:50.06ms
+step:1135/1490 train_time:56851ms step_avg:50.09ms
+step:1136/1490 train_time:56937ms step_avg:50.12ms
+step:1137/1490 train_time:57018ms step_avg:50.15ms
+step:1138/1490 train_time:57104ms step_avg:50.18ms
+step:1139/1490 train_time:57184ms step_avg:50.21ms
+step:1140/1490 train_time:57270ms step_avg:50.24ms
+step:1141/1490 train_time:57351ms step_avg:50.26ms
+step:1142/1490 train_time:57437ms step_avg:50.30ms
+step:1143/1490 train_time:57518ms step_avg:50.32ms
+step:1144/1490 train_time:57605ms step_avg:50.35ms
+step:1145/1490 train_time:57685ms step_avg:50.38ms
+step:1146/1490 train_time:57771ms step_avg:50.41ms
+step:1147/1490 train_time:57852ms step_avg:50.44ms
+step:1148/1490 train_time:57938ms step_avg:50.47ms
+step:1149/1490 train_time:58021ms step_avg:50.50ms
+step:1150/1490 train_time:58108ms step_avg:50.53ms
+step:1151/1490 train_time:58188ms step_avg:50.55ms
+step:1152/1490 train_time:58274ms step_avg:50.58ms
+step:1153/1490 train_time:58354ms step_avg:50.61ms
+step:1154/1490 train_time:58441ms step_avg:50.64ms
+step:1155/1490 train_time:58522ms step_avg:50.67ms
+step:1156/1490 train_time:58609ms step_avg:50.70ms
+step:1157/1490 train_time:58691ms step_avg:50.73ms
+step:1158/1490 train_time:58776ms step_avg:50.76ms
+step:1159/1490 train_time:58857ms step_avg:50.78ms
+step:1160/1490 train_time:58942ms step_avg:50.81ms
+step:1161/1490 train_time:59024ms step_avg:50.84ms
+step:1162/1490 train_time:59110ms step_avg:50.87ms
+step:1163/1490 train_time:59192ms step_avg:50.90ms
+step:1164/1490 train_time:59277ms step_avg:50.93ms
+step:1165/1490 train_time:59357ms step_avg:50.95ms
+step:1166/1490 train_time:59444ms step_avg:50.98ms
+step:1167/1490 train_time:59525ms step_avg:51.01ms
+step:1168/1490 train_time:59612ms step_avg:51.04ms
+step:1169/1490 train_time:59693ms step_avg:51.06ms
+step:1170/1490 train_time:59780ms step_avg:51.09ms
+step:1171/1490 train_time:59861ms step_avg:51.12ms
+step:1172/1490 train_time:59948ms step_avg:51.15ms
+step:1173/1490 train_time:60029ms step_avg:51.18ms
+step:1174/1490 train_time:60115ms step_avg:51.21ms
+step:1175/1490 train_time:60196ms step_avg:51.23ms
+step:1176/1490 train_time:60283ms step_avg:51.26ms
+step:1177/1490 train_time:60363ms step_avg:51.29ms
+step:1178/1490 train_time:60449ms step_avg:51.31ms
+step:1179/1490 train_time:60530ms step_avg:51.34ms
+step:1180/1490 train_time:60618ms step_avg:51.37ms
+step:1181/1490 train_time:60699ms step_avg:51.40ms
+step:1182/1490 train_time:60786ms step_avg:51.43ms
+step:1183/1490 train_time:60865ms step_avg:51.45ms
+step:1184/1490 train_time:60951ms step_avg:51.48ms
+step:1185/1490 train_time:61031ms step_avg:51.50ms
+step:1186/1490 train_time:61117ms step_avg:51.53ms
+step:1187/1490 train_time:61199ms step_avg:51.56ms
+step:1188/1490 train_time:61285ms step_avg:51.59ms
+step:1189/1490 train_time:61364ms step_avg:51.61ms
+step:1190/1490 train_time:61451ms step_avg:51.64ms
+step:1191/1490 train_time:61532ms step_avg:51.66ms
+step:1192/1490 train_time:61619ms step_avg:51.69ms
+step:1193/1490 train_time:61701ms step_avg:51.72ms
+step:1194/1490 train_time:61788ms step_avg:51.75ms
+step:1195/1490 train_time:61868ms step_avg:51.77ms
+step:1196/1490 train_time:61953ms step_avg:51.80ms
+step:1197/1490 train_time:62034ms step_avg:51.82ms
+step:1198/1490 train_time:62122ms step_avg:51.85ms
+step:1199/1490 train_time:62203ms step_avg:51.88ms
+step:1200/1490 train_time:62290ms step_avg:51.91ms
+step:1201/1490 train_time:62371ms step_avg:51.93ms
+step:1202/1490 train_time:62456ms step_avg:51.96ms
+step:1203/1490 train_time:62537ms step_avg:51.98ms
+step:1204/1490 train_time:62624ms step_avg:52.01ms
+step:1205/1490 train_time:62705ms step_avg:52.04ms
+step:1206/1490 train_time:62792ms step_avg:52.07ms
+step:1207/1490 train_time:62872ms step_avg:52.09ms
+step:1208/1490 train_time:62957ms step_avg:52.12ms
+step:1209/1490 train_time:63038ms step_avg:52.14ms
+step:1210/1490 train_time:63125ms step_avg:52.17ms
+step:1211/1490 train_time:63206ms step_avg:52.19ms
+step:1212/1490 train_time:63291ms step_avg:52.22ms
+step:1213/1490 train_time:63372ms step_avg:52.24ms
+step:1214/1490 train_time:63460ms step_avg:52.27ms
+step:1215/1490 train_time:63541ms step_avg:52.30ms
+step:1216/1490 train_time:63628ms step_avg:52.33ms
+step:1217/1490 train_time:63708ms step_avg:52.35ms
+step:1218/1490 train_time:63795ms step_avg:52.38ms
+step:1219/1490 train_time:63876ms step_avg:52.40ms
+step:1220/1490 train_time:63962ms step_avg:52.43ms
+step:1221/1490 train_time:64042ms step_avg:52.45ms
+step:1222/1490 train_time:64129ms step_avg:52.48ms
+step:1223/1490 train_time:64210ms step_avg:52.50ms
+step:1224/1490 train_time:64297ms step_avg:52.53ms
+step:1225/1490 train_time:64377ms step_avg:52.55ms
+step:1226/1490 train_time:64465ms step_avg:52.58ms
+step:1227/1490 train_time:64547ms step_avg:52.61ms
+step:1228/1490 train_time:64633ms step_avg:52.63ms
+step:1229/1490 train_time:64714ms step_avg:52.66ms
+step:1230/1490 train_time:64800ms step_avg:52.68ms
+step:1231/1490 train_time:64882ms step_avg:52.71ms
+step:1232/1490 train_time:64968ms step_avg:52.73ms
+step:1233/1490 train_time:65049ms step_avg:52.76ms
+step:1234/1490 train_time:65134ms step_avg:52.78ms
+step:1235/1490 train_time:65215ms step_avg:52.81ms
+step:1236/1490 train_time:65302ms step_avg:52.83ms
+step:1237/1490 train_time:65382ms step_avg:52.86ms
+step:1238/1490 train_time:65469ms step_avg:52.88ms
+step:1239/1490 train_time:65550ms step_avg:52.91ms
+step:1240/1490 train_time:65636ms step_avg:52.93ms
+step:1241/1490 train_time:65716ms step_avg:52.95ms
+step:1242/1490 train_time:65803ms step_avg:52.98ms
+step:1243/1490 train_time:65884ms step_avg:53.00ms
+step:1244/1490 train_time:65970ms step_avg:53.03ms
+step:1245/1490 train_time:66050ms step_avg:53.05ms
+step:1246/1490 train_time:66136ms step_avg:53.08ms
+step:1247/1490 train_time:66218ms step_avg:53.10ms
+step:1248/1490 train_time:66304ms step_avg:53.13ms
+step:1249/1490 train_time:66385ms step_avg:53.15ms
+step:1250/1490 train_time:66471ms step_avg:53.18ms
+step:1250/1490 val_loss:3.3701 train_time:66574ms step_avg:53.26ms
+step:1251/1490 train_time:66591ms step_avg:53.23ms
+step:1252/1490 train_time:66641ms step_avg:53.23ms
+step:1253/1490 train_time:66726ms step_avg:53.25ms
+step:1254/1490 train_time:66816ms step_avg:53.28ms
+step:1255/1490 train_time:66896ms step_avg:53.30ms
+step:1256/1490 train_time:66983ms step_avg:53.33ms
+step:1257/1490 train_time:67063ms step_avg:53.35ms
+step:1258/1490 train_time:67147ms step_avg:53.38ms
+step:1259/1490 train_time:67229ms step_avg:53.40ms
+step:1260/1490 train_time:67315ms step_avg:53.42ms
+step:1261/1490 train_time:67394ms step_avg:53.44ms
+step:1262/1490 train_time:67482ms step_avg:53.47ms
+step:1263/1490 train_time:67562ms step_avg:53.49ms
+step:1264/1490 train_time:67651ms step_avg:53.52ms
+step:1265/1490 train_time:67735ms step_avg:53.55ms
+step:1266/1490 train_time:67822ms step_avg:53.57ms
+step:1267/1490 train_time:67902ms step_avg:53.59ms
+step:1268/1490 train_time:67989ms step_avg:53.62ms
+step:1269/1490 train_time:68070ms step_avg:53.64ms
+step:1270/1490 train_time:68157ms step_avg:53.67ms
+step:1271/1490 train_time:68236ms step_avg:53.69ms
+step:1272/1490 train_time:68323ms step_avg:53.71ms
+step:1273/1490 train_time:68402ms step_avg:53.73ms
+step:1274/1490 train_time:68488ms step_avg:53.76ms
+step:1275/1490 train_time:68570ms step_avg:53.78ms
+step:1276/1490 train_time:68658ms step_avg:53.81ms
+step:1277/1490 train_time:68740ms step_avg:53.83ms
+step:1278/1490 train_time:68826ms step_avg:53.85ms
+step:1279/1490 train_time:68908ms step_avg:53.88ms
+step:1280/1490 train_time:68995ms step_avg:53.90ms
+step:1281/1490 train_time:69075ms step_avg:53.92ms
+step:1282/1490 train_time:69161ms step_avg:53.95ms
+step:1283/1490 train_time:69241ms step_avg:53.97ms
+step:1284/1490 train_time:69326ms step_avg:53.99ms
+step:1285/1490 train_time:69407ms step_avg:54.01ms
+step:1286/1490 train_time:69494ms step_avg:54.04ms
+step:1287/1490 train_time:69576ms step_avg:54.06ms
+step:1288/1490 train_time:69664ms step_avg:54.09ms
+step:1289/1490 train_time:69746ms step_avg:54.11ms
+step:1290/1490 train_time:69833ms step_avg:54.13ms
+step:1291/1490 train_time:69913ms step_avg:54.15ms
+step:1292/1490 train_time:69999ms step_avg:54.18ms
+step:1293/1490 train_time:70079ms step_avg:54.20ms
+step:1294/1490 train_time:70165ms step_avg:54.22ms
+step:1295/1490 train_time:70245ms step_avg:54.24ms
+step:1296/1490 train_time:70331ms step_avg:54.27ms
+step:1297/1490 train_time:70411ms step_avg:54.29ms
+step:1298/1490 train_time:70498ms step_avg:54.31ms
+step:1299/1490 train_time:70579ms step_avg:54.33ms
+step:1300/1490 train_time:70665ms step_avg:54.36ms
+step:1301/1490 train_time:70747ms step_avg:54.38ms
+step:1302/1490 train_time:70835ms step_avg:54.40ms
+step:1303/1490 train_time:70916ms step_avg:54.43ms
+step:1304/1490 train_time:71003ms step_avg:54.45ms
+step:1305/1490 train_time:71084ms step_avg:54.47ms
+step:1306/1490 train_time:71169ms step_avg:54.49ms
+step:1307/1490 train_time:71250ms step_avg:54.51ms
+step:1308/1490 train_time:71335ms step_avg:54.54ms
+step:1309/1490 train_time:71415ms step_avg:54.56ms
+step:1310/1490 train_time:71503ms step_avg:54.58ms
+step:1311/1490 train_time:71584ms step_avg:54.60ms
+step:1312/1490 train_time:71669ms step_avg:54.63ms
+step:1313/1490 train_time:71751ms step_avg:54.65ms
+step:1314/1490 train_time:71838ms step_avg:54.67ms
+step:1315/1490 train_time:71918ms step_avg:54.69ms
+step:1316/1490 train_time:72005ms step_avg:54.72ms
+step:1317/1490 train_time:72086ms step_avg:54.73ms
+step:1318/1490 train_time:72172ms step_avg:54.76ms
+step:1319/1490 train_time:72253ms step_avg:54.78ms
+step:1320/1490 train_time:72340ms step_avg:54.80ms
+step:1321/1490 train_time:72422ms step_avg:54.82ms
+step:1322/1490 train_time:72508ms step_avg:54.85ms
+step:1323/1490 train_time:72588ms step_avg:54.87ms
+step:1324/1490 train_time:72675ms step_avg:54.89ms
+step:1325/1490 train_time:72756ms step_avg:54.91ms
+step:1326/1490 train_time:72843ms step_avg:54.93ms
+step:1327/1490 train_time:72924ms step_avg:54.95ms
+step:1328/1490 train_time:73010ms step_avg:54.98ms
+step:1329/1490 train_time:73091ms step_avg:55.00ms
+step:1330/1490 train_time:73178ms step_avg:55.02ms
+step:1331/1490 train_time:73257ms step_avg:55.04ms
+step:1332/1490 train_time:73343ms step_avg:55.06ms
+step:1333/1490 train_time:73424ms step_avg:55.08ms
+step:1334/1490 train_time:73512ms step_avg:55.11ms
+step:1335/1490 train_time:73593ms step_avg:55.13ms
+step:1336/1490 train_time:73680ms step_avg:55.15ms
+step:1337/1490 train_time:73761ms step_avg:55.17ms
+step:1338/1490 train_time:73846ms step_avg:55.19ms
+step:1339/1490 train_time:73928ms step_avg:55.21ms
+step:1340/1490 train_time:74014ms step_avg:55.23ms
+step:1341/1490 train_time:74095ms step_avg:55.25ms
+step:1342/1490 train_time:74181ms step_avg:55.28ms
+step:1343/1490 train_time:74263ms step_avg:55.30ms
+step:1344/1490 train_time:74350ms step_avg:55.32ms
+step:1345/1490 train_time:74431ms step_avg:55.34ms
+step:1346/1490 train_time:74517ms step_avg:55.36ms
+step:1347/1490 train_time:74598ms step_avg:55.38ms
+step:1348/1490 train_time:74684ms step_avg:55.40ms
+step:1349/1490 train_time:74764ms step_avg:55.42ms
+step:1350/1490 train_time:74849ms step_avg:55.44ms
+step:1351/1490 train_time:74931ms step_avg:55.46ms
+step:1352/1490 train_time:75017ms step_avg:55.49ms
+step:1353/1490 train_time:75097ms step_avg:55.50ms
+step:1354/1490 train_time:75183ms step_avg:55.53ms
+step:1355/1490 train_time:75263ms step_avg:55.54ms
+step:1356/1490 train_time:75350ms step_avg:55.57ms
+step:1357/1490 train_time:75431ms step_avg:55.59ms
+step:1358/1490 train_time:75518ms step_avg:55.61ms
+step:1359/1490 train_time:75600ms step_avg:55.63ms
+step:1360/1490 train_time:75686ms step_avg:55.65ms
+step:1361/1490 train_time:75767ms step_avg:55.67ms
+step:1362/1490 train_time:75852ms step_avg:55.69ms
+step:1363/1490 train_time:75934ms step_avg:55.71ms
+step:1364/1490 train_time:76020ms step_avg:55.73ms
+step:1365/1490 train_time:76103ms step_avg:55.75ms
+step:1366/1490 train_time:76189ms step_avg:55.78ms
+step:1367/1490 train_time:76269ms step_avg:55.79ms
+step:1368/1490 train_time:76356ms step_avg:55.82ms
+step:1369/1490 train_time:76436ms step_avg:55.83ms
+step:1370/1490 train_time:76524ms step_avg:55.86ms
+step:1371/1490 train_time:76605ms step_avg:55.88ms
+step:1372/1490 train_time:76691ms step_avg:55.90ms
+step:1373/1490 train_time:76771ms step_avg:55.91ms
+step:1374/1490 train_time:76857ms step_avg:55.94ms
+step:1375/1490 train_time:76937ms step_avg:55.95ms
+step:1376/1490 train_time:77025ms step_avg:55.98ms
+step:1377/1490 train_time:77107ms step_avg:56.00ms
+step:1378/1490 train_time:77192ms step_avg:56.02ms
+step:1379/1490 train_time:77273ms step_avg:56.04ms
+step:1380/1490 train_time:77359ms step_avg:56.06ms
+step:1381/1490 train_time:77440ms step_avg:56.08ms
+step:1382/1490 train_time:77527ms step_avg:56.10ms
+step:1383/1490 train_time:77610ms step_avg:56.12ms
+step:1384/1490 train_time:77697ms step_avg:56.14ms
+step:1385/1490 train_time:77778ms step_avg:56.16ms
+step:1386/1490 train_time:77863ms step_avg:56.18ms
+step:1387/1490 train_time:77944ms step_avg:56.20ms
+step:1388/1490 train_time:78031ms step_avg:56.22ms
+step:1389/1490 train_time:78114ms step_avg:56.24ms
+step:1390/1490 train_time:78201ms step_avg:56.26ms
+step:1391/1490 train_time:78282ms step_avg:56.28ms
+step:1392/1490 train_time:78367ms step_avg:56.30ms
+step:1393/1490 train_time:78448ms step_avg:56.32ms
+step:1394/1490 train_time:78535ms step_avg:56.34ms
+step:1395/1490 train_time:78615ms step_avg:56.36ms
+step:1396/1490 train_time:78702ms step_avg:56.38ms
+step:1397/1490 train_time:78783ms step_avg:56.39ms
+step:1398/1490 train_time:78868ms step_avg:56.42ms
+step:1399/1490 train_time:78950ms step_avg:56.43ms
+step:1400/1490 train_time:79036ms step_avg:56.45ms
+step:1401/1490 train_time:79116ms step_avg:56.47ms
+step:1402/1490 train_time:79205ms step_avg:56.49ms
+step:1403/1490 train_time:79284ms step_avg:56.51ms
+step:1404/1490 train_time:79370ms step_avg:56.53ms
+step:1405/1490 train_time:79451ms step_avg:56.55ms
+step:1406/1490 train_time:79538ms step_avg:56.57ms
+step:1407/1490 train_time:79619ms step_avg:56.59ms
+step:1408/1490 train_time:79706ms step_avg:56.61ms
+step:1409/1490 train_time:79786ms step_avg:56.63ms
+step:1410/1490 train_time:79874ms step_avg:56.65ms
+step:1411/1490 train_time:79956ms step_avg:56.67ms
+step:1412/1490 train_time:80042ms step_avg:56.69ms
+step:1413/1490 train_time:80123ms step_avg:56.70ms
+step:1414/1490 train_time:80210ms step_avg:56.73ms
+step:1415/1490 train_time:80289ms step_avg:56.74ms
+step:1416/1490 train_time:80376ms step_avg:56.76ms
+step:1417/1490 train_time:80457ms step_avg:56.78ms
+step:1418/1490 train_time:80542ms step_avg:56.80ms
+step:1419/1490 train_time:80624ms step_avg:56.82ms
+step:1420/1490 train_time:80711ms step_avg:56.84ms
+step:1421/1490 train_time:80792ms step_avg:56.86ms
+step:1422/1490 train_time:80880ms step_avg:56.88ms
+step:1423/1490 train_time:80960ms step_avg:56.89ms
+step:1424/1490 train_time:81046ms step_avg:56.91ms
+step:1425/1490 train_time:81127ms step_avg:56.93ms
+step:1426/1490 train_time:81214ms step_avg:56.95ms
+step:1427/1490 train_time:81295ms step_avg:56.97ms
+step:1428/1490 train_time:81382ms step_avg:56.99ms
+step:1429/1490 train_time:81463ms step_avg:57.01ms
+step:1430/1490 train_time:81549ms step_avg:57.03ms
+step:1431/1490 train_time:81632ms step_avg:57.05ms
+step:1432/1490 train_time:81718ms step_avg:57.07ms
+step:1433/1490 train_time:81798ms step_avg:57.08ms
+step:1434/1490 train_time:81885ms step_avg:57.10ms
+step:1435/1490 train_time:81965ms step_avg:57.12ms
+step:1436/1490 train_time:82053ms step_avg:57.14ms
+step:1437/1490 train_time:82134ms step_avg:57.16ms
+step:1438/1490 train_time:82220ms step_avg:57.18ms
+step:1439/1490 train_time:82301ms step_avg:57.19ms
+step:1440/1490 train_time:82388ms step_avg:57.21ms
+step:1441/1490 train_time:82470ms step_avg:57.23ms
+step:1442/1490 train_time:82556ms step_avg:57.25ms
+step:1443/1490 train_time:82635ms step_avg:57.27ms
+step:1444/1490 train_time:82723ms step_avg:57.29ms
+step:1445/1490 train_time:82804ms step_avg:57.30ms
+step:1446/1490 train_time:82891ms step_avg:57.32ms
+step:1447/1490 train_time:82973ms step_avg:57.34ms
+step:1448/1490 train_time:83059ms step_avg:57.36ms
+step:1449/1490 train_time:83139ms step_avg:57.38ms
+step:1450/1490 train_time:83227ms step_avg:57.40ms
+step:1451/1490 train_time:83313ms step_avg:57.42ms
+step:1452/1490 train_time:83401ms step_avg:57.44ms
+step:1453/1490 train_time:83481ms step_avg:57.45ms
+step:1454/1490 train_time:83566ms step_avg:57.47ms
+step:1455/1490 train_time:83648ms step_avg:57.49ms
+step:1456/1490 train_time:83735ms step_avg:57.51ms
+step:1457/1490 train_time:83815ms step_avg:57.53ms
+step:1458/1490 train_time:83902ms step_avg:57.55ms
+step:1459/1490 train_time:83983ms step_avg:57.56ms
+step:1460/1490 train_time:84070ms step_avg:57.58ms
+step:1461/1490 train_time:84151ms step_avg:57.60ms
+step:1462/1490 train_time:84238ms step_avg:57.62ms
+step:1463/1490 train_time:84321ms step_avg:57.64ms
+step:1464/1490 train_time:84407ms step_avg:57.66ms
+step:1465/1490 train_time:84489ms step_avg:57.67ms
+step:1466/1490 train_time:84575ms step_avg:57.69ms
+step:1467/1490 train_time:84655ms step_avg:57.71ms
+step:1468/1490 train_time:84743ms step_avg:57.73ms
+step:1469/1490 train_time:84824ms step_avg:57.74ms
+step:1470/1490 train_time:84910ms step_avg:57.76ms
+step:1471/1490 train_time:84992ms step_avg:57.78ms
+step:1472/1490 train_time:85078ms step_avg:57.80ms
+step:1473/1490 train_time:85159ms step_avg:57.81ms
+step:1474/1490 train_time:85247ms step_avg:57.83ms
+step:1475/1490 train_time:85329ms step_avg:57.85ms
+step:1476/1490 train_time:85416ms step_avg:57.87ms
+step:1477/1490 train_time:85499ms step_avg:57.89ms
+step:1478/1490 train_time:85585ms step_avg:57.91ms
+step:1479/1490 train_time:85665ms step_avg:57.92ms
+step:1480/1490 train_time:85754ms step_avg:57.94ms
+step:1481/1490 train_time:85834ms step_avg:57.96ms
+step:1482/1490 train_time:85920ms step_avg:57.98ms
+step:1483/1490 train_time:86002ms step_avg:57.99ms
+step:1484/1490 train_time:86089ms step_avg:58.01ms
+step:1485/1490 train_time:86171ms step_avg:58.03ms
+step:1486/1490 train_time:86259ms step_avg:58.05ms
+step:1487/1490 train_time:86340ms step_avg:58.06ms
+step:1488/1490 train_time:86427ms step_avg:58.08ms
+step:1489/1490 train_time:86509ms step_avg:58.10ms
+step:1490/1490 train_time:86594ms step_avg:58.12ms
+step:1490/1490 val_loss:3.2773 train_time:86697ms step_avg:58.19ms
+peak memory allocated: 31296 MiB reserved: 47162 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/baseline/2026-03-22_19-58-11_time-185_secs_baseline_3057fa.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/baseline/2026-03-22_19-58-11_time-185_secs_baseline_3057fa.txt
@@ -1,0 +1,4456 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 19:58:26 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            122W /  700W |    1520MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            131W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   40C    P0            124W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1782239      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1782240      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1782241      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1782242      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1782243      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1782244      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1782245      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1782246      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8331 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:83ms step_avg:83.01ms
+step:2/1490 train_time:107ms step_avg:53.53ms
+step:3/1490 train_time:124ms step_avg:41.42ms
+step:4/1490 train_time:145ms step_avg:36.15ms
+step:5/1490 train_time:171ms step_avg:34.15ms
+step:6/1490 train_time:206ms step_avg:34.30ms
+step:7/1490 train_time:233ms step_avg:33.32ms
+step:8/1490 train_time:268ms step_avg:33.47ms
+step:9/1490 train_time:296ms step_avg:32.83ms
+step:10/1490 train_time:330ms step_avg:33.04ms
+step:11/1490 train_time:358ms step_avg:32.54ms
+step:12/1490 train_time:393ms step_avg:32.76ms
+step:13/1490 train_time:421ms step_avg:32.38ms
+step:14/1490 train_time:456ms step_avg:32.54ms
+step:15/1490 train_time:484ms step_avg:32.23ms
+step:16/1490 train_time:518ms step_avg:32.38ms
+step:17/1490 train_time:546ms step_avg:32.14ms
+step:18/1490 train_time:581ms step_avg:32.29ms
+step:19/1490 train_time:610ms step_avg:32.09ms
+step:20/1490 train_time:644ms step_avg:32.20ms
+step:21/1490 train_time:672ms step_avg:32.01ms
+step:22/1490 train_time:707ms step_avg:32.12ms
+step:23/1490 train_time:735ms step_avg:31.96ms
+step:24/1490 train_time:770ms step_avg:32.08ms
+step:25/1490 train_time:798ms step_avg:31.92ms
+step:26/1490 train_time:833ms step_avg:32.03ms
+step:27/1490 train_time:861ms step_avg:31.88ms
+step:28/1490 train_time:896ms step_avg:31.99ms
+step:29/1490 train_time:924ms step_avg:31.87ms
+step:30/1490 train_time:959ms step_avg:31.97ms
+step:31/1490 train_time:988ms step_avg:31.86ms
+step:32/1490 train_time:1023ms step_avg:31.97ms
+step:33/1490 train_time:1052ms step_avg:31.89ms
+step:34/1490 train_time:1087ms step_avg:31.98ms
+step:35/1490 train_time:1116ms step_avg:31.88ms
+step:36/1490 train_time:1151ms step_avg:31.97ms
+step:37/1490 train_time:1179ms step_avg:31.87ms
+step:38/1490 train_time:1215ms step_avg:31.96ms
+step:39/1490 train_time:1243ms step_avg:31.87ms
+step:40/1490 train_time:1278ms step_avg:31.94ms
+step:41/1490 train_time:1306ms step_avg:31.86ms
+step:42/1490 train_time:1341ms step_avg:31.93ms
+step:43/1490 train_time:1369ms step_avg:31.85ms
+step:44/1490 train_time:1404ms step_avg:31.91ms
+step:45/1490 train_time:1432ms step_avg:31.83ms
+step:46/1490 train_time:1467ms step_avg:31.90ms
+step:47/1490 train_time:1496ms step_avg:31.83ms
+step:48/1490 train_time:1531ms step_avg:31.89ms
+step:49/1490 train_time:1559ms step_avg:31.81ms
+step:50/1490 train_time:1594ms step_avg:31.87ms
+step:51/1490 train_time:1621ms step_avg:31.79ms
+step:52/1490 train_time:1656ms step_avg:31.84ms
+step:53/1490 train_time:1684ms step_avg:31.77ms
+step:54/1490 train_time:1718ms step_avg:31.82ms
+step:55/1490 train_time:1747ms step_avg:31.76ms
+step:56/1490 train_time:1782ms step_avg:31.81ms
+step:57/1490 train_time:1810ms step_avg:31.75ms
+step:58/1490 train_time:1844ms step_avg:31.79ms
+step:59/1490 train_time:1872ms step_avg:31.73ms
+step:60/1490 train_time:1908ms step_avg:31.79ms
+step:61/1490 train_time:1936ms step_avg:31.74ms
+step:62/1490 train_time:1971ms step_avg:31.79ms
+step:63/1490 train_time:1999ms step_avg:31.73ms
+step:64/1490 train_time:2034ms step_avg:31.78ms
+step:65/1490 train_time:2062ms step_avg:31.73ms
+step:66/1490 train_time:2098ms step_avg:31.78ms
+step:67/1490 train_time:2126ms step_avg:31.73ms
+step:68/1490 train_time:2160ms step_avg:31.77ms
+step:69/1490 train_time:2189ms step_avg:31.73ms
+step:70/1490 train_time:2224ms step_avg:31.77ms
+step:71/1490 train_time:2253ms step_avg:31.73ms
+step:72/1490 train_time:2287ms step_avg:31.76ms
+step:73/1490 train_time:2315ms step_avg:31.72ms
+step:74/1490 train_time:2350ms step_avg:31.76ms
+step:75/1490 train_time:2378ms step_avg:31.71ms
+step:76/1490 train_time:2414ms step_avg:31.76ms
+step:77/1490 train_time:2442ms step_avg:31.71ms
+step:78/1490 train_time:2476ms step_avg:31.75ms
+step:79/1490 train_time:2504ms step_avg:31.70ms
+step:80/1490 train_time:2539ms step_avg:31.74ms
+step:81/1490 train_time:2568ms step_avg:31.70ms
+step:82/1490 train_time:2603ms step_avg:31.74ms
+step:83/1490 train_time:2631ms step_avg:31.70ms
+step:84/1490 train_time:2665ms step_avg:31.73ms
+step:85/1490 train_time:2693ms step_avg:31.69ms
+step:86/1490 train_time:2728ms step_avg:31.72ms
+step:87/1490 train_time:2756ms step_avg:31.68ms
+step:88/1490 train_time:2791ms step_avg:31.72ms
+step:89/1490 train_time:2819ms step_avg:31.68ms
+step:90/1490 train_time:2854ms step_avg:31.71ms
+step:91/1490 train_time:2883ms step_avg:31.68ms
+step:92/1490 train_time:2918ms step_avg:31.71ms
+step:93/1490 train_time:2946ms step_avg:31.68ms
+step:94/1490 train_time:2981ms step_avg:31.71ms
+step:95/1490 train_time:3009ms step_avg:31.68ms
+step:96/1490 train_time:3044ms step_avg:31.71ms
+step:97/1490 train_time:3073ms step_avg:31.68ms
+step:98/1490 train_time:3108ms step_avg:31.71ms
+step:99/1490 train_time:3136ms step_avg:31.68ms
+step:100/1490 train_time:3171ms step_avg:31.71ms
+step:101/1490 train_time:3200ms step_avg:31.68ms
+step:102/1490 train_time:3235ms step_avg:31.72ms
+step:103/1490 train_time:3263ms step_avg:31.68ms
+step:104/1490 train_time:3299ms step_avg:31.72ms
+step:105/1490 train_time:3327ms step_avg:31.68ms
+step:106/1490 train_time:3361ms step_avg:31.71ms
+step:107/1490 train_time:3391ms step_avg:31.69ms
+step:108/1490 train_time:3425ms step_avg:31.72ms
+step:109/1490 train_time:3454ms step_avg:31.69ms
+step:110/1490 train_time:3489ms step_avg:31.71ms
+step:111/1490 train_time:3517ms step_avg:31.68ms
+step:112/1490 train_time:3552ms step_avg:31.71ms
+step:113/1490 train_time:3580ms step_avg:31.69ms
+step:114/1490 train_time:3615ms step_avg:31.71ms
+step:115/1490 train_time:3643ms step_avg:31.68ms
+step:116/1490 train_time:3678ms step_avg:31.71ms
+step:117/1490 train_time:3706ms step_avg:31.68ms
+step:118/1490 train_time:3742ms step_avg:31.71ms
+step:119/1490 train_time:3770ms step_avg:31.68ms
+step:120/1490 train_time:3805ms step_avg:31.70ms
+step:121/1490 train_time:3833ms step_avg:31.68ms
+step:122/1490 train_time:3867ms step_avg:31.70ms
+step:123/1490 train_time:3896ms step_avg:31.67ms
+step:124/1490 train_time:3930ms step_avg:31.70ms
+step:125/1490 train_time:3959ms step_avg:31.67ms
+step:126/1490 train_time:3993ms step_avg:31.69ms
+step:127/1490 train_time:4022ms step_avg:31.67ms
+step:128/1490 train_time:4057ms step_avg:31.69ms
+step:129/1490 train_time:4084ms step_avg:31.66ms
+step:130/1490 train_time:4119ms step_avg:31.69ms
+step:131/1490 train_time:4148ms step_avg:31.67ms
+step:132/1490 train_time:4183ms step_avg:31.69ms
+step:133/1490 train_time:4211ms step_avg:31.66ms
+step:134/1490 train_time:4246ms step_avg:31.68ms
+step:135/1490 train_time:4274ms step_avg:31.66ms
+step:136/1490 train_time:4309ms step_avg:31.68ms
+step:137/1490 train_time:4337ms step_avg:31.66ms
+step:138/1490 train_time:4372ms step_avg:31.68ms
+step:139/1490 train_time:4400ms step_avg:31.66ms
+step:140/1490 train_time:4435ms step_avg:31.68ms
+step:141/1490 train_time:4464ms step_avg:31.66ms
+step:142/1490 train_time:4498ms step_avg:31.68ms
+step:143/1490 train_time:4527ms step_avg:31.66ms
+step:144/1490 train_time:4562ms step_avg:31.68ms
+step:145/1490 train_time:4590ms step_avg:31.65ms
+step:146/1490 train_time:4624ms step_avg:31.67ms
+step:147/1490 train_time:4652ms step_avg:31.65ms
+step:148/1490 train_time:4687ms step_avg:31.67ms
+step:149/1490 train_time:4715ms step_avg:31.65ms
+step:150/1490 train_time:4750ms step_avg:31.66ms
+step:151/1490 train_time:4778ms step_avg:31.64ms
+step:152/1490 train_time:4813ms step_avg:31.66ms
+step:153/1490 train_time:4841ms step_avg:31.64ms
+step:154/1490 train_time:4876ms step_avg:31.66ms
+step:155/1490 train_time:4904ms step_avg:31.64ms
+step:156/1490 train_time:4939ms step_avg:31.66ms
+step:157/1490 train_time:4967ms step_avg:31.64ms
+step:158/1490 train_time:5002ms step_avg:31.66ms
+step:159/1490 train_time:5030ms step_avg:31.64ms
+step:160/1490 train_time:5065ms step_avg:31.65ms
+step:161/1490 train_time:5093ms step_avg:31.63ms
+step:162/1490 train_time:5128ms step_avg:31.65ms
+step:163/1490 train_time:5156ms step_avg:31.63ms
+step:164/1490 train_time:5190ms step_avg:31.65ms
+step:165/1490 train_time:5219ms step_avg:31.63ms
+step:166/1490 train_time:5254ms step_avg:31.65ms
+step:167/1490 train_time:5282ms step_avg:31.63ms
+step:168/1490 train_time:5316ms step_avg:31.65ms
+step:169/1490 train_time:5345ms step_avg:31.63ms
+step:170/1490 train_time:5380ms step_avg:31.65ms
+step:171/1490 train_time:5408ms step_avg:31.63ms
+step:172/1490 train_time:5444ms step_avg:31.65ms
+step:173/1490 train_time:5471ms step_avg:31.63ms
+step:174/1490 train_time:5506ms step_avg:31.64ms
+step:175/1490 train_time:5534ms step_avg:31.62ms
+step:176/1490 train_time:5568ms step_avg:31.64ms
+step:177/1490 train_time:5597ms step_avg:31.62ms
+step:178/1490 train_time:5632ms step_avg:31.64ms
+step:179/1490 train_time:5660ms step_avg:31.62ms
+step:180/1490 train_time:5695ms step_avg:31.64ms
+step:181/1490 train_time:5723ms step_avg:31.62ms
+step:182/1490 train_time:5757ms step_avg:31.63ms
+step:183/1490 train_time:5786ms step_avg:31.62ms
+step:184/1490 train_time:5820ms step_avg:31.63ms
+step:185/1490 train_time:5849ms step_avg:31.62ms
+step:186/1490 train_time:5883ms step_avg:31.63ms
+step:187/1490 train_time:5911ms step_avg:31.61ms
+step:188/1490 train_time:5946ms step_avg:31.63ms
+step:189/1490 train_time:5974ms step_avg:31.61ms
+step:190/1490 train_time:6009ms step_avg:31.62ms
+step:191/1490 train_time:6037ms step_avg:31.61ms
+step:192/1490 train_time:6072ms step_avg:31.63ms
+step:193/1490 train_time:6100ms step_avg:31.61ms
+step:194/1490 train_time:6135ms step_avg:31.63ms
+step:195/1490 train_time:6163ms step_avg:31.61ms
+step:196/1490 train_time:6198ms step_avg:31.62ms
+step:197/1490 train_time:6227ms step_avg:31.61ms
+step:198/1490 train_time:6262ms step_avg:31.62ms
+step:199/1490 train_time:6290ms step_avg:31.61ms
+step:200/1490 train_time:6324ms step_avg:31.62ms
+step:201/1490 train_time:6352ms step_avg:31.60ms
+step:202/1490 train_time:6387ms step_avg:31.62ms
+step:203/1490 train_time:6415ms step_avg:31.60ms
+step:204/1490 train_time:6450ms step_avg:31.62ms
+step:205/1490 train_time:6478ms step_avg:31.60ms
+step:206/1490 train_time:6513ms step_avg:31.62ms
+step:207/1490 train_time:6541ms step_avg:31.60ms
+step:208/1490 train_time:6576ms step_avg:31.61ms
+step:209/1490 train_time:6604ms step_avg:31.60ms
+step:210/1490 train_time:6639ms step_avg:31.61ms
+step:211/1490 train_time:6667ms step_avg:31.60ms
+step:212/1490 train_time:6702ms step_avg:31.61ms
+step:213/1490 train_time:6731ms step_avg:31.60ms
+step:214/1490 train_time:6765ms step_avg:31.61ms
+step:215/1490 train_time:6794ms step_avg:31.60ms
+step:216/1490 train_time:6829ms step_avg:31.62ms
+step:217/1490 train_time:6857ms step_avg:31.60ms
+step:218/1490 train_time:6892ms step_avg:31.62ms
+step:219/1490 train_time:6920ms step_avg:31.60ms
+step:220/1490 train_time:6955ms step_avg:31.61ms
+step:221/1490 train_time:6983ms step_avg:31.60ms
+step:222/1490 train_time:7018ms step_avg:31.61ms
+step:223/1490 train_time:7047ms step_avg:31.60ms
+step:224/1490 train_time:7084ms step_avg:31.62ms
+step:225/1490 train_time:7110ms step_avg:31.60ms
+step:226/1490 train_time:7145ms step_avg:31.61ms
+step:227/1490 train_time:7173ms step_avg:31.60ms
+step:228/1490 train_time:7208ms step_avg:31.61ms
+step:229/1490 train_time:7237ms step_avg:31.60ms
+step:230/1490 train_time:7271ms step_avg:31.61ms
+step:231/1490 train_time:7299ms step_avg:31.60ms
+step:232/1490 train_time:7335ms step_avg:31.61ms
+step:233/1490 train_time:7362ms step_avg:31.60ms
+step:234/1490 train_time:7396ms step_avg:31.61ms
+step:235/1490 train_time:7425ms step_avg:31.59ms
+step:236/1490 train_time:7460ms step_avg:31.61ms
+step:237/1490 train_time:7488ms step_avg:31.60ms
+step:238/1490 train_time:7523ms step_avg:31.61ms
+step:239/1490 train_time:7551ms step_avg:31.59ms
+step:240/1490 train_time:7586ms step_avg:31.61ms
+step:241/1490 train_time:7614ms step_avg:31.59ms
+step:242/1490 train_time:7649ms step_avg:31.61ms
+step:243/1490 train_time:7677ms step_avg:31.59ms
+step:244/1490 train_time:7712ms step_avg:31.61ms
+step:245/1490 train_time:7740ms step_avg:31.59ms
+step:246/1490 train_time:7774ms step_avg:31.60ms
+step:247/1490 train_time:7802ms step_avg:31.59ms
+step:248/1490 train_time:7837ms step_avg:31.60ms
+step:249/1490 train_time:7866ms step_avg:31.59ms
+step:250/1490 train_time:7900ms step_avg:31.60ms
+step:250/1490 val_loss:4.5142 train_time:7943ms step_avg:31.77ms
+step:251/1490 train_time:7962ms step_avg:31.72ms
+step:252/1490 train_time:7981ms step_avg:31.67ms
+step:253/1490 train_time:7995ms step_avg:31.60ms
+step:254/1490 train_time:8029ms step_avg:31.61ms
+step:255/1490 train_time:8059ms step_avg:31.60ms
+step:256/1490 train_time:8096ms step_avg:31.63ms
+step:257/1490 train_time:8124ms step_avg:31.61ms
+step:258/1490 train_time:8159ms step_avg:31.62ms
+step:259/1490 train_time:8187ms step_avg:31.61ms
+step:260/1490 train_time:8222ms step_avg:31.62ms
+step:261/1490 train_time:8251ms step_avg:31.61ms
+step:262/1490 train_time:8285ms step_avg:31.62ms
+step:263/1490 train_time:8314ms step_avg:31.61ms
+step:264/1490 train_time:8348ms step_avg:31.62ms
+step:265/1490 train_time:8376ms step_avg:31.61ms
+step:266/1490 train_time:8411ms step_avg:31.62ms
+step:267/1490 train_time:8439ms step_avg:31.61ms
+step:268/1490 train_time:8475ms step_avg:31.62ms
+step:269/1490 train_time:8502ms step_avg:31.61ms
+step:270/1490 train_time:8536ms step_avg:31.62ms
+step:271/1490 train_time:8564ms step_avg:31.60ms
+step:272/1490 train_time:8599ms step_avg:31.61ms
+step:273/1490 train_time:8626ms step_avg:31.60ms
+step:274/1490 train_time:8661ms step_avg:31.61ms
+step:275/1490 train_time:8689ms step_avg:31.60ms
+step:276/1490 train_time:8723ms step_avg:31.61ms
+step:277/1490 train_time:8752ms step_avg:31.59ms
+step:278/1490 train_time:8786ms step_avg:31.60ms
+step:279/1490 train_time:8815ms step_avg:31.59ms
+step:280/1490 train_time:8849ms step_avg:31.60ms
+step:281/1490 train_time:8877ms step_avg:31.59ms
+step:282/1490 train_time:8912ms step_avg:31.60ms
+step:283/1490 train_time:8941ms step_avg:31.59ms
+step:284/1490 train_time:8977ms step_avg:31.61ms
+step:285/1490 train_time:9005ms step_avg:31.60ms
+step:286/1490 train_time:9040ms step_avg:31.61ms
+step:287/1490 train_time:9069ms step_avg:31.60ms
+step:288/1490 train_time:9104ms step_avg:31.61ms
+step:289/1490 train_time:9133ms step_avg:31.60ms
+step:290/1490 train_time:9168ms step_avg:31.61ms
+step:291/1490 train_time:9196ms step_avg:31.60ms
+step:292/1490 train_time:9231ms step_avg:31.61ms
+step:293/1490 train_time:9259ms step_avg:31.60ms
+step:294/1490 train_time:9294ms step_avg:31.61ms
+step:295/1490 train_time:9322ms step_avg:31.60ms
+step:296/1490 train_time:9356ms step_avg:31.61ms
+step:297/1490 train_time:9384ms step_avg:31.60ms
+step:298/1490 train_time:9419ms step_avg:31.61ms
+step:299/1490 train_time:9447ms step_avg:31.60ms
+step:300/1490 train_time:9482ms step_avg:31.61ms
+step:301/1490 train_time:9511ms step_avg:31.60ms
+step:302/1490 train_time:9545ms step_avg:31.61ms
+step:303/1490 train_time:9574ms step_avg:31.60ms
+step:304/1490 train_time:9609ms step_avg:31.61ms
+step:305/1490 train_time:9636ms step_avg:31.59ms
+step:306/1490 train_time:9670ms step_avg:31.60ms
+step:307/1490 train_time:9698ms step_avg:31.59ms
+step:308/1490 train_time:9732ms step_avg:31.60ms
+step:309/1490 train_time:9761ms step_avg:31.59ms
+step:310/1490 train_time:9796ms step_avg:31.60ms
+step:311/1490 train_time:9823ms step_avg:31.59ms
+step:312/1490 train_time:9858ms step_avg:31.60ms
+step:313/1490 train_time:9886ms step_avg:31.58ms
+step:314/1490 train_time:9921ms step_avg:31.60ms
+step:315/1490 train_time:9950ms step_avg:31.59ms
+step:316/1490 train_time:9985ms step_avg:31.60ms
+step:317/1490 train_time:10013ms step_avg:31.59ms
+step:318/1490 train_time:10048ms step_avg:31.60ms
+step:319/1490 train_time:10077ms step_avg:31.59ms
+step:320/1490 train_time:10112ms step_avg:31.60ms
+step:321/1490 train_time:10140ms step_avg:31.59ms
+step:322/1490 train_time:10175ms step_avg:31.60ms
+step:323/1490 train_time:10203ms step_avg:31.59ms
+step:324/1490 train_time:10238ms step_avg:31.60ms
+step:325/1490 train_time:10267ms step_avg:31.59ms
+step:326/1490 train_time:10302ms step_avg:31.60ms
+step:327/1490 train_time:10330ms step_avg:31.59ms
+step:328/1490 train_time:10365ms step_avg:31.60ms
+step:329/1490 train_time:10393ms step_avg:31.59ms
+step:330/1490 train_time:10428ms step_avg:31.60ms
+step:331/1490 train_time:10457ms step_avg:31.59ms
+step:332/1490 train_time:10492ms step_avg:31.60ms
+step:333/1490 train_time:10520ms step_avg:31.59ms
+step:334/1490 train_time:10554ms step_avg:31.60ms
+step:335/1490 train_time:10582ms step_avg:31.59ms
+step:336/1490 train_time:10617ms step_avg:31.60ms
+step:337/1490 train_time:10645ms step_avg:31.59ms
+step:338/1490 train_time:10680ms step_avg:31.60ms
+step:339/1490 train_time:10708ms step_avg:31.59ms
+step:340/1490 train_time:10742ms step_avg:31.59ms
+step:341/1490 train_time:10770ms step_avg:31.58ms
+step:342/1490 train_time:10805ms step_avg:31.59ms
+step:343/1490 train_time:10833ms step_avg:31.58ms
+step:344/1490 train_time:10868ms step_avg:31.59ms
+step:345/1490 train_time:10896ms step_avg:31.58ms
+step:346/1490 train_time:10931ms step_avg:31.59ms
+step:347/1490 train_time:10959ms step_avg:31.58ms
+step:348/1490 train_time:10994ms step_avg:31.59ms
+step:349/1490 train_time:11022ms step_avg:31.58ms
+step:350/1490 train_time:11057ms step_avg:31.59ms
+step:351/1490 train_time:11085ms step_avg:31.58ms
+step:352/1490 train_time:11121ms step_avg:31.59ms
+step:353/1490 train_time:11149ms step_avg:31.58ms
+step:354/1490 train_time:11184ms step_avg:31.59ms
+step:355/1490 train_time:11212ms step_avg:31.58ms
+step:356/1490 train_time:11246ms step_avg:31.59ms
+step:357/1490 train_time:11275ms step_avg:31.58ms
+step:358/1490 train_time:11309ms step_avg:31.59ms
+step:359/1490 train_time:11338ms step_avg:31.58ms
+step:360/1490 train_time:11373ms step_avg:31.59ms
+step:361/1490 train_time:11401ms step_avg:31.58ms
+step:362/1490 train_time:11435ms step_avg:31.59ms
+step:363/1490 train_time:11464ms step_avg:31.58ms
+step:364/1490 train_time:11499ms step_avg:31.59ms
+step:365/1490 train_time:11527ms step_avg:31.58ms
+step:366/1490 train_time:11562ms step_avg:31.59ms
+step:367/1490 train_time:11590ms step_avg:31.58ms
+step:368/1490 train_time:11625ms step_avg:31.59ms
+step:369/1490 train_time:11653ms step_avg:31.58ms
+step:370/1490 train_time:11688ms step_avg:31.59ms
+step:371/1490 train_time:11716ms step_avg:31.58ms
+step:372/1490 train_time:11750ms step_avg:31.59ms
+step:373/1490 train_time:11779ms step_avg:31.58ms
+step:374/1490 train_time:11814ms step_avg:31.59ms
+step:375/1490 train_time:11842ms step_avg:31.58ms
+step:376/1490 train_time:11877ms step_avg:31.59ms
+step:377/1490 train_time:11905ms step_avg:31.58ms
+step:378/1490 train_time:11939ms step_avg:31.59ms
+step:379/1490 train_time:11967ms step_avg:31.58ms
+step:380/1490 train_time:12002ms step_avg:31.58ms
+step:381/1490 train_time:12030ms step_avg:31.58ms
+step:382/1490 train_time:12065ms step_avg:31.58ms
+step:383/1490 train_time:12095ms step_avg:31.58ms
+step:384/1490 train_time:12129ms step_avg:31.59ms
+step:385/1490 train_time:12157ms step_avg:31.58ms
+step:386/1490 train_time:12192ms step_avg:31.58ms
+step:387/1490 train_time:12220ms step_avg:31.58ms
+step:388/1490 train_time:12255ms step_avg:31.58ms
+step:389/1490 train_time:12283ms step_avg:31.58ms
+step:390/1490 train_time:12318ms step_avg:31.58ms
+step:391/1490 train_time:12346ms step_avg:31.57ms
+step:392/1490 train_time:12381ms step_avg:31.58ms
+step:393/1490 train_time:12409ms step_avg:31.57ms
+step:394/1490 train_time:12443ms step_avg:31.58ms
+step:395/1490 train_time:12472ms step_avg:31.57ms
+step:396/1490 train_time:12507ms step_avg:31.58ms
+step:397/1490 train_time:12535ms step_avg:31.57ms
+step:398/1490 train_time:12570ms step_avg:31.58ms
+step:399/1490 train_time:12598ms step_avg:31.57ms
+step:400/1490 train_time:12632ms step_avg:31.58ms
+step:401/1490 train_time:12661ms step_avg:31.57ms
+step:402/1490 train_time:12696ms step_avg:31.58ms
+step:403/1490 train_time:12724ms step_avg:31.57ms
+step:404/1490 train_time:12758ms step_avg:31.58ms
+step:405/1490 train_time:12786ms step_avg:31.57ms
+step:406/1490 train_time:12821ms step_avg:31.58ms
+step:407/1490 train_time:12849ms step_avg:31.57ms
+step:408/1490 train_time:12884ms step_avg:31.58ms
+step:409/1490 train_time:12912ms step_avg:31.57ms
+step:410/1490 train_time:12947ms step_avg:31.58ms
+step:411/1490 train_time:12975ms step_avg:31.57ms
+step:412/1490 train_time:13010ms step_avg:31.58ms
+step:413/1490 train_time:13038ms step_avg:31.57ms
+step:414/1490 train_time:13073ms step_avg:31.58ms
+step:415/1490 train_time:13102ms step_avg:31.57ms
+step:416/1490 train_time:13136ms step_avg:31.58ms
+step:417/1490 train_time:13164ms step_avg:31.57ms
+step:418/1490 train_time:13199ms step_avg:31.58ms
+step:419/1490 train_time:13227ms step_avg:31.57ms
+step:420/1490 train_time:13262ms step_avg:31.58ms
+step:421/1490 train_time:13290ms step_avg:31.57ms
+step:422/1490 train_time:13325ms step_avg:31.58ms
+step:423/1490 train_time:13353ms step_avg:31.57ms
+step:424/1490 train_time:13388ms step_avg:31.57ms
+step:425/1490 train_time:13416ms step_avg:31.57ms
+step:426/1490 train_time:13450ms step_avg:31.57ms
+step:427/1490 train_time:13479ms step_avg:31.57ms
+step:428/1490 train_time:13513ms step_avg:31.57ms
+step:429/1490 train_time:13541ms step_avg:31.57ms
+step:430/1490 train_time:13576ms step_avg:31.57ms
+step:431/1490 train_time:13604ms step_avg:31.56ms
+step:432/1490 train_time:13639ms step_avg:31.57ms
+step:433/1490 train_time:13667ms step_avg:31.56ms
+step:434/1490 train_time:13702ms step_avg:31.57ms
+step:435/1490 train_time:13730ms step_avg:31.56ms
+step:436/1490 train_time:13766ms step_avg:31.57ms
+step:437/1490 train_time:13793ms step_avg:31.56ms
+step:438/1490 train_time:13828ms step_avg:31.57ms
+step:439/1490 train_time:13856ms step_avg:31.56ms
+step:440/1490 train_time:13891ms step_avg:31.57ms
+step:441/1490 train_time:13919ms step_avg:31.56ms
+step:442/1490 train_time:13953ms step_avg:31.57ms
+step:443/1490 train_time:13981ms step_avg:31.56ms
+step:444/1490 train_time:14016ms step_avg:31.57ms
+step:445/1490 train_time:14044ms step_avg:31.56ms
+step:446/1490 train_time:14079ms step_avg:31.57ms
+step:447/1490 train_time:14107ms step_avg:31.56ms
+step:448/1490 train_time:14142ms step_avg:31.57ms
+step:449/1490 train_time:14170ms step_avg:31.56ms
+step:450/1490 train_time:14205ms step_avg:31.57ms
+step:451/1490 train_time:14233ms step_avg:31.56ms
+step:452/1490 train_time:14268ms step_avg:31.57ms
+step:453/1490 train_time:14296ms step_avg:31.56ms
+step:454/1490 train_time:14331ms step_avg:31.57ms
+step:455/1490 train_time:14359ms step_avg:31.56ms
+step:456/1490 train_time:14393ms step_avg:31.56ms
+step:457/1490 train_time:14422ms step_avg:31.56ms
+step:458/1490 train_time:14456ms step_avg:31.56ms
+step:459/1490 train_time:14484ms step_avg:31.56ms
+step:460/1490 train_time:14519ms step_avg:31.56ms
+step:461/1490 train_time:14547ms step_avg:31.56ms
+step:462/1490 train_time:14582ms step_avg:31.56ms
+step:463/1490 train_time:14610ms step_avg:31.56ms
+step:464/1490 train_time:14645ms step_avg:31.56ms
+step:465/1490 train_time:14673ms step_avg:31.56ms
+step:466/1490 train_time:14708ms step_avg:31.56ms
+step:467/1490 train_time:14736ms step_avg:31.55ms
+step:468/1490 train_time:14771ms step_avg:31.56ms
+step:469/1490 train_time:14799ms step_avg:31.55ms
+step:470/1490 train_time:14833ms step_avg:31.56ms
+step:471/1490 train_time:14862ms step_avg:31.55ms
+step:472/1490 train_time:14897ms step_avg:31.56ms
+step:473/1490 train_time:14925ms step_avg:31.55ms
+step:474/1490 train_time:14960ms step_avg:31.56ms
+step:475/1490 train_time:14988ms step_avg:31.55ms
+step:476/1490 train_time:15023ms step_avg:31.56ms
+step:477/1490 train_time:15051ms step_avg:31.55ms
+step:478/1490 train_time:15087ms step_avg:31.56ms
+step:479/1490 train_time:15114ms step_avg:31.55ms
+step:480/1490 train_time:15148ms step_avg:31.56ms
+step:481/1490 train_time:15177ms step_avg:31.55ms
+step:482/1490 train_time:15211ms step_avg:31.56ms
+step:483/1490 train_time:15240ms step_avg:31.55ms
+step:484/1490 train_time:15277ms step_avg:31.56ms
+step:485/1490 train_time:15329ms step_avg:31.61ms
+step:486/1490 train_time:15388ms step_avg:31.66ms
+step:487/1490 train_time:15444ms step_avg:31.71ms
+step:488/1490 train_time:15504ms step_avg:31.77ms
+step:489/1490 train_time:15558ms step_avg:31.82ms
+step:490/1490 train_time:15618ms step_avg:31.87ms
+step:491/1490 train_time:15671ms step_avg:31.92ms
+step:492/1490 train_time:15731ms step_avg:31.97ms
+step:493/1490 train_time:15786ms step_avg:32.02ms
+step:494/1490 train_time:15846ms step_avg:32.08ms
+step:495/1490 train_time:15900ms step_avg:32.12ms
+step:496/1490 train_time:15959ms step_avg:32.18ms
+step:497/1490 train_time:16014ms step_avg:32.22ms
+step:498/1490 train_time:16073ms step_avg:32.28ms
+step:499/1490 train_time:16127ms step_avg:32.32ms
+step:500/1490 train_time:16188ms step_avg:32.38ms
+step:500/1490 val_loss:4.2434 train_time:16261ms step_avg:32.52ms
+step:501/1490 train_time:16282ms step_avg:32.50ms
+step:502/1490 train_time:16305ms step_avg:32.48ms
+step:503/1490 train_time:16363ms step_avg:32.53ms
+step:504/1490 train_time:16424ms step_avg:32.59ms
+step:505/1490 train_time:16479ms step_avg:32.63ms
+step:506/1490 train_time:16539ms step_avg:32.69ms
+step:507/1490 train_time:16593ms step_avg:32.73ms
+step:508/1490 train_time:16651ms step_avg:32.78ms
+step:509/1490 train_time:16705ms step_avg:32.82ms
+step:510/1490 train_time:16764ms step_avg:32.87ms
+step:511/1490 train_time:16818ms step_avg:32.91ms
+step:512/1490 train_time:16877ms step_avg:32.96ms
+step:513/1490 train_time:16931ms step_avg:33.00ms
+step:514/1490 train_time:16990ms step_avg:33.05ms
+step:515/1490 train_time:17043ms step_avg:33.09ms
+step:516/1490 train_time:17103ms step_avg:33.14ms
+step:517/1490 train_time:17157ms step_avg:33.19ms
+step:518/1490 train_time:17218ms step_avg:33.24ms
+step:519/1490 train_time:17274ms step_avg:33.28ms
+step:520/1490 train_time:17334ms step_avg:33.33ms
+step:521/1490 train_time:17389ms step_avg:33.38ms
+step:522/1490 train_time:17451ms step_avg:33.43ms
+step:523/1490 train_time:17506ms step_avg:33.47ms
+step:524/1490 train_time:17566ms step_avg:33.52ms
+step:525/1490 train_time:17620ms step_avg:33.56ms
+step:526/1490 train_time:17680ms step_avg:33.61ms
+step:527/1490 train_time:17733ms step_avg:33.65ms
+step:528/1490 train_time:17793ms step_avg:33.70ms
+step:529/1490 train_time:17847ms step_avg:33.74ms
+step:530/1490 train_time:17907ms step_avg:33.79ms
+step:531/1490 train_time:17961ms step_avg:33.83ms
+step:532/1490 train_time:18020ms step_avg:33.87ms
+step:533/1490 train_time:18073ms step_avg:33.91ms
+step:534/1490 train_time:18132ms step_avg:33.96ms
+step:535/1490 train_time:18187ms step_avg:33.99ms
+step:536/1490 train_time:18247ms step_avg:34.04ms
+step:537/1490 train_time:18302ms step_avg:34.08ms
+step:538/1490 train_time:18364ms step_avg:34.13ms
+step:539/1490 train_time:18419ms step_avg:34.17ms
+step:540/1490 train_time:18479ms step_avg:34.22ms
+step:541/1490 train_time:18533ms step_avg:34.26ms
+step:542/1490 train_time:18593ms step_avg:34.30ms
+step:543/1490 train_time:18647ms step_avg:34.34ms
+step:544/1490 train_time:18708ms step_avg:34.39ms
+step:545/1490 train_time:18762ms step_avg:34.42ms
+step:546/1490 train_time:18822ms step_avg:34.47ms
+step:547/1490 train_time:18875ms step_avg:34.51ms
+step:548/1490 train_time:18934ms step_avg:34.55ms
+step:549/1490 train_time:18988ms step_avg:34.59ms
+step:550/1490 train_time:19048ms step_avg:34.63ms
+step:551/1490 train_time:19101ms step_avg:34.67ms
+step:552/1490 train_time:19161ms step_avg:34.71ms
+step:553/1490 train_time:19216ms step_avg:34.75ms
+step:554/1490 train_time:19276ms step_avg:34.79ms
+step:555/1490 train_time:19331ms step_avg:34.83ms
+step:556/1490 train_time:19390ms step_avg:34.87ms
+step:557/1490 train_time:19445ms step_avg:34.91ms
+step:558/1490 train_time:19506ms step_avg:34.96ms
+step:559/1490 train_time:19562ms step_avg:34.99ms
+step:560/1490 train_time:19622ms step_avg:35.04ms
+step:561/1490 train_time:19675ms step_avg:35.07ms
+step:562/1490 train_time:19734ms step_avg:35.11ms
+step:563/1490 train_time:19788ms step_avg:35.15ms
+step:564/1490 train_time:19848ms step_avg:35.19ms
+step:565/1490 train_time:19902ms step_avg:35.22ms
+step:566/1490 train_time:19961ms step_avg:35.27ms
+step:567/1490 train_time:20014ms step_avg:35.30ms
+step:568/1490 train_time:20074ms step_avg:35.34ms
+step:569/1490 train_time:20128ms step_avg:35.37ms
+step:570/1490 train_time:20188ms step_avg:35.42ms
+step:571/1490 train_time:20242ms step_avg:35.45ms
+step:572/1490 train_time:20303ms step_avg:35.50ms
+step:573/1490 train_time:20358ms step_avg:35.53ms
+step:574/1490 train_time:20418ms step_avg:35.57ms
+step:575/1490 train_time:20472ms step_avg:35.60ms
+step:576/1490 train_time:20532ms step_avg:35.65ms
+step:577/1490 train_time:20586ms step_avg:35.68ms
+step:578/1490 train_time:20647ms step_avg:35.72ms
+step:579/1490 train_time:20702ms step_avg:35.75ms
+step:580/1490 train_time:20762ms step_avg:35.80ms
+step:581/1490 train_time:20815ms step_avg:35.83ms
+step:582/1490 train_time:20874ms step_avg:35.87ms
+step:583/1490 train_time:20929ms step_avg:35.90ms
+step:584/1490 train_time:20989ms step_avg:35.94ms
+step:585/1490 train_time:21042ms step_avg:35.97ms
+step:586/1490 train_time:21102ms step_avg:36.01ms
+step:587/1490 train_time:21156ms step_avg:36.04ms
+step:588/1490 train_time:21215ms step_avg:36.08ms
+step:589/1490 train_time:21270ms step_avg:36.11ms
+step:590/1490 train_time:21330ms step_avg:36.15ms
+step:591/1490 train_time:21385ms step_avg:36.18ms
+step:592/1490 train_time:21446ms step_avg:36.23ms
+step:593/1490 train_time:21501ms step_avg:36.26ms
+step:594/1490 train_time:21561ms step_avg:36.30ms
+step:595/1490 train_time:21615ms step_avg:36.33ms
+step:596/1490 train_time:21675ms step_avg:36.37ms
+step:597/1490 train_time:21729ms step_avg:36.40ms
+step:598/1490 train_time:21789ms step_avg:36.44ms
+step:599/1490 train_time:21844ms step_avg:36.47ms
+step:600/1490 train_time:21904ms step_avg:36.51ms
+step:601/1490 train_time:21957ms step_avg:36.53ms
+step:602/1490 train_time:22016ms step_avg:36.57ms
+step:603/1490 train_time:22071ms step_avg:36.60ms
+step:604/1490 train_time:22130ms step_avg:36.64ms
+step:605/1490 train_time:22184ms step_avg:36.67ms
+step:606/1490 train_time:22244ms step_avg:36.71ms
+step:607/1490 train_time:22298ms step_avg:36.73ms
+step:608/1490 train_time:22358ms step_avg:36.77ms
+step:609/1490 train_time:22413ms step_avg:36.80ms
+step:610/1490 train_time:22473ms step_avg:36.84ms
+step:611/1490 train_time:22527ms step_avg:36.87ms
+step:612/1490 train_time:22587ms step_avg:36.91ms
+step:613/1490 train_time:22642ms step_avg:36.94ms
+step:614/1490 train_time:22701ms step_avg:36.97ms
+step:615/1490 train_time:22755ms step_avg:37.00ms
+step:616/1490 train_time:22814ms step_avg:37.04ms
+step:617/1490 train_time:22869ms step_avg:37.07ms
+step:618/1490 train_time:22928ms step_avg:37.10ms
+step:619/1490 train_time:22983ms step_avg:37.13ms
+step:620/1490 train_time:23043ms step_avg:37.17ms
+step:621/1490 train_time:23097ms step_avg:37.19ms
+step:622/1490 train_time:23156ms step_avg:37.23ms
+step:623/1490 train_time:23211ms step_avg:37.26ms
+step:624/1490 train_time:23271ms step_avg:37.29ms
+step:625/1490 train_time:23325ms step_avg:37.32ms
+step:626/1490 train_time:23386ms step_avg:37.36ms
+step:627/1490 train_time:23439ms step_avg:37.38ms
+step:628/1490 train_time:23498ms step_avg:37.42ms
+step:629/1490 train_time:23552ms step_avg:37.44ms
+step:630/1490 train_time:23613ms step_avg:37.48ms
+step:631/1490 train_time:23668ms step_avg:37.51ms
+step:632/1490 train_time:23727ms step_avg:37.54ms
+step:633/1490 train_time:23782ms step_avg:37.57ms
+step:634/1490 train_time:23842ms step_avg:37.61ms
+step:635/1490 train_time:23896ms step_avg:37.63ms
+step:636/1490 train_time:23955ms step_avg:37.66ms
+step:637/1490 train_time:24009ms step_avg:37.69ms
+step:638/1490 train_time:24069ms step_avg:37.73ms
+step:639/1490 train_time:24123ms step_avg:37.75ms
+step:640/1490 train_time:24184ms step_avg:37.79ms
+step:641/1490 train_time:24239ms step_avg:37.81ms
+step:642/1490 train_time:24299ms step_avg:37.85ms
+step:643/1490 train_time:24353ms step_avg:37.87ms
+step:644/1490 train_time:24414ms step_avg:37.91ms
+step:645/1490 train_time:24469ms step_avg:37.94ms
+step:646/1490 train_time:24529ms step_avg:37.97ms
+step:647/1490 train_time:24583ms step_avg:38.00ms
+step:648/1490 train_time:24643ms step_avg:38.03ms
+step:649/1490 train_time:24698ms step_avg:38.06ms
+step:650/1490 train_time:24757ms step_avg:38.09ms
+step:651/1490 train_time:24811ms step_avg:38.11ms
+step:652/1490 train_time:24871ms step_avg:38.15ms
+step:653/1490 train_time:24925ms step_avg:38.17ms
+step:654/1490 train_time:24985ms step_avg:38.20ms
+step:655/1490 train_time:25039ms step_avg:38.23ms
+step:656/1490 train_time:25098ms step_avg:38.26ms
+step:657/1490 train_time:25152ms step_avg:38.28ms
+step:658/1490 train_time:25212ms step_avg:38.32ms
+step:659/1490 train_time:25266ms step_avg:38.34ms
+step:660/1490 train_time:25327ms step_avg:38.37ms
+step:661/1490 train_time:25380ms step_avg:38.40ms
+step:662/1490 train_time:25440ms step_avg:38.43ms
+step:663/1490 train_time:25494ms step_avg:38.45ms
+step:664/1490 train_time:25553ms step_avg:38.48ms
+step:665/1490 train_time:25608ms step_avg:38.51ms
+step:666/1490 train_time:25668ms step_avg:38.54ms
+step:667/1490 train_time:25722ms step_avg:38.56ms
+step:668/1490 train_time:25783ms step_avg:38.60ms
+step:669/1490 train_time:25837ms step_avg:38.62ms
+step:670/1490 train_time:25896ms step_avg:38.65ms
+step:671/1490 train_time:25950ms step_avg:38.67ms
+step:672/1490 train_time:26010ms step_avg:38.71ms
+step:673/1490 train_time:26065ms step_avg:38.73ms
+step:674/1490 train_time:26126ms step_avg:38.76ms
+step:675/1490 train_time:26181ms step_avg:38.79ms
+step:676/1490 train_time:26240ms step_avg:38.82ms
+step:677/1490 train_time:26294ms step_avg:38.84ms
+step:678/1490 train_time:26353ms step_avg:38.87ms
+step:679/1490 train_time:26408ms step_avg:38.89ms
+step:680/1490 train_time:26468ms step_avg:38.92ms
+step:681/1490 train_time:26522ms step_avg:38.95ms
+step:682/1490 train_time:26582ms step_avg:38.98ms
+step:683/1490 train_time:26636ms step_avg:39.00ms
+step:684/1490 train_time:26696ms step_avg:39.03ms
+step:685/1490 train_time:26750ms step_avg:39.05ms
+step:686/1490 train_time:26810ms step_avg:39.08ms
+step:687/1490 train_time:26864ms step_avg:39.10ms
+step:688/1490 train_time:26925ms step_avg:39.13ms
+step:689/1490 train_time:26979ms step_avg:39.16ms
+step:690/1490 train_time:27037ms step_avg:39.18ms
+step:691/1490 train_time:27092ms step_avg:39.21ms
+step:692/1490 train_time:27151ms step_avg:39.24ms
+step:693/1490 train_time:27207ms step_avg:39.26ms
+step:694/1490 train_time:27266ms step_avg:39.29ms
+step:695/1490 train_time:27320ms step_avg:39.31ms
+step:696/1490 train_time:27380ms step_avg:39.34ms
+step:697/1490 train_time:27434ms step_avg:39.36ms
+step:698/1490 train_time:27494ms step_avg:39.39ms
+step:699/1490 train_time:27548ms step_avg:39.41ms
+step:700/1490 train_time:27609ms step_avg:39.44ms
+step:701/1490 train_time:27663ms step_avg:39.46ms
+step:702/1490 train_time:27723ms step_avg:39.49ms
+step:703/1490 train_time:27777ms step_avg:39.51ms
+step:704/1490 train_time:27835ms step_avg:39.54ms
+step:705/1490 train_time:27890ms step_avg:39.56ms
+step:706/1490 train_time:27950ms step_avg:39.59ms
+step:707/1490 train_time:28006ms step_avg:39.61ms
+step:708/1490 train_time:28066ms step_avg:39.64ms
+step:709/1490 train_time:28120ms step_avg:39.66ms
+step:710/1490 train_time:28180ms step_avg:39.69ms
+step:711/1490 train_time:28234ms step_avg:39.71ms
+step:712/1490 train_time:28294ms step_avg:39.74ms
+step:713/1490 train_time:28348ms step_avg:39.76ms
+step:714/1490 train_time:28408ms step_avg:39.79ms
+step:715/1490 train_time:28462ms step_avg:39.81ms
+step:716/1490 train_time:28522ms step_avg:39.83ms
+step:717/1490 train_time:28576ms step_avg:39.85ms
+step:718/1490 train_time:28635ms step_avg:39.88ms
+step:719/1490 train_time:28689ms step_avg:39.90ms
+step:720/1490 train_time:28749ms step_avg:39.93ms
+step:721/1490 train_time:28803ms step_avg:39.95ms
+step:722/1490 train_time:28863ms step_avg:39.98ms
+step:723/1490 train_time:28919ms step_avg:40.00ms
+step:724/1490 train_time:28978ms step_avg:40.02ms
+step:725/1490 train_time:29032ms step_avg:40.04ms
+step:726/1490 train_time:29092ms step_avg:40.07ms
+step:727/1490 train_time:29147ms step_avg:40.09ms
+step:728/1490 train_time:29207ms step_avg:40.12ms
+step:729/1490 train_time:29261ms step_avg:40.14ms
+step:730/1490 train_time:29322ms step_avg:40.17ms
+step:731/1490 train_time:29376ms step_avg:40.19ms
+step:732/1490 train_time:29435ms step_avg:40.21ms
+step:733/1490 train_time:29490ms step_avg:40.23ms
+step:734/1490 train_time:29550ms step_avg:40.26ms
+step:735/1490 train_time:29605ms step_avg:40.28ms
+step:736/1490 train_time:29665ms step_avg:40.31ms
+step:737/1490 train_time:29719ms step_avg:40.32ms
+step:738/1490 train_time:29778ms step_avg:40.35ms
+step:739/1490 train_time:29832ms step_avg:40.37ms
+step:740/1490 train_time:29893ms step_avg:40.40ms
+step:741/1490 train_time:29947ms step_avg:40.41ms
+step:742/1490 train_time:30008ms step_avg:40.44ms
+step:743/1490 train_time:30062ms step_avg:40.46ms
+step:744/1490 train_time:30122ms step_avg:40.49ms
+step:745/1490 train_time:30175ms step_avg:40.50ms
+step:746/1490 train_time:30235ms step_avg:40.53ms
+step:747/1490 train_time:30289ms step_avg:40.55ms
+step:748/1490 train_time:30349ms step_avg:40.57ms
+step:749/1490 train_time:30405ms step_avg:40.59ms
+step:750/1490 train_time:30466ms step_avg:40.62ms
+step:750/1490 val_loss:3.8128 train_time:30538ms step_avg:40.72ms
+step:751/1490 train_time:30557ms step_avg:40.69ms
+step:752/1490 train_time:30583ms step_avg:40.67ms
+step:753/1490 train_time:30638ms step_avg:40.69ms
+step:754/1490 train_time:30702ms step_avg:40.72ms
+step:755/1490 train_time:30757ms step_avg:40.74ms
+step:756/1490 train_time:30817ms step_avg:40.76ms
+step:757/1490 train_time:30871ms step_avg:40.78ms
+step:758/1490 train_time:30931ms step_avg:40.81ms
+step:759/1490 train_time:30984ms step_avg:40.82ms
+step:760/1490 train_time:31044ms step_avg:40.85ms
+step:761/1490 train_time:31098ms step_avg:40.87ms
+step:762/1490 train_time:31158ms step_avg:40.89ms
+step:763/1490 train_time:31211ms step_avg:40.91ms
+step:764/1490 train_time:31269ms step_avg:40.93ms
+step:765/1490 train_time:31322ms step_avg:40.94ms
+step:766/1490 train_time:31382ms step_avg:40.97ms
+step:767/1490 train_time:31436ms step_avg:40.99ms
+step:768/1490 train_time:31497ms step_avg:41.01ms
+step:769/1490 train_time:31553ms step_avg:41.03ms
+step:770/1490 train_time:31615ms step_avg:41.06ms
+step:771/1490 train_time:31670ms step_avg:41.08ms
+step:772/1490 train_time:31730ms step_avg:41.10ms
+step:773/1490 train_time:31785ms step_avg:41.12ms
+step:774/1490 train_time:31845ms step_avg:41.14ms
+step:775/1490 train_time:31899ms step_avg:41.16ms
+step:776/1490 train_time:31959ms step_avg:41.18ms
+step:777/1490 train_time:32013ms step_avg:41.20ms
+step:778/1490 train_time:32073ms step_avg:41.23ms
+step:779/1490 train_time:32126ms step_avg:41.24ms
+step:780/1490 train_time:32186ms step_avg:41.26ms
+step:781/1490 train_time:32240ms step_avg:41.28ms
+step:782/1490 train_time:32299ms step_avg:41.30ms
+step:783/1490 train_time:32352ms step_avg:41.32ms
+step:784/1490 train_time:32413ms step_avg:41.34ms
+step:785/1490 train_time:32467ms step_avg:41.36ms
+step:786/1490 train_time:32527ms step_avg:41.38ms
+step:787/1490 train_time:32581ms step_avg:41.40ms
+step:788/1490 train_time:32642ms step_avg:41.42ms
+step:789/1490 train_time:32698ms step_avg:41.44ms
+step:790/1490 train_time:32758ms step_avg:41.47ms
+step:791/1490 train_time:32812ms step_avg:41.48ms
+step:792/1490 train_time:32873ms step_avg:41.51ms
+step:793/1490 train_time:32927ms step_avg:41.52ms
+step:794/1490 train_time:32987ms step_avg:41.54ms
+step:795/1490 train_time:33041ms step_avg:41.56ms
+step:796/1490 train_time:33101ms step_avg:41.58ms
+step:797/1490 train_time:33155ms step_avg:41.60ms
+step:798/1490 train_time:33214ms step_avg:41.62ms
+step:799/1490 train_time:33268ms step_avg:41.64ms
+step:800/1490 train_time:33326ms step_avg:41.66ms
+step:801/1490 train_time:33380ms step_avg:41.67ms
+step:802/1490 train_time:33441ms step_avg:41.70ms
+step:803/1490 train_time:33495ms step_avg:41.71ms
+step:804/1490 train_time:33556ms step_avg:41.74ms
+step:805/1490 train_time:33610ms step_avg:41.75ms
+step:806/1490 train_time:33671ms step_avg:41.77ms
+step:807/1490 train_time:33724ms step_avg:41.79ms
+step:808/1490 train_time:33785ms step_avg:41.81ms
+step:809/1490 train_time:33840ms step_avg:41.83ms
+step:810/1490 train_time:33900ms step_avg:41.85ms
+step:811/1490 train_time:33955ms step_avg:41.87ms
+step:812/1490 train_time:34016ms step_avg:41.89ms
+step:813/1490 train_time:34069ms step_avg:41.91ms
+step:814/1490 train_time:34129ms step_avg:41.93ms
+step:815/1490 train_time:34183ms step_avg:41.94ms
+step:816/1490 train_time:34241ms step_avg:41.96ms
+step:817/1490 train_time:34296ms step_avg:41.98ms
+step:818/1490 train_time:34356ms step_avg:42.00ms
+step:819/1490 train_time:34410ms step_avg:42.01ms
+step:820/1490 train_time:34470ms step_avg:42.04ms
+step:821/1490 train_time:34523ms step_avg:42.05ms
+step:822/1490 train_time:34584ms step_avg:42.07ms
+step:823/1490 train_time:34639ms step_avg:42.09ms
+step:824/1490 train_time:34699ms step_avg:42.11ms
+step:825/1490 train_time:34753ms step_avg:42.12ms
+step:826/1490 train_time:34814ms step_avg:42.15ms
+step:827/1490 train_time:34868ms step_avg:42.16ms
+step:828/1490 train_time:34928ms step_avg:42.18ms
+step:829/1490 train_time:34982ms step_avg:42.20ms
+step:830/1490 train_time:35043ms step_avg:42.22ms
+step:831/1490 train_time:35098ms step_avg:42.24ms
+step:832/1490 train_time:35157ms step_avg:42.26ms
+step:833/1490 train_time:35211ms step_avg:42.27ms
+step:834/1490 train_time:35270ms step_avg:42.29ms
+step:835/1490 train_time:35324ms step_avg:42.30ms
+step:836/1490 train_time:35383ms step_avg:42.32ms
+step:837/1490 train_time:35438ms step_avg:42.34ms
+step:838/1490 train_time:35498ms step_avg:42.36ms
+step:839/1490 train_time:35552ms step_avg:42.37ms
+step:840/1490 train_time:35612ms step_avg:42.40ms
+step:841/1490 train_time:35667ms step_avg:42.41ms
+step:842/1490 train_time:35726ms step_avg:42.43ms
+step:843/1490 train_time:35780ms step_avg:42.44ms
+step:844/1490 train_time:35840ms step_avg:42.47ms
+step:845/1490 train_time:35895ms step_avg:42.48ms
+step:846/1490 train_time:35956ms step_avg:42.50ms
+step:847/1490 train_time:36010ms step_avg:42.51ms
+step:848/1490 train_time:36070ms step_avg:42.54ms
+step:849/1490 train_time:36124ms step_avg:42.55ms
+step:850/1490 train_time:36184ms step_avg:42.57ms
+step:851/1490 train_time:36239ms step_avg:42.58ms
+step:852/1490 train_time:36299ms step_avg:42.60ms
+step:853/1490 train_time:36353ms step_avg:42.62ms
+step:854/1490 train_time:36413ms step_avg:42.64ms
+step:855/1490 train_time:36467ms step_avg:42.65ms
+step:856/1490 train_time:36527ms step_avg:42.67ms
+step:857/1490 train_time:36581ms step_avg:42.69ms
+step:858/1490 train_time:36641ms step_avg:42.71ms
+step:859/1490 train_time:36696ms step_avg:42.72ms
+step:860/1490 train_time:36756ms step_avg:42.74ms
+step:861/1490 train_time:36810ms step_avg:42.75ms
+step:862/1490 train_time:36870ms step_avg:42.77ms
+step:863/1490 train_time:36924ms step_avg:42.79ms
+step:864/1490 train_time:36984ms step_avg:42.81ms
+step:865/1490 train_time:37039ms step_avg:42.82ms
+step:866/1490 train_time:37099ms step_avg:42.84ms
+step:867/1490 train_time:37153ms step_avg:42.85ms
+step:868/1490 train_time:37213ms step_avg:42.87ms
+step:869/1490 train_time:37267ms step_avg:42.89ms
+step:870/1490 train_time:37327ms step_avg:42.90ms
+step:871/1490 train_time:37381ms step_avg:42.92ms
+step:872/1490 train_time:37441ms step_avg:42.94ms
+step:873/1490 train_time:37496ms step_avg:42.95ms
+step:874/1490 train_time:37556ms step_avg:42.97ms
+step:875/1490 train_time:37610ms step_avg:42.98ms
+step:876/1490 train_time:37669ms step_avg:43.00ms
+step:877/1490 train_time:37723ms step_avg:43.01ms
+step:878/1490 train_time:37783ms step_avg:43.03ms
+step:879/1490 train_time:37838ms step_avg:43.05ms
+step:880/1490 train_time:37899ms step_avg:43.07ms
+step:881/1490 train_time:37954ms step_avg:43.08ms
+step:882/1490 train_time:38014ms step_avg:43.10ms
+step:883/1490 train_time:38068ms step_avg:43.11ms
+step:884/1490 train_time:38128ms step_avg:43.13ms
+step:885/1490 train_time:38181ms step_avg:43.14ms
+step:886/1490 train_time:38241ms step_avg:43.16ms
+step:887/1490 train_time:38296ms step_avg:43.17ms
+step:888/1490 train_time:38357ms step_avg:43.19ms
+step:889/1490 train_time:38411ms step_avg:43.21ms
+step:890/1490 train_time:38470ms step_avg:43.22ms
+step:891/1490 train_time:38523ms step_avg:43.24ms
+step:892/1490 train_time:38584ms step_avg:43.26ms
+step:893/1490 train_time:38639ms step_avg:43.27ms
+step:894/1490 train_time:38699ms step_avg:43.29ms
+step:895/1490 train_time:38753ms step_avg:43.30ms
+step:896/1490 train_time:38814ms step_avg:43.32ms
+step:897/1490 train_time:38869ms step_avg:43.33ms
+step:898/1490 train_time:38928ms step_avg:43.35ms
+step:899/1490 train_time:38982ms step_avg:43.36ms
+step:900/1490 train_time:39042ms step_avg:43.38ms
+step:901/1490 train_time:39096ms step_avg:43.39ms
+step:902/1490 train_time:39156ms step_avg:43.41ms
+step:903/1490 train_time:39210ms step_avg:43.42ms
+step:904/1490 train_time:39270ms step_avg:43.44ms
+step:905/1490 train_time:39324ms step_avg:43.45ms
+step:906/1490 train_time:39383ms step_avg:43.47ms
+step:907/1490 train_time:39438ms step_avg:43.48ms
+step:908/1490 train_time:39498ms step_avg:43.50ms
+step:909/1490 train_time:39552ms step_avg:43.51ms
+step:910/1490 train_time:39613ms step_avg:43.53ms
+step:911/1490 train_time:39667ms step_avg:43.54ms
+step:912/1490 train_time:39726ms step_avg:43.56ms
+step:913/1490 train_time:39781ms step_avg:43.57ms
+step:914/1490 train_time:39840ms step_avg:43.59ms
+step:915/1490 train_time:39895ms step_avg:43.60ms
+step:916/1490 train_time:39956ms step_avg:43.62ms
+step:917/1490 train_time:40010ms step_avg:43.63ms
+step:918/1490 train_time:40070ms step_avg:43.65ms
+step:919/1490 train_time:40123ms step_avg:43.66ms
+step:920/1490 train_time:40183ms step_avg:43.68ms
+step:921/1490 train_time:40238ms step_avg:43.69ms
+step:922/1490 train_time:40298ms step_avg:43.71ms
+step:923/1490 train_time:40352ms step_avg:43.72ms
+step:924/1490 train_time:40411ms step_avg:43.74ms
+step:925/1490 train_time:40466ms step_avg:43.75ms
+step:926/1490 train_time:40525ms step_avg:43.76ms
+step:927/1490 train_time:40579ms step_avg:43.77ms
+step:928/1490 train_time:40639ms step_avg:43.79ms
+step:929/1490 train_time:40693ms step_avg:43.80ms
+step:930/1490 train_time:40754ms step_avg:43.82ms
+step:931/1490 train_time:40810ms step_avg:43.83ms
+step:932/1490 train_time:40870ms step_avg:43.85ms
+step:933/1490 train_time:40923ms step_avg:43.86ms
+step:934/1490 train_time:40983ms step_avg:43.88ms
+step:935/1490 train_time:41038ms step_avg:43.89ms
+step:936/1490 train_time:41099ms step_avg:43.91ms
+step:937/1490 train_time:41152ms step_avg:43.92ms
+step:938/1490 train_time:41212ms step_avg:43.94ms
+step:939/1490 train_time:41267ms step_avg:43.95ms
+step:940/1490 train_time:41326ms step_avg:43.96ms
+step:941/1490 train_time:41380ms step_avg:43.97ms
+step:942/1490 train_time:41440ms step_avg:43.99ms
+step:943/1490 train_time:41495ms step_avg:44.00ms
+step:944/1490 train_time:41555ms step_avg:44.02ms
+step:945/1490 train_time:41609ms step_avg:44.03ms
+step:946/1490 train_time:41668ms step_avg:44.05ms
+step:947/1490 train_time:41722ms step_avg:44.06ms
+step:948/1490 train_time:41782ms step_avg:44.07ms
+step:949/1490 train_time:41837ms step_avg:44.09ms
+step:950/1490 train_time:41898ms step_avg:44.10ms
+step:951/1490 train_time:41952ms step_avg:44.11ms
+step:952/1490 train_time:42013ms step_avg:44.13ms
+step:953/1490 train_time:42067ms step_avg:44.14ms
+step:954/1490 train_time:42126ms step_avg:44.16ms
+step:955/1490 train_time:42180ms step_avg:44.17ms
+step:956/1490 train_time:42239ms step_avg:44.18ms
+step:957/1490 train_time:42293ms step_avg:44.19ms
+step:958/1490 train_time:42354ms step_avg:44.21ms
+step:959/1490 train_time:42408ms step_avg:44.22ms
+step:960/1490 train_time:42468ms step_avg:44.24ms
+step:961/1490 train_time:42522ms step_avg:44.25ms
+step:962/1490 train_time:42580ms step_avg:44.26ms
+step:963/1490 train_time:42636ms step_avg:44.27ms
+step:964/1490 train_time:42696ms step_avg:44.29ms
+step:965/1490 train_time:42750ms step_avg:44.30ms
+step:966/1490 train_time:42810ms step_avg:44.32ms
+step:967/1490 train_time:42864ms step_avg:44.33ms
+step:968/1490 train_time:42928ms step_avg:44.35ms
+step:969/1490 train_time:43006ms step_avg:44.38ms
+step:970/1490 train_time:43094ms step_avg:44.43ms
+step:971/1490 train_time:43176ms step_avg:44.47ms
+step:972/1490 train_time:43262ms step_avg:44.51ms
+step:973/1490 train_time:43343ms step_avg:44.55ms
+step:974/1490 train_time:43430ms step_avg:44.59ms
+step:975/1490 train_time:43510ms step_avg:44.63ms
+step:976/1490 train_time:43596ms step_avg:44.67ms
+step:977/1490 train_time:43677ms step_avg:44.70ms
+step:978/1490 train_time:43763ms step_avg:44.75ms
+step:979/1490 train_time:43844ms step_avg:44.78ms
+step:980/1490 train_time:43932ms step_avg:44.83ms
+step:981/1490 train_time:44013ms step_avg:44.86ms
+step:982/1490 train_time:44099ms step_avg:44.91ms
+step:983/1490 train_time:44179ms step_avg:44.94ms
+step:984/1490 train_time:44266ms step_avg:44.99ms
+step:985/1490 train_time:44348ms step_avg:45.02ms
+step:986/1490 train_time:44436ms step_avg:45.07ms
+step:987/1490 train_time:44515ms step_avg:45.10ms
+step:988/1490 train_time:44601ms step_avg:45.14ms
+step:989/1490 train_time:44683ms step_avg:45.18ms
+step:990/1490 train_time:44769ms step_avg:45.22ms
+step:991/1490 train_time:44851ms step_avg:45.26ms
+step:992/1490 train_time:44938ms step_avg:45.30ms
+step:993/1490 train_time:45021ms step_avg:45.34ms
+step:994/1490 train_time:45106ms step_avg:45.38ms
+step:995/1490 train_time:45187ms step_avg:45.41ms
+step:996/1490 train_time:45274ms step_avg:45.46ms
+step:997/1490 train_time:45355ms step_avg:45.49ms
+step:998/1490 train_time:45441ms step_avg:45.53ms
+step:999/1490 train_time:45522ms step_avg:45.57ms
+step:1000/1490 train_time:45608ms step_avg:45.61ms
+step:1000/1490 val_loss:3.5194 train_time:45711ms step_avg:45.71ms
+step:1001/1490 train_time:45733ms step_avg:45.69ms
+step:1002/1490 train_time:45778ms step_avg:45.69ms
+step:1003/1490 train_time:45862ms step_avg:45.72ms
+step:1004/1490 train_time:45950ms step_avg:45.77ms
+step:1005/1490 train_time:46031ms step_avg:45.80ms
+step:1006/1490 train_time:46116ms step_avg:45.84ms
+step:1007/1490 train_time:46196ms step_avg:45.87ms
+step:1008/1490 train_time:46280ms step_avg:45.91ms
+step:1009/1490 train_time:46361ms step_avg:45.95ms
+step:1010/1490 train_time:46447ms step_avg:45.99ms
+step:1011/1490 train_time:46528ms step_avg:46.02ms
+step:1012/1490 train_time:46614ms step_avg:46.06ms
+step:1013/1490 train_time:46699ms step_avg:46.10ms
+step:1014/1490 train_time:46785ms step_avg:46.14ms
+step:1015/1490 train_time:46868ms step_avg:46.18ms
+step:1016/1490 train_time:46956ms step_avg:46.22ms
+step:1017/1490 train_time:47039ms step_avg:46.25ms
+step:1018/1490 train_time:47125ms step_avg:46.29ms
+step:1019/1490 train_time:47206ms step_avg:46.33ms
+step:1020/1490 train_time:47292ms step_avg:46.36ms
+step:1021/1490 train_time:47372ms step_avg:46.40ms
+step:1022/1490 train_time:47458ms step_avg:46.44ms
+step:1023/1490 train_time:47539ms step_avg:46.47ms
+step:1024/1490 train_time:47625ms step_avg:46.51ms
+step:1025/1490 train_time:47706ms step_avg:46.54ms
+step:1026/1490 train_time:47793ms step_avg:46.58ms
+step:1027/1490 train_time:47876ms step_avg:46.62ms
+step:1028/1490 train_time:47963ms step_avg:46.66ms
+step:1029/1490 train_time:48045ms step_avg:46.69ms
+step:1030/1490 train_time:48131ms step_avg:46.73ms
+step:1031/1490 train_time:48212ms step_avg:46.76ms
+step:1032/1490 train_time:48298ms step_avg:46.80ms
+step:1033/1490 train_time:48379ms step_avg:46.83ms
+step:1034/1490 train_time:48465ms step_avg:46.87ms
+step:1035/1490 train_time:48545ms step_avg:46.90ms
+step:1036/1490 train_time:48632ms step_avg:46.94ms
+step:1037/1490 train_time:48712ms step_avg:46.97ms
+step:1038/1490 train_time:48798ms step_avg:47.01ms
+step:1039/1490 train_time:48881ms step_avg:47.05ms
+step:1040/1490 train_time:48967ms step_avg:47.08ms
+step:1041/1490 train_time:49049ms step_avg:47.12ms
+step:1042/1490 train_time:49136ms step_avg:47.16ms
+step:1043/1490 train_time:49216ms step_avg:47.19ms
+step:1044/1490 train_time:49302ms step_avg:47.22ms
+step:1045/1490 train_time:49381ms step_avg:47.25ms
+step:1046/1490 train_time:49467ms step_avg:47.29ms
+step:1047/1490 train_time:49548ms step_avg:47.32ms
+step:1048/1490 train_time:49637ms step_avg:47.36ms
+step:1049/1490 train_time:49718ms step_avg:47.40ms
+step:1050/1490 train_time:49804ms step_avg:47.43ms
+step:1051/1490 train_time:49886ms step_avg:47.47ms
+step:1052/1490 train_time:49973ms step_avg:47.50ms
+step:1053/1490 train_time:50052ms step_avg:47.53ms
+step:1054/1490 train_time:50140ms step_avg:47.57ms
+step:1055/1490 train_time:50222ms step_avg:47.60ms
+step:1056/1490 train_time:50307ms step_avg:47.64ms
+step:1057/1490 train_time:50388ms step_avg:47.67ms
+step:1058/1490 train_time:50474ms step_avg:47.71ms
+step:1059/1490 train_time:50556ms step_avg:47.74ms
+step:1060/1490 train_time:50642ms step_avg:47.78ms
+step:1061/1490 train_time:50722ms step_avg:47.81ms
+step:1062/1490 train_time:50809ms step_avg:47.84ms
+step:1063/1490 train_time:50891ms step_avg:47.87ms
+step:1064/1490 train_time:50977ms step_avg:47.91ms
+step:1065/1490 train_time:51058ms step_avg:47.94ms
+step:1066/1490 train_time:51145ms step_avg:47.98ms
+step:1067/1490 train_time:51226ms step_avg:48.01ms
+step:1068/1490 train_time:51312ms step_avg:48.04ms
+step:1069/1490 train_time:51393ms step_avg:48.08ms
+step:1070/1490 train_time:51479ms step_avg:48.11ms
+step:1071/1490 train_time:51561ms step_avg:48.14ms
+step:1072/1490 train_time:51647ms step_avg:48.18ms
+step:1073/1490 train_time:51727ms step_avg:48.21ms
+step:1074/1490 train_time:51813ms step_avg:48.24ms
+step:1075/1490 train_time:51894ms step_avg:48.27ms
+step:1076/1490 train_time:51980ms step_avg:48.31ms
+step:1077/1490 train_time:52062ms step_avg:48.34ms
+step:1078/1490 train_time:52149ms step_avg:48.38ms
+step:1079/1490 train_time:52230ms step_avg:48.41ms
+step:1080/1490 train_time:52317ms step_avg:48.44ms
+step:1081/1490 train_time:52399ms step_avg:48.47ms
+step:1082/1490 train_time:52485ms step_avg:48.51ms
+step:1083/1490 train_time:52567ms step_avg:48.54ms
+step:1084/1490 train_time:52653ms step_avg:48.57ms
+step:1085/1490 train_time:52735ms step_avg:48.60ms
+step:1086/1490 train_time:52822ms step_avg:48.64ms
+step:1087/1490 train_time:52902ms step_avg:48.67ms
+step:1088/1490 train_time:52988ms step_avg:48.70ms
+step:1089/1490 train_time:53068ms step_avg:48.73ms
+step:1090/1490 train_time:53155ms step_avg:48.77ms
+step:1091/1490 train_time:53235ms step_avg:48.80ms
+step:1092/1490 train_time:53322ms step_avg:48.83ms
+step:1093/1490 train_time:53403ms step_avg:48.86ms
+step:1094/1490 train_time:53491ms step_avg:48.89ms
+step:1095/1490 train_time:53572ms step_avg:48.92ms
+step:1096/1490 train_time:53658ms step_avg:48.96ms
+step:1097/1490 train_time:53740ms step_avg:48.99ms
+step:1098/1490 train_time:53825ms step_avg:49.02ms
+step:1099/1490 train_time:53907ms step_avg:49.05ms
+step:1100/1490 train_time:53993ms step_avg:49.08ms
+step:1101/1490 train_time:54074ms step_avg:49.11ms
+step:1102/1490 train_time:54162ms step_avg:49.15ms
+step:1103/1490 train_time:54244ms step_avg:49.18ms
+step:1104/1490 train_time:54330ms step_avg:49.21ms
+step:1105/1490 train_time:54412ms step_avg:49.24ms
+step:1106/1490 train_time:54498ms step_avg:49.27ms
+step:1107/1490 train_time:54579ms step_avg:49.30ms
+step:1108/1490 train_time:54667ms step_avg:49.34ms
+step:1109/1490 train_time:54749ms step_avg:49.37ms
+step:1110/1490 train_time:54836ms step_avg:49.40ms
+step:1111/1490 train_time:54916ms step_avg:49.43ms
+step:1112/1490 train_time:55002ms step_avg:49.46ms
+step:1113/1490 train_time:55082ms step_avg:49.49ms
+step:1114/1490 train_time:55168ms step_avg:49.52ms
+step:1115/1490 train_time:55251ms step_avg:49.55ms
+step:1116/1490 train_time:55339ms step_avg:49.59ms
+step:1117/1490 train_time:55420ms step_avg:49.61ms
+step:1118/1490 train_time:55506ms step_avg:49.65ms
+step:1119/1490 train_time:55587ms step_avg:49.68ms
+step:1120/1490 train_time:55673ms step_avg:49.71ms
+step:1121/1490 train_time:55753ms step_avg:49.74ms
+step:1122/1490 train_time:55840ms step_avg:49.77ms
+step:1123/1490 train_time:55920ms step_avg:49.80ms
+step:1124/1490 train_time:56006ms step_avg:49.83ms
+step:1125/1490 train_time:56088ms step_avg:49.86ms
+step:1126/1490 train_time:56174ms step_avg:49.89ms
+step:1127/1490 train_time:56255ms step_avg:49.92ms
+step:1128/1490 train_time:56342ms step_avg:49.95ms
+step:1129/1490 train_time:56423ms step_avg:49.98ms
+step:1130/1490 train_time:56509ms step_avg:50.01ms
+step:1131/1490 train_time:56592ms step_avg:50.04ms
+step:1132/1490 train_time:56679ms step_avg:50.07ms
+step:1133/1490 train_time:56759ms step_avg:50.10ms
+step:1134/1490 train_time:56846ms step_avg:50.13ms
+step:1135/1490 train_time:56927ms step_avg:50.16ms
+step:1136/1490 train_time:57014ms step_avg:50.19ms
+step:1137/1490 train_time:57095ms step_avg:50.22ms
+step:1138/1490 train_time:57181ms step_avg:50.25ms
+step:1139/1490 train_time:57262ms step_avg:50.27ms
+step:1140/1490 train_time:57348ms step_avg:50.31ms
+step:1141/1490 train_time:57429ms step_avg:50.33ms
+step:1142/1490 train_time:57517ms step_avg:50.36ms
+step:1143/1490 train_time:57598ms step_avg:50.39ms
+step:1144/1490 train_time:57684ms step_avg:50.42ms
+step:1145/1490 train_time:57766ms step_avg:50.45ms
+step:1146/1490 train_time:57852ms step_avg:50.48ms
+step:1147/1490 train_time:57932ms step_avg:50.51ms
+step:1148/1490 train_time:58018ms step_avg:50.54ms
+step:1149/1490 train_time:58100ms step_avg:50.57ms
+step:1150/1490 train_time:58187ms step_avg:50.60ms
+step:1151/1490 train_time:58268ms step_avg:50.62ms
+step:1152/1490 train_time:58354ms step_avg:50.65ms
+step:1153/1490 train_time:58436ms step_avg:50.68ms
+step:1154/1490 train_time:58521ms step_avg:50.71ms
+step:1155/1490 train_time:58602ms step_avg:50.74ms
+step:1156/1490 train_time:58689ms step_avg:50.77ms
+step:1157/1490 train_time:58770ms step_avg:50.80ms
+step:1158/1490 train_time:58858ms step_avg:50.83ms
+step:1159/1490 train_time:58939ms step_avg:50.85ms
+step:1160/1490 train_time:59025ms step_avg:50.88ms
+step:1161/1490 train_time:59106ms step_avg:50.91ms
+step:1162/1490 train_time:59191ms step_avg:50.94ms
+step:1163/1490 train_time:59273ms step_avg:50.97ms
+step:1164/1490 train_time:59359ms step_avg:51.00ms
+step:1165/1490 train_time:59442ms step_avg:51.02ms
+step:1166/1490 train_time:59528ms step_avg:51.05ms
+step:1167/1490 train_time:59608ms step_avg:51.08ms
+step:1168/1490 train_time:59695ms step_avg:51.11ms
+step:1169/1490 train_time:59777ms step_avg:51.14ms
+step:1170/1490 train_time:59864ms step_avg:51.17ms
+step:1171/1490 train_time:59945ms step_avg:51.19ms
+step:1172/1490 train_time:60032ms step_avg:51.22ms
+step:1173/1490 train_time:60112ms step_avg:51.25ms
+step:1174/1490 train_time:60199ms step_avg:51.28ms
+step:1175/1490 train_time:60280ms step_avg:51.30ms
+step:1176/1490 train_time:60366ms step_avg:51.33ms
+step:1177/1490 train_time:60448ms step_avg:51.36ms
+step:1178/1490 train_time:60534ms step_avg:51.39ms
+step:1179/1490 train_time:60615ms step_avg:51.41ms
+step:1180/1490 train_time:60701ms step_avg:51.44ms
+step:1181/1490 train_time:60782ms step_avg:51.47ms
+step:1182/1490 train_time:60869ms step_avg:51.50ms
+step:1183/1490 train_time:60950ms step_avg:51.52ms
+step:1184/1490 train_time:61038ms step_avg:51.55ms
+step:1185/1490 train_time:61118ms step_avg:51.58ms
+step:1186/1490 train_time:61204ms step_avg:51.61ms
+step:1187/1490 train_time:61285ms step_avg:51.63ms
+step:1188/1490 train_time:61372ms step_avg:51.66ms
+step:1189/1490 train_time:61453ms step_avg:51.68ms
+step:1190/1490 train_time:61541ms step_avg:51.72ms
+step:1191/1490 train_time:61621ms step_avg:51.74ms
+step:1192/1490 train_time:61707ms step_avg:51.77ms
+step:1193/1490 train_time:61788ms step_avg:51.79ms
+step:1194/1490 train_time:61875ms step_avg:51.82ms
+step:1195/1490 train_time:61957ms step_avg:51.85ms
+step:1196/1490 train_time:62043ms step_avg:51.88ms
+step:1197/1490 train_time:62123ms step_avg:51.90ms
+step:1198/1490 train_time:62209ms step_avg:51.93ms
+step:1199/1490 train_time:62291ms step_avg:51.95ms
+step:1200/1490 train_time:62377ms step_avg:51.98ms
+step:1201/1490 train_time:62458ms step_avg:52.01ms
+step:1202/1490 train_time:62545ms step_avg:52.03ms
+step:1203/1490 train_time:62625ms step_avg:52.06ms
+step:1204/1490 train_time:62711ms step_avg:52.09ms
+step:1205/1490 train_time:62793ms step_avg:52.11ms
+step:1206/1490 train_time:62880ms step_avg:52.14ms
+step:1207/1490 train_time:62961ms step_avg:52.16ms
+step:1208/1490 train_time:63048ms step_avg:52.19ms
+step:1209/1490 train_time:63128ms step_avg:52.22ms
+step:1210/1490 train_time:63214ms step_avg:52.24ms
+step:1211/1490 train_time:63295ms step_avg:52.27ms
+step:1212/1490 train_time:63382ms step_avg:52.30ms
+step:1213/1490 train_time:63462ms step_avg:52.32ms
+step:1214/1490 train_time:63550ms step_avg:52.35ms
+step:1215/1490 train_time:63631ms step_avg:52.37ms
+step:1216/1490 train_time:63717ms step_avg:52.40ms
+step:1217/1490 train_time:63797ms step_avg:52.42ms
+step:1218/1490 train_time:63884ms step_avg:52.45ms
+step:1219/1490 train_time:63965ms step_avg:52.47ms
+step:1220/1490 train_time:64051ms step_avg:52.50ms
+step:1221/1490 train_time:64131ms step_avg:52.52ms
+step:1222/1490 train_time:64218ms step_avg:52.55ms
+step:1223/1490 train_time:64300ms step_avg:52.58ms
+step:1224/1490 train_time:64387ms step_avg:52.60ms
+step:1225/1490 train_time:64469ms step_avg:52.63ms
+step:1226/1490 train_time:64556ms step_avg:52.66ms
+step:1227/1490 train_time:64638ms step_avg:52.68ms
+step:1228/1490 train_time:64724ms step_avg:52.71ms
+step:1229/1490 train_time:64805ms step_avg:52.73ms
+step:1230/1490 train_time:64891ms step_avg:52.76ms
+step:1231/1490 train_time:64972ms step_avg:52.78ms
+step:1232/1490 train_time:65058ms step_avg:52.81ms
+step:1233/1490 train_time:65139ms step_avg:52.83ms
+step:1234/1490 train_time:65224ms step_avg:52.86ms
+step:1235/1490 train_time:65306ms step_avg:52.88ms
+step:1236/1490 train_time:65393ms step_avg:52.91ms
+step:1237/1490 train_time:65474ms step_avg:52.93ms
+step:1238/1490 train_time:65560ms step_avg:52.96ms
+step:1239/1490 train_time:65642ms step_avg:52.98ms
+step:1240/1490 train_time:65728ms step_avg:53.01ms
+step:1241/1490 train_time:65809ms step_avg:53.03ms
+step:1242/1490 train_time:65896ms step_avg:53.06ms
+step:1243/1490 train_time:65977ms step_avg:53.08ms
+step:1244/1490 train_time:66062ms step_avg:53.10ms
+step:1245/1490 train_time:66142ms step_avg:53.13ms
+step:1246/1490 train_time:66229ms step_avg:53.15ms
+step:1247/1490 train_time:66311ms step_avg:53.18ms
+step:1248/1490 train_time:66398ms step_avg:53.20ms
+step:1249/1490 train_time:66479ms step_avg:53.23ms
+step:1250/1490 train_time:66565ms step_avg:53.25ms
+step:1250/1490 val_loss:3.3747 train_time:66669ms step_avg:53.34ms
+step:1251/1490 train_time:66691ms step_avg:53.31ms
+step:1252/1490 train_time:66738ms step_avg:53.30ms
+step:1253/1490 train_time:66824ms step_avg:53.33ms
+step:1254/1490 train_time:66912ms step_avg:53.36ms
+step:1255/1490 train_time:66992ms step_avg:53.38ms
+step:1256/1490 train_time:67077ms step_avg:53.41ms
+step:1257/1490 train_time:67157ms step_avg:53.43ms
+step:1258/1490 train_time:67243ms step_avg:53.45ms
+step:1259/1490 train_time:67322ms step_avg:53.47ms
+step:1260/1490 train_time:67407ms step_avg:53.50ms
+step:1261/1490 train_time:67486ms step_avg:53.52ms
+step:1262/1490 train_time:67573ms step_avg:53.54ms
+step:1263/1490 train_time:67654ms step_avg:53.57ms
+step:1264/1490 train_time:67744ms step_avg:53.59ms
+step:1265/1490 train_time:67826ms step_avg:53.62ms
+step:1266/1490 train_time:67913ms step_avg:53.64ms
+step:1267/1490 train_time:67995ms step_avg:53.67ms
+step:1268/1490 train_time:68082ms step_avg:53.69ms
+step:1269/1490 train_time:68161ms step_avg:53.71ms
+step:1270/1490 train_time:68246ms step_avg:53.74ms
+step:1271/1490 train_time:68325ms step_avg:53.76ms
+step:1272/1490 train_time:68411ms step_avg:53.78ms
+step:1273/1490 train_time:68490ms step_avg:53.80ms
+step:1274/1490 train_time:68578ms step_avg:53.83ms
+step:1275/1490 train_time:68660ms step_avg:53.85ms
+step:1276/1490 train_time:68748ms step_avg:53.88ms
+step:1277/1490 train_time:68830ms step_avg:53.90ms
+step:1278/1490 train_time:68918ms step_avg:53.93ms
+step:1279/1490 train_time:68999ms step_avg:53.95ms
+step:1280/1490 train_time:69085ms step_avg:53.97ms
+step:1281/1490 train_time:69166ms step_avg:53.99ms
+step:1282/1490 train_time:69252ms step_avg:54.02ms
+step:1283/1490 train_time:69331ms step_avg:54.04ms
+step:1284/1490 train_time:69416ms step_avg:54.06ms
+step:1285/1490 train_time:69496ms step_avg:54.08ms
+step:1286/1490 train_time:69583ms step_avg:54.11ms
+step:1287/1490 train_time:69666ms step_avg:54.13ms
+step:1288/1490 train_time:69753ms step_avg:54.16ms
+step:1289/1490 train_time:69834ms step_avg:54.18ms
+step:1290/1490 train_time:69922ms step_avg:54.20ms
+step:1291/1490 train_time:70004ms step_avg:54.22ms
+step:1292/1490 train_time:70090ms step_avg:54.25ms
+step:1293/1490 train_time:70171ms step_avg:54.27ms
+step:1294/1490 train_time:70257ms step_avg:54.29ms
+step:1295/1490 train_time:70336ms step_avg:54.31ms
+step:1296/1490 train_time:70421ms step_avg:54.34ms
+step:1297/1490 train_time:70502ms step_avg:54.36ms
+step:1298/1490 train_time:70589ms step_avg:54.38ms
+step:1299/1490 train_time:70670ms step_avg:54.40ms
+step:1300/1490 train_time:70758ms step_avg:54.43ms
+step:1301/1490 train_time:70839ms step_avg:54.45ms
+step:1302/1490 train_time:70925ms step_avg:54.47ms
+step:1303/1490 train_time:71007ms step_avg:54.49ms
+step:1304/1490 train_time:71094ms step_avg:54.52ms
+step:1305/1490 train_time:71175ms step_avg:54.54ms
+step:1306/1490 train_time:71262ms step_avg:54.57ms
+step:1307/1490 train_time:71342ms step_avg:54.58ms
+step:1308/1490 train_time:71428ms step_avg:54.61ms
+step:1309/1490 train_time:71509ms step_avg:54.63ms
+step:1310/1490 train_time:71596ms step_avg:54.65ms
+step:1311/1490 train_time:71678ms step_avg:54.67ms
+step:1312/1490 train_time:71764ms step_avg:54.70ms
+step:1313/1490 train_time:71845ms step_avg:54.72ms
+step:1314/1490 train_time:71933ms step_avg:54.74ms
+step:1315/1490 train_time:72013ms step_avg:54.76ms
+step:1316/1490 train_time:72102ms step_avg:54.79ms
+step:1317/1490 train_time:72182ms step_avg:54.81ms
+step:1318/1490 train_time:72269ms step_avg:54.83ms
+step:1319/1490 train_time:72350ms step_avg:54.85ms
+step:1320/1490 train_time:72435ms step_avg:54.88ms
+step:1321/1490 train_time:72516ms step_avg:54.89ms
+step:1322/1490 train_time:72602ms step_avg:54.92ms
+step:1323/1490 train_time:72683ms step_avg:54.94ms
+step:1324/1490 train_time:72770ms step_avg:54.96ms
+step:1325/1490 train_time:72852ms step_avg:54.98ms
+step:1326/1490 train_time:72938ms step_avg:55.01ms
+step:1327/1490 train_time:73021ms step_avg:55.03ms
+step:1328/1490 train_time:73107ms step_avg:55.05ms
+step:1329/1490 train_time:73187ms step_avg:55.07ms
+step:1330/1490 train_time:73273ms step_avg:55.09ms
+step:1331/1490 train_time:73355ms step_avg:55.11ms
+step:1332/1490 train_time:73441ms step_avg:55.14ms
+step:1333/1490 train_time:73523ms step_avg:55.16ms
+step:1334/1490 train_time:73609ms step_avg:55.18ms
+step:1335/1490 train_time:73691ms step_avg:55.20ms
+step:1336/1490 train_time:73779ms step_avg:55.22ms
+step:1337/1490 train_time:73861ms step_avg:55.24ms
+step:1338/1490 train_time:73946ms step_avg:55.27ms
+step:1339/1490 train_time:74029ms step_avg:55.29ms
+step:1340/1490 train_time:74115ms step_avg:55.31ms
+step:1341/1490 train_time:74196ms step_avg:55.33ms
+step:1342/1490 train_time:74282ms step_avg:55.35ms
+step:1343/1490 train_time:74363ms step_avg:55.37ms
+step:1344/1490 train_time:74449ms step_avg:55.39ms
+step:1345/1490 train_time:74529ms step_avg:55.41ms
+step:1346/1490 train_time:74615ms step_avg:55.43ms
+step:1347/1490 train_time:74696ms step_avg:55.45ms
+step:1348/1490 train_time:74783ms step_avg:55.48ms
+step:1349/1490 train_time:74864ms step_avg:55.50ms
+step:1350/1490 train_time:74951ms step_avg:55.52ms
+step:1351/1490 train_time:75032ms step_avg:55.54ms
+step:1352/1490 train_time:75118ms step_avg:55.56ms
+step:1353/1490 train_time:75198ms step_avg:55.58ms
+step:1354/1490 train_time:75284ms step_avg:55.60ms
+step:1355/1490 train_time:75367ms step_avg:55.62ms
+step:1356/1490 train_time:75453ms step_avg:55.64ms
+step:1357/1490 train_time:75533ms step_avg:55.66ms
+step:1358/1490 train_time:75619ms step_avg:55.68ms
+step:1359/1490 train_time:75701ms step_avg:55.70ms
+step:1360/1490 train_time:75788ms step_avg:55.73ms
+step:1361/1490 train_time:75869ms step_avg:55.75ms
+step:1362/1490 train_time:75956ms step_avg:55.77ms
+step:1363/1490 train_time:76037ms step_avg:55.79ms
+step:1364/1490 train_time:76124ms step_avg:55.81ms
+step:1365/1490 train_time:76205ms step_avg:55.83ms
+step:1366/1490 train_time:76291ms step_avg:55.85ms
+step:1367/1490 train_time:76373ms step_avg:55.87ms
+step:1368/1490 train_time:76459ms step_avg:55.89ms
+step:1369/1490 train_time:76540ms step_avg:55.91ms
+step:1370/1490 train_time:76627ms step_avg:55.93ms
+step:1371/1490 train_time:76708ms step_avg:55.95ms
+step:1372/1490 train_time:76795ms step_avg:55.97ms
+step:1373/1490 train_time:76876ms step_avg:55.99ms
+step:1374/1490 train_time:76963ms step_avg:56.01ms
+step:1375/1490 train_time:77043ms step_avg:56.03ms
+step:1376/1490 train_time:77130ms step_avg:56.05ms
+step:1377/1490 train_time:77212ms step_avg:56.07ms
+step:1378/1490 train_time:77299ms step_avg:56.09ms
+step:1379/1490 train_time:77380ms step_avg:56.11ms
+step:1380/1490 train_time:77467ms step_avg:56.14ms
+step:1381/1490 train_time:77547ms step_avg:56.15ms
+step:1382/1490 train_time:77633ms step_avg:56.17ms
+step:1383/1490 train_time:77713ms step_avg:56.19ms
+step:1384/1490 train_time:77800ms step_avg:56.21ms
+step:1385/1490 train_time:77882ms step_avg:56.23ms
+step:1386/1490 train_time:77968ms step_avg:56.25ms
+step:1387/1490 train_time:78049ms step_avg:56.27ms
+step:1388/1490 train_time:78136ms step_avg:56.29ms
+step:1389/1490 train_time:78216ms step_avg:56.31ms
+step:1390/1490 train_time:78303ms step_avg:56.33ms
+step:1391/1490 train_time:78384ms step_avg:56.35ms
+step:1392/1490 train_time:78471ms step_avg:56.37ms
+step:1393/1490 train_time:78552ms step_avg:56.39ms
+step:1394/1490 train_time:78639ms step_avg:56.41ms
+step:1395/1490 train_time:78719ms step_avg:56.43ms
+step:1396/1490 train_time:78806ms step_avg:56.45ms
+step:1397/1490 train_time:78887ms step_avg:56.47ms
+step:1398/1490 train_time:78973ms step_avg:56.49ms
+step:1399/1490 train_time:79054ms step_avg:56.51ms
+step:1400/1490 train_time:79138ms step_avg:56.53ms
+step:1401/1490 train_time:79220ms step_avg:56.55ms
+step:1402/1490 train_time:79306ms step_avg:56.57ms
+step:1403/1490 train_time:79387ms step_avg:56.58ms
+step:1404/1490 train_time:79473ms step_avg:56.60ms
+step:1405/1490 train_time:79554ms step_avg:56.62ms
+step:1406/1490 train_time:79640ms step_avg:56.64ms
+step:1407/1490 train_time:79720ms step_avg:56.66ms
+step:1408/1490 train_time:79806ms step_avg:56.68ms
+step:1409/1490 train_time:79888ms step_avg:56.70ms
+step:1410/1490 train_time:79975ms step_avg:56.72ms
+step:1411/1490 train_time:80056ms step_avg:56.74ms
+step:1412/1490 train_time:80143ms step_avg:56.76ms
+step:1413/1490 train_time:80223ms step_avg:56.77ms
+step:1414/1490 train_time:80310ms step_avg:56.80ms
+step:1415/1490 train_time:80390ms step_avg:56.81ms
+step:1416/1490 train_time:80477ms step_avg:56.83ms
+step:1417/1490 train_time:80558ms step_avg:56.85ms
+step:1418/1490 train_time:80644ms step_avg:56.87ms
+step:1419/1490 train_time:80725ms step_avg:56.89ms
+step:1420/1490 train_time:80812ms step_avg:56.91ms
+step:1421/1490 train_time:80894ms step_avg:56.93ms
+step:1422/1490 train_time:80981ms step_avg:56.95ms
+step:1423/1490 train_time:81063ms step_avg:56.97ms
+step:1424/1490 train_time:81149ms step_avg:56.99ms
+step:1425/1490 train_time:81230ms step_avg:57.00ms
+step:1426/1490 train_time:81315ms step_avg:57.02ms
+step:1427/1490 train_time:81397ms step_avg:57.04ms
+step:1428/1490 train_time:81483ms step_avg:57.06ms
+step:1429/1490 train_time:81564ms step_avg:57.08ms
+step:1430/1490 train_time:81650ms step_avg:57.10ms
+step:1431/1490 train_time:81732ms step_avg:57.12ms
+step:1432/1490 train_time:81817ms step_avg:57.14ms
+step:1433/1490 train_time:81899ms step_avg:57.15ms
+step:1434/1490 train_time:81986ms step_avg:57.17ms
+step:1435/1490 train_time:82066ms step_avg:57.19ms
+step:1436/1490 train_time:82153ms step_avg:57.21ms
+step:1437/1490 train_time:82233ms step_avg:57.23ms
+step:1438/1490 train_time:82322ms step_avg:57.25ms
+step:1439/1490 train_time:82401ms step_avg:57.26ms
+step:1440/1490 train_time:82488ms step_avg:57.28ms
+step:1441/1490 train_time:82569ms step_avg:57.30ms
+step:1442/1490 train_time:82655ms step_avg:57.32ms
+step:1443/1490 train_time:82735ms step_avg:57.34ms
+step:1444/1490 train_time:82822ms step_avg:57.36ms
+step:1445/1490 train_time:82903ms step_avg:57.37ms
+step:1446/1490 train_time:82991ms step_avg:57.39ms
+step:1447/1490 train_time:83073ms step_avg:57.41ms
+step:1448/1490 train_time:83161ms step_avg:57.43ms
+step:1449/1490 train_time:83241ms step_avg:57.45ms
+step:1450/1490 train_time:83328ms step_avg:57.47ms
+step:1451/1490 train_time:83412ms step_avg:57.49ms
+step:1452/1490 train_time:83501ms step_avg:57.51ms
+step:1453/1490 train_time:83581ms step_avg:57.52ms
+step:1454/1490 train_time:83668ms step_avg:57.54ms
+step:1455/1490 train_time:83749ms step_avg:57.56ms
+step:1456/1490 train_time:83836ms step_avg:57.58ms
+step:1457/1490 train_time:83916ms step_avg:57.60ms
+step:1458/1490 train_time:84003ms step_avg:57.62ms
+step:1459/1490 train_time:84085ms step_avg:57.63ms
+step:1460/1490 train_time:84173ms step_avg:57.65ms
+step:1461/1490 train_time:84256ms step_avg:57.67ms
+step:1462/1490 train_time:84340ms step_avg:57.69ms
+step:1463/1490 train_time:84423ms step_avg:57.71ms
+step:1464/1490 train_time:84510ms step_avg:57.73ms
+step:1465/1490 train_time:84591ms step_avg:57.74ms
+step:1466/1490 train_time:84677ms step_avg:57.76ms
+step:1467/1490 train_time:84757ms step_avg:57.78ms
+step:1468/1490 train_time:84844ms step_avg:57.80ms
+step:1469/1490 train_time:84924ms step_avg:57.81ms
+step:1470/1490 train_time:85011ms step_avg:57.83ms
+step:1471/1490 train_time:85093ms step_avg:57.85ms
+step:1472/1490 train_time:85179ms step_avg:57.87ms
+step:1473/1490 train_time:85262ms step_avg:57.88ms
+step:1474/1490 train_time:85347ms step_avg:57.90ms
+step:1475/1490 train_time:85429ms step_avg:57.92ms
+step:1476/1490 train_time:85515ms step_avg:57.94ms
+step:1477/1490 train_time:85598ms step_avg:57.95ms
+step:1478/1490 train_time:85683ms step_avg:57.97ms
+step:1479/1490 train_time:85764ms step_avg:57.99ms
+step:1480/1490 train_time:85852ms step_avg:58.01ms
+step:1481/1490 train_time:85933ms step_avg:58.02ms
+step:1482/1490 train_time:86020ms step_avg:58.04ms
+step:1483/1490 train_time:86101ms step_avg:58.06ms
+step:1484/1490 train_time:86189ms step_avg:58.08ms
+step:1485/1490 train_time:86270ms step_avg:58.09ms
+step:1486/1490 train_time:86356ms step_avg:58.11ms
+step:1487/1490 train_time:86436ms step_avg:58.13ms
+step:1488/1490 train_time:86523ms step_avg:58.15ms
+step:1489/1490 train_time:86604ms step_avg:58.16ms
+step:1490/1490 train_time:86690ms step_avg:58.18ms
+step:1490/1490 val_loss:3.2811 train_time:86796ms step_avg:58.25ms
+peak memory allocated: 31296 MiB reserved: 47042 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/baseline/2026-03-22_20-01-18_time-184_secs_baseline_ad80dc.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/baseline/2026-03-22_20-01-18_time-184_secs_baseline_ad80dc.txt
@@ -1,0 +1,4456 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 20:01:33 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            132W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   40C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1797756      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1797757      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1797758      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1797759      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1797760      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1797761      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1797762      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1797763      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8299 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:84ms step_avg:84.00ms
+step:2/1490 train_time:108ms step_avg:53.87ms
+step:3/1490 train_time:125ms step_avg:41.64ms
+step:4/1490 train_time:150ms step_avg:37.38ms
+step:5/1490 train_time:177ms step_avg:35.37ms
+step:6/1490 train_time:212ms step_avg:35.25ms
+step:7/1490 train_time:239ms step_avg:34.13ms
+step:8/1490 train_time:274ms step_avg:34.22ms
+step:9/1490 train_time:301ms step_avg:33.49ms
+step:10/1490 train_time:336ms step_avg:33.62ms
+step:11/1490 train_time:364ms step_avg:33.09ms
+step:12/1490 train_time:398ms step_avg:33.18ms
+step:13/1490 train_time:426ms step_avg:32.79ms
+step:14/1490 train_time:460ms step_avg:32.89ms
+step:15/1490 train_time:489ms step_avg:32.59ms
+step:16/1490 train_time:523ms step_avg:32.70ms
+step:17/1490 train_time:551ms step_avg:32.43ms
+step:18/1490 train_time:586ms step_avg:32.55ms
+step:19/1490 train_time:614ms step_avg:32.33ms
+step:20/1490 train_time:649ms step_avg:32.43ms
+step:21/1490 train_time:677ms step_avg:32.25ms
+step:22/1490 train_time:711ms step_avg:32.34ms
+step:23/1490 train_time:740ms step_avg:32.19ms
+step:24/1490 train_time:774ms step_avg:32.26ms
+step:25/1490 train_time:803ms step_avg:32.11ms
+step:26/1490 train_time:837ms step_avg:32.21ms
+step:27/1490 train_time:866ms step_avg:32.06ms
+step:28/1490 train_time:900ms step_avg:32.14ms
+step:29/1490 train_time:928ms step_avg:32.02ms
+step:30/1490 train_time:963ms step_avg:32.11ms
+step:31/1490 train_time:992ms step_avg:32.01ms
+step:32/1490 train_time:1029ms step_avg:32.14ms
+step:33/1490 train_time:1058ms step_avg:32.05ms
+step:34/1490 train_time:1092ms step_avg:32.12ms
+step:35/1490 train_time:1122ms step_avg:32.05ms
+step:36/1490 train_time:1156ms step_avg:32.11ms
+step:37/1490 train_time:1185ms step_avg:32.01ms
+step:38/1490 train_time:1219ms step_avg:32.08ms
+step:39/1490 train_time:1248ms step_avg:31.99ms
+step:40/1490 train_time:1282ms step_avg:32.05ms
+step:41/1490 train_time:1310ms step_avg:31.96ms
+step:42/1490 train_time:1346ms step_avg:32.04ms
+step:43/1490 train_time:1374ms step_avg:31.94ms
+step:44/1490 train_time:1408ms step_avg:32.00ms
+step:45/1490 train_time:1437ms step_avg:31.92ms
+step:46/1490 train_time:1471ms step_avg:31.98ms
+step:47/1490 train_time:1499ms step_avg:31.90ms
+step:48/1490 train_time:1534ms step_avg:31.95ms
+step:49/1490 train_time:1562ms step_avg:31.88ms
+step:50/1490 train_time:1597ms step_avg:31.93ms
+step:51/1490 train_time:1625ms step_avg:31.87ms
+step:52/1490 train_time:1660ms step_avg:31.92ms
+step:53/1490 train_time:1688ms step_avg:31.85ms
+step:54/1490 train_time:1723ms step_avg:31.90ms
+step:55/1490 train_time:1751ms step_avg:31.84ms
+step:56/1490 train_time:1786ms step_avg:31.89ms
+step:57/1490 train_time:1814ms step_avg:31.82ms
+step:58/1490 train_time:1848ms step_avg:31.86ms
+step:59/1490 train_time:1877ms step_avg:31.81ms
+step:60/1490 train_time:1911ms step_avg:31.85ms
+step:61/1490 train_time:1940ms step_avg:31.81ms
+step:62/1490 train_time:1975ms step_avg:31.86ms
+step:63/1490 train_time:2004ms step_avg:31.81ms
+step:64/1490 train_time:2039ms step_avg:31.86ms
+step:65/1490 train_time:2068ms step_avg:31.81ms
+step:66/1490 train_time:2102ms step_avg:31.85ms
+step:67/1490 train_time:2131ms step_avg:31.81ms
+step:68/1490 train_time:2166ms step_avg:31.86ms
+step:69/1490 train_time:2195ms step_avg:31.81ms
+step:70/1490 train_time:2230ms step_avg:31.86ms
+step:71/1490 train_time:2258ms step_avg:31.81ms
+step:72/1490 train_time:2292ms step_avg:31.84ms
+step:73/1490 train_time:2321ms step_avg:31.80ms
+step:74/1490 train_time:2355ms step_avg:31.83ms
+step:75/1490 train_time:2384ms step_avg:31.79ms
+step:76/1490 train_time:2419ms step_avg:31.82ms
+step:77/1490 train_time:2447ms step_avg:31.78ms
+step:78/1490 train_time:2481ms step_avg:31.81ms
+step:79/1490 train_time:2510ms step_avg:31.77ms
+step:80/1490 train_time:2544ms step_avg:31.80ms
+step:81/1490 train_time:2572ms step_avg:31.76ms
+step:82/1490 train_time:2607ms step_avg:31.79ms
+step:83/1490 train_time:2635ms step_avg:31.75ms
+step:84/1490 train_time:2670ms step_avg:31.78ms
+step:85/1490 train_time:2698ms step_avg:31.74ms
+step:86/1490 train_time:2733ms step_avg:31.78ms
+step:87/1490 train_time:2761ms step_avg:31.74ms
+step:88/1490 train_time:2795ms step_avg:31.77ms
+step:89/1490 train_time:2824ms step_avg:31.73ms
+step:90/1490 train_time:2858ms step_avg:31.76ms
+step:91/1490 train_time:2887ms step_avg:31.73ms
+step:92/1490 train_time:2922ms step_avg:31.76ms
+step:93/1490 train_time:2950ms step_avg:31.73ms
+step:94/1490 train_time:2985ms step_avg:31.75ms
+step:95/1490 train_time:3013ms step_avg:31.72ms
+step:96/1490 train_time:3048ms step_avg:31.75ms
+step:97/1490 train_time:3077ms step_avg:31.72ms
+step:98/1490 train_time:3112ms step_avg:31.75ms
+step:99/1490 train_time:3141ms step_avg:31.73ms
+step:100/1490 train_time:3175ms step_avg:31.75ms
+step:101/1490 train_time:3204ms step_avg:31.72ms
+step:102/1490 train_time:3239ms step_avg:31.75ms
+step:103/1490 train_time:3267ms step_avg:31.72ms
+step:104/1490 train_time:3302ms step_avg:31.75ms
+step:105/1490 train_time:3331ms step_avg:31.72ms
+step:106/1490 train_time:3365ms step_avg:31.74ms
+step:107/1490 train_time:3393ms step_avg:31.71ms
+step:108/1490 train_time:3428ms step_avg:31.74ms
+step:109/1490 train_time:3456ms step_avg:31.71ms
+step:110/1490 train_time:3490ms step_avg:31.73ms
+step:111/1490 train_time:3519ms step_avg:31.70ms
+step:112/1490 train_time:3553ms step_avg:31.73ms
+step:113/1490 train_time:3582ms step_avg:31.70ms
+step:114/1490 train_time:3617ms step_avg:31.73ms
+step:115/1490 train_time:3646ms step_avg:31.70ms
+step:116/1490 train_time:3681ms step_avg:31.73ms
+step:117/1490 train_time:3709ms step_avg:31.70ms
+step:118/1490 train_time:3744ms step_avg:31.73ms
+step:119/1490 train_time:3772ms step_avg:31.70ms
+step:120/1490 train_time:3807ms step_avg:31.72ms
+step:121/1490 train_time:3835ms step_avg:31.70ms
+step:122/1490 train_time:3870ms step_avg:31.72ms
+step:123/1490 train_time:3898ms step_avg:31.69ms
+step:124/1490 train_time:3933ms step_avg:31.72ms
+step:125/1490 train_time:3962ms step_avg:31.69ms
+step:126/1490 train_time:3996ms step_avg:31.71ms
+step:127/1490 train_time:4025ms step_avg:31.69ms
+step:128/1490 train_time:4059ms step_avg:31.71ms
+step:129/1490 train_time:4088ms step_avg:31.69ms
+step:130/1490 train_time:4122ms step_avg:31.71ms
+step:131/1490 train_time:4151ms step_avg:31.69ms
+step:132/1490 train_time:4186ms step_avg:31.71ms
+step:133/1490 train_time:4214ms step_avg:31.68ms
+step:134/1490 train_time:4248ms step_avg:31.70ms
+step:135/1490 train_time:4277ms step_avg:31.68ms
+step:136/1490 train_time:4311ms step_avg:31.70ms
+step:137/1490 train_time:4340ms step_avg:31.68ms
+step:138/1490 train_time:4374ms step_avg:31.69ms
+step:139/1490 train_time:4402ms step_avg:31.67ms
+step:140/1490 train_time:4437ms step_avg:31.69ms
+step:141/1490 train_time:4465ms step_avg:31.67ms
+step:142/1490 train_time:4499ms step_avg:31.69ms
+step:143/1490 train_time:4528ms step_avg:31.66ms
+step:144/1490 train_time:4562ms step_avg:31.68ms
+step:145/1490 train_time:4590ms step_avg:31.66ms
+step:146/1490 train_time:4625ms step_avg:31.68ms
+step:147/1490 train_time:4653ms step_avg:31.66ms
+step:148/1490 train_time:4688ms step_avg:31.67ms
+step:149/1490 train_time:4716ms step_avg:31.65ms
+step:150/1490 train_time:4751ms step_avg:31.67ms
+step:151/1490 train_time:4779ms step_avg:31.65ms
+step:152/1490 train_time:4814ms step_avg:31.67ms
+step:153/1490 train_time:4842ms step_avg:31.65ms
+step:154/1490 train_time:4877ms step_avg:31.67ms
+step:155/1490 train_time:4906ms step_avg:31.65ms
+step:156/1490 train_time:4940ms step_avg:31.67ms
+step:157/1490 train_time:4969ms step_avg:31.65ms
+step:158/1490 train_time:5003ms step_avg:31.67ms
+step:159/1490 train_time:5032ms step_avg:31.65ms
+step:160/1490 train_time:5066ms step_avg:31.66ms
+step:161/1490 train_time:5094ms step_avg:31.64ms
+step:162/1490 train_time:5129ms step_avg:31.66ms
+step:163/1490 train_time:5158ms step_avg:31.64ms
+step:164/1490 train_time:5192ms step_avg:31.66ms
+step:165/1490 train_time:5221ms step_avg:31.64ms
+step:166/1490 train_time:5255ms step_avg:31.66ms
+step:167/1490 train_time:5284ms step_avg:31.64ms
+step:168/1490 train_time:5318ms step_avg:31.65ms
+step:169/1490 train_time:5347ms step_avg:31.64ms
+step:170/1490 train_time:5381ms step_avg:31.65ms
+step:171/1490 train_time:5410ms step_avg:31.64ms
+step:172/1490 train_time:5444ms step_avg:31.65ms
+step:173/1490 train_time:5473ms step_avg:31.63ms
+step:174/1490 train_time:5507ms step_avg:31.65ms
+step:175/1490 train_time:5535ms step_avg:31.63ms
+step:176/1490 train_time:5570ms step_avg:31.65ms
+step:177/1490 train_time:5598ms step_avg:31.63ms
+step:178/1490 train_time:5632ms step_avg:31.64ms
+step:179/1490 train_time:5661ms step_avg:31.63ms
+step:180/1490 train_time:5695ms step_avg:31.64ms
+step:181/1490 train_time:5724ms step_avg:31.62ms
+step:182/1490 train_time:5758ms step_avg:31.64ms
+step:183/1490 train_time:5787ms step_avg:31.62ms
+step:184/1490 train_time:5822ms step_avg:31.64ms
+step:185/1490 train_time:5850ms step_avg:31.62ms
+step:186/1490 train_time:5885ms step_avg:31.64ms
+step:187/1490 train_time:5913ms step_avg:31.62ms
+step:188/1490 train_time:5947ms step_avg:31.64ms
+step:189/1490 train_time:5976ms step_avg:31.62ms
+step:190/1490 train_time:6010ms step_avg:31.63ms
+step:191/1490 train_time:6039ms step_avg:31.62ms
+step:192/1490 train_time:6073ms step_avg:31.63ms
+step:193/1490 train_time:6102ms step_avg:31.62ms
+step:194/1490 train_time:6137ms step_avg:31.63ms
+step:195/1490 train_time:6165ms step_avg:31.62ms
+step:196/1490 train_time:6200ms step_avg:31.63ms
+step:197/1490 train_time:6228ms step_avg:31.61ms
+step:198/1490 train_time:6263ms step_avg:31.63ms
+step:199/1490 train_time:6291ms step_avg:31.61ms
+step:200/1490 train_time:6325ms step_avg:31.63ms
+step:201/1490 train_time:6354ms step_avg:31.61ms
+step:202/1490 train_time:6389ms step_avg:31.63ms
+step:203/1490 train_time:6417ms step_avg:31.61ms
+step:204/1490 train_time:6452ms step_avg:31.63ms
+step:205/1490 train_time:6480ms step_avg:31.61ms
+step:206/1490 train_time:6515ms step_avg:31.63ms
+step:207/1490 train_time:6544ms step_avg:31.61ms
+step:208/1490 train_time:6578ms step_avg:31.63ms
+step:209/1490 train_time:6607ms step_avg:31.61ms
+step:210/1490 train_time:6641ms step_avg:31.62ms
+step:211/1490 train_time:6669ms step_avg:31.61ms
+step:212/1490 train_time:6704ms step_avg:31.62ms
+step:213/1490 train_time:6732ms step_avg:31.61ms
+step:214/1490 train_time:6766ms step_avg:31.62ms
+step:215/1490 train_time:6795ms step_avg:31.60ms
+step:216/1490 train_time:6829ms step_avg:31.62ms
+step:217/1490 train_time:6858ms step_avg:31.60ms
+step:218/1490 train_time:6892ms step_avg:31.62ms
+step:219/1490 train_time:6921ms step_avg:31.60ms
+step:220/1490 train_time:6955ms step_avg:31.61ms
+step:221/1490 train_time:6983ms step_avg:31.60ms
+step:222/1490 train_time:7018ms step_avg:31.61ms
+step:223/1490 train_time:7046ms step_avg:31.60ms
+step:224/1490 train_time:7081ms step_avg:31.61ms
+step:225/1490 train_time:7109ms step_avg:31.60ms
+step:226/1490 train_time:7144ms step_avg:31.61ms
+step:227/1490 train_time:7172ms step_avg:31.60ms
+step:228/1490 train_time:7207ms step_avg:31.61ms
+step:229/1490 train_time:7236ms step_avg:31.60ms
+step:230/1490 train_time:7270ms step_avg:31.61ms
+step:231/1490 train_time:7298ms step_avg:31.59ms
+step:232/1490 train_time:7332ms step_avg:31.61ms
+step:233/1490 train_time:7361ms step_avg:31.59ms
+step:234/1490 train_time:7395ms step_avg:31.60ms
+step:235/1490 train_time:7424ms step_avg:31.59ms
+step:236/1490 train_time:7458ms step_avg:31.60ms
+step:237/1490 train_time:7486ms step_avg:31.59ms
+step:238/1490 train_time:7521ms step_avg:31.60ms
+step:239/1490 train_time:7549ms step_avg:31.59ms
+step:240/1490 train_time:7583ms step_avg:31.60ms
+step:241/1490 train_time:7612ms step_avg:31.58ms
+step:242/1490 train_time:7646ms step_avg:31.60ms
+step:243/1490 train_time:7674ms step_avg:31.58ms
+step:244/1490 train_time:7709ms step_avg:31.59ms
+step:245/1490 train_time:7737ms step_avg:31.58ms
+step:246/1490 train_time:7772ms step_avg:31.59ms
+step:247/1490 train_time:7800ms step_avg:31.58ms
+step:248/1490 train_time:7835ms step_avg:31.59ms
+step:249/1490 train_time:7863ms step_avg:31.58ms
+step:250/1490 train_time:7897ms step_avg:31.59ms
+step:250/1490 val_loss:4.5042 train_time:7940ms step_avg:31.76ms
+step:251/1490 train_time:7956ms step_avg:31.70ms
+step:252/1490 train_time:7973ms step_avg:31.64ms
+step:253/1490 train_time:7992ms step_avg:31.59ms
+step:254/1490 train_time:8027ms step_avg:31.60ms
+step:255/1490 train_time:8055ms step_avg:31.59ms
+step:256/1490 train_time:8092ms step_avg:31.61ms
+step:257/1490 train_time:8120ms step_avg:31.60ms
+step:258/1490 train_time:8155ms step_avg:31.61ms
+step:259/1490 train_time:8183ms step_avg:31.60ms
+step:260/1490 train_time:8217ms step_avg:31.61ms
+step:261/1490 train_time:8246ms step_avg:31.59ms
+step:262/1490 train_time:8280ms step_avg:31.60ms
+step:263/1490 train_time:8308ms step_avg:31.59ms
+step:264/1490 train_time:8342ms step_avg:31.60ms
+step:265/1490 train_time:8371ms step_avg:31.59ms
+step:266/1490 train_time:8405ms step_avg:31.60ms
+step:267/1490 train_time:8433ms step_avg:31.58ms
+step:268/1490 train_time:8467ms step_avg:31.59ms
+step:269/1490 train_time:8496ms step_avg:31.58ms
+step:270/1490 train_time:8530ms step_avg:31.59ms
+step:271/1490 train_time:8558ms step_avg:31.58ms
+step:272/1490 train_time:8592ms step_avg:31.59ms
+step:273/1490 train_time:8621ms step_avg:31.58ms
+step:274/1490 train_time:8655ms step_avg:31.59ms
+step:275/1490 train_time:8683ms step_avg:31.58ms
+step:276/1490 train_time:8717ms step_avg:31.58ms
+step:277/1490 train_time:8745ms step_avg:31.57ms
+step:278/1490 train_time:8779ms step_avg:31.58ms
+step:279/1490 train_time:8808ms step_avg:31.57ms
+step:280/1490 train_time:8842ms step_avg:31.58ms
+step:281/1490 train_time:8871ms step_avg:31.57ms
+step:282/1490 train_time:8905ms step_avg:31.58ms
+step:283/1490 train_time:8934ms step_avg:31.57ms
+step:284/1490 train_time:8968ms step_avg:31.58ms
+step:285/1490 train_time:8997ms step_avg:31.57ms
+step:286/1490 train_time:9032ms step_avg:31.58ms
+step:287/1490 train_time:9061ms step_avg:31.57ms
+step:288/1490 train_time:9096ms step_avg:31.58ms
+step:289/1490 train_time:9124ms step_avg:31.57ms
+step:290/1490 train_time:9159ms step_avg:31.58ms
+step:291/1490 train_time:9188ms step_avg:31.57ms
+step:292/1490 train_time:9222ms step_avg:31.58ms
+step:293/1490 train_time:9251ms step_avg:31.57ms
+step:294/1490 train_time:9285ms step_avg:31.58ms
+step:295/1490 train_time:9313ms step_avg:31.57ms
+step:296/1490 train_time:9348ms step_avg:31.58ms
+step:297/1490 train_time:9376ms step_avg:31.57ms
+step:298/1490 train_time:9410ms step_avg:31.58ms
+step:299/1490 train_time:9439ms step_avg:31.57ms
+step:300/1490 train_time:9473ms step_avg:31.58ms
+step:301/1490 train_time:9502ms step_avg:31.57ms
+step:302/1490 train_time:9535ms step_avg:31.57ms
+step:303/1490 train_time:9564ms step_avg:31.56ms
+step:304/1490 train_time:9598ms step_avg:31.57ms
+step:305/1490 train_time:9626ms step_avg:31.56ms
+step:306/1490 train_time:9661ms step_avg:31.57ms
+step:307/1490 train_time:9689ms step_avg:31.56ms
+step:308/1490 train_time:9723ms step_avg:31.57ms
+step:309/1490 train_time:9752ms step_avg:31.56ms
+step:310/1490 train_time:9786ms step_avg:31.57ms
+step:311/1490 train_time:9814ms step_avg:31.56ms
+step:312/1490 train_time:9849ms step_avg:31.57ms
+step:313/1490 train_time:9877ms step_avg:31.56ms
+step:314/1490 train_time:9912ms step_avg:31.57ms
+step:315/1490 train_time:9941ms step_avg:31.56ms
+step:316/1490 train_time:9975ms step_avg:31.57ms
+step:317/1490 train_time:10004ms step_avg:31.56ms
+step:318/1490 train_time:10038ms step_avg:31.57ms
+step:319/1490 train_time:10067ms step_avg:31.56ms
+step:320/1490 train_time:10101ms step_avg:31.57ms
+step:321/1490 train_time:10130ms step_avg:31.56ms
+step:322/1490 train_time:10164ms step_avg:31.57ms
+step:323/1490 train_time:10193ms step_avg:31.56ms
+step:324/1490 train_time:10227ms step_avg:31.56ms
+step:325/1490 train_time:10255ms step_avg:31.55ms
+step:326/1490 train_time:10290ms step_avg:31.56ms
+step:327/1490 train_time:10318ms step_avg:31.55ms
+step:328/1490 train_time:10352ms step_avg:31.56ms
+step:329/1490 train_time:10381ms step_avg:31.55ms
+step:330/1490 train_time:10415ms step_avg:31.56ms
+step:331/1490 train_time:10443ms step_avg:31.55ms
+step:332/1490 train_time:10477ms step_avg:31.56ms
+step:333/1490 train_time:10506ms step_avg:31.55ms
+step:334/1490 train_time:10540ms step_avg:31.56ms
+step:335/1490 train_time:10568ms step_avg:31.55ms
+step:336/1490 train_time:10603ms step_avg:31.56ms
+step:337/1490 train_time:10631ms step_avg:31.55ms
+step:338/1490 train_time:10666ms step_avg:31.56ms
+step:339/1490 train_time:10694ms step_avg:31.55ms
+step:340/1490 train_time:10728ms step_avg:31.55ms
+step:341/1490 train_time:10756ms step_avg:31.54ms
+step:342/1490 train_time:10791ms step_avg:31.55ms
+step:343/1490 train_time:10819ms step_avg:31.54ms
+step:344/1490 train_time:10854ms step_avg:31.55ms
+step:345/1490 train_time:10882ms step_avg:31.54ms
+step:346/1490 train_time:10917ms step_avg:31.55ms
+step:347/1490 train_time:10945ms step_avg:31.54ms
+step:348/1490 train_time:10980ms step_avg:31.55ms
+step:349/1490 train_time:11008ms step_avg:31.54ms
+step:350/1490 train_time:11042ms step_avg:31.55ms
+step:351/1490 train_time:11071ms step_avg:31.54ms
+step:352/1490 train_time:11106ms step_avg:31.55ms
+step:353/1490 train_time:11134ms step_avg:31.54ms
+step:354/1490 train_time:11169ms step_avg:31.55ms
+step:355/1490 train_time:11197ms step_avg:31.54ms
+step:356/1490 train_time:11231ms step_avg:31.55ms
+step:357/1490 train_time:11260ms step_avg:31.54ms
+step:358/1490 train_time:11294ms step_avg:31.55ms
+step:359/1490 train_time:11322ms step_avg:31.54ms
+step:360/1490 train_time:11357ms step_avg:31.55ms
+step:361/1490 train_time:11386ms step_avg:31.54ms
+step:362/1490 train_time:11420ms step_avg:31.55ms
+step:363/1490 train_time:11448ms step_avg:31.54ms
+step:364/1490 train_time:11483ms step_avg:31.55ms
+step:365/1490 train_time:11511ms step_avg:31.54ms
+step:366/1490 train_time:11545ms step_avg:31.54ms
+step:367/1490 train_time:11573ms step_avg:31.54ms
+step:368/1490 train_time:11608ms step_avg:31.54ms
+step:369/1490 train_time:11636ms step_avg:31.53ms
+step:370/1490 train_time:11670ms step_avg:31.54ms
+step:371/1490 train_time:11698ms step_avg:31.53ms
+step:372/1490 train_time:11733ms step_avg:31.54ms
+step:373/1490 train_time:11761ms step_avg:31.53ms
+step:374/1490 train_time:11795ms step_avg:31.54ms
+step:375/1490 train_time:11824ms step_avg:31.53ms
+step:376/1490 train_time:11858ms step_avg:31.54ms
+step:377/1490 train_time:11887ms step_avg:31.53ms
+step:378/1490 train_time:11922ms step_avg:31.54ms
+step:379/1490 train_time:11950ms step_avg:31.53ms
+step:380/1490 train_time:11985ms step_avg:31.54ms
+step:381/1490 train_time:12013ms step_avg:31.53ms
+step:382/1490 train_time:12048ms step_avg:31.54ms
+step:383/1490 train_time:12076ms step_avg:31.53ms
+step:384/1490 train_time:12110ms step_avg:31.54ms
+step:385/1490 train_time:12139ms step_avg:31.53ms
+step:386/1490 train_time:12173ms step_avg:31.54ms
+step:387/1490 train_time:12202ms step_avg:31.53ms
+step:388/1490 train_time:12236ms step_avg:31.54ms
+step:389/1490 train_time:12265ms step_avg:31.53ms
+step:390/1490 train_time:12299ms step_avg:31.54ms
+step:391/1490 train_time:12327ms step_avg:31.53ms
+step:392/1490 train_time:12362ms step_avg:31.54ms
+step:393/1490 train_time:12391ms step_avg:31.53ms
+step:394/1490 train_time:12425ms step_avg:31.54ms
+step:395/1490 train_time:12453ms step_avg:31.53ms
+step:396/1490 train_time:12488ms step_avg:31.54ms
+step:397/1490 train_time:12517ms step_avg:31.53ms
+step:398/1490 train_time:12551ms step_avg:31.53ms
+step:399/1490 train_time:12579ms step_avg:31.53ms
+step:400/1490 train_time:12614ms step_avg:31.53ms
+step:401/1490 train_time:12642ms step_avg:31.53ms
+step:402/1490 train_time:12676ms step_avg:31.53ms
+step:403/1490 train_time:12705ms step_avg:31.53ms
+step:404/1490 train_time:12739ms step_avg:31.53ms
+step:405/1490 train_time:12767ms step_avg:31.52ms
+step:406/1490 train_time:12802ms step_avg:31.53ms
+step:407/1490 train_time:12830ms step_avg:31.52ms
+step:408/1490 train_time:12865ms step_avg:31.53ms
+step:409/1490 train_time:12893ms step_avg:31.52ms
+step:410/1490 train_time:12927ms step_avg:31.53ms
+step:411/1490 train_time:12956ms step_avg:31.52ms
+step:412/1490 train_time:12990ms step_avg:31.53ms
+step:413/1490 train_time:13018ms step_avg:31.52ms
+step:414/1490 train_time:13053ms step_avg:31.53ms
+step:415/1490 train_time:13081ms step_avg:31.52ms
+step:416/1490 train_time:13115ms step_avg:31.53ms
+step:417/1490 train_time:13144ms step_avg:31.52ms
+step:418/1490 train_time:13178ms step_avg:31.53ms
+step:419/1490 train_time:13207ms step_avg:31.52ms
+step:420/1490 train_time:13242ms step_avg:31.53ms
+step:421/1490 train_time:13270ms step_avg:31.52ms
+step:422/1490 train_time:13305ms step_avg:31.53ms
+step:423/1490 train_time:13333ms step_avg:31.52ms
+step:424/1490 train_time:13368ms step_avg:31.53ms
+step:425/1490 train_time:13396ms step_avg:31.52ms
+step:426/1490 train_time:13430ms step_avg:31.53ms
+step:427/1490 train_time:13459ms step_avg:31.52ms
+step:428/1490 train_time:13493ms step_avg:31.53ms
+step:429/1490 train_time:13521ms step_avg:31.52ms
+step:430/1490 train_time:13556ms step_avg:31.52ms
+step:431/1490 train_time:13584ms step_avg:31.52ms
+step:432/1490 train_time:13619ms step_avg:31.53ms
+step:433/1490 train_time:13648ms step_avg:31.52ms
+step:434/1490 train_time:13682ms step_avg:31.53ms
+step:435/1490 train_time:13710ms step_avg:31.52ms
+step:436/1490 train_time:13745ms step_avg:31.53ms
+step:437/1490 train_time:13773ms step_avg:31.52ms
+step:438/1490 train_time:13808ms step_avg:31.53ms
+step:439/1490 train_time:13836ms step_avg:31.52ms
+step:440/1490 train_time:13871ms step_avg:31.52ms
+step:441/1490 train_time:13899ms step_avg:31.52ms
+step:442/1490 train_time:13933ms step_avg:31.52ms
+step:443/1490 train_time:13962ms step_avg:31.52ms
+step:444/1490 train_time:13996ms step_avg:31.52ms
+step:445/1490 train_time:14025ms step_avg:31.52ms
+step:446/1490 train_time:14059ms step_avg:31.52ms
+step:447/1490 train_time:14088ms step_avg:31.52ms
+step:448/1490 train_time:14122ms step_avg:31.52ms
+step:449/1490 train_time:14150ms step_avg:31.51ms
+step:450/1490 train_time:14185ms step_avg:31.52ms
+step:451/1490 train_time:14213ms step_avg:31.51ms
+step:452/1490 train_time:14248ms step_avg:31.52ms
+step:453/1490 train_time:14276ms step_avg:31.51ms
+step:454/1490 train_time:14310ms step_avg:31.52ms
+step:455/1490 train_time:14338ms step_avg:31.51ms
+step:456/1490 train_time:14373ms step_avg:31.52ms
+step:457/1490 train_time:14401ms step_avg:31.51ms
+step:458/1490 train_time:14436ms step_avg:31.52ms
+step:459/1490 train_time:14464ms step_avg:31.51ms
+step:460/1490 train_time:14498ms step_avg:31.52ms
+step:461/1490 train_time:14527ms step_avg:31.51ms
+step:462/1490 train_time:14561ms step_avg:31.52ms
+step:463/1490 train_time:14590ms step_avg:31.51ms
+step:464/1490 train_time:14624ms step_avg:31.52ms
+step:465/1490 train_time:14653ms step_avg:31.51ms
+step:466/1490 train_time:14687ms step_avg:31.52ms
+step:467/1490 train_time:14715ms step_avg:31.51ms
+step:468/1490 train_time:14750ms step_avg:31.52ms
+step:469/1490 train_time:14778ms step_avg:31.51ms
+step:470/1490 train_time:14813ms step_avg:31.52ms
+step:471/1490 train_time:14842ms step_avg:31.51ms
+step:472/1490 train_time:14876ms step_avg:31.52ms
+step:473/1490 train_time:14904ms step_avg:31.51ms
+step:474/1490 train_time:14938ms step_avg:31.52ms
+step:475/1490 train_time:14967ms step_avg:31.51ms
+step:476/1490 train_time:15001ms step_avg:31.52ms
+step:477/1490 train_time:15030ms step_avg:31.51ms
+step:478/1490 train_time:15064ms step_avg:31.51ms
+step:479/1490 train_time:15093ms step_avg:31.51ms
+step:480/1490 train_time:15127ms step_avg:31.51ms
+step:481/1490 train_time:15155ms step_avg:31.51ms
+step:482/1490 train_time:15189ms step_avg:31.51ms
+step:483/1490 train_time:15218ms step_avg:31.51ms
+step:484/1490 train_time:15255ms step_avg:31.52ms
+step:485/1490 train_time:15308ms step_avg:31.56ms
+step:486/1490 train_time:15366ms step_avg:31.62ms
+step:487/1490 train_time:15421ms step_avg:31.67ms
+step:488/1490 train_time:15481ms step_avg:31.72ms
+step:489/1490 train_time:15535ms step_avg:31.77ms
+step:490/1490 train_time:15595ms step_avg:31.83ms
+step:491/1490 train_time:15649ms step_avg:31.87ms
+step:492/1490 train_time:15709ms step_avg:31.93ms
+step:493/1490 train_time:15764ms step_avg:31.97ms
+step:494/1490 train_time:15823ms step_avg:32.03ms
+step:495/1490 train_time:15877ms step_avg:32.08ms
+step:496/1490 train_time:15937ms step_avg:32.13ms
+step:497/1490 train_time:15992ms step_avg:32.18ms
+step:498/1490 train_time:16053ms step_avg:32.24ms
+step:499/1490 train_time:16107ms step_avg:32.28ms
+step:500/1490 train_time:16167ms step_avg:32.33ms
+step:500/1490 val_loss:4.2432 train_time:16240ms step_avg:32.48ms
+step:501/1490 train_time:16261ms step_avg:32.46ms
+step:502/1490 train_time:16284ms step_avg:32.44ms
+step:503/1490 train_time:16340ms step_avg:32.49ms
+step:504/1490 train_time:16402ms step_avg:32.54ms
+step:505/1490 train_time:16457ms step_avg:32.59ms
+step:506/1490 train_time:16517ms step_avg:32.64ms
+step:507/1490 train_time:16572ms step_avg:32.69ms
+step:508/1490 train_time:16631ms step_avg:32.74ms
+step:509/1490 train_time:16684ms step_avg:32.78ms
+step:510/1490 train_time:16744ms step_avg:32.83ms
+step:511/1490 train_time:16798ms step_avg:32.87ms
+step:512/1490 train_time:16857ms step_avg:32.92ms
+step:513/1490 train_time:16909ms step_avg:32.96ms
+step:514/1490 train_time:16969ms step_avg:33.01ms
+step:515/1490 train_time:17022ms step_avg:33.05ms
+step:516/1490 train_time:17081ms step_avg:33.10ms
+step:517/1490 train_time:17135ms step_avg:33.14ms
+step:518/1490 train_time:17195ms step_avg:33.19ms
+step:519/1490 train_time:17250ms step_avg:33.24ms
+step:520/1490 train_time:17311ms step_avg:33.29ms
+step:521/1490 train_time:17366ms step_avg:33.33ms
+step:522/1490 train_time:17428ms step_avg:33.39ms
+step:523/1490 train_time:17483ms step_avg:33.43ms
+step:524/1490 train_time:17543ms step_avg:33.48ms
+step:525/1490 train_time:17597ms step_avg:33.52ms
+step:526/1490 train_time:17656ms step_avg:33.57ms
+step:527/1490 train_time:17710ms step_avg:33.61ms
+step:528/1490 train_time:17769ms step_avg:33.65ms
+step:529/1490 train_time:17823ms step_avg:33.69ms
+step:530/1490 train_time:17882ms step_avg:33.74ms
+step:531/1490 train_time:17936ms step_avg:33.78ms
+step:532/1490 train_time:17994ms step_avg:33.82ms
+step:533/1490 train_time:18048ms step_avg:33.86ms
+step:534/1490 train_time:18107ms step_avg:33.91ms
+step:535/1490 train_time:18162ms step_avg:33.95ms
+step:536/1490 train_time:18222ms step_avg:34.00ms
+step:537/1490 train_time:18276ms step_avg:34.03ms
+step:538/1490 train_time:18336ms step_avg:34.08ms
+step:539/1490 train_time:18390ms step_avg:34.12ms
+step:540/1490 train_time:18450ms step_avg:34.17ms
+step:541/1490 train_time:18505ms step_avg:34.20ms
+step:542/1490 train_time:18565ms step_avg:34.25ms
+step:543/1490 train_time:18620ms step_avg:34.29ms
+step:544/1490 train_time:18681ms step_avg:34.34ms
+step:545/1490 train_time:18735ms step_avg:34.38ms
+step:546/1490 train_time:18793ms step_avg:34.42ms
+step:547/1490 train_time:18847ms step_avg:34.46ms
+step:548/1490 train_time:18906ms step_avg:34.50ms
+step:549/1490 train_time:18960ms step_avg:34.54ms
+step:550/1490 train_time:19021ms step_avg:34.58ms
+step:551/1490 train_time:19074ms step_avg:34.62ms
+step:552/1490 train_time:19134ms step_avg:34.66ms
+step:553/1490 train_time:19188ms step_avg:34.70ms
+step:554/1490 train_time:19247ms step_avg:34.74ms
+step:555/1490 train_time:19302ms step_avg:34.78ms
+step:556/1490 train_time:19363ms step_avg:34.83ms
+step:557/1490 train_time:19418ms step_avg:34.86ms
+step:558/1490 train_time:19478ms step_avg:34.91ms
+step:559/1490 train_time:19531ms step_avg:34.94ms
+step:560/1490 train_time:19591ms step_avg:34.98ms
+step:561/1490 train_time:19645ms step_avg:35.02ms
+step:562/1490 train_time:19705ms step_avg:35.06ms
+step:563/1490 train_time:19760ms step_avg:35.10ms
+step:564/1490 train_time:19820ms step_avg:35.14ms
+step:565/1490 train_time:19874ms step_avg:35.18ms
+step:566/1490 train_time:19934ms step_avg:35.22ms
+step:567/1490 train_time:19987ms step_avg:35.25ms
+step:568/1490 train_time:20047ms step_avg:35.29ms
+step:569/1490 train_time:20100ms step_avg:35.33ms
+step:570/1490 train_time:20162ms step_avg:35.37ms
+step:571/1490 train_time:20216ms step_avg:35.40ms
+step:572/1490 train_time:20275ms step_avg:35.45ms
+step:573/1490 train_time:20329ms step_avg:35.48ms
+step:574/1490 train_time:20389ms step_avg:35.52ms
+step:575/1490 train_time:20444ms step_avg:35.56ms
+step:576/1490 train_time:20504ms step_avg:35.60ms
+step:577/1490 train_time:20559ms step_avg:35.63ms
+step:578/1490 train_time:20618ms step_avg:35.67ms
+step:579/1490 train_time:20673ms step_avg:35.70ms
+step:580/1490 train_time:20732ms step_avg:35.74ms
+step:581/1490 train_time:20787ms step_avg:35.78ms
+step:582/1490 train_time:20846ms step_avg:35.82ms
+step:583/1490 train_time:20900ms step_avg:35.85ms
+step:584/1490 train_time:20960ms step_avg:35.89ms
+step:585/1490 train_time:21014ms step_avg:35.92ms
+step:586/1490 train_time:21073ms step_avg:35.96ms
+step:587/1490 train_time:21128ms step_avg:35.99ms
+step:588/1490 train_time:21187ms step_avg:36.03ms
+step:589/1490 train_time:21242ms step_avg:36.06ms
+step:590/1490 train_time:21302ms step_avg:36.10ms
+step:591/1490 train_time:21356ms step_avg:36.14ms
+step:592/1490 train_time:21415ms step_avg:36.17ms
+step:593/1490 train_time:21470ms step_avg:36.21ms
+step:594/1490 train_time:21530ms step_avg:36.25ms
+step:595/1490 train_time:21585ms step_avg:36.28ms
+step:596/1490 train_time:21645ms step_avg:36.32ms
+step:597/1490 train_time:21700ms step_avg:36.35ms
+step:598/1490 train_time:21760ms step_avg:36.39ms
+step:599/1490 train_time:21813ms step_avg:36.42ms
+step:600/1490 train_time:21873ms step_avg:36.46ms
+step:601/1490 train_time:21927ms step_avg:36.48ms
+step:602/1490 train_time:21987ms step_avg:36.52ms
+step:603/1490 train_time:22042ms step_avg:36.55ms
+step:604/1490 train_time:22101ms step_avg:36.59ms
+step:605/1490 train_time:22155ms step_avg:36.62ms
+step:606/1490 train_time:22215ms step_avg:36.66ms
+step:607/1490 train_time:22269ms step_avg:36.69ms
+step:608/1490 train_time:22329ms step_avg:36.73ms
+step:609/1490 train_time:22385ms step_avg:36.76ms
+step:610/1490 train_time:22445ms step_avg:36.79ms
+step:611/1490 train_time:22499ms step_avg:36.82ms
+step:612/1490 train_time:22560ms step_avg:36.86ms
+step:613/1490 train_time:22614ms step_avg:36.89ms
+step:614/1490 train_time:22673ms step_avg:36.93ms
+step:615/1490 train_time:22727ms step_avg:36.95ms
+step:616/1490 train_time:22787ms step_avg:36.99ms
+step:617/1490 train_time:22842ms step_avg:37.02ms
+step:618/1490 train_time:22902ms step_avg:37.06ms
+step:619/1490 train_time:22957ms step_avg:37.09ms
+step:620/1490 train_time:23016ms step_avg:37.12ms
+step:621/1490 train_time:23070ms step_avg:37.15ms
+step:622/1490 train_time:23130ms step_avg:37.19ms
+step:623/1490 train_time:23185ms step_avg:37.21ms
+step:624/1490 train_time:23244ms step_avg:37.25ms
+step:625/1490 train_time:23299ms step_avg:37.28ms
+step:626/1490 train_time:23359ms step_avg:37.32ms
+step:627/1490 train_time:23414ms step_avg:37.34ms
+step:628/1490 train_time:23473ms step_avg:37.38ms
+step:629/1490 train_time:23528ms step_avg:37.41ms
+step:630/1490 train_time:23587ms step_avg:37.44ms
+step:631/1490 train_time:23642ms step_avg:37.47ms
+step:632/1490 train_time:23702ms step_avg:37.50ms
+step:633/1490 train_time:23756ms step_avg:37.53ms
+step:634/1490 train_time:23816ms step_avg:37.56ms
+step:635/1490 train_time:23870ms step_avg:37.59ms
+step:636/1490 train_time:23930ms step_avg:37.63ms
+step:637/1490 train_time:23984ms step_avg:37.65ms
+step:638/1490 train_time:24045ms step_avg:37.69ms
+step:639/1490 train_time:24099ms step_avg:37.71ms
+step:640/1490 train_time:24159ms step_avg:37.75ms
+step:641/1490 train_time:24212ms step_avg:37.77ms
+step:642/1490 train_time:24272ms step_avg:37.81ms
+step:643/1490 train_time:24327ms step_avg:37.83ms
+step:644/1490 train_time:24387ms step_avg:37.87ms
+step:645/1490 train_time:24442ms step_avg:37.89ms
+step:646/1490 train_time:24502ms step_avg:37.93ms
+step:647/1490 train_time:24557ms step_avg:37.95ms
+step:648/1490 train_time:24616ms step_avg:37.99ms
+step:649/1490 train_time:24670ms step_avg:38.01ms
+step:650/1490 train_time:24730ms step_avg:38.05ms
+step:651/1490 train_time:24784ms step_avg:38.07ms
+step:652/1490 train_time:24844ms step_avg:38.10ms
+step:653/1490 train_time:24898ms step_avg:38.13ms
+step:654/1490 train_time:24958ms step_avg:38.16ms
+step:655/1490 train_time:25011ms step_avg:38.18ms
+step:656/1490 train_time:25071ms step_avg:38.22ms
+step:657/1490 train_time:25126ms step_avg:38.24ms
+step:658/1490 train_time:25185ms step_avg:38.28ms
+step:659/1490 train_time:25239ms step_avg:38.30ms
+step:660/1490 train_time:25300ms step_avg:38.33ms
+step:661/1490 train_time:25354ms step_avg:38.36ms
+step:662/1490 train_time:25413ms step_avg:38.39ms
+step:663/1490 train_time:25467ms step_avg:38.41ms
+step:664/1490 train_time:25527ms step_avg:38.44ms
+step:665/1490 train_time:25581ms step_avg:38.47ms
+step:666/1490 train_time:25642ms step_avg:38.50ms
+step:667/1490 train_time:25696ms step_avg:38.52ms
+step:668/1490 train_time:25755ms step_avg:38.56ms
+step:669/1490 train_time:25809ms step_avg:38.58ms
+step:670/1490 train_time:25869ms step_avg:38.61ms
+step:671/1490 train_time:25924ms step_avg:38.63ms
+step:672/1490 train_time:25984ms step_avg:38.67ms
+step:673/1490 train_time:26038ms step_avg:38.69ms
+step:674/1490 train_time:26098ms step_avg:38.72ms
+step:675/1490 train_time:26152ms step_avg:38.74ms
+step:676/1490 train_time:26212ms step_avg:38.77ms
+step:677/1490 train_time:26266ms step_avg:38.80ms
+step:678/1490 train_time:26327ms step_avg:38.83ms
+step:679/1490 train_time:26381ms step_avg:38.85ms
+step:680/1490 train_time:26441ms step_avg:38.88ms
+step:681/1490 train_time:26495ms step_avg:38.91ms
+step:682/1490 train_time:26554ms step_avg:38.94ms
+step:683/1490 train_time:26608ms step_avg:38.96ms
+step:684/1490 train_time:26668ms step_avg:38.99ms
+step:685/1490 train_time:26722ms step_avg:39.01ms
+step:686/1490 train_time:26782ms step_avg:39.04ms
+step:687/1490 train_time:26836ms step_avg:39.06ms
+step:688/1490 train_time:26895ms step_avg:39.09ms
+step:689/1490 train_time:26949ms step_avg:39.11ms
+step:690/1490 train_time:27009ms step_avg:39.14ms
+step:691/1490 train_time:27065ms step_avg:39.17ms
+step:692/1490 train_time:27125ms step_avg:39.20ms
+step:693/1490 train_time:27179ms step_avg:39.22ms
+step:694/1490 train_time:27238ms step_avg:39.25ms
+step:695/1490 train_time:27292ms step_avg:39.27ms
+step:696/1490 train_time:27351ms step_avg:39.30ms
+step:697/1490 train_time:27405ms step_avg:39.32ms
+step:698/1490 train_time:27465ms step_avg:39.35ms
+step:699/1490 train_time:27521ms step_avg:39.37ms
+step:700/1490 train_time:27581ms step_avg:39.40ms
+step:701/1490 train_time:27636ms step_avg:39.42ms
+step:702/1490 train_time:27695ms step_avg:39.45ms
+step:703/1490 train_time:27749ms step_avg:39.47ms
+step:704/1490 train_time:27809ms step_avg:39.50ms
+step:705/1490 train_time:27864ms step_avg:39.52ms
+step:706/1490 train_time:27924ms step_avg:39.55ms
+step:707/1490 train_time:27978ms step_avg:39.57ms
+step:708/1490 train_time:28038ms step_avg:39.60ms
+step:709/1490 train_time:28092ms step_avg:39.62ms
+step:710/1490 train_time:28152ms step_avg:39.65ms
+step:711/1490 train_time:28207ms step_avg:39.67ms
+step:712/1490 train_time:28267ms step_avg:39.70ms
+step:713/1490 train_time:28323ms step_avg:39.72ms
+step:714/1490 train_time:28383ms step_avg:39.75ms
+step:715/1490 train_time:28437ms step_avg:39.77ms
+step:716/1490 train_time:28496ms step_avg:39.80ms
+step:717/1490 train_time:28549ms step_avg:39.82ms
+step:718/1490 train_time:28610ms step_avg:39.85ms
+step:719/1490 train_time:28665ms step_avg:39.87ms
+step:720/1490 train_time:28726ms step_avg:39.90ms
+step:721/1490 train_time:28779ms step_avg:39.92ms
+step:722/1490 train_time:28839ms step_avg:39.94ms
+step:723/1490 train_time:28894ms step_avg:39.96ms
+step:724/1490 train_time:28953ms step_avg:39.99ms
+step:725/1490 train_time:29007ms step_avg:40.01ms
+step:726/1490 train_time:29067ms step_avg:40.04ms
+step:727/1490 train_time:29123ms step_avg:40.06ms
+step:728/1490 train_time:29182ms step_avg:40.09ms
+step:729/1490 train_time:29237ms step_avg:40.11ms
+step:730/1490 train_time:29296ms step_avg:40.13ms
+step:731/1490 train_time:29350ms step_avg:40.15ms
+step:732/1490 train_time:29410ms step_avg:40.18ms
+step:733/1490 train_time:29465ms step_avg:40.20ms
+step:734/1490 train_time:29526ms step_avg:40.23ms
+step:735/1490 train_time:29579ms step_avg:40.24ms
+step:736/1490 train_time:29639ms step_avg:40.27ms
+step:737/1490 train_time:29692ms step_avg:40.29ms
+step:738/1490 train_time:29751ms step_avg:40.31ms
+step:739/1490 train_time:29806ms step_avg:40.33ms
+step:740/1490 train_time:29866ms step_avg:40.36ms
+step:741/1490 train_time:29920ms step_avg:40.38ms
+step:742/1490 train_time:29981ms step_avg:40.41ms
+step:743/1490 train_time:30035ms step_avg:40.42ms
+step:744/1490 train_time:30095ms step_avg:40.45ms
+step:745/1490 train_time:30148ms step_avg:40.47ms
+step:746/1490 train_time:30208ms step_avg:40.49ms
+step:747/1490 train_time:30263ms step_avg:40.51ms
+step:748/1490 train_time:30325ms step_avg:40.54ms
+step:749/1490 train_time:30378ms step_avg:40.56ms
+step:750/1490 train_time:30439ms step_avg:40.58ms
+step:750/1490 val_loss:3.8078 train_time:30510ms step_avg:40.68ms
+step:751/1490 train_time:30528ms step_avg:40.65ms
+step:752/1490 train_time:30555ms step_avg:40.63ms
+step:753/1490 train_time:30611ms step_avg:40.65ms
+step:754/1490 train_time:30674ms step_avg:40.68ms
+step:755/1490 train_time:30729ms step_avg:40.70ms
+step:756/1490 train_time:30788ms step_avg:40.73ms
+step:757/1490 train_time:30842ms step_avg:40.74ms
+step:758/1490 train_time:30902ms step_avg:40.77ms
+step:759/1490 train_time:30956ms step_avg:40.78ms
+step:760/1490 train_time:31015ms step_avg:40.81ms
+step:761/1490 train_time:31069ms step_avg:40.83ms
+step:762/1490 train_time:31128ms step_avg:40.85ms
+step:763/1490 train_time:31182ms step_avg:40.87ms
+step:764/1490 train_time:31240ms step_avg:40.89ms
+step:765/1490 train_time:31295ms step_avg:40.91ms
+step:766/1490 train_time:31355ms step_avg:40.93ms
+step:767/1490 train_time:31408ms step_avg:40.95ms
+step:768/1490 train_time:31469ms step_avg:40.98ms
+step:769/1490 train_time:31525ms step_avg:40.99ms
+step:770/1490 train_time:31585ms step_avg:41.02ms
+step:771/1490 train_time:31639ms step_avg:41.04ms
+step:772/1490 train_time:31700ms step_avg:41.06ms
+step:773/1490 train_time:31755ms step_avg:41.08ms
+step:774/1490 train_time:31815ms step_avg:41.10ms
+step:775/1490 train_time:31870ms step_avg:41.12ms
+step:776/1490 train_time:31930ms step_avg:41.15ms
+step:777/1490 train_time:31983ms step_avg:41.16ms
+step:778/1490 train_time:32043ms step_avg:41.19ms
+step:779/1490 train_time:32096ms step_avg:41.20ms
+step:780/1490 train_time:32156ms step_avg:41.23ms
+step:781/1490 train_time:32209ms step_avg:41.24ms
+step:782/1490 train_time:32269ms step_avg:41.26ms
+step:783/1490 train_time:32322ms step_avg:41.28ms
+step:784/1490 train_time:32381ms step_avg:41.30ms
+step:785/1490 train_time:32436ms step_avg:41.32ms
+step:786/1490 train_time:32496ms step_avg:41.34ms
+step:787/1490 train_time:32552ms step_avg:41.36ms
+step:788/1490 train_time:32613ms step_avg:41.39ms
+step:789/1490 train_time:32668ms step_avg:41.40ms
+step:790/1490 train_time:32728ms step_avg:41.43ms
+step:791/1490 train_time:32783ms step_avg:41.44ms
+step:792/1490 train_time:32842ms step_avg:41.47ms
+step:793/1490 train_time:32896ms step_avg:41.48ms
+step:794/1490 train_time:32956ms step_avg:41.51ms
+step:795/1490 train_time:33010ms step_avg:41.52ms
+step:796/1490 train_time:33069ms step_avg:41.54ms
+step:797/1490 train_time:33123ms step_avg:41.56ms
+step:798/1490 train_time:33182ms step_avg:41.58ms
+step:799/1490 train_time:33235ms step_avg:41.60ms
+step:800/1490 train_time:33295ms step_avg:41.62ms
+step:801/1490 train_time:33349ms step_avg:41.63ms
+step:802/1490 train_time:33408ms step_avg:41.66ms
+step:803/1490 train_time:33462ms step_avg:41.67ms
+step:804/1490 train_time:33522ms step_avg:41.69ms
+step:805/1490 train_time:33577ms step_avg:41.71ms
+step:806/1490 train_time:33636ms step_avg:41.73ms
+step:807/1490 train_time:33692ms step_avg:41.75ms
+step:808/1490 train_time:33754ms step_avg:41.77ms
+step:809/1490 train_time:33808ms step_avg:41.79ms
+step:810/1490 train_time:33869ms step_avg:41.81ms
+step:811/1490 train_time:33922ms step_avg:41.83ms
+step:812/1490 train_time:33981ms step_avg:41.85ms
+step:813/1490 train_time:34035ms step_avg:41.86ms
+step:814/1490 train_time:34095ms step_avg:41.89ms
+step:815/1490 train_time:34149ms step_avg:41.90ms
+step:816/1490 train_time:34208ms step_avg:41.92ms
+step:817/1490 train_time:34262ms step_avg:41.94ms
+step:818/1490 train_time:34321ms step_avg:41.96ms
+step:819/1490 train_time:34375ms step_avg:41.97ms
+step:820/1490 train_time:34434ms step_avg:41.99ms
+step:821/1490 train_time:34490ms step_avg:42.01ms
+step:822/1490 train_time:34552ms step_avg:42.03ms
+step:823/1490 train_time:34606ms step_avg:42.05ms
+step:824/1490 train_time:34665ms step_avg:42.07ms
+step:825/1490 train_time:34719ms step_avg:42.08ms
+step:826/1490 train_time:34779ms step_avg:42.11ms
+step:827/1490 train_time:34834ms step_avg:42.12ms
+step:828/1490 train_time:34895ms step_avg:42.14ms
+step:829/1490 train_time:34950ms step_avg:42.16ms
+step:830/1490 train_time:35011ms step_avg:42.18ms
+step:831/1490 train_time:35065ms step_avg:42.20ms
+step:832/1490 train_time:35124ms step_avg:42.22ms
+step:833/1490 train_time:35178ms step_avg:42.23ms
+step:834/1490 train_time:35237ms step_avg:42.25ms
+step:835/1490 train_time:35291ms step_avg:42.26ms
+step:836/1490 train_time:35351ms step_avg:42.29ms
+step:837/1490 train_time:35405ms step_avg:42.30ms
+step:838/1490 train_time:35465ms step_avg:42.32ms
+step:839/1490 train_time:35518ms step_avg:42.33ms
+step:840/1490 train_time:35578ms step_avg:42.36ms
+step:841/1490 train_time:35633ms step_avg:42.37ms
+step:842/1490 train_time:35694ms step_avg:42.39ms
+step:843/1490 train_time:35748ms step_avg:42.41ms
+step:844/1490 train_time:35809ms step_avg:42.43ms
+step:845/1490 train_time:35862ms step_avg:42.44ms
+step:846/1490 train_time:35922ms step_avg:42.46ms
+step:847/1490 train_time:35976ms step_avg:42.47ms
+step:848/1490 train_time:36036ms step_avg:42.50ms
+step:849/1490 train_time:36091ms step_avg:42.51ms
+step:850/1490 train_time:36151ms step_avg:42.53ms
+step:851/1490 train_time:36205ms step_avg:42.54ms
+step:852/1490 train_time:36265ms step_avg:42.56ms
+step:853/1490 train_time:36318ms step_avg:42.58ms
+step:854/1490 train_time:36377ms step_avg:42.60ms
+step:855/1490 train_time:36432ms step_avg:42.61ms
+step:856/1490 train_time:36491ms step_avg:42.63ms
+step:857/1490 train_time:36546ms step_avg:42.64ms
+step:858/1490 train_time:36606ms step_avg:42.66ms
+step:859/1490 train_time:36659ms step_avg:42.68ms
+step:860/1490 train_time:36719ms step_avg:42.70ms
+step:861/1490 train_time:36773ms step_avg:42.71ms
+step:862/1490 train_time:36834ms step_avg:42.73ms
+step:863/1490 train_time:36888ms step_avg:42.74ms
+step:864/1490 train_time:36949ms step_avg:42.77ms
+step:865/1490 train_time:37004ms step_avg:42.78ms
+step:866/1490 train_time:37064ms step_avg:42.80ms
+step:867/1490 train_time:37117ms step_avg:42.81ms
+step:868/1490 train_time:37178ms step_avg:42.83ms
+step:869/1490 train_time:37232ms step_avg:42.84ms
+step:870/1490 train_time:37292ms step_avg:42.86ms
+step:871/1490 train_time:37345ms step_avg:42.88ms
+step:872/1490 train_time:37405ms step_avg:42.90ms
+step:873/1490 train_time:37459ms step_avg:42.91ms
+step:874/1490 train_time:37519ms step_avg:42.93ms
+step:875/1490 train_time:37573ms step_avg:42.94ms
+step:876/1490 train_time:37633ms step_avg:42.96ms
+step:877/1490 train_time:37688ms step_avg:42.97ms
+step:878/1490 train_time:37748ms step_avg:42.99ms
+step:879/1490 train_time:37803ms step_avg:43.01ms
+step:880/1490 train_time:37862ms step_avg:43.03ms
+step:881/1490 train_time:37916ms step_avg:43.04ms
+step:882/1490 train_time:37975ms step_avg:43.06ms
+step:883/1490 train_time:38029ms step_avg:43.07ms
+step:884/1490 train_time:38090ms step_avg:43.09ms
+step:885/1490 train_time:38144ms step_avg:43.10ms
+step:886/1490 train_time:38203ms step_avg:43.12ms
+step:887/1490 train_time:38257ms step_avg:43.13ms
+step:888/1490 train_time:38316ms step_avg:43.15ms
+step:889/1490 train_time:38370ms step_avg:43.16ms
+step:890/1490 train_time:38431ms step_avg:43.18ms
+step:891/1490 train_time:38485ms step_avg:43.19ms
+step:892/1490 train_time:38545ms step_avg:43.21ms
+step:893/1490 train_time:38599ms step_avg:43.22ms
+step:894/1490 train_time:38658ms step_avg:43.24ms
+step:895/1490 train_time:38713ms step_avg:43.25ms
+step:896/1490 train_time:38773ms step_avg:43.27ms
+step:897/1490 train_time:38827ms step_avg:43.29ms
+step:898/1490 train_time:38887ms step_avg:43.30ms
+step:899/1490 train_time:38941ms step_avg:43.32ms
+step:900/1490 train_time:39001ms step_avg:43.33ms
+step:901/1490 train_time:39055ms step_avg:43.35ms
+step:902/1490 train_time:39114ms step_avg:43.36ms
+step:903/1490 train_time:39169ms step_avg:43.38ms
+step:904/1490 train_time:39229ms step_avg:43.40ms
+step:905/1490 train_time:39283ms step_avg:43.41ms
+step:906/1490 train_time:39343ms step_avg:43.42ms
+step:907/1490 train_time:39397ms step_avg:43.44ms
+step:908/1490 train_time:39457ms step_avg:43.45ms
+step:909/1490 train_time:39510ms step_avg:43.47ms
+step:910/1490 train_time:39570ms step_avg:43.48ms
+step:911/1490 train_time:39625ms step_avg:43.50ms
+step:912/1490 train_time:39685ms step_avg:43.51ms
+step:913/1490 train_time:39738ms step_avg:43.52ms
+step:914/1490 train_time:39798ms step_avg:43.54ms
+step:915/1490 train_time:39851ms step_avg:43.55ms
+step:916/1490 train_time:39912ms step_avg:43.57ms
+step:917/1490 train_time:39966ms step_avg:43.58ms
+step:918/1490 train_time:40026ms step_avg:43.60ms
+step:919/1490 train_time:40079ms step_avg:43.61ms
+step:920/1490 train_time:40139ms step_avg:43.63ms
+step:921/1490 train_time:40194ms step_avg:43.64ms
+step:922/1490 train_time:40254ms step_avg:43.66ms
+step:923/1490 train_time:40309ms step_avg:43.67ms
+step:924/1490 train_time:40370ms step_avg:43.69ms
+step:925/1490 train_time:40424ms step_avg:43.70ms
+step:926/1490 train_time:40483ms step_avg:43.72ms
+step:927/1490 train_time:40536ms step_avg:43.73ms
+step:928/1490 train_time:40596ms step_avg:43.75ms
+step:929/1490 train_time:40650ms step_avg:43.76ms
+step:930/1490 train_time:40711ms step_avg:43.78ms
+step:931/1490 train_time:40766ms step_avg:43.79ms
+step:932/1490 train_time:40826ms step_avg:43.80ms
+step:933/1490 train_time:40879ms step_avg:43.81ms
+step:934/1490 train_time:40939ms step_avg:43.83ms
+step:935/1490 train_time:40993ms step_avg:43.84ms
+step:936/1490 train_time:41053ms step_avg:43.86ms
+step:937/1490 train_time:41107ms step_avg:43.87ms
+step:938/1490 train_time:41167ms step_avg:43.89ms
+step:939/1490 train_time:41220ms step_avg:43.90ms
+step:940/1490 train_time:41280ms step_avg:43.91ms
+step:941/1490 train_time:41334ms step_avg:43.93ms
+step:942/1490 train_time:41394ms step_avg:43.94ms
+step:943/1490 train_time:41448ms step_avg:43.95ms
+step:944/1490 train_time:41509ms step_avg:43.97ms
+step:945/1490 train_time:41564ms step_avg:43.98ms
+step:946/1490 train_time:41623ms step_avg:44.00ms
+step:947/1490 train_time:41677ms step_avg:44.01ms
+step:948/1490 train_time:41737ms step_avg:44.03ms
+step:949/1490 train_time:41791ms step_avg:44.04ms
+step:950/1490 train_time:41852ms step_avg:44.05ms
+step:951/1490 train_time:41905ms step_avg:44.06ms
+step:952/1490 train_time:41965ms step_avg:44.08ms
+step:953/1490 train_time:42019ms step_avg:44.09ms
+step:954/1490 train_time:42079ms step_avg:44.11ms
+step:955/1490 train_time:42133ms step_avg:44.12ms
+step:956/1490 train_time:42193ms step_avg:44.13ms
+step:957/1490 train_time:42247ms step_avg:44.14ms
+step:958/1490 train_time:42307ms step_avg:44.16ms
+step:959/1490 train_time:42360ms step_avg:44.17ms
+step:960/1490 train_time:42420ms step_avg:44.19ms
+step:961/1490 train_time:42474ms step_avg:44.20ms
+step:962/1490 train_time:42534ms step_avg:44.21ms
+step:963/1490 train_time:42588ms step_avg:44.22ms
+step:964/1490 train_time:42649ms step_avg:44.24ms
+step:965/1490 train_time:42703ms step_avg:44.25ms
+step:966/1490 train_time:42763ms step_avg:44.27ms
+step:967/1490 train_time:42817ms step_avg:44.28ms
+step:968/1490 train_time:42880ms step_avg:44.30ms
+step:969/1490 train_time:42958ms step_avg:44.33ms
+step:970/1490 train_time:43045ms step_avg:44.38ms
+step:971/1490 train_time:43127ms step_avg:44.42ms
+step:972/1490 train_time:43213ms step_avg:44.46ms
+step:973/1490 train_time:43292ms step_avg:44.49ms
+step:974/1490 train_time:43379ms step_avg:44.54ms
+step:975/1490 train_time:43458ms step_avg:44.57ms
+step:976/1490 train_time:43544ms step_avg:44.61ms
+step:977/1490 train_time:43625ms step_avg:44.65ms
+step:978/1490 train_time:43713ms step_avg:44.70ms
+step:979/1490 train_time:43794ms step_avg:44.73ms
+step:980/1490 train_time:43880ms step_avg:44.78ms
+step:981/1490 train_time:43960ms step_avg:44.81ms
+step:982/1490 train_time:44046ms step_avg:44.85ms
+step:983/1490 train_time:44128ms step_avg:44.89ms
+step:984/1490 train_time:44214ms step_avg:44.93ms
+step:985/1490 train_time:44296ms step_avg:44.97ms
+step:986/1490 train_time:44382ms step_avg:45.01ms
+step:987/1490 train_time:44462ms step_avg:45.05ms
+step:988/1490 train_time:44548ms step_avg:45.09ms
+step:989/1490 train_time:44630ms step_avg:45.13ms
+step:990/1490 train_time:44717ms step_avg:45.17ms
+step:991/1490 train_time:44799ms step_avg:45.21ms
+step:992/1490 train_time:44885ms step_avg:45.25ms
+step:993/1490 train_time:44965ms step_avg:45.28ms
+step:994/1490 train_time:45051ms step_avg:45.32ms
+step:995/1490 train_time:45132ms step_avg:45.36ms
+step:996/1490 train_time:45219ms step_avg:45.40ms
+step:997/1490 train_time:45299ms step_avg:45.44ms
+step:998/1490 train_time:45385ms step_avg:45.48ms
+step:999/1490 train_time:45466ms step_avg:45.51ms
+step:1000/1490 train_time:45552ms step_avg:45.55ms
+step:1000/1490 val_loss:3.5210 train_time:45655ms step_avg:45.66ms
+step:1001/1490 train_time:45673ms step_avg:45.63ms
+step:1002/1490 train_time:45724ms step_avg:45.63ms
+step:1003/1490 train_time:45806ms step_avg:45.67ms
+step:1004/1490 train_time:45894ms step_avg:45.71ms
+step:1005/1490 train_time:45975ms step_avg:45.75ms
+step:1006/1490 train_time:46060ms step_avg:45.79ms
+step:1007/1490 train_time:46141ms step_avg:45.82ms
+step:1008/1490 train_time:46226ms step_avg:45.86ms
+step:1009/1490 train_time:46307ms step_avg:45.89ms
+step:1010/1490 train_time:46392ms step_avg:45.93ms
+step:1011/1490 train_time:46471ms step_avg:45.97ms
+step:1012/1490 train_time:46558ms step_avg:46.01ms
+step:1013/1490 train_time:46640ms step_avg:46.04ms
+step:1014/1490 train_time:46727ms step_avg:46.08ms
+step:1015/1490 train_time:46810ms step_avg:46.12ms
+step:1016/1490 train_time:46898ms step_avg:46.16ms
+step:1017/1490 train_time:46978ms step_avg:46.19ms
+step:1018/1490 train_time:47064ms step_avg:46.23ms
+step:1019/1490 train_time:47146ms step_avg:46.27ms
+step:1020/1490 train_time:47232ms step_avg:46.31ms
+step:1021/1490 train_time:47312ms step_avg:46.34ms
+step:1022/1490 train_time:47398ms step_avg:46.38ms
+step:1023/1490 train_time:47478ms step_avg:46.41ms
+step:1024/1490 train_time:47562ms step_avg:46.45ms
+step:1025/1490 train_time:47644ms step_avg:46.48ms
+step:1026/1490 train_time:47733ms step_avg:46.52ms
+step:1027/1490 train_time:47816ms step_avg:46.56ms
+step:1028/1490 train_time:47903ms step_avg:46.60ms
+step:1029/1490 train_time:47984ms step_avg:46.63ms
+step:1030/1490 train_time:48069ms step_avg:46.67ms
+step:1031/1490 train_time:48149ms step_avg:46.70ms
+step:1032/1490 train_time:48236ms step_avg:46.74ms
+step:1033/1490 train_time:48316ms step_avg:46.77ms
+step:1034/1490 train_time:48402ms step_avg:46.81ms
+step:1035/1490 train_time:48482ms step_avg:46.84ms
+step:1036/1490 train_time:48568ms step_avg:46.88ms
+step:1037/1490 train_time:48649ms step_avg:46.91ms
+step:1038/1490 train_time:48737ms step_avg:46.95ms
+step:1039/1490 train_time:48819ms step_avg:46.99ms
+step:1040/1490 train_time:48906ms step_avg:47.03ms
+step:1041/1490 train_time:48988ms step_avg:47.06ms
+step:1042/1490 train_time:49073ms step_avg:47.10ms
+step:1043/1490 train_time:49154ms step_avg:47.13ms
+step:1044/1490 train_time:49240ms step_avg:47.16ms
+step:1045/1490 train_time:49320ms step_avg:47.20ms
+step:1046/1490 train_time:49405ms step_avg:47.23ms
+step:1047/1490 train_time:49485ms step_avg:47.26ms
+step:1048/1490 train_time:49571ms step_avg:47.30ms
+step:1049/1490 train_time:49651ms step_avg:47.33ms
+step:1050/1490 train_time:49739ms step_avg:47.37ms
+step:1051/1490 train_time:49821ms step_avg:47.40ms
+step:1052/1490 train_time:49909ms step_avg:47.44ms
+step:1053/1490 train_time:49989ms step_avg:47.47ms
+step:1054/1490 train_time:50075ms step_avg:47.51ms
+step:1055/1490 train_time:50157ms step_avg:47.54ms
+step:1056/1490 train_time:50242ms step_avg:47.58ms
+step:1057/1490 train_time:50323ms step_avg:47.61ms
+step:1058/1490 train_time:50408ms step_avg:47.64ms
+step:1059/1490 train_time:50489ms step_avg:47.68ms
+step:1060/1490 train_time:50575ms step_avg:47.71ms
+step:1061/1490 train_time:50657ms step_avg:47.74ms
+step:1062/1490 train_time:50743ms step_avg:47.78ms
+step:1063/1490 train_time:50825ms step_avg:47.81ms
+step:1064/1490 train_time:50911ms step_avg:47.85ms
+step:1065/1490 train_time:50993ms step_avg:47.88ms
+step:1066/1490 train_time:51077ms step_avg:47.91ms
+step:1067/1490 train_time:51158ms step_avg:47.95ms
+step:1068/1490 train_time:51245ms step_avg:47.98ms
+step:1069/1490 train_time:51325ms step_avg:48.01ms
+step:1070/1490 train_time:51411ms step_avg:48.05ms
+step:1071/1490 train_time:51492ms step_avg:48.08ms
+step:1072/1490 train_time:51578ms step_avg:48.11ms
+step:1073/1490 train_time:51658ms step_avg:48.14ms
+step:1074/1490 train_time:51747ms step_avg:48.18ms
+step:1075/1490 train_time:51828ms step_avg:48.21ms
+step:1076/1490 train_time:51914ms step_avg:48.25ms
+step:1077/1490 train_time:51995ms step_avg:48.28ms
+step:1078/1490 train_time:52081ms step_avg:48.31ms
+step:1079/1490 train_time:52163ms step_avg:48.34ms
+step:1080/1490 train_time:52249ms step_avg:48.38ms
+step:1081/1490 train_time:52329ms step_avg:48.41ms
+step:1082/1490 train_time:52415ms step_avg:48.44ms
+step:1083/1490 train_time:52497ms step_avg:48.47ms
+step:1084/1490 train_time:52583ms step_avg:48.51ms
+step:1085/1490 train_time:52664ms step_avg:48.54ms
+step:1086/1490 train_time:52749ms step_avg:48.57ms
+step:1087/1490 train_time:52832ms step_avg:48.60ms
+step:1088/1490 train_time:52918ms step_avg:48.64ms
+step:1089/1490 train_time:53001ms step_avg:48.67ms
+step:1090/1490 train_time:53087ms step_avg:48.70ms
+step:1091/1490 train_time:53168ms step_avg:48.73ms
+step:1092/1490 train_time:53252ms step_avg:48.77ms
+step:1093/1490 train_time:53334ms step_avg:48.80ms
+step:1094/1490 train_time:53421ms step_avg:48.83ms
+step:1095/1490 train_time:53502ms step_avg:48.86ms
+step:1096/1490 train_time:53587ms step_avg:48.89ms
+step:1097/1490 train_time:53667ms step_avg:48.92ms
+step:1098/1490 train_time:53753ms step_avg:48.96ms
+step:1099/1490 train_time:53834ms step_avg:48.98ms
+step:1100/1490 train_time:53922ms step_avg:49.02ms
+step:1101/1490 train_time:54003ms step_avg:49.05ms
+step:1102/1490 train_time:54089ms step_avg:49.08ms
+step:1103/1490 train_time:54168ms step_avg:49.11ms
+step:1104/1490 train_time:54254ms step_avg:49.14ms
+step:1105/1490 train_time:54336ms step_avg:49.17ms
+step:1106/1490 train_time:54422ms step_avg:49.21ms
+step:1107/1490 train_time:54504ms step_avg:49.24ms
+step:1108/1490 train_time:54590ms step_avg:49.27ms
+step:1109/1490 train_time:54671ms step_avg:49.30ms
+step:1110/1490 train_time:54757ms step_avg:49.33ms
+step:1111/1490 train_time:54837ms step_avg:49.36ms
+step:1112/1490 train_time:54923ms step_avg:49.39ms
+step:1113/1490 train_time:55004ms step_avg:49.42ms
+step:1114/1490 train_time:55091ms step_avg:49.45ms
+step:1115/1490 train_time:55171ms step_avg:49.48ms
+step:1116/1490 train_time:55258ms step_avg:49.51ms
+step:1117/1490 train_time:55338ms step_avg:49.54ms
+step:1118/1490 train_time:55425ms step_avg:49.57ms
+step:1119/1490 train_time:55507ms step_avg:49.60ms
+step:1120/1490 train_time:55594ms step_avg:49.64ms
+step:1121/1490 train_time:55674ms step_avg:49.67ms
+step:1122/1490 train_time:55761ms step_avg:49.70ms
+step:1123/1490 train_time:55843ms step_avg:49.73ms
+step:1124/1490 train_time:55929ms step_avg:49.76ms
+step:1125/1490 train_time:56009ms step_avg:49.79ms
+step:1126/1490 train_time:56098ms step_avg:49.82ms
+step:1127/1490 train_time:56178ms step_avg:49.85ms
+step:1128/1490 train_time:56264ms step_avg:49.88ms
+step:1129/1490 train_time:56345ms step_avg:49.91ms
+step:1130/1490 train_time:56431ms step_avg:49.94ms
+step:1131/1490 train_time:56513ms step_avg:49.97ms
+step:1132/1490 train_time:56598ms step_avg:50.00ms
+step:1133/1490 train_time:56677ms step_avg:50.02ms
+step:1134/1490 train_time:56763ms step_avg:50.06ms
+step:1135/1490 train_time:56846ms step_avg:50.08ms
+step:1136/1490 train_time:56932ms step_avg:50.12ms
+step:1137/1490 train_time:57014ms step_avg:50.14ms
+step:1138/1490 train_time:57102ms step_avg:50.18ms
+step:1139/1490 train_time:57183ms step_avg:50.20ms
+step:1140/1490 train_time:57269ms step_avg:50.24ms
+step:1141/1490 train_time:57349ms step_avg:50.26ms
+step:1142/1490 train_time:57437ms step_avg:50.29ms
+step:1143/1490 train_time:57517ms step_avg:50.32ms
+step:1144/1490 train_time:57604ms step_avg:50.35ms
+step:1145/1490 train_time:57685ms step_avg:50.38ms
+step:1146/1490 train_time:57770ms step_avg:50.41ms
+step:1147/1490 train_time:57850ms step_avg:50.44ms
+step:1148/1490 train_time:57937ms step_avg:50.47ms
+step:1149/1490 train_time:58019ms step_avg:50.50ms
+step:1150/1490 train_time:58105ms step_avg:50.53ms
+step:1151/1490 train_time:58186ms step_avg:50.55ms
+step:1152/1490 train_time:58272ms step_avg:50.58ms
+step:1153/1490 train_time:58354ms step_avg:50.61ms
+step:1154/1490 train_time:58440ms step_avg:50.64ms
+step:1155/1490 train_time:58521ms step_avg:50.67ms
+step:1156/1490 train_time:58608ms step_avg:50.70ms
+step:1157/1490 train_time:58689ms step_avg:50.72ms
+step:1158/1490 train_time:58774ms step_avg:50.75ms
+step:1159/1490 train_time:58855ms step_avg:50.78ms
+step:1160/1490 train_time:58942ms step_avg:50.81ms
+step:1161/1490 train_time:59023ms step_avg:50.84ms
+step:1162/1490 train_time:59109ms step_avg:50.87ms
+step:1163/1490 train_time:59191ms step_avg:50.89ms
+step:1164/1490 train_time:59276ms step_avg:50.92ms
+step:1165/1490 train_time:59357ms step_avg:50.95ms
+step:1166/1490 train_time:59443ms step_avg:50.98ms
+step:1167/1490 train_time:59525ms step_avg:51.01ms
+step:1168/1490 train_time:59612ms step_avg:51.04ms
+step:1169/1490 train_time:59692ms step_avg:51.06ms
+step:1170/1490 train_time:59779ms step_avg:51.09ms
+step:1171/1490 train_time:59860ms step_avg:51.12ms
+step:1172/1490 train_time:59947ms step_avg:51.15ms
+step:1173/1490 train_time:60028ms step_avg:51.18ms
+step:1174/1490 train_time:60116ms step_avg:51.21ms
+step:1175/1490 train_time:60197ms step_avg:51.23ms
+step:1176/1490 train_time:60284ms step_avg:51.26ms
+step:1177/1490 train_time:60364ms step_avg:51.29ms
+step:1178/1490 train_time:60449ms step_avg:51.32ms
+step:1179/1490 train_time:60530ms step_avg:51.34ms
+step:1180/1490 train_time:60618ms step_avg:51.37ms
+step:1181/1490 train_time:60698ms step_avg:51.40ms
+step:1182/1490 train_time:60785ms step_avg:51.43ms
+step:1183/1490 train_time:60865ms step_avg:51.45ms
+step:1184/1490 train_time:60951ms step_avg:51.48ms
+step:1185/1490 train_time:61033ms step_avg:51.50ms
+step:1186/1490 train_time:61121ms step_avg:51.54ms
+step:1187/1490 train_time:61201ms step_avg:51.56ms
+step:1188/1490 train_time:61287ms step_avg:51.59ms
+step:1189/1490 train_time:61369ms step_avg:51.61ms
+step:1190/1490 train_time:61455ms step_avg:51.64ms
+step:1191/1490 train_time:61534ms step_avg:51.67ms
+step:1192/1490 train_time:61622ms step_avg:51.70ms
+step:1193/1490 train_time:61703ms step_avg:51.72ms
+step:1194/1490 train_time:61790ms step_avg:51.75ms
+step:1195/1490 train_time:61871ms step_avg:51.77ms
+step:1196/1490 train_time:61957ms step_avg:51.80ms
+step:1197/1490 train_time:62037ms step_avg:51.83ms
+step:1198/1490 train_time:62124ms step_avg:51.86ms
+step:1199/1490 train_time:62206ms step_avg:51.88ms
+step:1200/1490 train_time:62292ms step_avg:51.91ms
+step:1201/1490 train_time:62372ms step_avg:51.93ms
+step:1202/1490 train_time:62458ms step_avg:51.96ms
+step:1203/1490 train_time:62539ms step_avg:51.99ms
+step:1204/1490 train_time:62626ms step_avg:52.01ms
+step:1205/1490 train_time:62707ms step_avg:52.04ms
+step:1206/1490 train_time:62794ms step_avg:52.07ms
+step:1207/1490 train_time:62874ms step_avg:52.09ms
+step:1208/1490 train_time:62960ms step_avg:52.12ms
+step:1209/1490 train_time:63042ms step_avg:52.14ms
+step:1210/1490 train_time:63128ms step_avg:52.17ms
+step:1211/1490 train_time:63210ms step_avg:52.20ms
+step:1212/1490 train_time:63296ms step_avg:52.22ms
+step:1213/1490 train_time:63377ms step_avg:52.25ms
+step:1214/1490 train_time:63462ms step_avg:52.28ms
+step:1215/1490 train_time:63544ms step_avg:52.30ms
+step:1216/1490 train_time:63631ms step_avg:52.33ms
+step:1217/1490 train_time:63712ms step_avg:52.35ms
+step:1218/1490 train_time:63798ms step_avg:52.38ms
+step:1219/1490 train_time:63879ms step_avg:52.40ms
+step:1220/1490 train_time:63965ms step_avg:52.43ms
+step:1221/1490 train_time:64048ms step_avg:52.45ms
+step:1222/1490 train_time:64134ms step_avg:52.48ms
+step:1223/1490 train_time:64215ms step_avg:52.51ms
+step:1224/1490 train_time:64301ms step_avg:52.53ms
+step:1225/1490 train_time:64381ms step_avg:52.56ms
+step:1226/1490 train_time:64467ms step_avg:52.58ms
+step:1227/1490 train_time:64548ms step_avg:52.61ms
+step:1228/1490 train_time:64636ms step_avg:52.64ms
+step:1229/1490 train_time:64717ms step_avg:52.66ms
+step:1230/1490 train_time:64803ms step_avg:52.69ms
+step:1231/1490 train_time:64884ms step_avg:52.71ms
+step:1232/1490 train_time:64969ms step_avg:52.73ms
+step:1233/1490 train_time:65049ms step_avg:52.76ms
+step:1234/1490 train_time:65137ms step_avg:52.79ms
+step:1235/1490 train_time:65218ms step_avg:52.81ms
+step:1236/1490 train_time:65304ms step_avg:52.84ms
+step:1237/1490 train_time:65386ms step_avg:52.86ms
+step:1238/1490 train_time:65472ms step_avg:52.89ms
+step:1239/1490 train_time:65553ms step_avg:52.91ms
+step:1240/1490 train_time:65641ms step_avg:52.94ms
+step:1241/1490 train_time:65722ms step_avg:52.96ms
+step:1242/1490 train_time:65808ms step_avg:52.99ms
+step:1243/1490 train_time:65889ms step_avg:53.01ms
+step:1244/1490 train_time:65974ms step_avg:53.03ms
+step:1245/1490 train_time:66056ms step_avg:53.06ms
+step:1246/1490 train_time:66142ms step_avg:53.08ms
+step:1247/1490 train_time:66224ms step_avg:53.11ms
+step:1248/1490 train_time:66310ms step_avg:53.13ms
+step:1249/1490 train_time:66390ms step_avg:53.15ms
+step:1250/1490 train_time:66476ms step_avg:53.18ms
+step:1250/1490 val_loss:3.3731 train_time:66579ms step_avg:53.26ms
+step:1251/1490 train_time:66599ms step_avg:53.24ms
+step:1252/1490 train_time:66646ms step_avg:53.23ms
+step:1253/1490 train_time:66732ms step_avg:53.26ms
+step:1254/1490 train_time:66822ms step_avg:53.29ms
+step:1255/1490 train_time:66901ms step_avg:53.31ms
+step:1256/1490 train_time:66987ms step_avg:53.33ms
+step:1257/1490 train_time:67068ms step_avg:53.36ms
+step:1258/1490 train_time:67153ms step_avg:53.38ms
+step:1259/1490 train_time:67231ms step_avg:53.40ms
+step:1260/1490 train_time:67318ms step_avg:53.43ms
+step:1261/1490 train_time:67397ms step_avg:53.45ms
+step:1262/1490 train_time:67482ms step_avg:53.47ms
+step:1263/1490 train_time:67565ms step_avg:53.50ms
+step:1264/1490 train_time:67655ms step_avg:53.52ms
+step:1265/1490 train_time:67739ms step_avg:53.55ms
+step:1266/1490 train_time:67826ms step_avg:53.58ms
+step:1267/1490 train_time:67908ms step_avg:53.60ms
+step:1268/1490 train_time:67994ms step_avg:53.62ms
+step:1269/1490 train_time:68074ms step_avg:53.64ms
+step:1270/1490 train_time:68159ms step_avg:53.67ms
+step:1271/1490 train_time:68240ms step_avg:53.69ms
+step:1272/1490 train_time:68325ms step_avg:53.71ms
+step:1273/1490 train_time:68405ms step_avg:53.74ms
+step:1274/1490 train_time:68491ms step_avg:53.76ms
+step:1275/1490 train_time:68572ms step_avg:53.78ms
+step:1276/1490 train_time:68662ms step_avg:53.81ms
+step:1277/1490 train_time:68745ms step_avg:53.83ms
+step:1278/1490 train_time:68831ms step_avg:53.86ms
+step:1279/1490 train_time:68914ms step_avg:53.88ms
+step:1280/1490 train_time:68999ms step_avg:53.91ms
+step:1281/1490 train_time:69079ms step_avg:53.93ms
+step:1282/1490 train_time:69164ms step_avg:53.95ms
+step:1283/1490 train_time:69244ms step_avg:53.97ms
+step:1284/1490 train_time:69330ms step_avg:54.00ms
+step:1285/1490 train_time:69410ms step_avg:54.02ms
+step:1286/1490 train_time:69496ms step_avg:54.04ms
+step:1287/1490 train_time:69577ms step_avg:54.06ms
+step:1288/1490 train_time:69665ms step_avg:54.09ms
+step:1289/1490 train_time:69747ms step_avg:54.11ms
+step:1290/1490 train_time:69835ms step_avg:54.14ms
+step:1291/1490 train_time:69917ms step_avg:54.16ms
+step:1292/1490 train_time:70005ms step_avg:54.18ms
+step:1293/1490 train_time:70085ms step_avg:54.20ms
+step:1294/1490 train_time:70170ms step_avg:54.23ms
+step:1295/1490 train_time:70250ms step_avg:54.25ms
+step:1296/1490 train_time:70335ms step_avg:54.27ms
+step:1297/1490 train_time:70416ms step_avg:54.29ms
+step:1298/1490 train_time:70502ms step_avg:54.32ms
+step:1299/1490 train_time:70584ms step_avg:54.34ms
+step:1300/1490 train_time:70669ms step_avg:54.36ms
+step:1301/1490 train_time:70753ms step_avg:54.38ms
+step:1302/1490 train_time:70839ms step_avg:54.41ms
+step:1303/1490 train_time:70921ms step_avg:54.43ms
+step:1304/1490 train_time:71009ms step_avg:54.45ms
+step:1305/1490 train_time:71089ms step_avg:54.47ms
+step:1306/1490 train_time:71175ms step_avg:54.50ms
+step:1307/1490 train_time:71255ms step_avg:54.52ms
+step:1308/1490 train_time:71340ms step_avg:54.54ms
+step:1309/1490 train_time:71420ms step_avg:54.56ms
+step:1310/1490 train_time:71507ms step_avg:54.59ms
+step:1311/1490 train_time:71587ms step_avg:54.61ms
+step:1312/1490 train_time:71673ms step_avg:54.63ms
+step:1313/1490 train_time:71754ms step_avg:54.65ms
+step:1314/1490 train_time:71841ms step_avg:54.67ms
+step:1315/1490 train_time:71924ms step_avg:54.69ms
+step:1316/1490 train_time:72012ms step_avg:54.72ms
+step:1317/1490 train_time:72092ms step_avg:54.74ms
+step:1318/1490 train_time:72178ms step_avg:54.76ms
+step:1319/1490 train_time:72259ms step_avg:54.78ms
+step:1320/1490 train_time:72345ms step_avg:54.81ms
+step:1321/1490 train_time:72426ms step_avg:54.83ms
+step:1322/1490 train_time:72511ms step_avg:54.85ms
+step:1323/1490 train_time:72592ms step_avg:54.87ms
+step:1324/1490 train_time:72678ms step_avg:54.89ms
+step:1325/1490 train_time:72760ms step_avg:54.91ms
+step:1326/1490 train_time:72846ms step_avg:54.94ms
+step:1327/1490 train_time:72927ms step_avg:54.96ms
+step:1328/1490 train_time:73013ms step_avg:54.98ms
+step:1329/1490 train_time:73094ms step_avg:55.00ms
+step:1330/1490 train_time:73179ms step_avg:55.02ms
+step:1331/1490 train_time:73261ms step_avg:55.04ms
+step:1332/1490 train_time:73348ms step_avg:55.07ms
+step:1333/1490 train_time:73429ms step_avg:55.09ms
+step:1334/1490 train_time:73515ms step_avg:55.11ms
+step:1335/1490 train_time:73596ms step_avg:55.13ms
+step:1336/1490 train_time:73683ms step_avg:55.15ms
+step:1337/1490 train_time:73764ms step_avg:55.17ms
+step:1338/1490 train_time:73852ms step_avg:55.20ms
+step:1339/1490 train_time:73933ms step_avg:55.21ms
+step:1340/1490 train_time:74019ms step_avg:55.24ms
+step:1341/1490 train_time:74100ms step_avg:55.26ms
+step:1342/1490 train_time:74185ms step_avg:55.28ms
+step:1343/1490 train_time:74265ms step_avg:55.30ms
+step:1344/1490 train_time:74353ms step_avg:55.32ms
+step:1345/1490 train_time:74435ms step_avg:55.34ms
+step:1346/1490 train_time:74521ms step_avg:55.36ms
+step:1347/1490 train_time:74602ms step_avg:55.38ms
+step:1348/1490 train_time:74687ms step_avg:55.41ms
+step:1349/1490 train_time:74768ms step_avg:55.43ms
+step:1350/1490 train_time:74855ms step_avg:55.45ms
+step:1351/1490 train_time:74935ms step_avg:55.47ms
+step:1352/1490 train_time:75022ms step_avg:55.49ms
+step:1353/1490 train_time:75104ms step_avg:55.51ms
+step:1354/1490 train_time:75190ms step_avg:55.53ms
+step:1355/1490 train_time:75270ms step_avg:55.55ms
+step:1356/1490 train_time:75358ms step_avg:55.57ms
+step:1357/1490 train_time:75439ms step_avg:55.59ms
+step:1358/1490 train_time:75524ms step_avg:55.61ms
+step:1359/1490 train_time:75605ms step_avg:55.63ms
+step:1360/1490 train_time:75692ms step_avg:55.66ms
+step:1361/1490 train_time:75773ms step_avg:55.67ms
+step:1362/1490 train_time:75859ms step_avg:55.70ms
+step:1363/1490 train_time:75940ms step_avg:55.72ms
+step:1364/1490 train_time:76027ms step_avg:55.74ms
+step:1365/1490 train_time:76108ms step_avg:55.76ms
+step:1366/1490 train_time:76193ms step_avg:55.78ms
+step:1367/1490 train_time:76275ms step_avg:55.80ms
+step:1368/1490 train_time:76361ms step_avg:55.82ms
+step:1369/1490 train_time:76443ms step_avg:55.84ms
+step:1370/1490 train_time:76530ms step_avg:55.86ms
+step:1371/1490 train_time:76611ms step_avg:55.88ms
+step:1372/1490 train_time:76697ms step_avg:55.90ms
+step:1373/1490 train_time:76779ms step_avg:55.92ms
+step:1374/1490 train_time:76865ms step_avg:55.94ms
+step:1375/1490 train_time:76945ms step_avg:55.96ms
+step:1376/1490 train_time:77032ms step_avg:55.98ms
+step:1377/1490 train_time:77113ms step_avg:56.00ms
+step:1378/1490 train_time:77199ms step_avg:56.02ms
+step:1379/1490 train_time:77280ms step_avg:56.04ms
+step:1380/1490 train_time:77367ms step_avg:56.06ms
+step:1381/1490 train_time:77446ms step_avg:56.08ms
+step:1382/1490 train_time:77533ms step_avg:56.10ms
+step:1383/1490 train_time:77615ms step_avg:56.12ms
+step:1384/1490 train_time:77701ms step_avg:56.14ms
+step:1385/1490 train_time:77783ms step_avg:56.16ms
+step:1386/1490 train_time:77870ms step_avg:56.18ms
+step:1387/1490 train_time:77952ms step_avg:56.20ms
+step:1388/1490 train_time:78038ms step_avg:56.22ms
+step:1389/1490 train_time:78120ms step_avg:56.24ms
+step:1390/1490 train_time:78207ms step_avg:56.26ms
+step:1391/1490 train_time:78288ms step_avg:56.28ms
+step:1392/1490 train_time:78373ms step_avg:56.30ms
+step:1393/1490 train_time:78454ms step_avg:56.32ms
+step:1394/1490 train_time:78540ms step_avg:56.34ms
+step:1395/1490 train_time:78621ms step_avg:56.36ms
+step:1396/1490 train_time:78707ms step_avg:56.38ms
+step:1397/1490 train_time:78788ms step_avg:56.40ms
+step:1398/1490 train_time:78874ms step_avg:56.42ms
+step:1399/1490 train_time:78954ms step_avg:56.44ms
+step:1400/1490 train_time:79041ms step_avg:56.46ms
+step:1401/1490 train_time:79123ms step_avg:56.48ms
+step:1402/1490 train_time:79211ms step_avg:56.50ms
+step:1403/1490 train_time:79291ms step_avg:56.52ms
+step:1404/1490 train_time:79376ms step_avg:56.54ms
+step:1405/1490 train_time:79457ms step_avg:56.55ms
+step:1406/1490 train_time:79544ms step_avg:56.57ms
+step:1407/1490 train_time:79626ms step_avg:56.59ms
+step:1408/1490 train_time:79713ms step_avg:56.61ms
+step:1409/1490 train_time:79794ms step_avg:56.63ms
+step:1410/1490 train_time:79879ms step_avg:56.65ms
+step:1411/1490 train_time:79960ms step_avg:56.67ms
+step:1412/1490 train_time:80046ms step_avg:56.69ms
+step:1413/1490 train_time:80127ms step_avg:56.71ms
+step:1414/1490 train_time:80213ms step_avg:56.73ms
+step:1415/1490 train_time:80294ms step_avg:56.74ms
+step:1416/1490 train_time:80381ms step_avg:56.77ms
+step:1417/1490 train_time:80463ms step_avg:56.78ms
+step:1418/1490 train_time:80550ms step_avg:56.81ms
+step:1419/1490 train_time:80631ms step_avg:56.82ms
+step:1420/1490 train_time:80718ms step_avg:56.84ms
+step:1421/1490 train_time:80800ms step_avg:56.86ms
+step:1422/1490 train_time:80886ms step_avg:56.88ms
+step:1423/1490 train_time:80968ms step_avg:56.90ms
+step:1424/1490 train_time:81054ms step_avg:56.92ms
+step:1425/1490 train_time:81136ms step_avg:56.94ms
+step:1426/1490 train_time:81222ms step_avg:56.96ms
+step:1427/1490 train_time:81302ms step_avg:56.97ms
+step:1428/1490 train_time:81389ms step_avg:57.00ms
+step:1429/1490 train_time:81469ms step_avg:57.01ms
+step:1430/1490 train_time:81555ms step_avg:57.03ms
+step:1431/1490 train_time:81636ms step_avg:57.05ms
+step:1432/1490 train_time:81722ms step_avg:57.07ms
+step:1433/1490 train_time:81804ms step_avg:57.09ms
+step:1434/1490 train_time:81890ms step_avg:57.11ms
+step:1435/1490 train_time:81971ms step_avg:57.12ms
+step:1436/1490 train_time:82058ms step_avg:57.14ms
+step:1437/1490 train_time:82139ms step_avg:57.16ms
+step:1438/1490 train_time:82225ms step_avg:57.18ms
+step:1439/1490 train_time:82305ms step_avg:57.20ms
+step:1440/1490 train_time:82392ms step_avg:57.22ms
+step:1441/1490 train_time:82474ms step_avg:57.23ms
+step:1442/1490 train_time:82561ms step_avg:57.25ms
+step:1443/1490 train_time:82641ms step_avg:57.27ms
+step:1444/1490 train_time:82726ms step_avg:57.29ms
+step:1445/1490 train_time:82808ms step_avg:57.31ms
+step:1446/1490 train_time:82894ms step_avg:57.33ms
+step:1447/1490 train_time:82975ms step_avg:57.34ms
+step:1448/1490 train_time:83063ms step_avg:57.36ms
+step:1449/1490 train_time:83144ms step_avg:57.38ms
+step:1450/1490 train_time:83230ms step_avg:57.40ms
+step:1451/1490 train_time:83316ms step_avg:57.42ms
+step:1452/1490 train_time:83404ms step_avg:57.44ms
+step:1453/1490 train_time:83484ms step_avg:57.46ms
+step:1454/1490 train_time:83571ms step_avg:57.48ms
+step:1455/1490 train_time:83652ms step_avg:57.49ms
+step:1456/1490 train_time:83739ms step_avg:57.51ms
+step:1457/1490 train_time:83820ms step_avg:57.53ms
+step:1458/1490 train_time:83907ms step_avg:57.55ms
+step:1459/1490 train_time:83989ms step_avg:57.57ms
+step:1460/1490 train_time:84075ms step_avg:57.59ms
+step:1461/1490 train_time:84156ms step_avg:57.60ms
+step:1462/1490 train_time:84243ms step_avg:57.62ms
+step:1463/1490 train_time:84324ms step_avg:57.64ms
+step:1464/1490 train_time:84412ms step_avg:57.66ms
+step:1465/1490 train_time:84493ms step_avg:57.67ms
+step:1466/1490 train_time:84580ms step_avg:57.69ms
+step:1467/1490 train_time:84663ms step_avg:57.71ms
+step:1468/1490 train_time:84751ms step_avg:57.73ms
+step:1469/1490 train_time:84832ms step_avg:57.75ms
+step:1470/1490 train_time:84920ms step_avg:57.77ms
+step:1471/1490 train_time:85002ms step_avg:57.79ms
+step:1472/1490 train_time:85088ms step_avg:57.80ms
+step:1473/1490 train_time:85169ms step_avg:57.82ms
+step:1474/1490 train_time:85254ms step_avg:57.84ms
+step:1475/1490 train_time:85336ms step_avg:57.86ms
+step:1476/1490 train_time:85423ms step_avg:57.87ms
+step:1477/1490 train_time:85502ms step_avg:57.89ms
+step:1478/1490 train_time:85588ms step_avg:57.91ms
+step:1479/1490 train_time:85670ms step_avg:57.92ms
+step:1480/1490 train_time:85757ms step_avg:57.94ms
+step:1481/1490 train_time:85838ms step_avg:57.96ms
+step:1482/1490 train_time:85925ms step_avg:57.98ms
+step:1483/1490 train_time:86007ms step_avg:58.00ms
+step:1484/1490 train_time:86093ms step_avg:58.01ms
+step:1485/1490 train_time:86174ms step_avg:58.03ms
+step:1486/1490 train_time:86260ms step_avg:58.05ms
+step:1487/1490 train_time:86344ms step_avg:58.07ms
+step:1488/1490 train_time:86430ms step_avg:58.08ms
+step:1489/1490 train_time:86511ms step_avg:58.10ms
+step:1490/1490 train_time:86597ms step_avg:58.12ms
+step:1490/1490 val_loss:3.2800 train_time:86701ms step_avg:58.19ms
+peak memory allocated: 31296 MiB reserved: 47042 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/baseline/2026-03-22_20-04-24_time-187_secs_baseline_0dc49d.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/baseline/2026-03-22_20-04-24_time-187_secs_baseline_0dc49d.txt
@@ -1,0 +1,4456 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 20:04:39 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   36C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            131W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   41C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1813059      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1813060      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1813061      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1813062      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1813063      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1813064      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1813065      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1813066      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8305 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:91ms step_avg:91.18ms
+step:2/1490 train_time:112ms step_avg:55.86ms
+step:3/1490 train_time:128ms step_avg:42.64ms
+step:4/1490 train_time:157ms step_avg:39.14ms
+step:5/1490 train_time:184ms step_avg:36.82ms
+step:6/1490 train_time:219ms step_avg:36.48ms
+step:7/1490 train_time:246ms step_avg:35.21ms
+step:8/1490 train_time:282ms step_avg:35.19ms
+step:9/1490 train_time:309ms step_avg:34.38ms
+step:10/1490 train_time:344ms step_avg:34.40ms
+step:11/1490 train_time:373ms step_avg:33.87ms
+step:12/1490 train_time:407ms step_avg:33.89ms
+step:13/1490 train_time:435ms step_avg:33.48ms
+step:14/1490 train_time:469ms step_avg:33.53ms
+step:15/1490 train_time:498ms step_avg:33.18ms
+step:16/1490 train_time:532ms step_avg:33.25ms
+step:17/1490 train_time:561ms step_avg:32.98ms
+step:18/1490 train_time:595ms step_avg:33.05ms
+step:19/1490 train_time:623ms step_avg:32.79ms
+step:20/1490 train_time:657ms step_avg:32.86ms
+step:21/1490 train_time:685ms step_avg:32.64ms
+step:22/1490 train_time:720ms step_avg:32.72ms
+step:23/1490 train_time:749ms step_avg:32.55ms
+step:24/1490 train_time:783ms step_avg:32.62ms
+step:25/1490 train_time:812ms step_avg:32.47ms
+step:26/1490 train_time:846ms step_avg:32.54ms
+step:27/1490 train_time:874ms step_avg:32.38ms
+step:28/1490 train_time:909ms step_avg:32.45ms
+step:29/1490 train_time:937ms step_avg:32.31ms
+step:30/1490 train_time:972ms step_avg:32.38ms
+step:31/1490 train_time:1001ms step_avg:32.29ms
+step:32/1490 train_time:1037ms step_avg:32.40ms
+step:33/1490 train_time:1066ms step_avg:32.30ms
+step:34/1490 train_time:1101ms step_avg:32.38ms
+step:35/1490 train_time:1131ms step_avg:32.30ms
+step:36/1490 train_time:1165ms step_avg:32.37ms
+step:37/1490 train_time:1194ms step_avg:32.27ms
+step:38/1490 train_time:1229ms step_avg:32.33ms
+step:39/1490 train_time:1258ms step_avg:32.25ms
+step:40/1490 train_time:1293ms step_avg:32.31ms
+step:41/1490 train_time:1321ms step_avg:32.22ms
+step:42/1490 train_time:1356ms step_avg:32.28ms
+step:43/1490 train_time:1384ms step_avg:32.19ms
+step:44/1490 train_time:1419ms step_avg:32.24ms
+step:45/1490 train_time:1447ms step_avg:32.16ms
+step:46/1490 train_time:1482ms step_avg:32.22ms
+step:47/1490 train_time:1511ms step_avg:32.15ms
+step:48/1490 train_time:1545ms step_avg:32.19ms
+step:49/1490 train_time:1574ms step_avg:32.11ms
+step:50/1490 train_time:1607ms step_avg:32.15ms
+step:51/1490 train_time:1636ms step_avg:32.08ms
+step:52/1490 train_time:1670ms step_avg:32.12ms
+step:53/1490 train_time:1699ms step_avg:32.06ms
+step:54/1490 train_time:1733ms step_avg:32.10ms
+step:55/1490 train_time:1762ms step_avg:32.03ms
+step:56/1490 train_time:1796ms step_avg:32.08ms
+step:57/1490 train_time:1825ms step_avg:32.01ms
+step:58/1490 train_time:1859ms step_avg:32.05ms
+step:59/1490 train_time:1888ms step_avg:31.99ms
+step:60/1490 train_time:1922ms step_avg:32.04ms
+step:61/1490 train_time:1951ms step_avg:31.99ms
+step:62/1490 train_time:1986ms step_avg:32.04ms
+step:63/1490 train_time:2015ms step_avg:31.98ms
+step:64/1490 train_time:2050ms step_avg:32.02ms
+step:65/1490 train_time:2078ms step_avg:31.98ms
+step:66/1490 train_time:2113ms step_avg:32.02ms
+step:67/1490 train_time:2142ms step_avg:31.97ms
+step:68/1490 train_time:2177ms step_avg:32.01ms
+step:69/1490 train_time:2205ms step_avg:31.96ms
+step:70/1490 train_time:2240ms step_avg:32.00ms
+step:71/1490 train_time:2268ms step_avg:31.95ms
+step:72/1490 train_time:2303ms step_avg:31.98ms
+step:73/1490 train_time:2331ms step_avg:31.93ms
+step:74/1490 train_time:2366ms step_avg:31.97ms
+step:75/1490 train_time:2394ms step_avg:31.92ms
+step:76/1490 train_time:2429ms step_avg:31.95ms
+step:77/1490 train_time:2457ms step_avg:31.91ms
+step:78/1490 train_time:2492ms step_avg:31.95ms
+step:79/1490 train_time:2520ms step_avg:31.90ms
+step:80/1490 train_time:2555ms step_avg:31.94ms
+step:81/1490 train_time:2583ms step_avg:31.89ms
+step:82/1490 train_time:2618ms step_avg:31.93ms
+step:83/1490 train_time:2646ms step_avg:31.88ms
+step:84/1490 train_time:2681ms step_avg:31.92ms
+step:85/1490 train_time:2709ms step_avg:31.87ms
+step:86/1490 train_time:2744ms step_avg:31.91ms
+step:87/1490 train_time:2773ms step_avg:31.87ms
+step:88/1490 train_time:2807ms step_avg:31.89ms
+step:89/1490 train_time:2835ms step_avg:31.86ms
+step:90/1490 train_time:2869ms step_avg:31.88ms
+step:91/1490 train_time:2898ms step_avg:31.84ms
+step:92/1490 train_time:2932ms step_avg:31.87ms
+step:93/1490 train_time:2960ms step_avg:31.83ms
+step:94/1490 train_time:2995ms step_avg:31.86ms
+step:95/1490 train_time:3023ms step_avg:31.82ms
+step:96/1490 train_time:3058ms step_avg:31.85ms
+step:97/1490 train_time:3087ms step_avg:31.82ms
+step:98/1490 train_time:3121ms step_avg:31.85ms
+step:99/1490 train_time:3151ms step_avg:31.83ms
+step:100/1490 train_time:3186ms step_avg:31.86ms
+step:101/1490 train_time:3214ms step_avg:31.82ms
+step:102/1490 train_time:3249ms step_avg:31.86ms
+step:103/1490 train_time:3278ms step_avg:31.82ms
+step:104/1490 train_time:3312ms step_avg:31.85ms
+step:105/1490 train_time:3341ms step_avg:31.82ms
+step:106/1490 train_time:3376ms step_avg:31.85ms
+step:107/1490 train_time:3404ms step_avg:31.82ms
+step:108/1490 train_time:3439ms step_avg:31.84ms
+step:109/1490 train_time:3467ms step_avg:31.81ms
+step:110/1490 train_time:3501ms step_avg:31.83ms
+step:111/1490 train_time:3530ms step_avg:31.80ms
+step:112/1490 train_time:3564ms step_avg:31.82ms
+step:113/1490 train_time:3593ms step_avg:31.80ms
+step:114/1490 train_time:3627ms step_avg:31.82ms
+step:115/1490 train_time:3656ms step_avg:31.79ms
+step:116/1490 train_time:3690ms step_avg:31.81ms
+step:117/1490 train_time:3719ms step_avg:31.78ms
+step:118/1490 train_time:3753ms step_avg:31.80ms
+step:119/1490 train_time:3782ms step_avg:31.78ms
+step:120/1490 train_time:3816ms step_avg:31.80ms
+step:121/1490 train_time:3844ms step_avg:31.77ms
+step:122/1490 train_time:3879ms step_avg:31.79ms
+step:123/1490 train_time:3907ms step_avg:31.77ms
+step:124/1490 train_time:3942ms step_avg:31.79ms
+step:125/1490 train_time:3971ms step_avg:31.76ms
+step:126/1490 train_time:4005ms step_avg:31.78ms
+step:127/1490 train_time:4033ms step_avg:31.76ms
+step:128/1490 train_time:4068ms step_avg:31.78ms
+step:129/1490 train_time:4096ms step_avg:31.75ms
+step:130/1490 train_time:4132ms step_avg:31.79ms
+step:131/1490 train_time:4160ms step_avg:31.75ms
+step:132/1490 train_time:4194ms step_avg:31.78ms
+step:133/1490 train_time:4223ms step_avg:31.75ms
+step:134/1490 train_time:4258ms step_avg:31.77ms
+step:135/1490 train_time:4286ms step_avg:31.75ms
+step:136/1490 train_time:4321ms step_avg:31.77ms
+step:137/1490 train_time:4349ms step_avg:31.75ms
+step:138/1490 train_time:4384ms step_avg:31.77ms
+step:139/1490 train_time:4413ms step_avg:31.75ms
+step:140/1490 train_time:4448ms step_avg:31.77ms
+step:141/1490 train_time:4476ms step_avg:31.75ms
+step:142/1490 train_time:4510ms step_avg:31.76ms
+step:143/1490 train_time:4539ms step_avg:31.74ms
+step:144/1490 train_time:4573ms step_avg:31.76ms
+step:145/1490 train_time:4601ms step_avg:31.73ms
+step:146/1490 train_time:4636ms step_avg:31.75ms
+step:147/1490 train_time:4664ms step_avg:31.73ms
+step:148/1490 train_time:4699ms step_avg:31.75ms
+step:149/1490 train_time:4727ms step_avg:31.72ms
+step:150/1490 train_time:4762ms step_avg:31.75ms
+step:151/1490 train_time:4791ms step_avg:31.73ms
+step:152/1490 train_time:4825ms step_avg:31.75ms
+step:153/1490 train_time:4854ms step_avg:31.73ms
+step:154/1490 train_time:4889ms step_avg:31.75ms
+step:155/1490 train_time:4917ms step_avg:31.72ms
+step:156/1490 train_time:4952ms step_avg:31.74ms
+step:157/1490 train_time:4980ms step_avg:31.72ms
+step:158/1490 train_time:5015ms step_avg:31.74ms
+step:159/1490 train_time:5043ms step_avg:31.72ms
+step:160/1490 train_time:5078ms step_avg:31.74ms
+step:161/1490 train_time:5106ms step_avg:31.72ms
+step:162/1490 train_time:5141ms step_avg:31.73ms
+step:163/1490 train_time:5170ms step_avg:31.72ms
+step:164/1490 train_time:5204ms step_avg:31.73ms
+step:165/1490 train_time:5232ms step_avg:31.71ms
+step:166/1490 train_time:5267ms step_avg:31.73ms
+step:167/1490 train_time:5296ms step_avg:31.71ms
+step:168/1490 train_time:5330ms step_avg:31.73ms
+step:169/1490 train_time:5359ms step_avg:31.71ms
+step:170/1490 train_time:5394ms step_avg:31.73ms
+step:171/1490 train_time:5423ms step_avg:31.71ms
+step:172/1490 train_time:5457ms step_avg:31.73ms
+step:173/1490 train_time:5485ms step_avg:31.71ms
+step:174/1490 train_time:5520ms step_avg:31.72ms
+step:175/1490 train_time:5548ms step_avg:31.70ms
+step:176/1490 train_time:5583ms step_avg:31.72ms
+step:177/1490 train_time:5611ms step_avg:31.70ms
+step:178/1490 train_time:5645ms step_avg:31.72ms
+step:179/1490 train_time:5674ms step_avg:31.70ms
+step:180/1490 train_time:5708ms step_avg:31.71ms
+step:181/1490 train_time:5737ms step_avg:31.69ms
+step:182/1490 train_time:5771ms step_avg:31.71ms
+step:183/1490 train_time:5799ms step_avg:31.69ms
+step:184/1490 train_time:5834ms step_avg:31.70ms
+step:185/1490 train_time:5862ms step_avg:31.69ms
+step:186/1490 train_time:5897ms step_avg:31.70ms
+step:187/1490 train_time:5925ms step_avg:31.68ms
+step:188/1490 train_time:5959ms step_avg:31.70ms
+step:189/1490 train_time:5988ms step_avg:31.68ms
+step:190/1490 train_time:6022ms step_avg:31.70ms
+step:191/1490 train_time:6050ms step_avg:31.68ms
+step:192/1490 train_time:6085ms step_avg:31.69ms
+step:193/1490 train_time:6114ms step_avg:31.68ms
+step:194/1490 train_time:6148ms step_avg:31.69ms
+step:195/1490 train_time:6177ms step_avg:31.68ms
+step:196/1490 train_time:6211ms step_avg:31.69ms
+step:197/1490 train_time:6239ms step_avg:31.67ms
+step:198/1490 train_time:6274ms step_avg:31.69ms
+step:199/1490 train_time:6303ms step_avg:31.67ms
+step:200/1490 train_time:6337ms step_avg:31.69ms
+step:201/1490 train_time:6366ms step_avg:31.67ms
+step:202/1490 train_time:6400ms step_avg:31.68ms
+step:203/1490 train_time:6429ms step_avg:31.67ms
+step:204/1490 train_time:6463ms step_avg:31.68ms
+step:205/1490 train_time:6492ms step_avg:31.67ms
+step:206/1490 train_time:6527ms step_avg:31.68ms
+step:207/1490 train_time:6556ms step_avg:31.67ms
+step:208/1490 train_time:6590ms step_avg:31.68ms
+step:209/1490 train_time:6618ms step_avg:31.67ms
+step:210/1490 train_time:6652ms step_avg:31.68ms
+step:211/1490 train_time:6681ms step_avg:31.66ms
+step:212/1490 train_time:6716ms step_avg:31.68ms
+step:213/1490 train_time:6744ms step_avg:31.66ms
+step:214/1490 train_time:6779ms step_avg:31.68ms
+step:215/1490 train_time:6807ms step_avg:31.66ms
+step:216/1490 train_time:6842ms step_avg:31.68ms
+step:217/1490 train_time:6871ms step_avg:31.66ms
+step:218/1490 train_time:6905ms step_avg:31.67ms
+step:219/1490 train_time:6933ms step_avg:31.66ms
+step:220/1490 train_time:6967ms step_avg:31.67ms
+step:221/1490 train_time:6996ms step_avg:31.65ms
+step:222/1490 train_time:7030ms step_avg:31.67ms
+step:223/1490 train_time:7059ms step_avg:31.65ms
+step:224/1490 train_time:7093ms step_avg:31.67ms
+step:225/1490 train_time:7122ms step_avg:31.65ms
+step:226/1490 train_time:7156ms step_avg:31.66ms
+step:227/1490 train_time:7184ms step_avg:31.65ms
+step:228/1490 train_time:7218ms step_avg:31.66ms
+step:229/1490 train_time:7247ms step_avg:31.65ms
+step:230/1490 train_time:7282ms step_avg:31.66ms
+step:231/1490 train_time:7310ms step_avg:31.65ms
+step:232/1490 train_time:7345ms step_avg:31.66ms
+step:233/1490 train_time:7374ms step_avg:31.65ms
+step:234/1490 train_time:7408ms step_avg:31.66ms
+step:235/1490 train_time:7436ms step_avg:31.64ms
+step:236/1490 train_time:7471ms step_avg:31.66ms
+step:237/1490 train_time:7499ms step_avg:31.64ms
+step:238/1490 train_time:7534ms step_avg:31.66ms
+step:239/1490 train_time:7562ms step_avg:31.64ms
+step:240/1490 train_time:7597ms step_avg:31.65ms
+step:241/1490 train_time:7625ms step_avg:31.64ms
+step:242/1490 train_time:7659ms step_avg:31.65ms
+step:243/1490 train_time:7688ms step_avg:31.64ms
+step:244/1490 train_time:7722ms step_avg:31.65ms
+step:245/1490 train_time:7751ms step_avg:31.64ms
+step:246/1490 train_time:7785ms step_avg:31.65ms
+step:247/1490 train_time:7814ms step_avg:31.63ms
+step:248/1490 train_time:7848ms step_avg:31.64ms
+step:249/1490 train_time:7876ms step_avg:31.63ms
+step:250/1490 train_time:7911ms step_avg:31.64ms
+step:250/1490 val_loss:4.4990 train_time:7954ms step_avg:31.81ms
+step:251/1490 train_time:7971ms step_avg:31.76ms
+step:252/1490 train_time:7988ms step_avg:31.70ms
+step:253/1490 train_time:8004ms step_avg:31.64ms
+step:254/1490 train_time:8041ms step_avg:31.66ms
+step:255/1490 train_time:8071ms step_avg:31.65ms
+step:256/1490 train_time:8107ms step_avg:31.67ms
+step:257/1490 train_time:8136ms step_avg:31.66ms
+step:258/1490 train_time:8170ms step_avg:31.67ms
+step:259/1490 train_time:8199ms step_avg:31.66ms
+step:260/1490 train_time:8234ms step_avg:31.67ms
+step:261/1490 train_time:8262ms step_avg:31.65ms
+step:262/1490 train_time:8296ms step_avg:31.67ms
+step:263/1490 train_time:8325ms step_avg:31.65ms
+step:264/1490 train_time:8359ms step_avg:31.66ms
+step:265/1490 train_time:8388ms step_avg:31.65ms
+step:266/1490 train_time:8422ms step_avg:31.66ms
+step:267/1490 train_time:8451ms step_avg:31.65ms
+step:268/1490 train_time:8485ms step_avg:31.66ms
+step:269/1490 train_time:8513ms step_avg:31.65ms
+step:270/1490 train_time:8548ms step_avg:31.66ms
+step:271/1490 train_time:8576ms step_avg:31.64ms
+step:272/1490 train_time:8609ms step_avg:31.65ms
+step:273/1490 train_time:8638ms step_avg:31.64ms
+step:274/1490 train_time:8671ms step_avg:31.65ms
+step:275/1490 train_time:8700ms step_avg:31.64ms
+step:276/1490 train_time:8734ms step_avg:31.64ms
+step:277/1490 train_time:8762ms step_avg:31.63ms
+step:278/1490 train_time:8796ms step_avg:31.64ms
+step:279/1490 train_time:8824ms step_avg:31.63ms
+step:280/1490 train_time:8858ms step_avg:31.64ms
+step:281/1490 train_time:8886ms step_avg:31.62ms
+step:282/1490 train_time:8920ms step_avg:31.63ms
+step:283/1490 train_time:8949ms step_avg:31.62ms
+step:284/1490 train_time:8983ms step_avg:31.63ms
+step:285/1490 train_time:9012ms step_avg:31.62ms
+step:286/1490 train_time:9046ms step_avg:31.63ms
+step:287/1490 train_time:9075ms step_avg:31.62ms
+step:288/1490 train_time:9110ms step_avg:31.63ms
+step:289/1490 train_time:9139ms step_avg:31.62ms
+step:290/1490 train_time:9173ms step_avg:31.63ms
+step:291/1490 train_time:9202ms step_avg:31.62ms
+step:292/1490 train_time:9237ms step_avg:31.63ms
+step:293/1490 train_time:9266ms step_avg:31.62ms
+step:294/1490 train_time:9301ms step_avg:31.63ms
+step:295/1490 train_time:9329ms step_avg:31.62ms
+step:296/1490 train_time:9363ms step_avg:31.63ms
+step:297/1490 train_time:9392ms step_avg:31.62ms
+step:298/1490 train_time:9426ms step_avg:31.63ms
+step:299/1490 train_time:9455ms step_avg:31.62ms
+step:300/1490 train_time:9490ms step_avg:31.63ms
+step:301/1490 train_time:9518ms step_avg:31.62ms
+step:302/1490 train_time:9553ms step_avg:31.63ms
+step:303/1490 train_time:9581ms step_avg:31.62ms
+step:304/1490 train_time:9615ms step_avg:31.63ms
+step:305/1490 train_time:9643ms step_avg:31.62ms
+step:306/1490 train_time:9677ms step_avg:31.62ms
+step:307/1490 train_time:9705ms step_avg:31.61ms
+step:308/1490 train_time:9739ms step_avg:31.62ms
+step:309/1490 train_time:9767ms step_avg:31.61ms
+step:310/1490 train_time:9802ms step_avg:31.62ms
+step:311/1490 train_time:9830ms step_avg:31.61ms
+step:312/1490 train_time:9864ms step_avg:31.62ms
+step:313/1490 train_time:9892ms step_avg:31.60ms
+step:314/1490 train_time:9926ms step_avg:31.61ms
+step:315/1490 train_time:9954ms step_avg:31.60ms
+step:316/1490 train_time:9989ms step_avg:31.61ms
+step:317/1490 train_time:10017ms step_avg:31.60ms
+step:318/1490 train_time:10051ms step_avg:31.61ms
+step:319/1490 train_time:10080ms step_avg:31.60ms
+step:320/1490 train_time:10114ms step_avg:31.61ms
+step:321/1490 train_time:10143ms step_avg:31.60ms
+step:322/1490 train_time:10178ms step_avg:31.61ms
+step:323/1490 train_time:10206ms step_avg:31.60ms
+step:324/1490 train_time:10240ms step_avg:31.61ms
+step:325/1490 train_time:10269ms step_avg:31.60ms
+step:326/1490 train_time:10304ms step_avg:31.61ms
+step:327/1490 train_time:10333ms step_avg:31.60ms
+step:328/1490 train_time:10367ms step_avg:31.61ms
+step:329/1490 train_time:10396ms step_avg:31.60ms
+step:330/1490 train_time:10430ms step_avg:31.61ms
+step:331/1490 train_time:10459ms step_avg:31.60ms
+step:332/1490 train_time:10494ms step_avg:31.61ms
+step:333/1490 train_time:10522ms step_avg:31.60ms
+step:334/1490 train_time:10556ms step_avg:31.60ms
+step:335/1490 train_time:10584ms step_avg:31.60ms
+step:336/1490 train_time:10618ms step_avg:31.60ms
+step:337/1490 train_time:10647ms step_avg:31.59ms
+step:338/1490 train_time:10681ms step_avg:31.60ms
+step:339/1490 train_time:10709ms step_avg:31.59ms
+step:340/1490 train_time:10743ms step_avg:31.60ms
+step:341/1490 train_time:10772ms step_avg:31.59ms
+step:342/1490 train_time:10806ms step_avg:31.60ms
+step:343/1490 train_time:10834ms step_avg:31.59ms
+step:344/1490 train_time:10869ms step_avg:31.59ms
+step:345/1490 train_time:10897ms step_avg:31.59ms
+step:346/1490 train_time:10931ms step_avg:31.59ms
+step:347/1490 train_time:10960ms step_avg:31.58ms
+step:348/1490 train_time:10996ms step_avg:31.60ms
+step:349/1490 train_time:11023ms step_avg:31.58ms
+step:350/1490 train_time:11057ms step_avg:31.59ms
+step:351/1490 train_time:11086ms step_avg:31.58ms
+step:352/1490 train_time:11120ms step_avg:31.59ms
+step:353/1490 train_time:11148ms step_avg:31.58ms
+step:354/1490 train_time:11183ms step_avg:31.59ms
+step:355/1490 train_time:11211ms step_avg:31.58ms
+step:356/1490 train_time:11246ms step_avg:31.59ms
+step:357/1490 train_time:11274ms step_avg:31.58ms
+step:358/1490 train_time:11308ms step_avg:31.59ms
+step:359/1490 train_time:11337ms step_avg:31.58ms
+step:360/1490 train_time:11371ms step_avg:31.59ms
+step:361/1490 train_time:11400ms step_avg:31.58ms
+step:362/1490 train_time:11434ms step_avg:31.59ms
+step:363/1490 train_time:11463ms step_avg:31.58ms
+step:364/1490 train_time:11497ms step_avg:31.59ms
+step:365/1490 train_time:11526ms step_avg:31.58ms
+step:366/1490 train_time:11560ms step_avg:31.58ms
+step:367/1490 train_time:11588ms step_avg:31.58ms
+step:368/1490 train_time:11623ms step_avg:31.58ms
+step:369/1490 train_time:11651ms step_avg:31.57ms
+step:370/1490 train_time:11685ms step_avg:31.58ms
+step:371/1490 train_time:11714ms step_avg:31.57ms
+step:372/1490 train_time:11748ms step_avg:31.58ms
+step:373/1490 train_time:11776ms step_avg:31.57ms
+step:374/1490 train_time:11810ms step_avg:31.58ms
+step:375/1490 train_time:11839ms step_avg:31.57ms
+step:376/1490 train_time:11872ms step_avg:31.58ms
+step:377/1490 train_time:11901ms step_avg:31.57ms
+step:378/1490 train_time:11935ms step_avg:31.58ms
+step:379/1490 train_time:11964ms step_avg:31.57ms
+step:380/1490 train_time:11998ms step_avg:31.57ms
+step:381/1490 train_time:12027ms step_avg:31.57ms
+step:382/1490 train_time:12061ms step_avg:31.57ms
+step:383/1490 train_time:12089ms step_avg:31.56ms
+step:384/1490 train_time:12124ms step_avg:31.57ms
+step:385/1490 train_time:12152ms step_avg:31.56ms
+step:386/1490 train_time:12187ms step_avg:31.57ms
+step:387/1490 train_time:12215ms step_avg:31.56ms
+step:388/1490 train_time:12250ms step_avg:31.57ms
+step:389/1490 train_time:12278ms step_avg:31.56ms
+step:390/1490 train_time:12312ms step_avg:31.57ms
+step:391/1490 train_time:12340ms step_avg:31.56ms
+step:392/1490 train_time:12375ms step_avg:31.57ms
+step:393/1490 train_time:12403ms step_avg:31.56ms
+step:394/1490 train_time:12438ms step_avg:31.57ms
+step:395/1490 train_time:12466ms step_avg:31.56ms
+step:396/1490 train_time:12500ms step_avg:31.57ms
+step:397/1490 train_time:12529ms step_avg:31.56ms
+step:398/1490 train_time:12563ms step_avg:31.57ms
+step:399/1490 train_time:12591ms step_avg:31.56ms
+step:400/1490 train_time:12626ms step_avg:31.56ms
+step:401/1490 train_time:12654ms step_avg:31.56ms
+step:402/1490 train_time:12689ms step_avg:31.56ms
+step:403/1490 train_time:12717ms step_avg:31.56ms
+step:404/1490 train_time:12751ms step_avg:31.56ms
+step:405/1490 train_time:12779ms step_avg:31.55ms
+step:406/1490 train_time:12813ms step_avg:31.56ms
+step:407/1490 train_time:12842ms step_avg:31.55ms
+step:408/1490 train_time:12876ms step_avg:31.56ms
+step:409/1490 train_time:12904ms step_avg:31.55ms
+step:410/1490 train_time:12939ms step_avg:31.56ms
+step:411/1490 train_time:12967ms step_avg:31.55ms
+step:412/1490 train_time:13002ms step_avg:31.56ms
+step:413/1490 train_time:13030ms step_avg:31.55ms
+step:414/1490 train_time:13065ms step_avg:31.56ms
+step:415/1490 train_time:13094ms step_avg:31.55ms
+step:416/1490 train_time:13128ms step_avg:31.56ms
+step:417/1490 train_time:13157ms step_avg:31.55ms
+step:418/1490 train_time:13191ms step_avg:31.56ms
+step:419/1490 train_time:13219ms step_avg:31.55ms
+step:420/1490 train_time:13254ms step_avg:31.56ms
+step:421/1490 train_time:13282ms step_avg:31.55ms
+step:422/1490 train_time:13316ms step_avg:31.56ms
+step:423/1490 train_time:13345ms step_avg:31.55ms
+step:424/1490 train_time:13379ms step_avg:31.55ms
+step:425/1490 train_time:13407ms step_avg:31.55ms
+step:426/1490 train_time:13442ms step_avg:31.55ms
+step:427/1490 train_time:13470ms step_avg:31.55ms
+step:428/1490 train_time:13504ms step_avg:31.55ms
+step:429/1490 train_time:13533ms step_avg:31.55ms
+step:430/1490 train_time:13568ms step_avg:31.55ms
+step:431/1490 train_time:13596ms step_avg:31.55ms
+step:432/1490 train_time:13631ms step_avg:31.55ms
+step:433/1490 train_time:13659ms step_avg:31.55ms
+step:434/1490 train_time:13693ms step_avg:31.55ms
+step:435/1490 train_time:13722ms step_avg:31.55ms
+step:436/1490 train_time:13757ms step_avg:31.55ms
+step:437/1490 train_time:13785ms step_avg:31.54ms
+step:438/1490 train_time:13819ms step_avg:31.55ms
+step:439/1490 train_time:13847ms step_avg:31.54ms
+step:440/1490 train_time:13882ms step_avg:31.55ms
+step:441/1490 train_time:13911ms step_avg:31.54ms
+step:442/1490 train_time:13945ms step_avg:31.55ms
+step:443/1490 train_time:13974ms step_avg:31.54ms
+step:444/1490 train_time:14008ms step_avg:31.55ms
+step:445/1490 train_time:14036ms step_avg:31.54ms
+step:446/1490 train_time:14071ms step_avg:31.55ms
+step:447/1490 train_time:14099ms step_avg:31.54ms
+step:448/1490 train_time:14133ms step_avg:31.55ms
+step:449/1490 train_time:14161ms step_avg:31.54ms
+step:450/1490 train_time:14195ms step_avg:31.55ms
+step:451/1490 train_time:14224ms step_avg:31.54ms
+step:452/1490 train_time:14259ms step_avg:31.55ms
+step:453/1490 train_time:14287ms step_avg:31.54ms
+step:454/1490 train_time:14321ms step_avg:31.54ms
+step:455/1490 train_time:14350ms step_avg:31.54ms
+step:456/1490 train_time:14384ms step_avg:31.54ms
+step:457/1490 train_time:14413ms step_avg:31.54ms
+step:458/1490 train_time:14447ms step_avg:31.54ms
+step:459/1490 train_time:14476ms step_avg:31.54ms
+step:460/1490 train_time:14510ms step_avg:31.54ms
+step:461/1490 train_time:14538ms step_avg:31.54ms
+step:462/1490 train_time:14573ms step_avg:31.54ms
+step:463/1490 train_time:14601ms step_avg:31.54ms
+step:464/1490 train_time:14635ms step_avg:31.54ms
+step:465/1490 train_time:14664ms step_avg:31.53ms
+step:466/1490 train_time:14698ms step_avg:31.54ms
+step:467/1490 train_time:14726ms step_avg:31.53ms
+step:468/1490 train_time:14761ms step_avg:31.54ms
+step:469/1490 train_time:14789ms step_avg:31.53ms
+step:470/1490 train_time:14823ms step_avg:31.54ms
+step:471/1490 train_time:14852ms step_avg:31.53ms
+step:472/1490 train_time:14887ms step_avg:31.54ms
+step:473/1490 train_time:14915ms step_avg:31.53ms
+step:474/1490 train_time:14949ms step_avg:31.54ms
+step:475/1490 train_time:14977ms step_avg:31.53ms
+step:476/1490 train_time:15012ms step_avg:31.54ms
+step:477/1490 train_time:15040ms step_avg:31.53ms
+step:478/1490 train_time:15075ms step_avg:31.54ms
+step:479/1490 train_time:15103ms step_avg:31.53ms
+step:480/1490 train_time:15138ms step_avg:31.54ms
+step:481/1490 train_time:15166ms step_avg:31.53ms
+step:482/1490 train_time:15201ms step_avg:31.54ms
+step:483/1490 train_time:15229ms step_avg:31.53ms
+step:484/1490 train_time:15266ms step_avg:31.54ms
+step:485/1490 train_time:15319ms step_avg:31.58ms
+step:486/1490 train_time:15378ms step_avg:31.64ms
+step:487/1490 train_time:15432ms step_avg:31.69ms
+step:488/1490 train_time:15493ms step_avg:31.75ms
+step:489/1490 train_time:15547ms step_avg:31.79ms
+step:490/1490 train_time:15607ms step_avg:31.85ms
+step:491/1490 train_time:15660ms step_avg:31.89ms
+step:492/1490 train_time:15720ms step_avg:31.95ms
+step:493/1490 train_time:15776ms step_avg:32.00ms
+step:494/1490 train_time:15836ms step_avg:32.06ms
+step:495/1490 train_time:15890ms step_avg:32.10ms
+step:496/1490 train_time:15949ms step_avg:32.16ms
+step:497/1490 train_time:16004ms step_avg:32.20ms
+step:498/1490 train_time:16065ms step_avg:32.26ms
+step:499/1490 train_time:16120ms step_avg:32.30ms
+step:500/1490 train_time:16179ms step_avg:32.36ms
+step:500/1490 val_loss:4.2349 train_time:16251ms step_avg:32.50ms
+step:501/1490 train_time:16267ms step_avg:32.47ms
+step:502/1490 train_time:16294ms step_avg:32.46ms
+step:503/1490 train_time:16349ms step_avg:32.50ms
+step:504/1490 train_time:16412ms step_avg:32.56ms
+step:505/1490 train_time:16470ms step_avg:32.61ms
+step:506/1490 train_time:16530ms step_avg:32.67ms
+step:507/1490 train_time:16584ms step_avg:32.71ms
+step:508/1490 train_time:16644ms step_avg:32.76ms
+step:509/1490 train_time:16698ms step_avg:32.81ms
+step:510/1490 train_time:16757ms step_avg:32.86ms
+step:511/1490 train_time:16810ms step_avg:32.90ms
+step:512/1490 train_time:16870ms step_avg:32.95ms
+step:513/1490 train_time:16923ms step_avg:32.99ms
+step:514/1490 train_time:16983ms step_avg:33.04ms
+step:515/1490 train_time:17036ms step_avg:33.08ms
+step:516/1490 train_time:17095ms step_avg:33.13ms
+step:517/1490 train_time:17150ms step_avg:33.17ms
+step:518/1490 train_time:17210ms step_avg:33.22ms
+step:519/1490 train_time:17265ms step_avg:33.27ms
+step:520/1490 train_time:17328ms step_avg:33.32ms
+step:521/1490 train_time:17383ms step_avg:33.37ms
+step:522/1490 train_time:17444ms step_avg:33.42ms
+step:523/1490 train_time:17498ms step_avg:33.46ms
+step:524/1490 train_time:17557ms step_avg:33.51ms
+step:525/1490 train_time:17611ms step_avg:33.54ms
+step:526/1490 train_time:17672ms step_avg:33.60ms
+step:527/1490 train_time:17726ms step_avg:33.64ms
+step:528/1490 train_time:17785ms step_avg:33.68ms
+step:529/1490 train_time:17839ms step_avg:33.72ms
+step:530/1490 train_time:17898ms step_avg:33.77ms
+step:531/1490 train_time:17952ms step_avg:33.81ms
+step:532/1490 train_time:18010ms step_avg:33.85ms
+step:533/1490 train_time:18064ms step_avg:33.89ms
+step:534/1490 train_time:18125ms step_avg:33.94ms
+step:535/1490 train_time:18180ms step_avg:33.98ms
+step:536/1490 train_time:18240ms step_avg:34.03ms
+step:537/1490 train_time:18294ms step_avg:34.07ms
+step:538/1490 train_time:18354ms step_avg:34.12ms
+step:539/1490 train_time:18409ms step_avg:34.15ms
+step:540/1490 train_time:18471ms step_avg:34.20ms
+step:541/1490 train_time:18525ms step_avg:34.24ms
+step:542/1490 train_time:18585ms step_avg:34.29ms
+step:543/1490 train_time:18639ms step_avg:34.33ms
+step:544/1490 train_time:18698ms step_avg:34.37ms
+step:545/1490 train_time:18752ms step_avg:34.41ms
+step:546/1490 train_time:18812ms step_avg:34.45ms
+step:547/1490 train_time:18866ms step_avg:34.49ms
+step:548/1490 train_time:18926ms step_avg:34.54ms
+step:549/1490 train_time:18980ms step_avg:34.57ms
+step:550/1490 train_time:19039ms step_avg:34.62ms
+step:551/1490 train_time:19093ms step_avg:34.65ms
+step:552/1490 train_time:19153ms step_avg:34.70ms
+step:553/1490 train_time:19208ms step_avg:34.73ms
+step:554/1490 train_time:19269ms step_avg:34.78ms
+step:555/1490 train_time:19323ms step_avg:34.82ms
+step:556/1490 train_time:19384ms step_avg:34.86ms
+step:557/1490 train_time:19438ms step_avg:34.90ms
+step:558/1490 train_time:19498ms step_avg:34.94ms
+step:559/1490 train_time:19552ms step_avg:34.98ms
+step:560/1490 train_time:19612ms step_avg:35.02ms
+step:561/1490 train_time:19667ms step_avg:35.06ms
+step:562/1490 train_time:19728ms step_avg:35.10ms
+step:563/1490 train_time:19782ms step_avg:35.14ms
+step:564/1490 train_time:19842ms step_avg:35.18ms
+step:565/1490 train_time:19896ms step_avg:35.21ms
+step:566/1490 train_time:19955ms step_avg:35.26ms
+step:567/1490 train_time:20009ms step_avg:35.29ms
+step:568/1490 train_time:20069ms step_avg:35.33ms
+step:569/1490 train_time:20122ms step_avg:35.36ms
+step:570/1490 train_time:20183ms step_avg:35.41ms
+step:571/1490 train_time:20237ms step_avg:35.44ms
+step:572/1490 train_time:20297ms step_avg:35.48ms
+step:573/1490 train_time:20351ms step_avg:35.52ms
+step:574/1490 train_time:20411ms step_avg:35.56ms
+step:575/1490 train_time:20466ms step_avg:35.59ms
+step:576/1490 train_time:20527ms step_avg:35.64ms
+step:577/1490 train_time:20580ms step_avg:35.67ms
+step:578/1490 train_time:20640ms step_avg:35.71ms
+step:579/1490 train_time:20694ms step_avg:35.74ms
+step:580/1490 train_time:20754ms step_avg:35.78ms
+step:581/1490 train_time:20809ms step_avg:35.82ms
+step:582/1490 train_time:20869ms step_avg:35.86ms
+step:583/1490 train_time:20924ms step_avg:35.89ms
+step:584/1490 train_time:20984ms step_avg:35.93ms
+step:585/1490 train_time:21037ms step_avg:35.96ms
+step:586/1490 train_time:21096ms step_avg:36.00ms
+step:587/1490 train_time:21150ms step_avg:36.03ms
+step:588/1490 train_time:21210ms step_avg:36.07ms
+step:589/1490 train_time:21264ms step_avg:36.10ms
+step:590/1490 train_time:21324ms step_avg:36.14ms
+step:591/1490 train_time:21379ms step_avg:36.17ms
+step:592/1490 train_time:21439ms step_avg:36.21ms
+step:593/1490 train_time:21492ms step_avg:36.24ms
+step:594/1490 train_time:21552ms step_avg:36.28ms
+step:595/1490 train_time:21606ms step_avg:36.31ms
+step:596/1490 train_time:21668ms step_avg:36.36ms
+step:597/1490 train_time:21722ms step_avg:36.39ms
+step:598/1490 train_time:21782ms step_avg:36.42ms
+step:599/1490 train_time:21835ms step_avg:36.45ms
+step:600/1490 train_time:21894ms step_avg:36.49ms
+step:601/1490 train_time:21949ms step_avg:36.52ms
+step:602/1490 train_time:22008ms step_avg:36.56ms
+step:603/1490 train_time:22062ms step_avg:36.59ms
+step:604/1490 train_time:22122ms step_avg:36.63ms
+step:605/1490 train_time:22177ms step_avg:36.66ms
+step:606/1490 train_time:22235ms step_avg:36.69ms
+step:607/1490 train_time:22290ms step_avg:36.72ms
+step:608/1490 train_time:22350ms step_avg:36.76ms
+step:609/1490 train_time:22404ms step_avg:36.79ms
+step:610/1490 train_time:22464ms step_avg:36.83ms
+step:611/1490 train_time:22518ms step_avg:36.85ms
+step:612/1490 train_time:22577ms step_avg:36.89ms
+step:613/1490 train_time:22632ms step_avg:36.92ms
+step:614/1490 train_time:22692ms step_avg:36.96ms
+step:615/1490 train_time:22746ms step_avg:36.99ms
+step:616/1490 train_time:22807ms step_avg:37.02ms
+step:617/1490 train_time:22861ms step_avg:37.05ms
+step:618/1490 train_time:22921ms step_avg:37.09ms
+step:619/1490 train_time:22974ms step_avg:37.11ms
+step:620/1490 train_time:23034ms step_avg:37.15ms
+step:621/1490 train_time:23089ms step_avg:37.18ms
+step:622/1490 train_time:23148ms step_avg:37.22ms
+step:623/1490 train_time:23202ms step_avg:37.24ms
+step:624/1490 train_time:23262ms step_avg:37.28ms
+step:625/1490 train_time:23315ms step_avg:37.30ms
+step:626/1490 train_time:23375ms step_avg:37.34ms
+step:627/1490 train_time:23430ms step_avg:37.37ms
+step:628/1490 train_time:23490ms step_avg:37.40ms
+step:629/1490 train_time:23544ms step_avg:37.43ms
+step:630/1490 train_time:23605ms step_avg:37.47ms
+step:631/1490 train_time:23660ms step_avg:37.50ms
+step:632/1490 train_time:23719ms step_avg:37.53ms
+step:633/1490 train_time:23773ms step_avg:37.56ms
+step:634/1490 train_time:23833ms step_avg:37.59ms
+step:635/1490 train_time:23888ms step_avg:37.62ms
+step:636/1490 train_time:23948ms step_avg:37.65ms
+step:637/1490 train_time:24003ms step_avg:37.68ms
+step:638/1490 train_time:24063ms step_avg:37.72ms
+step:639/1490 train_time:24117ms step_avg:37.74ms
+step:640/1490 train_time:24176ms step_avg:37.77ms
+step:641/1490 train_time:24230ms step_avg:37.80ms
+step:642/1490 train_time:24290ms step_avg:37.84ms
+step:643/1490 train_time:24345ms step_avg:37.86ms
+step:644/1490 train_time:24406ms step_avg:37.90ms
+step:645/1490 train_time:24460ms step_avg:37.92ms
+step:646/1490 train_time:24520ms step_avg:37.96ms
+step:647/1490 train_time:24573ms step_avg:37.98ms
+step:648/1490 train_time:24634ms step_avg:38.02ms
+step:649/1490 train_time:24689ms step_avg:38.04ms
+step:650/1490 train_time:24749ms step_avg:38.07ms
+step:651/1490 train_time:24803ms step_avg:38.10ms
+step:652/1490 train_time:24863ms step_avg:38.13ms
+step:653/1490 train_time:24917ms step_avg:38.16ms
+step:654/1490 train_time:24976ms step_avg:38.19ms
+step:655/1490 train_time:25031ms step_avg:38.21ms
+step:656/1490 train_time:25090ms step_avg:38.25ms
+step:657/1490 train_time:25144ms step_avg:38.27ms
+step:658/1490 train_time:25205ms step_avg:38.31ms
+step:659/1490 train_time:25260ms step_avg:38.33ms
+step:660/1490 train_time:25319ms step_avg:38.36ms
+step:661/1490 train_time:25373ms step_avg:38.39ms
+step:662/1490 train_time:25433ms step_avg:38.42ms
+step:663/1490 train_time:25487ms step_avg:38.44ms
+step:664/1490 train_time:25547ms step_avg:38.47ms
+step:665/1490 train_time:25602ms step_avg:38.50ms
+step:666/1490 train_time:25662ms step_avg:38.53ms
+step:667/1490 train_time:25715ms step_avg:38.55ms
+step:668/1490 train_time:25774ms step_avg:38.58ms
+step:669/1490 train_time:25829ms step_avg:38.61ms
+step:670/1490 train_time:25888ms step_avg:38.64ms
+step:671/1490 train_time:25943ms step_avg:38.66ms
+step:672/1490 train_time:26002ms step_avg:38.69ms
+step:673/1490 train_time:26056ms step_avg:38.72ms
+step:674/1490 train_time:26116ms step_avg:38.75ms
+step:675/1490 train_time:26170ms step_avg:38.77ms
+step:676/1490 train_time:26231ms step_avg:38.80ms
+step:677/1490 train_time:26285ms step_avg:38.83ms
+step:678/1490 train_time:26344ms step_avg:38.86ms
+step:679/1490 train_time:26398ms step_avg:38.88ms
+step:680/1490 train_time:26458ms step_avg:38.91ms
+step:681/1490 train_time:26512ms step_avg:38.93ms
+step:682/1490 train_time:26571ms step_avg:38.96ms
+step:683/1490 train_time:26627ms step_avg:38.98ms
+step:684/1490 train_time:26687ms step_avg:39.02ms
+step:685/1490 train_time:26741ms step_avg:39.04ms
+step:686/1490 train_time:26801ms step_avg:39.07ms
+step:687/1490 train_time:26854ms step_avg:39.09ms
+step:688/1490 train_time:26914ms step_avg:39.12ms
+step:689/1490 train_time:26968ms step_avg:39.14ms
+step:690/1490 train_time:27029ms step_avg:39.17ms
+step:691/1490 train_time:27083ms step_avg:39.19ms
+step:692/1490 train_time:27143ms step_avg:39.22ms
+step:693/1490 train_time:27198ms step_avg:39.25ms
+step:694/1490 train_time:27257ms step_avg:39.27ms
+step:695/1490 train_time:27311ms step_avg:39.30ms
+step:696/1490 train_time:27370ms step_avg:39.33ms
+step:697/1490 train_time:27425ms step_avg:39.35ms
+step:698/1490 train_time:27485ms step_avg:39.38ms
+step:699/1490 train_time:27539ms step_avg:39.40ms
+step:700/1490 train_time:27599ms step_avg:39.43ms
+step:701/1490 train_time:27653ms step_avg:39.45ms
+step:702/1490 train_time:27713ms step_avg:39.48ms
+step:703/1490 train_time:27768ms step_avg:39.50ms
+step:704/1490 train_time:27828ms step_avg:39.53ms
+step:705/1490 train_time:27883ms step_avg:39.55ms
+step:706/1490 train_time:27943ms step_avg:39.58ms
+step:707/1490 train_time:27996ms step_avg:39.60ms
+step:708/1490 train_time:28055ms step_avg:39.63ms
+step:709/1490 train_time:28110ms step_avg:39.65ms
+step:710/1490 train_time:28169ms step_avg:39.68ms
+step:711/1490 train_time:28224ms step_avg:39.70ms
+step:712/1490 train_time:28284ms step_avg:39.72ms
+step:713/1490 train_time:28338ms step_avg:39.74ms
+step:714/1490 train_time:28397ms step_avg:39.77ms
+step:715/1490 train_time:28451ms step_avg:39.79ms
+step:716/1490 train_time:28511ms step_avg:39.82ms
+step:717/1490 train_time:28566ms step_avg:39.84ms
+step:718/1490 train_time:28627ms step_avg:39.87ms
+step:719/1490 train_time:28681ms step_avg:39.89ms
+step:720/1490 train_time:28742ms step_avg:39.92ms
+step:721/1490 train_time:28796ms step_avg:39.94ms
+step:722/1490 train_time:28856ms step_avg:39.97ms
+step:723/1490 train_time:28910ms step_avg:39.99ms
+step:724/1490 train_time:28970ms step_avg:40.01ms
+step:725/1490 train_time:29024ms step_avg:40.03ms
+step:726/1490 train_time:29084ms step_avg:40.06ms
+step:727/1490 train_time:29137ms step_avg:40.08ms
+step:728/1490 train_time:29197ms step_avg:40.11ms
+step:729/1490 train_time:29251ms step_avg:40.13ms
+step:730/1490 train_time:29311ms step_avg:40.15ms
+step:731/1490 train_time:29366ms step_avg:40.17ms
+step:732/1490 train_time:29428ms step_avg:40.20ms
+step:733/1490 train_time:29481ms step_avg:40.22ms
+step:734/1490 train_time:29541ms step_avg:40.25ms
+step:735/1490 train_time:29595ms step_avg:40.27ms
+step:736/1490 train_time:29655ms step_avg:40.29ms
+step:737/1490 train_time:29710ms step_avg:40.31ms
+step:738/1490 train_time:29769ms step_avg:40.34ms
+step:739/1490 train_time:29824ms step_avg:40.36ms
+step:740/1490 train_time:29884ms step_avg:40.38ms
+step:741/1490 train_time:29938ms step_avg:40.40ms
+step:742/1490 train_time:29998ms step_avg:40.43ms
+step:743/1490 train_time:30052ms step_avg:40.45ms
+step:744/1490 train_time:30111ms step_avg:40.47ms
+step:745/1490 train_time:30166ms step_avg:40.49ms
+step:746/1490 train_time:30226ms step_avg:40.52ms
+step:747/1490 train_time:30279ms step_avg:40.53ms
+step:748/1490 train_time:30339ms step_avg:40.56ms
+step:749/1490 train_time:30393ms step_avg:40.58ms
+step:750/1490 train_time:30453ms step_avg:40.60ms
+step:750/1490 val_loss:3.8023 train_time:30525ms step_avg:40.70ms
+step:751/1490 train_time:30541ms step_avg:40.67ms
+step:752/1490 train_time:30569ms step_avg:40.65ms
+step:753/1490 train_time:30626ms step_avg:40.67ms
+step:754/1490 train_time:30690ms step_avg:40.70ms
+step:755/1490 train_time:30744ms step_avg:40.72ms
+step:756/1490 train_time:30805ms step_avg:40.75ms
+step:757/1490 train_time:30859ms step_avg:40.76ms
+step:758/1490 train_time:30918ms step_avg:40.79ms
+step:759/1490 train_time:30971ms step_avg:40.81ms
+step:760/1490 train_time:31030ms step_avg:40.83ms
+step:761/1490 train_time:31084ms step_avg:40.85ms
+step:762/1490 train_time:31144ms step_avg:40.87ms
+step:763/1490 train_time:31198ms step_avg:40.89ms
+step:764/1490 train_time:31256ms step_avg:40.91ms
+step:765/1490 train_time:31309ms step_avg:40.93ms
+step:766/1490 train_time:31368ms step_avg:40.95ms
+step:767/1490 train_time:31422ms step_avg:40.97ms
+step:768/1490 train_time:31484ms step_avg:41.00ms
+step:769/1490 train_time:31539ms step_avg:41.01ms
+step:770/1490 train_time:31601ms step_avg:41.04ms
+step:771/1490 train_time:31656ms step_avg:41.06ms
+step:772/1490 train_time:31717ms step_avg:41.08ms
+step:773/1490 train_time:31772ms step_avg:41.10ms
+step:774/1490 train_time:31832ms step_avg:41.13ms
+step:775/1490 train_time:31886ms step_avg:41.14ms
+step:776/1490 train_time:31946ms step_avg:41.17ms
+step:777/1490 train_time:31999ms step_avg:41.18ms
+step:778/1490 train_time:32059ms step_avg:41.21ms
+step:779/1490 train_time:32112ms step_avg:41.22ms
+step:780/1490 train_time:32171ms step_avg:41.25ms
+step:781/1490 train_time:32224ms step_avg:41.26ms
+step:782/1490 train_time:32284ms step_avg:41.28ms
+step:783/1490 train_time:32338ms step_avg:41.30ms
+step:784/1490 train_time:32398ms step_avg:41.32ms
+step:785/1490 train_time:32452ms step_avg:41.34ms
+step:786/1490 train_time:32512ms step_avg:41.36ms
+step:787/1490 train_time:32567ms step_avg:41.38ms
+step:788/1490 train_time:32627ms step_avg:41.41ms
+step:789/1490 train_time:32682ms step_avg:41.42ms
+step:790/1490 train_time:32745ms step_avg:41.45ms
+step:791/1490 train_time:32799ms step_avg:41.47ms
+step:792/1490 train_time:32860ms step_avg:41.49ms
+step:793/1490 train_time:32913ms step_avg:41.50ms
+step:794/1490 train_time:32972ms step_avg:41.53ms
+step:795/1490 train_time:33027ms step_avg:41.54ms
+step:796/1490 train_time:33087ms step_avg:41.57ms
+step:797/1490 train_time:33140ms step_avg:41.58ms
+step:798/1490 train_time:33200ms step_avg:41.60ms
+step:799/1490 train_time:33254ms step_avg:41.62ms
+step:800/1490 train_time:33313ms step_avg:41.64ms
+step:801/1490 train_time:33367ms step_avg:41.66ms
+step:802/1490 train_time:33427ms step_avg:41.68ms
+step:803/1490 train_time:33482ms step_avg:41.70ms
+step:804/1490 train_time:33542ms step_avg:41.72ms
+step:805/1490 train_time:33596ms step_avg:41.73ms
+step:806/1490 train_time:33656ms step_avg:41.76ms
+step:807/1490 train_time:33711ms step_avg:41.77ms
+step:808/1490 train_time:33770ms step_avg:41.79ms
+step:809/1490 train_time:33826ms step_avg:41.81ms
+step:810/1490 train_time:33885ms step_avg:41.83ms
+step:811/1490 train_time:33939ms step_avg:41.85ms
+step:812/1490 train_time:33999ms step_avg:41.87ms
+step:813/1490 train_time:34053ms step_avg:41.89ms
+step:814/1490 train_time:34113ms step_avg:41.91ms
+step:815/1490 train_time:34166ms step_avg:41.92ms
+step:816/1490 train_time:34226ms step_avg:41.94ms
+step:817/1490 train_time:34281ms step_avg:41.96ms
+step:818/1490 train_time:34341ms step_avg:41.98ms
+step:819/1490 train_time:34396ms step_avg:42.00ms
+step:820/1490 train_time:34456ms step_avg:42.02ms
+step:821/1490 train_time:34509ms step_avg:42.03ms
+step:822/1490 train_time:34569ms step_avg:42.05ms
+step:823/1490 train_time:34625ms step_avg:42.07ms
+step:824/1490 train_time:34686ms step_avg:42.09ms
+step:825/1490 train_time:34740ms step_avg:42.11ms
+step:826/1490 train_time:34801ms step_avg:42.13ms
+step:827/1490 train_time:34855ms step_avg:42.15ms
+step:828/1490 train_time:34913ms step_avg:42.17ms
+step:829/1490 train_time:34968ms step_avg:42.18ms
+step:830/1490 train_time:35027ms step_avg:42.20ms
+step:831/1490 train_time:35082ms step_avg:42.22ms
+step:832/1490 train_time:35141ms step_avg:42.24ms
+step:833/1490 train_time:35195ms step_avg:42.25ms
+step:834/1490 train_time:35255ms step_avg:42.27ms
+step:835/1490 train_time:35309ms step_avg:42.29ms
+step:836/1490 train_time:35368ms step_avg:42.31ms
+step:837/1490 train_time:35422ms step_avg:42.32ms
+step:838/1490 train_time:35482ms step_avg:42.34ms
+step:839/1490 train_time:35536ms step_avg:42.36ms
+step:840/1490 train_time:35596ms step_avg:42.38ms
+step:841/1490 train_time:35651ms step_avg:42.39ms
+step:842/1490 train_time:35711ms step_avg:42.41ms
+step:843/1490 train_time:35765ms step_avg:42.43ms
+step:844/1490 train_time:35825ms step_avg:42.45ms
+step:845/1490 train_time:35880ms step_avg:42.46ms
+step:846/1490 train_time:35941ms step_avg:42.48ms
+step:847/1490 train_time:35995ms step_avg:42.50ms
+step:848/1490 train_time:36054ms step_avg:42.52ms
+step:849/1490 train_time:36108ms step_avg:42.53ms
+step:850/1490 train_time:36167ms step_avg:42.55ms
+step:851/1490 train_time:36221ms step_avg:42.56ms
+step:852/1490 train_time:36281ms step_avg:42.58ms
+step:853/1490 train_time:36335ms step_avg:42.60ms
+step:854/1490 train_time:36394ms step_avg:42.62ms
+step:855/1490 train_time:36448ms step_avg:42.63ms
+step:856/1490 train_time:36508ms step_avg:42.65ms
+step:857/1490 train_time:36562ms step_avg:42.66ms
+step:858/1490 train_time:36623ms step_avg:42.68ms
+step:859/1490 train_time:36677ms step_avg:42.70ms
+step:860/1490 train_time:36738ms step_avg:42.72ms
+step:861/1490 train_time:36792ms step_avg:42.73ms
+step:862/1490 train_time:36852ms step_avg:42.75ms
+step:863/1490 train_time:36906ms step_avg:42.77ms
+step:864/1490 train_time:36966ms step_avg:42.78ms
+step:865/1490 train_time:37021ms step_avg:42.80ms
+step:866/1490 train_time:37081ms step_avg:42.82ms
+step:867/1490 train_time:37134ms step_avg:42.83ms
+step:868/1490 train_time:37193ms step_avg:42.85ms
+step:869/1490 train_time:37248ms step_avg:42.86ms
+step:870/1490 train_time:37307ms step_avg:42.88ms
+step:871/1490 train_time:37361ms step_avg:42.89ms
+step:872/1490 train_time:37422ms step_avg:42.92ms
+step:873/1490 train_time:37477ms step_avg:42.93ms
+step:874/1490 train_time:37536ms step_avg:42.95ms
+step:875/1490 train_time:37591ms step_avg:42.96ms
+step:876/1490 train_time:37651ms step_avg:42.98ms
+step:877/1490 train_time:37705ms step_avg:42.99ms
+step:878/1490 train_time:37765ms step_avg:43.01ms
+step:879/1490 train_time:37820ms step_avg:43.03ms
+step:880/1490 train_time:37880ms step_avg:43.05ms
+step:881/1490 train_time:37933ms step_avg:43.06ms
+step:882/1490 train_time:37994ms step_avg:43.08ms
+step:883/1490 train_time:38048ms step_avg:43.09ms
+step:884/1490 train_time:38107ms step_avg:43.11ms
+step:885/1490 train_time:38161ms step_avg:43.12ms
+step:886/1490 train_time:38221ms step_avg:43.14ms
+step:887/1490 train_time:38275ms step_avg:43.15ms
+step:888/1490 train_time:38335ms step_avg:43.17ms
+step:889/1490 train_time:38389ms step_avg:43.18ms
+step:890/1490 train_time:38449ms step_avg:43.20ms
+step:891/1490 train_time:38503ms step_avg:43.21ms
+step:892/1490 train_time:38563ms step_avg:43.23ms
+step:893/1490 train_time:38618ms step_avg:43.25ms
+step:894/1490 train_time:38678ms step_avg:43.26ms
+step:895/1490 train_time:38731ms step_avg:43.27ms
+step:896/1490 train_time:38791ms step_avg:43.29ms
+step:897/1490 train_time:38846ms step_avg:43.31ms
+step:898/1490 train_time:38906ms step_avg:43.33ms
+step:899/1490 train_time:38960ms step_avg:43.34ms
+step:900/1490 train_time:39020ms step_avg:43.36ms
+step:901/1490 train_time:39074ms step_avg:43.37ms
+step:902/1490 train_time:39133ms step_avg:43.39ms
+step:903/1490 train_time:39188ms step_avg:43.40ms
+step:904/1490 train_time:39248ms step_avg:43.42ms
+step:905/1490 train_time:39302ms step_avg:43.43ms
+step:906/1490 train_time:39362ms step_avg:43.45ms
+step:907/1490 train_time:39417ms step_avg:43.46ms
+step:908/1490 train_time:39476ms step_avg:43.48ms
+step:909/1490 train_time:39530ms step_avg:43.49ms
+step:910/1490 train_time:39590ms step_avg:43.51ms
+step:911/1490 train_time:39644ms step_avg:43.52ms
+step:912/1490 train_time:39704ms step_avg:43.54ms
+step:913/1490 train_time:39759ms step_avg:43.55ms
+step:914/1490 train_time:39818ms step_avg:43.57ms
+step:915/1490 train_time:39872ms step_avg:43.58ms
+step:916/1490 train_time:39931ms step_avg:43.59ms
+step:917/1490 train_time:39986ms step_avg:43.61ms
+step:918/1490 train_time:40046ms step_avg:43.62ms
+step:919/1490 train_time:40100ms step_avg:43.63ms
+step:920/1490 train_time:40161ms step_avg:43.65ms
+step:921/1490 train_time:40215ms step_avg:43.66ms
+step:922/1490 train_time:40274ms step_avg:43.68ms
+step:923/1490 train_time:40328ms step_avg:43.69ms
+step:924/1490 train_time:40388ms step_avg:43.71ms
+step:925/1490 train_time:40442ms step_avg:43.72ms
+step:926/1490 train_time:40503ms step_avg:43.74ms
+step:927/1490 train_time:40557ms step_avg:43.75ms
+step:928/1490 train_time:40616ms step_avg:43.77ms
+step:929/1490 train_time:40669ms step_avg:43.78ms
+step:930/1490 train_time:40729ms step_avg:43.79ms
+step:931/1490 train_time:40784ms step_avg:43.81ms
+step:932/1490 train_time:40845ms step_avg:43.83ms
+step:933/1490 train_time:40899ms step_avg:43.84ms
+step:934/1490 train_time:40960ms step_avg:43.85ms
+step:935/1490 train_time:41013ms step_avg:43.86ms
+step:936/1490 train_time:41073ms step_avg:43.88ms
+step:937/1490 train_time:41127ms step_avg:43.89ms
+step:938/1490 train_time:41187ms step_avg:43.91ms
+step:939/1490 train_time:41241ms step_avg:43.92ms
+step:940/1490 train_time:41301ms step_avg:43.94ms
+step:941/1490 train_time:41356ms step_avg:43.95ms
+step:942/1490 train_time:41415ms step_avg:43.96ms
+step:943/1490 train_time:41469ms step_avg:43.98ms
+step:944/1490 train_time:41530ms step_avg:43.99ms
+step:945/1490 train_time:41584ms step_avg:44.00ms
+step:946/1490 train_time:41644ms step_avg:44.02ms
+step:947/1490 train_time:41698ms step_avg:44.03ms
+step:948/1490 train_time:41757ms step_avg:44.05ms
+step:949/1490 train_time:41811ms step_avg:44.06ms
+step:950/1490 train_time:41871ms step_avg:44.08ms
+step:951/1490 train_time:41926ms step_avg:44.09ms
+step:952/1490 train_time:41986ms step_avg:44.10ms
+step:953/1490 train_time:42041ms step_avg:44.11ms
+step:954/1490 train_time:42102ms step_avg:44.13ms
+step:955/1490 train_time:42157ms step_avg:44.14ms
+step:956/1490 train_time:42216ms step_avg:44.16ms
+step:957/1490 train_time:42270ms step_avg:44.17ms
+step:958/1490 train_time:42329ms step_avg:44.19ms
+step:959/1490 train_time:42384ms step_avg:44.20ms
+step:960/1490 train_time:42444ms step_avg:44.21ms
+step:961/1490 train_time:42498ms step_avg:44.22ms
+step:962/1490 train_time:42558ms step_avg:44.24ms
+step:963/1490 train_time:42611ms step_avg:44.25ms
+step:964/1490 train_time:42671ms step_avg:44.26ms
+step:965/1490 train_time:42725ms step_avg:44.27ms
+step:966/1490 train_time:42785ms step_avg:44.29ms
+step:967/1490 train_time:42839ms step_avg:44.30ms
+step:968/1490 train_time:42903ms step_avg:44.32ms
+step:969/1490 train_time:42981ms step_avg:44.36ms
+step:970/1490 train_time:43070ms step_avg:44.40ms
+step:971/1490 train_time:43149ms step_avg:44.44ms
+step:972/1490 train_time:43235ms step_avg:44.48ms
+step:973/1490 train_time:43317ms step_avg:44.52ms
+step:974/1490 train_time:43403ms step_avg:44.56ms
+step:975/1490 train_time:43484ms step_avg:44.60ms
+step:976/1490 train_time:43572ms step_avg:44.64ms
+step:977/1490 train_time:43652ms step_avg:44.68ms
+step:978/1490 train_time:43738ms step_avg:44.72ms
+step:979/1490 train_time:43820ms step_avg:44.76ms
+step:980/1490 train_time:43907ms step_avg:44.80ms
+step:981/1490 train_time:43987ms step_avg:44.84ms
+step:982/1490 train_time:44075ms step_avg:44.88ms
+step:983/1490 train_time:44154ms step_avg:44.92ms
+step:984/1490 train_time:44240ms step_avg:44.96ms
+step:985/1490 train_time:44323ms step_avg:45.00ms
+step:986/1490 train_time:44409ms step_avg:45.04ms
+step:987/1490 train_time:44491ms step_avg:45.08ms
+step:988/1490 train_time:44577ms step_avg:45.12ms
+step:989/1490 train_time:44658ms step_avg:45.15ms
+step:990/1490 train_time:44745ms step_avg:45.20ms
+step:991/1490 train_time:44824ms step_avg:45.23ms
+step:992/1490 train_time:44912ms step_avg:45.27ms
+step:993/1490 train_time:44994ms step_avg:45.31ms
+step:994/1490 train_time:45080ms step_avg:45.35ms
+step:995/1490 train_time:45160ms step_avg:45.39ms
+step:996/1490 train_time:45247ms step_avg:45.43ms
+step:997/1490 train_time:45327ms step_avg:45.46ms
+step:998/1490 train_time:45413ms step_avg:45.50ms
+step:999/1490 train_time:45495ms step_avg:45.54ms
+step:1000/1490 train_time:45582ms step_avg:45.58ms
+step:1000/1490 val_loss:3.5147 train_time:45686ms step_avg:45.69ms
+step:1001/1490 train_time:45702ms step_avg:45.66ms
+step:1002/1490 train_time:45752ms step_avg:45.66ms
+step:1003/1490 train_time:45836ms step_avg:45.70ms
+step:1004/1490 train_time:45928ms step_avg:45.74ms
+step:1005/1490 train_time:46010ms step_avg:45.78ms
+step:1006/1490 train_time:46095ms step_avg:45.82ms
+step:1007/1490 train_time:46176ms step_avg:45.86ms
+step:1008/1490 train_time:46260ms step_avg:45.89ms
+step:1009/1490 train_time:46340ms step_avg:45.93ms
+step:1010/1490 train_time:46425ms step_avg:45.97ms
+step:1011/1490 train_time:46505ms step_avg:46.00ms
+step:1012/1490 train_time:46591ms step_avg:46.04ms
+step:1013/1490 train_time:46672ms step_avg:46.07ms
+step:1014/1490 train_time:46761ms step_avg:46.12ms
+step:1015/1490 train_time:46844ms step_avg:46.15ms
+step:1016/1490 train_time:46931ms step_avg:46.19ms
+step:1017/1490 train_time:47014ms step_avg:46.23ms
+step:1018/1490 train_time:47101ms step_avg:46.27ms
+step:1019/1490 train_time:47182ms step_avg:46.30ms
+step:1020/1490 train_time:47267ms step_avg:46.34ms
+step:1021/1490 train_time:47346ms step_avg:46.37ms
+step:1022/1490 train_time:47432ms step_avg:46.41ms
+step:1023/1490 train_time:47511ms step_avg:46.44ms
+step:1024/1490 train_time:47597ms step_avg:46.48ms
+step:1025/1490 train_time:47679ms step_avg:46.52ms
+step:1026/1490 train_time:47766ms step_avg:46.56ms
+step:1027/1490 train_time:47849ms step_avg:46.59ms
+step:1028/1490 train_time:47937ms step_avg:46.63ms
+step:1029/1490 train_time:48020ms step_avg:46.67ms
+step:1030/1490 train_time:48105ms step_avg:46.70ms
+step:1031/1490 train_time:48185ms step_avg:46.74ms
+step:1032/1490 train_time:48270ms step_avg:46.77ms
+step:1033/1490 train_time:48352ms step_avg:46.81ms
+step:1034/1490 train_time:48438ms step_avg:46.85ms
+step:1035/1490 train_time:48518ms step_avg:46.88ms
+step:1036/1490 train_time:48605ms step_avg:46.92ms
+step:1037/1490 train_time:48687ms step_avg:46.95ms
+step:1038/1490 train_time:48774ms step_avg:46.99ms
+step:1039/1490 train_time:48854ms step_avg:47.02ms
+step:1040/1490 train_time:48941ms step_avg:47.06ms
+step:1041/1490 train_time:49022ms step_avg:47.09ms
+step:1042/1490 train_time:49108ms step_avg:47.13ms
+step:1043/1490 train_time:49189ms step_avg:47.16ms
+step:1044/1490 train_time:49275ms step_avg:47.20ms
+step:1045/1490 train_time:49355ms step_avg:47.23ms
+step:1046/1490 train_time:49441ms step_avg:47.27ms
+step:1047/1490 train_time:49521ms step_avg:47.30ms
+step:1048/1490 train_time:49607ms step_avg:47.33ms
+step:1049/1490 train_time:49688ms step_avg:47.37ms
+step:1050/1490 train_time:49775ms step_avg:47.40ms
+step:1051/1490 train_time:49856ms step_avg:47.44ms
+step:1052/1490 train_time:49944ms step_avg:47.48ms
+step:1053/1490 train_time:50025ms step_avg:47.51ms
+step:1054/1490 train_time:50111ms step_avg:47.54ms
+step:1055/1490 train_time:50191ms step_avg:47.57ms
+step:1056/1490 train_time:50277ms step_avg:47.61ms
+step:1057/1490 train_time:50358ms step_avg:47.64ms
+step:1058/1490 train_time:50444ms step_avg:47.68ms
+step:1059/1490 train_time:50525ms step_avg:47.71ms
+step:1060/1490 train_time:50611ms step_avg:47.75ms
+step:1061/1490 train_time:50693ms step_avg:47.78ms
+step:1062/1490 train_time:50780ms step_avg:47.82ms
+step:1063/1490 train_time:50862ms step_avg:47.85ms
+step:1064/1490 train_time:50948ms step_avg:47.88ms
+step:1065/1490 train_time:51029ms step_avg:47.91ms
+step:1066/1490 train_time:51115ms step_avg:47.95ms
+step:1067/1490 train_time:51196ms step_avg:47.98ms
+step:1068/1490 train_time:51282ms step_avg:48.02ms
+step:1069/1490 train_time:51363ms step_avg:48.05ms
+step:1070/1490 train_time:51449ms step_avg:48.08ms
+step:1071/1490 train_time:51529ms step_avg:48.11ms
+step:1072/1490 train_time:51615ms step_avg:48.15ms
+step:1073/1490 train_time:51696ms step_avg:48.18ms
+step:1074/1490 train_time:51783ms step_avg:48.22ms
+step:1075/1490 train_time:51864ms step_avg:48.25ms
+step:1076/1490 train_time:51950ms step_avg:48.28ms
+step:1077/1490 train_time:52032ms step_avg:48.31ms
+step:1078/1490 train_time:52118ms step_avg:48.35ms
+step:1079/1490 train_time:52200ms step_avg:48.38ms
+step:1080/1490 train_time:52286ms step_avg:48.41ms
+step:1081/1490 train_time:52366ms step_avg:48.44ms
+step:1082/1490 train_time:52452ms step_avg:48.48ms
+step:1083/1490 train_time:52533ms step_avg:48.51ms
+step:1084/1490 train_time:52620ms step_avg:48.54ms
+step:1085/1490 train_time:52702ms step_avg:48.57ms
+step:1086/1490 train_time:52788ms step_avg:48.61ms
+step:1087/1490 train_time:52869ms step_avg:48.64ms
+step:1088/1490 train_time:52956ms step_avg:48.67ms
+step:1089/1490 train_time:53036ms step_avg:48.70ms
+step:1090/1490 train_time:53124ms step_avg:48.74ms
+step:1091/1490 train_time:53205ms step_avg:48.77ms
+step:1092/1490 train_time:53291ms step_avg:48.80ms
+step:1093/1490 train_time:53371ms step_avg:48.83ms
+step:1094/1490 train_time:53457ms step_avg:48.86ms
+step:1095/1490 train_time:53538ms step_avg:48.89ms
+step:1096/1490 train_time:53624ms step_avg:48.93ms
+step:1097/1490 train_time:53705ms step_avg:48.96ms
+step:1098/1490 train_time:53791ms step_avg:48.99ms
+step:1099/1490 train_time:53873ms step_avg:49.02ms
+step:1100/1490 train_time:53960ms step_avg:49.05ms
+step:1101/1490 train_time:54041ms step_avg:49.08ms
+step:1102/1490 train_time:54126ms step_avg:49.12ms
+step:1103/1490 train_time:54208ms step_avg:49.15ms
+step:1104/1490 train_time:54295ms step_avg:49.18ms
+step:1105/1490 train_time:54376ms step_avg:49.21ms
+step:1106/1490 train_time:54463ms step_avg:49.24ms
+step:1107/1490 train_time:54543ms step_avg:49.27ms
+step:1108/1490 train_time:54630ms step_avg:49.30ms
+step:1109/1490 train_time:54711ms step_avg:49.33ms
+step:1110/1490 train_time:54797ms step_avg:49.37ms
+step:1111/1490 train_time:54878ms step_avg:49.40ms
+step:1112/1490 train_time:54965ms step_avg:49.43ms
+step:1113/1490 train_time:55047ms step_avg:49.46ms
+step:1114/1490 train_time:55132ms step_avg:49.49ms
+step:1115/1490 train_time:55213ms step_avg:49.52ms
+step:1116/1490 train_time:55299ms step_avg:49.55ms
+step:1117/1490 train_time:55380ms step_avg:49.58ms
+step:1118/1490 train_time:55466ms step_avg:49.61ms
+step:1119/1490 train_time:55546ms step_avg:49.64ms
+step:1120/1490 train_time:55632ms step_avg:49.67ms
+step:1121/1490 train_time:55713ms step_avg:49.70ms
+step:1122/1490 train_time:55801ms step_avg:49.73ms
+step:1123/1490 train_time:55885ms step_avg:49.76ms
+step:1124/1490 train_time:55971ms step_avg:49.80ms
+step:1125/1490 train_time:56052ms step_avg:49.82ms
+step:1126/1490 train_time:56139ms step_avg:49.86ms
+step:1127/1490 train_time:56218ms step_avg:49.88ms
+step:1128/1490 train_time:56305ms step_avg:49.92ms
+step:1129/1490 train_time:56386ms step_avg:49.94ms
+step:1130/1490 train_time:56472ms step_avg:49.98ms
+step:1131/1490 train_time:56553ms step_avg:50.00ms
+step:1132/1490 train_time:56639ms step_avg:50.03ms
+step:1133/1490 train_time:56720ms step_avg:50.06ms
+step:1134/1490 train_time:56806ms step_avg:50.09ms
+step:1135/1490 train_time:56888ms step_avg:50.12ms
+step:1136/1490 train_time:56974ms step_avg:50.15ms
+step:1137/1490 train_time:57056ms step_avg:50.18ms
+step:1138/1490 train_time:57143ms step_avg:50.21ms
+step:1139/1490 train_time:57223ms step_avg:50.24ms
+step:1140/1490 train_time:57309ms step_avg:50.27ms
+step:1141/1490 train_time:57390ms step_avg:50.30ms
+step:1142/1490 train_time:57477ms step_avg:50.33ms
+step:1143/1490 train_time:57558ms step_avg:50.36ms
+step:1144/1490 train_time:57644ms step_avg:50.39ms
+step:1145/1490 train_time:57725ms step_avg:50.41ms
+step:1146/1490 train_time:57811ms step_avg:50.45ms
+step:1147/1490 train_time:57894ms step_avg:50.47ms
+step:1148/1490 train_time:57980ms step_avg:50.51ms
+step:1149/1490 train_time:58060ms step_avg:50.53ms
+step:1150/1490 train_time:58147ms step_avg:50.56ms
+step:1151/1490 train_time:58227ms step_avg:50.59ms
+step:1152/1490 train_time:58314ms step_avg:50.62ms
+step:1153/1490 train_time:58395ms step_avg:50.65ms
+step:1154/1490 train_time:58482ms step_avg:50.68ms
+step:1155/1490 train_time:58562ms step_avg:50.70ms
+step:1156/1490 train_time:58648ms step_avg:50.73ms
+step:1157/1490 train_time:58729ms step_avg:50.76ms
+step:1158/1490 train_time:58815ms step_avg:50.79ms
+step:1159/1490 train_time:58897ms step_avg:50.82ms
+step:1160/1490 train_time:58982ms step_avg:50.85ms
+step:1161/1490 train_time:59063ms step_avg:50.87ms
+step:1162/1490 train_time:59148ms step_avg:50.90ms
+step:1163/1490 train_time:59231ms step_avg:50.93ms
+step:1164/1490 train_time:59316ms step_avg:50.96ms
+step:1165/1490 train_time:59396ms step_avg:50.98ms
+step:1166/1490 train_time:59484ms step_avg:51.02ms
+step:1167/1490 train_time:59563ms step_avg:51.04ms
+step:1168/1490 train_time:59651ms step_avg:51.07ms
+step:1169/1490 train_time:59731ms step_avg:51.10ms
+step:1170/1490 train_time:59819ms step_avg:51.13ms
+step:1171/1490 train_time:59900ms step_avg:51.15ms
+step:1172/1490 train_time:59987ms step_avg:51.18ms
+step:1173/1490 train_time:60068ms step_avg:51.21ms
+step:1174/1490 train_time:60156ms step_avg:51.24ms
+step:1175/1490 train_time:60238ms step_avg:51.27ms
+step:1176/1490 train_time:60324ms step_avg:51.30ms
+step:1177/1490 train_time:60405ms step_avg:51.32ms
+step:1178/1490 train_time:60490ms step_avg:51.35ms
+step:1179/1490 train_time:60571ms step_avg:51.38ms
+step:1180/1490 train_time:60660ms step_avg:51.41ms
+step:1181/1490 train_time:60741ms step_avg:51.43ms
+step:1182/1490 train_time:60827ms step_avg:51.46ms
+step:1183/1490 train_time:60909ms step_avg:51.49ms
+step:1184/1490 train_time:60995ms step_avg:51.52ms
+step:1185/1490 train_time:61076ms step_avg:51.54ms
+step:1186/1490 train_time:61162ms step_avg:51.57ms
+step:1187/1490 train_time:61243ms step_avg:51.59ms
+step:1188/1490 train_time:61330ms step_avg:51.62ms
+step:1189/1490 train_time:61411ms step_avg:51.65ms
+step:1190/1490 train_time:61497ms step_avg:51.68ms
+step:1191/1490 train_time:61577ms step_avg:51.70ms
+step:1192/1490 train_time:61663ms step_avg:51.73ms
+step:1193/1490 train_time:61745ms step_avg:51.76ms
+step:1194/1490 train_time:61832ms step_avg:51.79ms
+step:1195/1490 train_time:61912ms step_avg:51.81ms
+step:1196/1490 train_time:61999ms step_avg:51.84ms
+step:1197/1490 train_time:62079ms step_avg:51.86ms
+step:1198/1490 train_time:62165ms step_avg:51.89ms
+step:1199/1490 train_time:62247ms step_avg:51.92ms
+step:1200/1490 train_time:62334ms step_avg:51.94ms
+step:1201/1490 train_time:62416ms step_avg:51.97ms
+step:1202/1490 train_time:62502ms step_avg:52.00ms
+step:1203/1490 train_time:62584ms step_avg:52.02ms
+step:1204/1490 train_time:62669ms step_avg:52.05ms
+step:1205/1490 train_time:62750ms step_avg:52.07ms
+step:1206/1490 train_time:62837ms step_avg:52.10ms
+step:1207/1490 train_time:62919ms step_avg:52.13ms
+step:1208/1490 train_time:63005ms step_avg:52.16ms
+step:1209/1490 train_time:63086ms step_avg:52.18ms
+step:1210/1490 train_time:63172ms step_avg:52.21ms
+step:1211/1490 train_time:63253ms step_avg:52.23ms
+step:1212/1490 train_time:63339ms step_avg:52.26ms
+step:1213/1490 train_time:63421ms step_avg:52.28ms
+step:1214/1490 train_time:63507ms step_avg:52.31ms
+step:1215/1490 train_time:63587ms step_avg:52.34ms
+step:1216/1490 train_time:63673ms step_avg:52.36ms
+step:1217/1490 train_time:63753ms step_avg:52.39ms
+step:1218/1490 train_time:63840ms step_avg:52.41ms
+step:1219/1490 train_time:63921ms step_avg:52.44ms
+step:1220/1490 train_time:64008ms step_avg:52.47ms
+step:1221/1490 train_time:64090ms step_avg:52.49ms
+step:1222/1490 train_time:64176ms step_avg:52.52ms
+step:1223/1490 train_time:64257ms step_avg:52.54ms
+step:1224/1490 train_time:64344ms step_avg:52.57ms
+step:1225/1490 train_time:64425ms step_avg:52.59ms
+step:1226/1490 train_time:64512ms step_avg:52.62ms
+step:1227/1490 train_time:64594ms step_avg:52.64ms
+step:1228/1490 train_time:64681ms step_avg:52.67ms
+step:1229/1490 train_time:64762ms step_avg:52.69ms
+step:1230/1490 train_time:64847ms step_avg:52.72ms
+step:1231/1490 train_time:64928ms step_avg:52.74ms
+step:1232/1490 train_time:65014ms step_avg:52.77ms
+step:1233/1490 train_time:65095ms step_avg:52.79ms
+step:1234/1490 train_time:65183ms step_avg:52.82ms
+step:1235/1490 train_time:65264ms step_avg:52.85ms
+step:1236/1490 train_time:65349ms step_avg:52.87ms
+step:1237/1490 train_time:65431ms step_avg:52.89ms
+step:1238/1490 train_time:65517ms step_avg:52.92ms
+step:1239/1490 train_time:65598ms step_avg:52.94ms
+step:1240/1490 train_time:65685ms step_avg:52.97ms
+step:1241/1490 train_time:65766ms step_avg:52.99ms
+step:1242/1490 train_time:65852ms step_avg:53.02ms
+step:1243/1490 train_time:65935ms step_avg:53.04ms
+step:1244/1490 train_time:66020ms step_avg:53.07ms
+step:1245/1490 train_time:66101ms step_avg:53.09ms
+step:1246/1490 train_time:66188ms step_avg:53.12ms
+step:1247/1490 train_time:66269ms step_avg:53.14ms
+step:1248/1490 train_time:66356ms step_avg:53.17ms
+step:1249/1490 train_time:66438ms step_avg:53.19ms
+step:1250/1490 train_time:66525ms step_avg:53.22ms
+step:1250/1490 val_loss:3.3700 train_time:66628ms step_avg:53.30ms
+step:1251/1490 train_time:66644ms step_avg:53.27ms
+step:1252/1490 train_time:66698ms step_avg:53.27ms
+step:1253/1490 train_time:66782ms step_avg:53.30ms
+step:1254/1490 train_time:66869ms step_avg:53.32ms
+step:1255/1490 train_time:66950ms step_avg:53.35ms
+step:1256/1490 train_time:67037ms step_avg:53.37ms
+step:1257/1490 train_time:67117ms step_avg:53.39ms
+step:1258/1490 train_time:67202ms step_avg:53.42ms
+step:1259/1490 train_time:67281ms step_avg:53.44ms
+step:1260/1490 train_time:67364ms step_avg:53.46ms
+step:1261/1490 train_time:67444ms step_avg:53.48ms
+step:1262/1490 train_time:67531ms step_avg:53.51ms
+step:1263/1490 train_time:67614ms step_avg:53.53ms
+step:1264/1490 train_time:67703ms step_avg:53.56ms
+step:1265/1490 train_time:67786ms step_avg:53.59ms
+step:1266/1490 train_time:67874ms step_avg:53.61ms
+step:1267/1490 train_time:67956ms step_avg:53.64ms
+step:1268/1490 train_time:68041ms step_avg:53.66ms
+step:1269/1490 train_time:68122ms step_avg:53.68ms
+step:1270/1490 train_time:68208ms step_avg:53.71ms
+step:1271/1490 train_time:68289ms step_avg:53.73ms
+step:1272/1490 train_time:68374ms step_avg:53.75ms
+step:1273/1490 train_time:68452ms step_avg:53.77ms
+step:1274/1490 train_time:68538ms step_avg:53.80ms
+step:1275/1490 train_time:68620ms step_avg:53.82ms
+step:1276/1490 train_time:68709ms step_avg:53.85ms
+step:1277/1490 train_time:68794ms step_avg:53.87ms
+step:1278/1490 train_time:68880ms step_avg:53.90ms
+step:1279/1490 train_time:68962ms step_avg:53.92ms
+step:1280/1490 train_time:69048ms step_avg:53.94ms
+step:1281/1490 train_time:69127ms step_avg:53.96ms
+step:1282/1490 train_time:69214ms step_avg:53.99ms
+step:1283/1490 train_time:69294ms step_avg:54.01ms
+step:1284/1490 train_time:69379ms step_avg:54.03ms
+step:1285/1490 train_time:69460ms step_avg:54.05ms
+step:1286/1490 train_time:69548ms step_avg:54.08ms
+step:1287/1490 train_time:69629ms step_avg:54.10ms
+step:1288/1490 train_time:69717ms step_avg:54.13ms
+step:1289/1490 train_time:69800ms step_avg:54.15ms
+step:1290/1490 train_time:69887ms step_avg:54.18ms
+step:1291/1490 train_time:69968ms step_avg:54.20ms
+step:1292/1490 train_time:70053ms step_avg:54.22ms
+step:1293/1490 train_time:70134ms step_avg:54.24ms
+step:1294/1490 train_time:70220ms step_avg:54.27ms
+step:1295/1490 train_time:70301ms step_avg:54.29ms
+step:1296/1490 train_time:70388ms step_avg:54.31ms
+step:1297/1490 train_time:70468ms step_avg:54.33ms
+step:1298/1490 train_time:70553ms step_avg:54.36ms
+step:1299/1490 train_time:70634ms step_avg:54.38ms
+step:1300/1490 train_time:70720ms step_avg:54.40ms
+step:1301/1490 train_time:70801ms step_avg:54.42ms
+step:1302/1490 train_time:70889ms step_avg:54.45ms
+step:1303/1490 train_time:70969ms step_avg:54.47ms
+step:1304/1490 train_time:71055ms step_avg:54.49ms
+step:1305/1490 train_time:71136ms step_avg:54.51ms
+step:1306/1490 train_time:71222ms step_avg:54.53ms
+step:1307/1490 train_time:71302ms step_avg:54.55ms
+step:1308/1490 train_time:71388ms step_avg:54.58ms
+step:1309/1490 train_time:71469ms step_avg:54.60ms
+step:1310/1490 train_time:71556ms step_avg:54.62ms
+step:1311/1490 train_time:71636ms step_avg:54.64ms
+step:1312/1490 train_time:71722ms step_avg:54.67ms
+step:1313/1490 train_time:71805ms step_avg:54.69ms
+step:1314/1490 train_time:71892ms step_avg:54.71ms
+step:1315/1490 train_time:71973ms step_avg:54.73ms
+step:1316/1490 train_time:72060ms step_avg:54.76ms
+step:1317/1490 train_time:72141ms step_avg:54.78ms
+step:1318/1490 train_time:72228ms step_avg:54.80ms
+step:1319/1490 train_time:72307ms step_avg:54.82ms
+step:1320/1490 train_time:72393ms step_avg:54.84ms
+step:1321/1490 train_time:72473ms step_avg:54.86ms
+step:1322/1490 train_time:72560ms step_avg:54.89ms
+step:1323/1490 train_time:72641ms step_avg:54.91ms
+step:1324/1490 train_time:72730ms step_avg:54.93ms
+step:1325/1490 train_time:72812ms step_avg:54.95ms
+step:1326/1490 train_time:72898ms step_avg:54.98ms
+step:1327/1490 train_time:72980ms step_avg:55.00ms
+step:1328/1490 train_time:73066ms step_avg:55.02ms
+step:1329/1490 train_time:73146ms step_avg:55.04ms
+step:1330/1490 train_time:73233ms step_avg:55.06ms
+step:1331/1490 train_time:73314ms step_avg:55.08ms
+step:1332/1490 train_time:73400ms step_avg:55.10ms
+step:1333/1490 train_time:73482ms step_avg:55.13ms
+step:1334/1490 train_time:73568ms step_avg:55.15ms
+step:1335/1490 train_time:73649ms step_avg:55.17ms
+step:1336/1490 train_time:73736ms step_avg:55.19ms
+step:1337/1490 train_time:73817ms step_avg:55.21ms
+step:1338/1490 train_time:73903ms step_avg:55.23ms
+step:1339/1490 train_time:73984ms step_avg:55.25ms
+step:1340/1490 train_time:74071ms step_avg:55.28ms
+step:1341/1490 train_time:74153ms step_avg:55.30ms
+step:1342/1490 train_time:74240ms step_avg:55.32ms
+step:1343/1490 train_time:74320ms step_avg:55.34ms
+step:1344/1490 train_time:74407ms step_avg:55.36ms
+step:1345/1490 train_time:74489ms step_avg:55.38ms
+step:1346/1490 train_time:74575ms step_avg:55.41ms
+step:1347/1490 train_time:74655ms step_avg:55.42ms
+step:1348/1490 train_time:74742ms step_avg:55.45ms
+step:1349/1490 train_time:74824ms step_avg:55.47ms
+step:1350/1490 train_time:74910ms step_avg:55.49ms
+step:1351/1490 train_time:74991ms step_avg:55.51ms
+step:1352/1490 train_time:75076ms step_avg:55.53ms
+step:1353/1490 train_time:75157ms step_avg:55.55ms
+step:1354/1490 train_time:75245ms step_avg:55.57ms
+step:1355/1490 train_time:75327ms step_avg:55.59ms
+step:1356/1490 train_time:75413ms step_avg:55.61ms
+step:1357/1490 train_time:75495ms step_avg:55.63ms
+step:1358/1490 train_time:75580ms step_avg:55.66ms
+step:1359/1490 train_time:75661ms step_avg:55.67ms
+step:1360/1490 train_time:75749ms step_avg:55.70ms
+step:1361/1490 train_time:75829ms step_avg:55.72ms
+step:1362/1490 train_time:75916ms step_avg:55.74ms
+step:1363/1490 train_time:75998ms step_avg:55.76ms
+step:1364/1490 train_time:76084ms step_avg:55.78ms
+step:1365/1490 train_time:76165ms step_avg:55.80ms
+step:1366/1490 train_time:76252ms step_avg:55.82ms
+step:1367/1490 train_time:76332ms step_avg:55.84ms
+step:1368/1490 train_time:76418ms step_avg:55.86ms
+step:1369/1490 train_time:76500ms step_avg:55.88ms
+step:1370/1490 train_time:76588ms step_avg:55.90ms
+step:1371/1490 train_time:76667ms step_avg:55.92ms
+step:1372/1490 train_time:76754ms step_avg:55.94ms
+step:1373/1490 train_time:76834ms step_avg:55.96ms
+step:1374/1490 train_time:76921ms step_avg:55.98ms
+step:1375/1490 train_time:77004ms step_avg:56.00ms
+step:1376/1490 train_time:77090ms step_avg:56.02ms
+step:1377/1490 train_time:77171ms step_avg:56.04ms
+step:1378/1490 train_time:77257ms step_avg:56.06ms
+step:1379/1490 train_time:77338ms step_avg:56.08ms
+step:1380/1490 train_time:77425ms step_avg:56.11ms
+step:1381/1490 train_time:77507ms step_avg:56.12ms
+step:1382/1490 train_time:77593ms step_avg:56.15ms
+step:1383/1490 train_time:77673ms step_avg:56.16ms
+step:1384/1490 train_time:77759ms step_avg:56.18ms
+step:1385/1490 train_time:77840ms step_avg:56.20ms
+step:1386/1490 train_time:77929ms step_avg:56.23ms
+step:1387/1490 train_time:78011ms step_avg:56.24ms
+step:1388/1490 train_time:78098ms step_avg:56.27ms
+step:1389/1490 train_time:78178ms step_avg:56.28ms
+step:1390/1490 train_time:78264ms step_avg:56.31ms
+step:1391/1490 train_time:78344ms step_avg:56.32ms
+step:1392/1490 train_time:78433ms step_avg:56.35ms
+step:1393/1490 train_time:78514ms step_avg:56.36ms
+step:1394/1490 train_time:78601ms step_avg:56.39ms
+step:1395/1490 train_time:78681ms step_avg:56.40ms
+step:1396/1490 train_time:78766ms step_avg:56.42ms
+step:1397/1490 train_time:78847ms step_avg:56.44ms
+step:1398/1490 train_time:78933ms step_avg:56.46ms
+step:1399/1490 train_time:79014ms step_avg:56.48ms
+step:1400/1490 train_time:79099ms step_avg:56.50ms
+step:1401/1490 train_time:79181ms step_avg:56.52ms
+step:1402/1490 train_time:79268ms step_avg:56.54ms
+step:1403/1490 train_time:79347ms step_avg:56.56ms
+step:1404/1490 train_time:79434ms step_avg:56.58ms
+step:1405/1490 train_time:79517ms step_avg:56.60ms
+step:1406/1490 train_time:79604ms step_avg:56.62ms
+step:1407/1490 train_time:79686ms step_avg:56.64ms
+step:1408/1490 train_time:79773ms step_avg:56.66ms
+step:1409/1490 train_time:79853ms step_avg:56.67ms
+step:1410/1490 train_time:79940ms step_avg:56.69ms
+step:1411/1490 train_time:80022ms step_avg:56.71ms
+step:1412/1490 train_time:80108ms step_avg:56.73ms
+step:1413/1490 train_time:80190ms step_avg:56.75ms
+step:1414/1490 train_time:80276ms step_avg:56.77ms
+step:1415/1490 train_time:80356ms step_avg:56.79ms
+step:1416/1490 train_time:80443ms step_avg:56.81ms
+step:1417/1490 train_time:80523ms step_avg:56.83ms
+step:1418/1490 train_time:80610ms step_avg:56.85ms
+step:1419/1490 train_time:80692ms step_avg:56.87ms
+step:1420/1490 train_time:80778ms step_avg:56.89ms
+step:1421/1490 train_time:80858ms step_avg:56.90ms
+step:1422/1490 train_time:80944ms step_avg:56.92ms
+step:1423/1490 train_time:81026ms step_avg:56.94ms
+step:1424/1490 train_time:81112ms step_avg:56.96ms
+step:1425/1490 train_time:81194ms step_avg:56.98ms
+step:1426/1490 train_time:81280ms step_avg:57.00ms
+step:1427/1490 train_time:81361ms step_avg:57.02ms
+step:1428/1490 train_time:81447ms step_avg:57.04ms
+step:1429/1490 train_time:81528ms step_avg:57.05ms
+step:1430/1490 train_time:81613ms step_avg:57.07ms
+step:1431/1490 train_time:81696ms step_avg:57.09ms
+step:1432/1490 train_time:81782ms step_avg:57.11ms
+step:1433/1490 train_time:81863ms step_avg:57.13ms
+step:1434/1490 train_time:81949ms step_avg:57.15ms
+step:1435/1490 train_time:82030ms step_avg:57.16ms
+step:1436/1490 train_time:82118ms step_avg:57.19ms
+step:1437/1490 train_time:82198ms step_avg:57.20ms
+step:1438/1490 train_time:82285ms step_avg:57.22ms
+step:1439/1490 train_time:82365ms step_avg:57.24ms
+step:1440/1490 train_time:82453ms step_avg:57.26ms
+step:1441/1490 train_time:82534ms step_avg:57.28ms
+step:1442/1490 train_time:82620ms step_avg:57.30ms
+step:1443/1490 train_time:82701ms step_avg:57.31ms
+step:1444/1490 train_time:82788ms step_avg:57.33ms
+step:1445/1490 train_time:82867ms step_avg:57.35ms
+step:1446/1490 train_time:82953ms step_avg:57.37ms
+step:1447/1490 train_time:83035ms step_avg:57.38ms
+step:1448/1490 train_time:83121ms step_avg:57.40ms
+step:1449/1490 train_time:83203ms step_avg:57.42ms
+step:1450/1490 train_time:83291ms step_avg:57.44ms
+step:1451/1490 train_time:83375ms step_avg:57.46ms
+step:1452/1490 train_time:83462ms step_avg:57.48ms
+step:1453/1490 train_time:83543ms step_avg:57.50ms
+step:1454/1490 train_time:83631ms step_avg:57.52ms
+step:1455/1490 train_time:83712ms step_avg:57.53ms
+step:1456/1490 train_time:83799ms step_avg:57.55ms
+step:1457/1490 train_time:83882ms step_avg:57.57ms
+step:1458/1490 train_time:83969ms step_avg:57.59ms
+step:1459/1490 train_time:84050ms step_avg:57.61ms
+step:1460/1490 train_time:84136ms step_avg:57.63ms
+step:1461/1490 train_time:84217ms step_avg:57.64ms
+step:1462/1490 train_time:84303ms step_avg:57.66ms
+step:1463/1490 train_time:84385ms step_avg:57.68ms
+step:1464/1490 train_time:84471ms step_avg:57.70ms
+step:1465/1490 train_time:84554ms step_avg:57.72ms
+step:1466/1490 train_time:84642ms step_avg:57.74ms
+step:1467/1490 train_time:84723ms step_avg:57.75ms
+step:1468/1490 train_time:84812ms step_avg:57.77ms
+step:1469/1490 train_time:84895ms step_avg:57.79ms
+step:1470/1490 train_time:84981ms step_avg:57.81ms
+step:1471/1490 train_time:85062ms step_avg:57.83ms
+step:1472/1490 train_time:85148ms step_avg:57.85ms
+step:1473/1490 train_time:85229ms step_avg:57.86ms
+step:1474/1490 train_time:85316ms step_avg:57.88ms
+step:1475/1490 train_time:85396ms step_avg:57.90ms
+step:1476/1490 train_time:85484ms step_avg:57.92ms
+step:1477/1490 train_time:85564ms step_avg:57.93ms
+step:1478/1490 train_time:85652ms step_avg:57.95ms
+step:1479/1490 train_time:85734ms step_avg:57.97ms
+step:1480/1490 train_time:85821ms step_avg:57.99ms
+step:1481/1490 train_time:85903ms step_avg:58.00ms
+step:1482/1490 train_time:85990ms step_avg:58.02ms
+step:1483/1490 train_time:86072ms step_avg:58.04ms
+step:1484/1490 train_time:86157ms step_avg:58.06ms
+step:1485/1490 train_time:86238ms step_avg:58.07ms
+step:1486/1490 train_time:86325ms step_avg:58.09ms
+step:1487/1490 train_time:86407ms step_avg:58.11ms
+step:1488/1490 train_time:86493ms step_avg:58.13ms
+step:1489/1490 train_time:86575ms step_avg:58.14ms
+step:1490/1490 train_time:86661ms step_avg:58.16ms
+step:1490/1490 val_loss:3.2772 train_time:86766ms step_avg:58.23ms
+peak memory allocated: 31277 MiB reserved: 47182 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/combined/2026-03-22_20-07-32_time-186_secs_06-mbeta2-max-docs_227ce8.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/combined/2026-03-22_20-07-32_time-186_secs_06-mbeta2-max-docs_227ce8.txt
@@ -1,0 +1,4457 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 20:07:47 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            132W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   40C    P0            124W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1828601      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1828602      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1828603      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1828604      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1828605      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1828606      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1828607      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1828608      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8288 train_time:0ms step_avg:0.05ms
+step:1/1490 train_time:98ms step_avg:98.24ms
+step:2/1490 train_time:122ms step_avg:61.21ms
+step:3/1490 train_time:139ms step_avg:46.46ms
+step:4/1490 train_time:160ms step_avg:40.00ms
+step:5/1490 train_time:183ms step_avg:36.61ms
+step:6/1490 train_time:218ms step_avg:36.37ms
+step:7/1490 train_time:245ms step_avg:35.00ms
+step:8/1490 train_time:280ms step_avg:35.02ms
+step:9/1490 train_time:307ms step_avg:34.13ms
+step:10/1490 train_time:342ms step_avg:34.22ms
+step:11/1490 train_time:370ms step_avg:33.61ms
+step:12/1490 train_time:408ms step_avg:34.03ms
+step:13/1490 train_time:432ms step_avg:33.23ms
+step:14/1490 train_time:467ms step_avg:33.35ms
+step:15/1490 train_time:494ms step_avg:32.96ms
+step:16/1490 train_time:529ms step_avg:33.05ms
+step:17/1490 train_time:556ms step_avg:32.73ms
+step:18/1490 train_time:592ms step_avg:32.86ms
+step:19/1490 train_time:619ms step_avg:32.57ms
+step:20/1490 train_time:654ms step_avg:32.70ms
+step:21/1490 train_time:681ms step_avg:32.45ms
+step:22/1490 train_time:716ms step_avg:32.54ms
+step:23/1490 train_time:744ms step_avg:32.34ms
+step:24/1490 train_time:780ms step_avg:32.50ms
+step:25/1490 train_time:806ms step_avg:32.25ms
+step:26/1490 train_time:841ms step_avg:32.34ms
+step:27/1490 train_time:868ms step_avg:32.16ms
+step:28/1490 train_time:903ms step_avg:32.25ms
+step:29/1490 train_time:930ms step_avg:32.08ms
+step:30/1490 train_time:966ms step_avg:32.21ms
+step:31/1490 train_time:994ms step_avg:32.05ms
+step:32/1490 train_time:1030ms step_avg:32.18ms
+step:33/1490 train_time:1059ms step_avg:32.09ms
+step:34/1490 train_time:1094ms step_avg:32.17ms
+step:35/1490 train_time:1123ms step_avg:32.08ms
+step:36/1490 train_time:1158ms step_avg:32.17ms
+step:37/1490 train_time:1185ms step_avg:32.03ms
+step:38/1490 train_time:1220ms step_avg:32.10ms
+step:39/1490 train_time:1248ms step_avg:32.00ms
+step:40/1490 train_time:1284ms step_avg:32.10ms
+step:41/1490 train_time:1311ms step_avg:31.98ms
+step:42/1490 train_time:1346ms step_avg:32.05ms
+step:43/1490 train_time:1374ms step_avg:31.95ms
+step:44/1490 train_time:1409ms step_avg:32.02ms
+step:45/1490 train_time:1436ms step_avg:31.92ms
+step:46/1490 train_time:1472ms step_avg:32.00ms
+step:47/1490 train_time:1499ms step_avg:31.90ms
+step:48/1490 train_time:1533ms step_avg:31.95ms
+step:49/1490 train_time:1561ms step_avg:31.87ms
+step:50/1490 train_time:1596ms step_avg:31.92ms
+step:51/1490 train_time:1624ms step_avg:31.84ms
+step:52/1490 train_time:1659ms step_avg:31.90ms
+step:53/1490 train_time:1687ms step_avg:31.83ms
+step:54/1490 train_time:1721ms step_avg:31.87ms
+step:55/1490 train_time:1749ms step_avg:31.81ms
+step:56/1490 train_time:1784ms step_avg:31.86ms
+step:57/1490 train_time:1812ms step_avg:31.79ms
+step:58/1490 train_time:1847ms step_avg:31.84ms
+step:59/1490 train_time:1875ms step_avg:31.77ms
+step:60/1490 train_time:1909ms step_avg:31.82ms
+step:61/1490 train_time:1937ms step_avg:31.76ms
+step:62/1490 train_time:1974ms step_avg:31.83ms
+step:63/1490 train_time:2001ms step_avg:31.76ms
+step:64/1490 train_time:2036ms step_avg:31.81ms
+step:65/1490 train_time:2064ms step_avg:31.75ms
+step:66/1490 train_time:2099ms step_avg:31.80ms
+step:67/1490 train_time:2128ms step_avg:31.76ms
+step:68/1490 train_time:2163ms step_avg:31.80ms
+step:69/1490 train_time:2191ms step_avg:31.75ms
+step:70/1490 train_time:2225ms step_avg:31.79ms
+step:71/1490 train_time:2253ms step_avg:31.74ms
+step:72/1490 train_time:2289ms step_avg:31.79ms
+step:73/1490 train_time:2317ms step_avg:31.74ms
+step:74/1490 train_time:2352ms step_avg:31.78ms
+step:75/1490 train_time:2379ms step_avg:31.73ms
+step:76/1490 train_time:2414ms step_avg:31.76ms
+step:77/1490 train_time:2442ms step_avg:31.72ms
+step:78/1490 train_time:2477ms step_avg:31.76ms
+step:79/1490 train_time:2505ms step_avg:31.71ms
+step:80/1490 train_time:2539ms step_avg:31.74ms
+step:81/1490 train_time:2568ms step_avg:31.70ms
+step:82/1490 train_time:2602ms step_avg:31.74ms
+step:83/1490 train_time:2630ms step_avg:31.69ms
+step:84/1490 train_time:2665ms step_avg:31.73ms
+step:85/1490 train_time:2693ms step_avg:31.68ms
+step:86/1490 train_time:2727ms step_avg:31.71ms
+step:87/1490 train_time:2755ms step_avg:31.67ms
+step:88/1490 train_time:2790ms step_avg:31.70ms
+step:89/1490 train_time:2818ms step_avg:31.66ms
+step:90/1490 train_time:2852ms step_avg:31.69ms
+step:91/1490 train_time:2880ms step_avg:31.65ms
+step:92/1490 train_time:2915ms step_avg:31.69ms
+step:93/1490 train_time:2943ms step_avg:31.65ms
+step:94/1490 train_time:2978ms step_avg:31.68ms
+step:95/1490 train_time:3007ms step_avg:31.65ms
+step:96/1490 train_time:3041ms step_avg:31.68ms
+step:97/1490 train_time:3070ms step_avg:31.65ms
+step:98/1490 train_time:3105ms step_avg:31.68ms
+step:99/1490 train_time:3133ms step_avg:31.64ms
+step:100/1490 train_time:3168ms step_avg:31.68ms
+step:101/1490 train_time:3196ms step_avg:31.64ms
+step:102/1490 train_time:3230ms step_avg:31.67ms
+step:103/1490 train_time:3258ms step_avg:31.63ms
+step:104/1490 train_time:3293ms step_avg:31.67ms
+step:105/1490 train_time:3322ms step_avg:31.64ms
+step:106/1490 train_time:3356ms step_avg:31.66ms
+step:107/1490 train_time:3385ms step_avg:31.63ms
+step:108/1490 train_time:3423ms step_avg:31.69ms
+step:109/1490 train_time:3448ms step_avg:31.63ms
+step:110/1490 train_time:3483ms step_avg:31.66ms
+step:111/1490 train_time:3511ms step_avg:31.63ms
+step:112/1490 train_time:3546ms step_avg:31.66ms
+step:113/1490 train_time:3574ms step_avg:31.63ms
+step:114/1490 train_time:3608ms step_avg:31.65ms
+step:115/1490 train_time:3636ms step_avg:31.62ms
+step:116/1490 train_time:3671ms step_avg:31.65ms
+step:117/1490 train_time:3699ms step_avg:31.62ms
+step:118/1490 train_time:3736ms step_avg:31.66ms
+step:119/1490 train_time:3762ms step_avg:31.62ms
+step:120/1490 train_time:3797ms step_avg:31.64ms
+step:121/1490 train_time:3825ms step_avg:31.61ms
+step:122/1490 train_time:3860ms step_avg:31.64ms
+step:123/1490 train_time:3888ms step_avg:31.61ms
+step:124/1490 train_time:3924ms step_avg:31.65ms
+step:125/1490 train_time:3950ms step_avg:31.60ms
+step:126/1490 train_time:3985ms step_avg:31.63ms
+step:127/1490 train_time:4013ms step_avg:31.60ms
+step:128/1490 train_time:4048ms step_avg:31.62ms
+step:129/1490 train_time:4075ms step_avg:31.59ms
+step:130/1490 train_time:4110ms step_avg:31.62ms
+step:131/1490 train_time:4139ms step_avg:31.59ms
+step:132/1490 train_time:4174ms step_avg:31.62ms
+step:133/1490 train_time:4202ms step_avg:31.59ms
+step:134/1490 train_time:4237ms step_avg:31.62ms
+step:135/1490 train_time:4265ms step_avg:31.59ms
+step:136/1490 train_time:4300ms step_avg:31.61ms
+step:137/1490 train_time:4328ms step_avg:31.59ms
+step:138/1490 train_time:4362ms step_avg:31.61ms
+step:139/1490 train_time:4390ms step_avg:31.58ms
+step:140/1490 train_time:4425ms step_avg:31.61ms
+step:141/1490 train_time:4453ms step_avg:31.58ms
+step:142/1490 train_time:4487ms step_avg:31.60ms
+step:143/1490 train_time:4515ms step_avg:31.58ms
+step:144/1490 train_time:4550ms step_avg:31.60ms
+step:145/1490 train_time:4578ms step_avg:31.57ms
+step:146/1490 train_time:4613ms step_avg:31.59ms
+step:147/1490 train_time:4641ms step_avg:31.57ms
+step:148/1490 train_time:4675ms step_avg:31.59ms
+step:149/1490 train_time:4703ms step_avg:31.56ms
+step:150/1490 train_time:4738ms step_avg:31.58ms
+step:151/1490 train_time:4766ms step_avg:31.56ms
+step:152/1490 train_time:4800ms step_avg:31.58ms
+step:153/1490 train_time:4828ms step_avg:31.56ms
+step:154/1490 train_time:4863ms step_avg:31.58ms
+step:155/1490 train_time:4891ms step_avg:31.56ms
+step:156/1490 train_time:4925ms step_avg:31.57ms
+step:157/1490 train_time:4953ms step_avg:31.55ms
+step:158/1490 train_time:4988ms step_avg:31.57ms
+step:159/1490 train_time:5016ms step_avg:31.55ms
+step:160/1490 train_time:5050ms step_avg:31.57ms
+step:161/1490 train_time:5079ms step_avg:31.54ms
+step:162/1490 train_time:5113ms step_avg:31.56ms
+step:163/1490 train_time:5141ms step_avg:31.54ms
+step:164/1490 train_time:5176ms step_avg:31.56ms
+step:165/1490 train_time:5204ms step_avg:31.54ms
+step:166/1490 train_time:5239ms step_avg:31.56ms
+step:167/1490 train_time:5267ms step_avg:31.54ms
+step:168/1490 train_time:5302ms step_avg:31.56ms
+step:169/1490 train_time:5330ms step_avg:31.54ms
+step:170/1490 train_time:5364ms step_avg:31.56ms
+step:171/1490 train_time:5393ms step_avg:31.54ms
+step:172/1490 train_time:5427ms step_avg:31.55ms
+step:173/1490 train_time:5455ms step_avg:31.53ms
+step:174/1490 train_time:5489ms step_avg:31.55ms
+step:175/1490 train_time:5517ms step_avg:31.53ms
+step:176/1490 train_time:5552ms step_avg:31.55ms
+step:177/1490 train_time:5580ms step_avg:31.53ms
+step:178/1490 train_time:5615ms step_avg:31.54ms
+step:179/1490 train_time:5643ms step_avg:31.53ms
+step:180/1490 train_time:5678ms step_avg:31.54ms
+step:181/1490 train_time:5706ms step_avg:31.52ms
+step:182/1490 train_time:5741ms step_avg:31.54ms
+step:183/1490 train_time:5769ms step_avg:31.52ms
+step:184/1490 train_time:5803ms step_avg:31.54ms
+step:185/1490 train_time:5832ms step_avg:31.52ms
+step:186/1490 train_time:5866ms step_avg:31.54ms
+step:187/1490 train_time:5895ms step_avg:31.52ms
+step:188/1490 train_time:5929ms step_avg:31.54ms
+step:189/1490 train_time:5957ms step_avg:31.52ms
+step:190/1490 train_time:5992ms step_avg:31.54ms
+step:191/1490 train_time:6020ms step_avg:31.52ms
+step:192/1490 train_time:6054ms step_avg:31.53ms
+step:193/1490 train_time:6083ms step_avg:31.52ms
+step:194/1490 train_time:6117ms step_avg:31.53ms
+step:195/1490 train_time:6146ms step_avg:31.52ms
+step:196/1490 train_time:6181ms step_avg:31.53ms
+step:197/1490 train_time:6209ms step_avg:31.52ms
+step:198/1490 train_time:6243ms step_avg:31.53ms
+step:199/1490 train_time:6272ms step_avg:31.52ms
+step:200/1490 train_time:6306ms step_avg:31.53ms
+step:201/1490 train_time:6334ms step_avg:31.51ms
+step:202/1490 train_time:6371ms step_avg:31.54ms
+step:203/1490 train_time:6397ms step_avg:31.51ms
+step:204/1490 train_time:6431ms step_avg:31.53ms
+step:205/1490 train_time:6459ms step_avg:31.51ms
+step:206/1490 train_time:6494ms step_avg:31.53ms
+step:207/1490 train_time:6522ms step_avg:31.51ms
+step:208/1490 train_time:6557ms step_avg:31.52ms
+step:209/1490 train_time:6585ms step_avg:31.51ms
+step:210/1490 train_time:6619ms step_avg:31.52ms
+step:211/1490 train_time:6648ms step_avg:31.51ms
+step:212/1490 train_time:6682ms step_avg:31.52ms
+step:213/1490 train_time:6711ms step_avg:31.51ms
+step:214/1490 train_time:6745ms step_avg:31.52ms
+step:215/1490 train_time:6773ms step_avg:31.50ms
+step:216/1490 train_time:6808ms step_avg:31.52ms
+step:217/1490 train_time:6836ms step_avg:31.50ms
+step:218/1490 train_time:6871ms step_avg:31.52ms
+step:219/1490 train_time:6898ms step_avg:31.50ms
+step:220/1490 train_time:6933ms step_avg:31.51ms
+step:221/1490 train_time:6961ms step_avg:31.50ms
+step:222/1490 train_time:6996ms step_avg:31.51ms
+step:223/1490 train_time:7024ms step_avg:31.50ms
+step:224/1490 train_time:7059ms step_avg:31.51ms
+step:225/1490 train_time:7087ms step_avg:31.50ms
+step:226/1490 train_time:7121ms step_avg:31.51ms
+step:227/1490 train_time:7149ms step_avg:31.50ms
+step:228/1490 train_time:7184ms step_avg:31.51ms
+step:229/1490 train_time:7212ms step_avg:31.49ms
+step:230/1490 train_time:7246ms step_avg:31.51ms
+step:231/1490 train_time:7274ms step_avg:31.49ms
+step:232/1490 train_time:7309ms step_avg:31.50ms
+step:233/1490 train_time:7337ms step_avg:31.49ms
+step:234/1490 train_time:7372ms step_avg:31.50ms
+step:235/1490 train_time:7400ms step_avg:31.49ms
+step:236/1490 train_time:7434ms step_avg:31.50ms
+step:237/1490 train_time:7463ms step_avg:31.49ms
+step:238/1490 train_time:7498ms step_avg:31.50ms
+step:239/1490 train_time:7526ms step_avg:31.49ms
+step:240/1490 train_time:7560ms step_avg:31.50ms
+step:241/1490 train_time:7589ms step_avg:31.49ms
+step:242/1490 train_time:7623ms step_avg:31.50ms
+step:243/1490 train_time:7651ms step_avg:31.49ms
+step:244/1490 train_time:7686ms step_avg:31.50ms
+step:245/1490 train_time:7714ms step_avg:31.48ms
+step:246/1490 train_time:7748ms step_avg:31.50ms
+step:247/1490 train_time:7776ms step_avg:31.48ms
+step:248/1490 train_time:7810ms step_avg:31.49ms
+step:249/1490 train_time:7838ms step_avg:31.48ms
+step:250/1490 train_time:7873ms step_avg:31.49ms
+step:250/1490 val_loss:4.4998 train_time:7915ms step_avg:31.66ms
+step:251/1490 train_time:7939ms step_avg:31.63ms
+step:252/1490 train_time:7960ms step_avg:31.59ms
+step:253/1490 train_time:7974ms step_avg:31.52ms
+step:254/1490 train_time:8002ms step_avg:31.50ms
+step:255/1490 train_time:8030ms step_avg:31.49ms
+step:256/1490 train_time:8066ms step_avg:31.51ms
+step:257/1490 train_time:8094ms step_avg:31.49ms
+step:258/1490 train_time:8129ms step_avg:31.51ms
+step:259/1490 train_time:8157ms step_avg:31.50ms
+step:260/1490 train_time:8192ms step_avg:31.51ms
+step:261/1490 train_time:8220ms step_avg:31.49ms
+step:262/1490 train_time:8255ms step_avg:31.51ms
+step:263/1490 train_time:8282ms step_avg:31.49ms
+step:264/1490 train_time:8317ms step_avg:31.50ms
+step:265/1490 train_time:8345ms step_avg:31.49ms
+step:266/1490 train_time:8379ms step_avg:31.50ms
+step:267/1490 train_time:8407ms step_avg:31.49ms
+step:268/1490 train_time:8441ms step_avg:31.50ms
+step:269/1490 train_time:8470ms step_avg:31.49ms
+step:270/1490 train_time:8504ms step_avg:31.50ms
+step:271/1490 train_time:8531ms step_avg:31.48ms
+step:272/1490 train_time:8565ms step_avg:31.49ms
+step:273/1490 train_time:8593ms step_avg:31.48ms
+step:274/1490 train_time:8628ms step_avg:31.49ms
+step:275/1490 train_time:8655ms step_avg:31.47ms
+step:276/1490 train_time:8689ms step_avg:31.48ms
+step:277/1490 train_time:8717ms step_avg:31.47ms
+step:278/1490 train_time:8752ms step_avg:31.48ms
+step:279/1490 train_time:8780ms step_avg:31.47ms
+step:280/1490 train_time:8817ms step_avg:31.49ms
+step:281/1490 train_time:8842ms step_avg:31.47ms
+step:282/1490 train_time:8877ms step_avg:31.48ms
+step:283/1490 train_time:8906ms step_avg:31.47ms
+step:284/1490 train_time:8940ms step_avg:31.48ms
+step:285/1490 train_time:8969ms step_avg:31.47ms
+step:286/1490 train_time:9005ms step_avg:31.48ms
+step:287/1490 train_time:9033ms step_avg:31.47ms
+step:288/1490 train_time:9068ms step_avg:31.49ms
+step:289/1490 train_time:9097ms step_avg:31.48ms
+step:290/1490 train_time:9131ms step_avg:31.49ms
+step:291/1490 train_time:9160ms step_avg:31.48ms
+step:292/1490 train_time:9195ms step_avg:31.49ms
+step:293/1490 train_time:9223ms step_avg:31.48ms
+step:294/1490 train_time:9257ms step_avg:31.49ms
+step:295/1490 train_time:9286ms step_avg:31.48ms
+step:296/1490 train_time:9320ms step_avg:31.49ms
+step:297/1490 train_time:9348ms step_avg:31.47ms
+step:298/1490 train_time:9383ms step_avg:31.49ms
+step:299/1490 train_time:9411ms step_avg:31.47ms
+step:300/1490 train_time:9445ms step_avg:31.48ms
+step:301/1490 train_time:9472ms step_avg:31.47ms
+step:302/1490 train_time:9507ms step_avg:31.48ms
+step:303/1490 train_time:9534ms step_avg:31.47ms
+step:304/1490 train_time:9569ms step_avg:31.48ms
+step:305/1490 train_time:9597ms step_avg:31.47ms
+step:306/1490 train_time:9631ms step_avg:31.47ms
+step:307/1490 train_time:9659ms step_avg:31.46ms
+step:308/1490 train_time:9694ms step_avg:31.47ms
+step:309/1490 train_time:9722ms step_avg:31.46ms
+step:310/1490 train_time:9756ms step_avg:31.47ms
+step:311/1490 train_time:9784ms step_avg:31.46ms
+step:312/1490 train_time:9819ms step_avg:31.47ms
+step:313/1490 train_time:9846ms step_avg:31.46ms
+step:314/1490 train_time:9881ms step_avg:31.47ms
+step:315/1490 train_time:9909ms step_avg:31.46ms
+step:316/1490 train_time:9944ms step_avg:31.47ms
+step:317/1490 train_time:9972ms step_avg:31.46ms
+step:318/1490 train_time:10009ms step_avg:31.47ms
+step:319/1490 train_time:10035ms step_avg:31.46ms
+step:320/1490 train_time:10070ms step_avg:31.47ms
+step:321/1490 train_time:10099ms step_avg:31.46ms
+step:322/1490 train_time:10133ms step_avg:31.47ms
+step:323/1490 train_time:10161ms step_avg:31.46ms
+step:324/1490 train_time:10196ms step_avg:31.47ms
+step:325/1490 train_time:10224ms step_avg:31.46ms
+step:326/1490 train_time:10258ms step_avg:31.47ms
+step:327/1490 train_time:10286ms step_avg:31.46ms
+step:328/1490 train_time:10321ms step_avg:31.47ms
+step:329/1490 train_time:10350ms step_avg:31.46ms
+step:330/1490 train_time:10384ms step_avg:31.47ms
+step:331/1490 train_time:10411ms step_avg:31.45ms
+step:332/1490 train_time:10446ms step_avg:31.46ms
+step:333/1490 train_time:10474ms step_avg:31.45ms
+step:334/1490 train_time:10508ms step_avg:31.46ms
+step:335/1490 train_time:10537ms step_avg:31.45ms
+step:336/1490 train_time:10571ms step_avg:31.46ms
+step:337/1490 train_time:10599ms step_avg:31.45ms
+step:338/1490 train_time:10633ms step_avg:31.46ms
+step:339/1490 train_time:10661ms step_avg:31.45ms
+step:340/1490 train_time:10696ms step_avg:31.46ms
+step:341/1490 train_time:10724ms step_avg:31.45ms
+step:342/1490 train_time:10758ms step_avg:31.46ms
+step:343/1490 train_time:10786ms step_avg:31.45ms
+step:344/1490 train_time:10821ms step_avg:31.46ms
+step:345/1490 train_time:10849ms step_avg:31.45ms
+step:346/1490 train_time:10883ms step_avg:31.46ms
+step:347/1490 train_time:10911ms step_avg:31.45ms
+step:348/1490 train_time:10946ms step_avg:31.45ms
+step:349/1490 train_time:10974ms step_avg:31.45ms
+step:350/1490 train_time:11010ms step_avg:31.46ms
+step:351/1490 train_time:11038ms step_avg:31.45ms
+step:352/1490 train_time:11073ms step_avg:31.46ms
+step:353/1490 train_time:11101ms step_avg:31.45ms
+step:354/1490 train_time:11136ms step_avg:31.46ms
+step:355/1490 train_time:11164ms step_avg:31.45ms
+step:356/1490 train_time:11199ms step_avg:31.46ms
+step:357/1490 train_time:11227ms step_avg:31.45ms
+step:358/1490 train_time:11262ms step_avg:31.46ms
+step:359/1490 train_time:11289ms step_avg:31.45ms
+step:360/1490 train_time:11325ms step_avg:31.46ms
+step:361/1490 train_time:11352ms step_avg:31.45ms
+step:362/1490 train_time:11387ms step_avg:31.46ms
+step:363/1490 train_time:11415ms step_avg:31.45ms
+step:364/1490 train_time:11450ms step_avg:31.45ms
+step:365/1490 train_time:11478ms step_avg:31.45ms
+step:366/1490 train_time:11512ms step_avg:31.45ms
+step:367/1490 train_time:11540ms step_avg:31.45ms
+step:368/1490 train_time:11575ms step_avg:31.45ms
+step:369/1490 train_time:11603ms step_avg:31.44ms
+step:370/1490 train_time:11638ms step_avg:31.45ms
+step:371/1490 train_time:11666ms step_avg:31.44ms
+step:372/1490 train_time:11700ms step_avg:31.45ms
+step:373/1490 train_time:11728ms step_avg:31.44ms
+step:374/1490 train_time:11763ms step_avg:31.45ms
+step:375/1490 train_time:11790ms step_avg:31.44ms
+step:376/1490 train_time:11827ms step_avg:31.45ms
+step:377/1490 train_time:11853ms step_avg:31.44ms
+step:378/1490 train_time:11888ms step_avg:31.45ms
+step:379/1490 train_time:11916ms step_avg:31.44ms
+step:380/1490 train_time:11950ms step_avg:31.45ms
+step:381/1490 train_time:11979ms step_avg:31.44ms
+step:382/1490 train_time:12013ms step_avg:31.45ms
+step:383/1490 train_time:12042ms step_avg:31.44ms
+step:384/1490 train_time:12076ms step_avg:31.45ms
+step:385/1490 train_time:12104ms step_avg:31.44ms
+step:386/1490 train_time:12140ms step_avg:31.45ms
+step:387/1490 train_time:12167ms step_avg:31.44ms
+step:388/1490 train_time:12202ms step_avg:31.45ms
+step:389/1490 train_time:12230ms step_avg:31.44ms
+step:390/1490 train_time:12265ms step_avg:31.45ms
+step:391/1490 train_time:12294ms step_avg:31.44ms
+step:392/1490 train_time:12329ms step_avg:31.45ms
+step:393/1490 train_time:12357ms step_avg:31.44ms
+step:394/1490 train_time:12391ms step_avg:31.45ms
+step:395/1490 train_time:12419ms step_avg:31.44ms
+step:396/1490 train_time:12454ms step_avg:31.45ms
+step:397/1490 train_time:12482ms step_avg:31.44ms
+step:398/1490 train_time:12517ms step_avg:31.45ms
+step:399/1490 train_time:12545ms step_avg:31.44ms
+step:400/1490 train_time:12580ms step_avg:31.45ms
+step:401/1490 train_time:12608ms step_avg:31.44ms
+step:402/1490 train_time:12643ms step_avg:31.45ms
+step:403/1490 train_time:12670ms step_avg:31.44ms
+step:404/1490 train_time:12705ms step_avg:31.45ms
+step:405/1490 train_time:12733ms step_avg:31.44ms
+step:406/1490 train_time:12767ms step_avg:31.45ms
+step:407/1490 train_time:12795ms step_avg:31.44ms
+step:408/1490 train_time:12830ms step_avg:31.45ms
+step:409/1490 train_time:12858ms step_avg:31.44ms
+step:410/1490 train_time:12893ms step_avg:31.45ms
+step:411/1490 train_time:12921ms step_avg:31.44ms
+step:412/1490 train_time:12955ms step_avg:31.44ms
+step:413/1490 train_time:12983ms step_avg:31.44ms
+step:414/1490 train_time:13018ms step_avg:31.44ms
+step:415/1490 train_time:13046ms step_avg:31.44ms
+step:416/1490 train_time:13080ms step_avg:31.44ms
+step:417/1490 train_time:13109ms step_avg:31.44ms
+step:418/1490 train_time:13144ms step_avg:31.44ms
+step:419/1490 train_time:13171ms step_avg:31.43ms
+step:420/1490 train_time:13206ms step_avg:31.44ms
+step:421/1490 train_time:13234ms step_avg:31.43ms
+step:422/1490 train_time:13268ms step_avg:31.44ms
+step:423/1490 train_time:13297ms step_avg:31.43ms
+step:424/1490 train_time:13331ms step_avg:31.44ms
+step:425/1490 train_time:13359ms step_avg:31.43ms
+step:426/1490 train_time:13394ms step_avg:31.44ms
+step:427/1490 train_time:13422ms step_avg:31.43ms
+step:428/1490 train_time:13457ms step_avg:31.44ms
+step:429/1490 train_time:13485ms step_avg:31.43ms
+step:430/1490 train_time:13519ms step_avg:31.44ms
+step:431/1490 train_time:13547ms step_avg:31.43ms
+step:432/1490 train_time:13582ms step_avg:31.44ms
+step:433/1490 train_time:13610ms step_avg:31.43ms
+step:434/1490 train_time:13644ms step_avg:31.44ms
+step:435/1490 train_time:13672ms step_avg:31.43ms
+step:436/1490 train_time:13706ms step_avg:31.44ms
+step:437/1490 train_time:13734ms step_avg:31.43ms
+step:438/1490 train_time:13771ms step_avg:31.44ms
+step:439/1490 train_time:13797ms step_avg:31.43ms
+step:440/1490 train_time:13832ms step_avg:31.44ms
+step:441/1490 train_time:13860ms step_avg:31.43ms
+step:442/1490 train_time:13894ms step_avg:31.44ms
+step:443/1490 train_time:13923ms step_avg:31.43ms
+step:444/1490 train_time:13958ms step_avg:31.44ms
+step:445/1490 train_time:13985ms step_avg:31.43ms
+step:446/1490 train_time:14020ms step_avg:31.43ms
+step:447/1490 train_time:14048ms step_avg:31.43ms
+step:448/1490 train_time:14083ms step_avg:31.43ms
+step:449/1490 train_time:14111ms step_avg:31.43ms
+step:450/1490 train_time:14146ms step_avg:31.43ms
+step:451/1490 train_time:14173ms step_avg:31.43ms
+step:452/1490 train_time:14208ms step_avg:31.43ms
+step:453/1490 train_time:14236ms step_avg:31.43ms
+step:454/1490 train_time:14272ms step_avg:31.44ms
+step:455/1490 train_time:14299ms step_avg:31.43ms
+step:456/1490 train_time:14334ms step_avg:31.43ms
+step:457/1490 train_time:14362ms step_avg:31.43ms
+step:458/1490 train_time:14396ms step_avg:31.43ms
+step:459/1490 train_time:14424ms step_avg:31.42ms
+step:460/1490 train_time:14458ms step_avg:31.43ms
+step:461/1490 train_time:14487ms step_avg:31.43ms
+step:462/1490 train_time:14521ms step_avg:31.43ms
+step:463/1490 train_time:14549ms step_avg:31.42ms
+step:464/1490 train_time:14584ms step_avg:31.43ms
+step:465/1490 train_time:14612ms step_avg:31.42ms
+step:466/1490 train_time:14647ms step_avg:31.43ms
+step:467/1490 train_time:14674ms step_avg:31.42ms
+step:468/1490 train_time:14709ms step_avg:31.43ms
+step:469/1490 train_time:14737ms step_avg:31.42ms
+step:470/1490 train_time:14773ms step_avg:31.43ms
+step:471/1490 train_time:14800ms step_avg:31.42ms
+step:472/1490 train_time:14835ms step_avg:31.43ms
+step:473/1490 train_time:14863ms step_avg:31.42ms
+step:474/1490 train_time:14897ms step_avg:31.43ms
+step:475/1490 train_time:14925ms step_avg:31.42ms
+step:476/1490 train_time:14960ms step_avg:31.43ms
+step:477/1490 train_time:14988ms step_avg:31.42ms
+step:478/1490 train_time:15022ms step_avg:31.43ms
+step:479/1490 train_time:15050ms step_avg:31.42ms
+step:480/1490 train_time:15085ms step_avg:31.43ms
+step:481/1490 train_time:15113ms step_avg:31.42ms
+step:482/1490 train_time:15149ms step_avg:31.43ms
+step:483/1490 train_time:15175ms step_avg:31.42ms
+step:484/1490 train_time:15214ms step_avg:31.43ms
+step:485/1490 train_time:15265ms step_avg:31.47ms
+step:486/1490 train_time:15324ms step_avg:31.53ms
+step:487/1490 train_time:15379ms step_avg:31.58ms
+step:488/1490 train_time:15438ms step_avg:31.64ms
+step:489/1490 train_time:15492ms step_avg:31.68ms
+step:490/1490 train_time:15552ms step_avg:31.74ms
+step:491/1490 train_time:15606ms step_avg:31.78ms
+step:492/1490 train_time:15666ms step_avg:31.84ms
+step:493/1490 train_time:15721ms step_avg:31.89ms
+step:494/1490 train_time:15781ms step_avg:31.95ms
+step:495/1490 train_time:15834ms step_avg:31.99ms
+step:496/1490 train_time:15895ms step_avg:32.05ms
+step:497/1490 train_time:15949ms step_avg:32.09ms
+step:498/1490 train_time:16009ms step_avg:32.15ms
+step:499/1490 train_time:16063ms step_avg:32.19ms
+step:500/1490 train_time:16123ms step_avg:32.25ms
+step:500/1490 val_loss:4.2154 train_time:16196ms step_avg:32.39ms
+step:501/1490 train_time:16222ms step_avg:32.38ms
+step:502/1490 train_time:16243ms step_avg:32.36ms
+step:503/1490 train_time:16296ms step_avg:32.40ms
+step:504/1490 train_time:16358ms step_avg:32.46ms
+step:505/1490 train_time:16413ms step_avg:32.50ms
+step:506/1490 train_time:16473ms step_avg:32.56ms
+step:507/1490 train_time:16528ms step_avg:32.60ms
+step:508/1490 train_time:16587ms step_avg:32.65ms
+step:509/1490 train_time:16640ms step_avg:32.69ms
+step:510/1490 train_time:16698ms step_avg:32.74ms
+step:511/1490 train_time:16751ms step_avg:32.78ms
+step:512/1490 train_time:16811ms step_avg:32.83ms
+step:513/1490 train_time:16864ms step_avg:32.87ms
+step:514/1490 train_time:16922ms step_avg:32.92ms
+step:515/1490 train_time:16977ms step_avg:32.96ms
+step:516/1490 train_time:17035ms step_avg:33.01ms
+step:517/1490 train_time:17089ms step_avg:33.05ms
+step:518/1490 train_time:17151ms step_avg:33.11ms
+step:519/1490 train_time:17207ms step_avg:33.15ms
+step:520/1490 train_time:17269ms step_avg:33.21ms
+step:521/1490 train_time:17325ms step_avg:33.25ms
+step:522/1490 train_time:17386ms step_avg:33.31ms
+step:523/1490 train_time:17439ms step_avg:33.34ms
+step:524/1490 train_time:17498ms step_avg:33.39ms
+step:525/1490 train_time:17552ms step_avg:33.43ms
+step:526/1490 train_time:17612ms step_avg:33.48ms
+step:527/1490 train_time:17666ms step_avg:33.52ms
+step:528/1490 train_time:17725ms step_avg:33.57ms
+step:529/1490 train_time:17779ms step_avg:33.61ms
+step:530/1490 train_time:17838ms step_avg:33.66ms
+step:531/1490 train_time:17892ms step_avg:33.69ms
+step:532/1490 train_time:17951ms step_avg:33.74ms
+step:533/1490 train_time:18004ms step_avg:33.78ms
+step:534/1490 train_time:18064ms step_avg:33.83ms
+step:535/1490 train_time:18119ms step_avg:33.87ms
+step:536/1490 train_time:18180ms step_avg:33.92ms
+step:537/1490 train_time:18235ms step_avg:33.96ms
+step:538/1490 train_time:18294ms step_avg:34.00ms
+step:539/1490 train_time:18350ms step_avg:34.04ms
+step:540/1490 train_time:18410ms step_avg:34.09ms
+step:541/1490 train_time:18464ms step_avg:34.13ms
+step:542/1490 train_time:18525ms step_avg:34.18ms
+step:543/1490 train_time:18579ms step_avg:34.22ms
+step:544/1490 train_time:18638ms step_avg:34.26ms
+step:545/1490 train_time:18691ms step_avg:34.30ms
+step:546/1490 train_time:18751ms step_avg:34.34ms
+step:547/1490 train_time:18805ms step_avg:34.38ms
+step:548/1490 train_time:18865ms step_avg:34.43ms
+step:549/1490 train_time:18918ms step_avg:34.46ms
+step:550/1490 train_time:18978ms step_avg:34.51ms
+step:551/1490 train_time:19031ms step_avg:34.54ms
+step:552/1490 train_time:19091ms step_avg:34.59ms
+step:553/1490 train_time:19146ms step_avg:34.62ms
+step:554/1490 train_time:19207ms step_avg:34.67ms
+step:555/1490 train_time:19262ms step_avg:34.71ms
+step:556/1490 train_time:19321ms step_avg:34.75ms
+step:557/1490 train_time:19376ms step_avg:34.79ms
+step:558/1490 train_time:19435ms step_avg:34.83ms
+step:559/1490 train_time:19489ms step_avg:34.86ms
+step:560/1490 train_time:19549ms step_avg:34.91ms
+step:561/1490 train_time:19603ms step_avg:34.94ms
+step:562/1490 train_time:19663ms step_avg:34.99ms
+step:563/1490 train_time:19716ms step_avg:35.02ms
+step:564/1490 train_time:19777ms step_avg:35.07ms
+step:565/1490 train_time:19830ms step_avg:35.10ms
+step:566/1490 train_time:19890ms step_avg:35.14ms
+step:567/1490 train_time:19944ms step_avg:35.17ms
+step:568/1490 train_time:20002ms step_avg:35.21ms
+step:569/1490 train_time:20055ms step_avg:35.25ms
+step:570/1490 train_time:20117ms step_avg:35.29ms
+step:571/1490 train_time:20171ms step_avg:35.33ms
+step:572/1490 train_time:20230ms step_avg:35.37ms
+step:573/1490 train_time:20284ms step_avg:35.40ms
+step:574/1490 train_time:20344ms step_avg:35.44ms
+step:575/1490 train_time:20398ms step_avg:35.47ms
+step:576/1490 train_time:20458ms step_avg:35.52ms
+step:577/1490 train_time:20512ms step_avg:35.55ms
+step:578/1490 train_time:20573ms step_avg:35.59ms
+step:579/1490 train_time:20627ms step_avg:35.63ms
+step:580/1490 train_time:20687ms step_avg:35.67ms
+step:581/1490 train_time:20740ms step_avg:35.70ms
+step:582/1490 train_time:20799ms step_avg:35.74ms
+step:583/1490 train_time:20852ms step_avg:35.77ms
+step:584/1490 train_time:20912ms step_avg:35.81ms
+step:585/1490 train_time:20967ms step_avg:35.84ms
+step:586/1490 train_time:21027ms step_avg:35.88ms
+step:587/1490 train_time:21081ms step_avg:35.91ms
+step:588/1490 train_time:21140ms step_avg:35.95ms
+step:589/1490 train_time:21194ms step_avg:35.98ms
+step:590/1490 train_time:21254ms step_avg:36.02ms
+step:591/1490 train_time:21309ms step_avg:36.06ms
+step:592/1490 train_time:21370ms step_avg:36.10ms
+step:593/1490 train_time:21424ms step_avg:36.13ms
+step:594/1490 train_time:21483ms step_avg:36.17ms
+step:595/1490 train_time:21536ms step_avg:36.20ms
+step:596/1490 train_time:21596ms step_avg:36.24ms
+step:597/1490 train_time:21650ms step_avg:36.26ms
+step:598/1490 train_time:21711ms step_avg:36.31ms
+step:599/1490 train_time:21766ms step_avg:36.34ms
+step:600/1490 train_time:21825ms step_avg:36.37ms
+step:601/1490 train_time:21878ms step_avg:36.40ms
+step:602/1490 train_time:21937ms step_avg:36.44ms
+step:603/1490 train_time:21991ms step_avg:36.47ms
+step:604/1490 train_time:22052ms step_avg:36.51ms
+step:605/1490 train_time:22107ms step_avg:36.54ms
+step:606/1490 train_time:22166ms step_avg:36.58ms
+step:607/1490 train_time:22221ms step_avg:36.61ms
+step:608/1490 train_time:22281ms step_avg:36.65ms
+step:609/1490 train_time:22335ms step_avg:36.68ms
+step:610/1490 train_time:22395ms step_avg:36.71ms
+step:611/1490 train_time:22449ms step_avg:36.74ms
+step:612/1490 train_time:22509ms step_avg:36.78ms
+step:613/1490 train_time:22564ms step_avg:36.81ms
+step:614/1490 train_time:22623ms step_avg:36.85ms
+step:615/1490 train_time:22677ms step_avg:36.87ms
+step:616/1490 train_time:22736ms step_avg:36.91ms
+step:617/1490 train_time:22790ms step_avg:36.94ms
+step:618/1490 train_time:22850ms step_avg:36.97ms
+step:619/1490 train_time:22906ms step_avg:37.00ms
+step:620/1490 train_time:22965ms step_avg:37.04ms
+step:621/1490 train_time:23019ms step_avg:37.07ms
+step:622/1490 train_time:23079ms step_avg:37.11ms
+step:623/1490 train_time:23133ms step_avg:37.13ms
+step:624/1490 train_time:23193ms step_avg:37.17ms
+step:625/1490 train_time:23247ms step_avg:37.20ms
+step:626/1490 train_time:23307ms step_avg:37.23ms
+step:627/1490 train_time:23361ms step_avg:37.26ms
+step:628/1490 train_time:23421ms step_avg:37.29ms
+step:629/1490 train_time:23475ms step_avg:37.32ms
+step:630/1490 train_time:23535ms step_avg:37.36ms
+step:631/1490 train_time:23590ms step_avg:37.38ms
+step:632/1490 train_time:23650ms step_avg:37.42ms
+step:633/1490 train_time:23704ms step_avg:37.45ms
+step:634/1490 train_time:23764ms step_avg:37.48ms
+step:635/1490 train_time:23818ms step_avg:37.51ms
+step:636/1490 train_time:23878ms step_avg:37.54ms
+step:637/1490 train_time:23932ms step_avg:37.57ms
+step:638/1490 train_time:23991ms step_avg:37.60ms
+step:639/1490 train_time:24045ms step_avg:37.63ms
+step:640/1490 train_time:24105ms step_avg:37.66ms
+step:641/1490 train_time:24158ms step_avg:37.69ms
+step:642/1490 train_time:24218ms step_avg:37.72ms
+step:643/1490 train_time:24272ms step_avg:37.75ms
+step:644/1490 train_time:24332ms step_avg:37.78ms
+step:645/1490 train_time:24386ms step_avg:37.81ms
+step:646/1490 train_time:24446ms step_avg:37.84ms
+step:647/1490 train_time:24500ms step_avg:37.87ms
+step:648/1490 train_time:24559ms step_avg:37.90ms
+step:649/1490 train_time:24614ms step_avg:37.93ms
+step:650/1490 train_time:24674ms step_avg:37.96ms
+step:651/1490 train_time:24728ms step_avg:37.99ms
+step:652/1490 train_time:24789ms step_avg:38.02ms
+step:653/1490 train_time:24843ms step_avg:38.04ms
+step:654/1490 train_time:24903ms step_avg:38.08ms
+step:655/1490 train_time:24956ms step_avg:38.10ms
+step:656/1490 train_time:25016ms step_avg:38.13ms
+step:657/1490 train_time:25070ms step_avg:38.16ms
+step:658/1490 train_time:25130ms step_avg:38.19ms
+step:659/1490 train_time:25184ms step_avg:38.22ms
+step:660/1490 train_time:25244ms step_avg:38.25ms
+step:661/1490 train_time:25297ms step_avg:38.27ms
+step:662/1490 train_time:25357ms step_avg:38.30ms
+step:663/1490 train_time:25411ms step_avg:38.33ms
+step:664/1490 train_time:25472ms step_avg:38.36ms
+step:665/1490 train_time:25526ms step_avg:38.38ms
+step:666/1490 train_time:25586ms step_avg:38.42ms
+step:667/1490 train_time:25640ms step_avg:38.44ms
+step:668/1490 train_time:25699ms step_avg:38.47ms
+step:669/1490 train_time:25753ms step_avg:38.50ms
+step:670/1490 train_time:25813ms step_avg:38.53ms
+step:671/1490 train_time:25867ms step_avg:38.55ms
+step:672/1490 train_time:25927ms step_avg:38.58ms
+step:673/1490 train_time:25982ms step_avg:38.61ms
+step:674/1490 train_time:26040ms step_avg:38.64ms
+step:675/1490 train_time:26094ms step_avg:38.66ms
+step:676/1490 train_time:26153ms step_avg:38.69ms
+step:677/1490 train_time:26209ms step_avg:38.71ms
+step:678/1490 train_time:26270ms step_avg:38.75ms
+step:679/1490 train_time:26324ms step_avg:38.77ms
+step:680/1490 train_time:26384ms step_avg:38.80ms
+step:681/1490 train_time:26437ms step_avg:38.82ms
+step:682/1490 train_time:26497ms step_avg:38.85ms
+step:683/1490 train_time:26551ms step_avg:38.87ms
+step:684/1490 train_time:26611ms step_avg:38.90ms
+step:685/1490 train_time:26665ms step_avg:38.93ms
+step:686/1490 train_time:26725ms step_avg:38.96ms
+step:687/1490 train_time:26779ms step_avg:38.98ms
+step:688/1490 train_time:26838ms step_avg:39.01ms
+step:689/1490 train_time:26892ms step_avg:39.03ms
+step:690/1490 train_time:26952ms step_avg:39.06ms
+step:691/1490 train_time:27008ms step_avg:39.08ms
+step:692/1490 train_time:27067ms step_avg:39.11ms
+step:693/1490 train_time:27121ms step_avg:39.14ms
+step:694/1490 train_time:27181ms step_avg:39.17ms
+step:695/1490 train_time:27235ms step_avg:39.19ms
+step:696/1490 train_time:27295ms step_avg:39.22ms
+step:697/1490 train_time:27349ms step_avg:39.24ms
+step:698/1490 train_time:27409ms step_avg:39.27ms
+step:699/1490 train_time:27463ms step_avg:39.29ms
+step:700/1490 train_time:27522ms step_avg:39.32ms
+step:701/1490 train_time:27576ms step_avg:39.34ms
+step:702/1490 train_time:27635ms step_avg:39.37ms
+step:703/1490 train_time:27689ms step_avg:39.39ms
+step:704/1490 train_time:27748ms step_avg:39.42ms
+step:705/1490 train_time:27803ms step_avg:39.44ms
+step:706/1490 train_time:27862ms step_avg:39.46ms
+step:707/1490 train_time:27916ms step_avg:39.48ms
+step:708/1490 train_time:27976ms step_avg:39.51ms
+step:709/1490 train_time:28030ms step_avg:39.53ms
+step:710/1490 train_time:28089ms step_avg:39.56ms
+step:711/1490 train_time:28144ms step_avg:39.58ms
+step:712/1490 train_time:28205ms step_avg:39.61ms
+step:713/1490 train_time:28258ms step_avg:39.63ms
+step:714/1490 train_time:28317ms step_avg:39.66ms
+step:715/1490 train_time:28370ms step_avg:39.68ms
+step:716/1490 train_time:28432ms step_avg:39.71ms
+step:717/1490 train_time:28486ms step_avg:39.73ms
+step:718/1490 train_time:28547ms step_avg:39.76ms
+step:719/1490 train_time:28600ms step_avg:39.78ms
+step:720/1490 train_time:28659ms step_avg:39.80ms
+step:721/1490 train_time:28713ms step_avg:39.82ms
+step:722/1490 train_time:28774ms step_avg:39.85ms
+step:723/1490 train_time:28829ms step_avg:39.87ms
+step:724/1490 train_time:28889ms step_avg:39.90ms
+step:725/1490 train_time:28944ms step_avg:39.92ms
+step:726/1490 train_time:29003ms step_avg:39.95ms
+step:727/1490 train_time:29057ms step_avg:39.97ms
+step:728/1490 train_time:29117ms step_avg:40.00ms
+step:729/1490 train_time:29171ms step_avg:40.02ms
+step:730/1490 train_time:29231ms step_avg:40.04ms
+step:731/1490 train_time:29284ms step_avg:40.06ms
+step:732/1490 train_time:29343ms step_avg:40.09ms
+step:733/1490 train_time:29397ms step_avg:40.11ms
+step:734/1490 train_time:29457ms step_avg:40.13ms
+step:735/1490 train_time:29512ms step_avg:40.15ms
+step:736/1490 train_time:29573ms step_avg:40.18ms
+step:737/1490 train_time:29627ms step_avg:40.20ms
+step:738/1490 train_time:29687ms step_avg:40.23ms
+step:739/1490 train_time:29740ms step_avg:40.24ms
+step:740/1490 train_time:29799ms step_avg:40.27ms
+step:741/1490 train_time:29853ms step_avg:40.29ms
+step:742/1490 train_time:29912ms step_avg:40.31ms
+step:743/1490 train_time:29967ms step_avg:40.33ms
+step:744/1490 train_time:30028ms step_avg:40.36ms
+step:745/1490 train_time:30083ms step_avg:40.38ms
+step:746/1490 train_time:30142ms step_avg:40.41ms
+step:747/1490 train_time:30196ms step_avg:40.42ms
+step:748/1490 train_time:30256ms step_avg:40.45ms
+step:749/1490 train_time:30310ms step_avg:40.47ms
+step:750/1490 train_time:30371ms step_avg:40.50ms
+step:750/1490 val_loss:3.8083 train_time:30444ms step_avg:40.59ms
+step:751/1490 train_time:30463ms step_avg:40.56ms
+step:752/1490 train_time:30491ms step_avg:40.55ms
+step:753/1490 train_time:30547ms step_avg:40.57ms
+step:754/1490 train_time:30610ms step_avg:40.60ms
+step:755/1490 train_time:30663ms step_avg:40.61ms
+step:756/1490 train_time:30723ms step_avg:40.64ms
+step:757/1490 train_time:30776ms step_avg:40.66ms
+step:758/1490 train_time:30835ms step_avg:40.68ms
+step:759/1490 train_time:30890ms step_avg:40.70ms
+step:760/1490 train_time:30949ms step_avg:40.72ms
+step:761/1490 train_time:31002ms step_avg:40.74ms
+step:762/1490 train_time:31061ms step_avg:40.76ms
+step:763/1490 train_time:31115ms step_avg:40.78ms
+step:764/1490 train_time:31173ms step_avg:40.80ms
+step:765/1490 train_time:31227ms step_avg:40.82ms
+step:766/1490 train_time:31286ms step_avg:40.84ms
+step:767/1490 train_time:31340ms step_avg:40.86ms
+step:768/1490 train_time:31401ms step_avg:40.89ms
+step:769/1490 train_time:31456ms step_avg:40.90ms
+step:770/1490 train_time:31518ms step_avg:40.93ms
+step:771/1490 train_time:31573ms step_avg:40.95ms
+step:772/1490 train_time:31635ms step_avg:40.98ms
+step:773/1490 train_time:31691ms step_avg:41.00ms
+step:774/1490 train_time:31751ms step_avg:41.02ms
+step:775/1490 train_time:31805ms step_avg:41.04ms
+step:776/1490 train_time:31863ms step_avg:41.06ms
+step:777/1490 train_time:31917ms step_avg:41.08ms
+step:778/1490 train_time:31976ms step_avg:41.10ms
+step:779/1490 train_time:32030ms step_avg:41.12ms
+step:780/1490 train_time:32090ms step_avg:41.14ms
+step:781/1490 train_time:32143ms step_avg:41.16ms
+step:782/1490 train_time:32202ms step_avg:41.18ms
+step:783/1490 train_time:32256ms step_avg:41.20ms
+step:784/1490 train_time:32316ms step_avg:41.22ms
+step:785/1490 train_time:32371ms step_avg:41.24ms
+step:786/1490 train_time:32431ms step_avg:41.26ms
+step:787/1490 train_time:32486ms step_avg:41.28ms
+step:788/1490 train_time:32546ms step_avg:41.30ms
+step:789/1490 train_time:32600ms step_avg:41.32ms
+step:790/1490 train_time:32661ms step_avg:41.34ms
+step:791/1490 train_time:32715ms step_avg:41.36ms
+step:792/1490 train_time:32775ms step_avg:41.38ms
+step:793/1490 train_time:32830ms step_avg:41.40ms
+step:794/1490 train_time:32891ms step_avg:41.42ms
+step:795/1490 train_time:32945ms step_avg:41.44ms
+step:796/1490 train_time:33004ms step_avg:41.46ms
+step:797/1490 train_time:33058ms step_avg:41.48ms
+step:798/1490 train_time:33117ms step_avg:41.50ms
+step:799/1490 train_time:33170ms step_avg:41.51ms
+step:800/1490 train_time:33230ms step_avg:41.54ms
+step:801/1490 train_time:33283ms step_avg:41.55ms
+step:802/1490 train_time:33343ms step_avg:41.57ms
+step:803/1490 train_time:33397ms step_avg:41.59ms
+step:804/1490 train_time:33457ms step_avg:41.61ms
+step:805/1490 train_time:33511ms step_avg:41.63ms
+step:806/1490 train_time:33572ms step_avg:41.65ms
+step:807/1490 train_time:33626ms step_avg:41.67ms
+step:808/1490 train_time:33686ms step_avg:41.69ms
+step:809/1490 train_time:33740ms step_avg:41.71ms
+step:810/1490 train_time:33800ms step_avg:41.73ms
+step:811/1490 train_time:33854ms step_avg:41.74ms
+step:812/1490 train_time:33914ms step_avg:41.77ms
+step:813/1490 train_time:33969ms step_avg:41.78ms
+step:814/1490 train_time:34029ms step_avg:41.80ms
+step:815/1490 train_time:34081ms step_avg:41.82ms
+step:816/1490 train_time:34140ms step_avg:41.84ms
+step:817/1490 train_time:34194ms step_avg:41.85ms
+step:818/1490 train_time:34254ms step_avg:41.88ms
+step:819/1490 train_time:34309ms step_avg:41.89ms
+step:820/1490 train_time:34369ms step_avg:41.91ms
+step:821/1490 train_time:34423ms step_avg:41.93ms
+step:822/1490 train_time:34482ms step_avg:41.95ms
+step:823/1490 train_time:34538ms step_avg:41.97ms
+step:824/1490 train_time:34598ms step_avg:41.99ms
+step:825/1490 train_time:34652ms step_avg:42.00ms
+step:826/1490 train_time:34713ms step_avg:42.02ms
+step:827/1490 train_time:34769ms step_avg:42.04ms
+step:828/1490 train_time:34828ms step_avg:42.06ms
+step:829/1490 train_time:34882ms step_avg:42.08ms
+step:830/1490 train_time:34941ms step_avg:42.10ms
+step:831/1490 train_time:34996ms step_avg:42.11ms
+step:832/1490 train_time:35055ms step_avg:42.13ms
+step:833/1490 train_time:35109ms step_avg:42.15ms
+step:834/1490 train_time:35168ms step_avg:42.17ms
+step:835/1490 train_time:35221ms step_avg:42.18ms
+step:836/1490 train_time:35281ms step_avg:42.20ms
+step:837/1490 train_time:35336ms step_avg:42.22ms
+step:838/1490 train_time:35396ms step_avg:42.24ms
+step:839/1490 train_time:35450ms step_avg:42.25ms
+step:840/1490 train_time:35510ms step_avg:42.27ms
+step:841/1490 train_time:35566ms step_avg:42.29ms
+step:842/1490 train_time:35625ms step_avg:42.31ms
+step:843/1490 train_time:35678ms step_avg:42.32ms
+step:844/1490 train_time:35739ms step_avg:42.34ms
+step:845/1490 train_time:35793ms step_avg:42.36ms
+step:846/1490 train_time:35853ms step_avg:42.38ms
+step:847/1490 train_time:35906ms step_avg:42.39ms
+step:848/1490 train_time:35965ms step_avg:42.41ms
+step:849/1490 train_time:36019ms step_avg:42.43ms
+step:850/1490 train_time:36079ms step_avg:42.45ms
+step:851/1490 train_time:36134ms step_avg:42.46ms
+step:852/1490 train_time:36194ms step_avg:42.48ms
+step:853/1490 train_time:36248ms step_avg:42.49ms
+step:854/1490 train_time:36308ms step_avg:42.52ms
+step:855/1490 train_time:36361ms step_avg:42.53ms
+step:856/1490 train_time:36421ms step_avg:42.55ms
+step:857/1490 train_time:36475ms step_avg:42.56ms
+step:858/1490 train_time:36537ms step_avg:42.58ms
+step:859/1490 train_time:36591ms step_avg:42.60ms
+step:860/1490 train_time:36652ms step_avg:42.62ms
+step:861/1490 train_time:36706ms step_avg:42.63ms
+step:862/1490 train_time:36765ms step_avg:42.65ms
+step:863/1490 train_time:36819ms step_avg:42.66ms
+step:864/1490 train_time:36878ms step_avg:42.68ms
+step:865/1490 train_time:36932ms step_avg:42.70ms
+step:866/1490 train_time:36993ms step_avg:42.72ms
+step:867/1490 train_time:37046ms step_avg:42.73ms
+step:868/1490 train_time:37106ms step_avg:42.75ms
+step:869/1490 train_time:37160ms step_avg:42.76ms
+step:870/1490 train_time:37219ms step_avg:42.78ms
+step:871/1490 train_time:37273ms step_avg:42.79ms
+step:872/1490 train_time:37332ms step_avg:42.81ms
+step:873/1490 train_time:37387ms step_avg:42.83ms
+step:874/1490 train_time:37448ms step_avg:42.85ms
+step:875/1490 train_time:37501ms step_avg:42.86ms
+step:876/1490 train_time:37561ms step_avg:42.88ms
+step:877/1490 train_time:37616ms step_avg:42.89ms
+step:878/1490 train_time:37677ms step_avg:42.91ms
+step:879/1490 train_time:37732ms step_avg:42.93ms
+step:880/1490 train_time:37792ms step_avg:42.95ms
+step:881/1490 train_time:37847ms step_avg:42.96ms
+step:882/1490 train_time:37906ms step_avg:42.98ms
+step:883/1490 train_time:37959ms step_avg:42.99ms
+step:884/1490 train_time:38018ms step_avg:43.01ms
+step:885/1490 train_time:38072ms step_avg:43.02ms
+step:886/1490 train_time:38133ms step_avg:43.04ms
+step:887/1490 train_time:38187ms step_avg:43.05ms
+step:888/1490 train_time:38247ms step_avg:43.07ms
+step:889/1490 train_time:38301ms step_avg:43.08ms
+step:890/1490 train_time:38361ms step_avg:43.10ms
+step:891/1490 train_time:38415ms step_avg:43.11ms
+step:892/1490 train_time:38475ms step_avg:43.13ms
+step:893/1490 train_time:38530ms step_avg:43.15ms
+step:894/1490 train_time:38591ms step_avg:43.17ms
+step:895/1490 train_time:38644ms step_avg:43.18ms
+step:896/1490 train_time:38704ms step_avg:43.20ms
+step:897/1490 train_time:38758ms step_avg:43.21ms
+step:898/1490 train_time:38818ms step_avg:43.23ms
+step:899/1490 train_time:38872ms step_avg:43.24ms
+step:900/1490 train_time:38931ms step_avg:43.26ms
+step:901/1490 train_time:38984ms step_avg:43.27ms
+step:902/1490 train_time:39044ms step_avg:43.29ms
+step:903/1490 train_time:39098ms step_avg:43.30ms
+step:904/1490 train_time:39157ms step_avg:43.32ms
+step:905/1490 train_time:39211ms step_avg:43.33ms
+step:906/1490 train_time:39271ms step_avg:43.35ms
+step:907/1490 train_time:39325ms step_avg:43.36ms
+step:908/1490 train_time:39384ms step_avg:43.37ms
+step:909/1490 train_time:39439ms step_avg:43.39ms
+step:910/1490 train_time:39499ms step_avg:43.41ms
+step:911/1490 train_time:39553ms step_avg:43.42ms
+step:912/1490 train_time:39613ms step_avg:43.44ms
+step:913/1490 train_time:39669ms step_avg:43.45ms
+step:914/1490 train_time:39728ms step_avg:43.47ms
+step:915/1490 train_time:39782ms step_avg:43.48ms
+step:916/1490 train_time:39841ms step_avg:43.49ms
+step:917/1490 train_time:39895ms step_avg:43.51ms
+step:918/1490 train_time:39955ms step_avg:43.52ms
+step:919/1490 train_time:40009ms step_avg:43.54ms
+step:920/1490 train_time:40069ms step_avg:43.55ms
+step:921/1490 train_time:40122ms step_avg:43.56ms
+step:922/1490 train_time:40181ms step_avg:43.58ms
+step:923/1490 train_time:40236ms step_avg:43.59ms
+step:924/1490 train_time:40296ms step_avg:43.61ms
+step:925/1490 train_time:40350ms step_avg:43.62ms
+step:926/1490 train_time:40409ms step_avg:43.64ms
+step:927/1490 train_time:40464ms step_avg:43.65ms
+step:928/1490 train_time:40523ms step_avg:43.67ms
+step:929/1490 train_time:40577ms step_avg:43.68ms
+step:930/1490 train_time:40637ms step_avg:43.70ms
+step:931/1490 train_time:40691ms step_avg:43.71ms
+step:932/1490 train_time:40752ms step_avg:43.73ms
+step:933/1490 train_time:40805ms step_avg:43.74ms
+step:934/1490 train_time:40865ms step_avg:43.75ms
+step:935/1490 train_time:40918ms step_avg:43.76ms
+step:936/1490 train_time:40978ms step_avg:43.78ms
+step:937/1490 train_time:41032ms step_avg:43.79ms
+step:938/1490 train_time:41092ms step_avg:43.81ms
+step:939/1490 train_time:41146ms step_avg:43.82ms
+step:940/1490 train_time:41205ms step_avg:43.84ms
+step:941/1490 train_time:41259ms step_avg:43.85ms
+step:942/1490 train_time:41319ms step_avg:43.86ms
+step:943/1490 train_time:41373ms step_avg:43.87ms
+step:944/1490 train_time:41434ms step_avg:43.89ms
+step:945/1490 train_time:41487ms step_avg:43.90ms
+step:946/1490 train_time:41548ms step_avg:43.92ms
+step:947/1490 train_time:41602ms step_avg:43.93ms
+step:948/1490 train_time:41661ms step_avg:43.95ms
+step:949/1490 train_time:41716ms step_avg:43.96ms
+step:950/1490 train_time:41775ms step_avg:43.97ms
+step:951/1490 train_time:41830ms step_avg:43.99ms
+step:952/1490 train_time:41891ms step_avg:44.00ms
+step:953/1490 train_time:41945ms step_avg:44.01ms
+step:954/1490 train_time:42004ms step_avg:44.03ms
+step:955/1490 train_time:42058ms step_avg:44.04ms
+step:956/1490 train_time:42118ms step_avg:44.06ms
+step:957/1490 train_time:42171ms step_avg:44.07ms
+step:958/1490 train_time:42231ms step_avg:44.08ms
+step:959/1490 train_time:42285ms step_avg:44.09ms
+step:960/1490 train_time:42345ms step_avg:44.11ms
+step:961/1490 train_time:42398ms step_avg:44.12ms
+step:962/1490 train_time:42458ms step_avg:44.13ms
+step:963/1490 train_time:42513ms step_avg:44.15ms
+step:964/1490 train_time:42573ms step_avg:44.16ms
+step:965/1490 train_time:42627ms step_avg:44.17ms
+step:966/1490 train_time:42688ms step_avg:44.19ms
+step:967/1490 train_time:42742ms step_avg:44.20ms
+step:968/1490 train_time:42805ms step_avg:44.22ms
+step:969/1490 train_time:42883ms step_avg:44.25ms
+step:970/1490 train_time:42968ms step_avg:44.30ms
+step:971/1490 train_time:43048ms step_avg:44.33ms
+step:972/1490 train_time:43134ms step_avg:44.38ms
+step:973/1490 train_time:43215ms step_avg:44.41ms
+step:974/1490 train_time:43300ms step_avg:44.46ms
+step:975/1490 train_time:43381ms step_avg:44.49ms
+step:976/1490 train_time:43467ms step_avg:44.54ms
+step:977/1490 train_time:43547ms step_avg:44.57ms
+step:978/1490 train_time:43634ms step_avg:44.62ms
+step:979/1490 train_time:43715ms step_avg:44.65ms
+step:980/1490 train_time:43800ms step_avg:44.69ms
+step:981/1490 train_time:43880ms step_avg:44.73ms
+step:982/1490 train_time:43965ms step_avg:44.77ms
+step:983/1490 train_time:44046ms step_avg:44.81ms
+step:984/1490 train_time:44131ms step_avg:44.85ms
+step:985/1490 train_time:44211ms step_avg:44.88ms
+step:986/1490 train_time:44297ms step_avg:44.93ms
+step:987/1490 train_time:44377ms step_avg:44.96ms
+step:988/1490 train_time:44461ms step_avg:45.00ms
+step:989/1490 train_time:44541ms step_avg:45.04ms
+step:990/1490 train_time:44629ms step_avg:45.08ms
+step:991/1490 train_time:44710ms step_avg:45.12ms
+step:992/1490 train_time:44795ms step_avg:45.16ms
+step:993/1490 train_time:44877ms step_avg:45.19ms
+step:994/1490 train_time:44961ms step_avg:45.23ms
+step:995/1490 train_time:45041ms step_avg:45.27ms
+step:996/1490 train_time:45127ms step_avg:45.31ms
+step:997/1490 train_time:45207ms step_avg:45.34ms
+step:998/1490 train_time:45294ms step_avg:45.38ms
+step:999/1490 train_time:45374ms step_avg:45.42ms
+step:1000/1490 train_time:45461ms step_avg:45.46ms
+step:1000/1490 val_loss:3.5185 train_time:45563ms step_avg:45.56ms
+step:1001/1490 train_time:45583ms step_avg:45.54ms
+step:1002/1490 train_time:45632ms step_avg:45.54ms
+step:1003/1490 train_time:45715ms step_avg:45.58ms
+step:1004/1490 train_time:45803ms step_avg:45.62ms
+step:1005/1490 train_time:45883ms step_avg:45.65ms
+step:1006/1490 train_time:45967ms step_avg:45.69ms
+step:1007/1490 train_time:46047ms step_avg:45.73ms
+step:1008/1490 train_time:46131ms step_avg:45.77ms
+step:1009/1490 train_time:46210ms step_avg:45.80ms
+step:1010/1490 train_time:46294ms step_avg:45.84ms
+step:1011/1490 train_time:46373ms step_avg:45.87ms
+step:1012/1490 train_time:46457ms step_avg:45.91ms
+step:1013/1490 train_time:46541ms step_avg:45.94ms
+step:1014/1490 train_time:46629ms step_avg:45.98ms
+step:1015/1490 train_time:46710ms step_avg:46.02ms
+step:1016/1490 train_time:46798ms step_avg:46.06ms
+step:1017/1490 train_time:46878ms step_avg:46.09ms
+step:1018/1490 train_time:46963ms step_avg:46.13ms
+step:1019/1490 train_time:47044ms step_avg:46.17ms
+step:1020/1490 train_time:47127ms step_avg:46.20ms
+step:1021/1490 train_time:47207ms step_avg:46.24ms
+step:1022/1490 train_time:47292ms step_avg:46.27ms
+step:1023/1490 train_time:47371ms step_avg:46.31ms
+step:1024/1490 train_time:47455ms step_avg:46.34ms
+step:1025/1490 train_time:47538ms step_avg:46.38ms
+step:1026/1490 train_time:47626ms step_avg:46.42ms
+step:1027/1490 train_time:47709ms step_avg:46.45ms
+step:1028/1490 train_time:47795ms step_avg:46.49ms
+step:1029/1490 train_time:47876ms step_avg:46.53ms
+step:1030/1490 train_time:47962ms step_avg:46.56ms
+step:1031/1490 train_time:48043ms step_avg:46.60ms
+step:1032/1490 train_time:48129ms step_avg:46.64ms
+step:1033/1490 train_time:48207ms step_avg:46.67ms
+step:1034/1490 train_time:48291ms step_avg:46.70ms
+step:1035/1490 train_time:48369ms step_avg:46.73ms
+step:1036/1490 train_time:48455ms step_avg:46.77ms
+step:1037/1490 train_time:48536ms step_avg:46.80ms
+step:1038/1490 train_time:48622ms step_avg:46.84ms
+step:1039/1490 train_time:48703ms step_avg:46.88ms
+step:1040/1490 train_time:48790ms step_avg:46.91ms
+step:1041/1490 train_time:48870ms step_avg:46.95ms
+step:1042/1490 train_time:48956ms step_avg:46.98ms
+step:1043/1490 train_time:49037ms step_avg:47.02ms
+step:1044/1490 train_time:49124ms step_avg:47.05ms
+step:1045/1490 train_time:49202ms step_avg:47.08ms
+step:1046/1490 train_time:49287ms step_avg:47.12ms
+step:1047/1490 train_time:49367ms step_avg:47.15ms
+step:1048/1490 train_time:49453ms step_avg:47.19ms
+step:1049/1490 train_time:49533ms step_avg:47.22ms
+step:1050/1490 train_time:49619ms step_avg:47.26ms
+step:1051/1490 train_time:49700ms step_avg:47.29ms
+step:1052/1490 train_time:49786ms step_avg:47.33ms
+step:1053/1490 train_time:49866ms step_avg:47.36ms
+step:1054/1490 train_time:49952ms step_avg:47.39ms
+step:1055/1490 train_time:50032ms step_avg:47.42ms
+step:1056/1490 train_time:50117ms step_avg:47.46ms
+step:1057/1490 train_time:50198ms step_avg:47.49ms
+step:1058/1490 train_time:50283ms step_avg:47.53ms
+step:1059/1490 train_time:50363ms step_avg:47.56ms
+step:1060/1490 train_time:50449ms step_avg:47.59ms
+step:1061/1490 train_time:50529ms step_avg:47.62ms
+step:1062/1490 train_time:50615ms step_avg:47.66ms
+step:1063/1490 train_time:50695ms step_avg:47.69ms
+step:1064/1490 train_time:50780ms step_avg:47.73ms
+step:1065/1490 train_time:50861ms step_avg:47.76ms
+step:1066/1490 train_time:50947ms step_avg:47.79ms
+step:1067/1490 train_time:51028ms step_avg:47.82ms
+step:1068/1490 train_time:51113ms step_avg:47.86ms
+step:1069/1490 train_time:51195ms step_avg:47.89ms
+step:1070/1490 train_time:51281ms step_avg:47.93ms
+step:1071/1490 train_time:51360ms step_avg:47.96ms
+step:1072/1490 train_time:51445ms step_avg:47.99ms
+step:1073/1490 train_time:51527ms step_avg:48.02ms
+step:1074/1490 train_time:51612ms step_avg:48.06ms
+step:1075/1490 train_time:51693ms step_avg:48.09ms
+step:1076/1490 train_time:51779ms step_avg:48.12ms
+step:1077/1490 train_time:51858ms step_avg:48.15ms
+step:1078/1490 train_time:51945ms step_avg:48.19ms
+step:1079/1490 train_time:52027ms step_avg:48.22ms
+step:1080/1490 train_time:52112ms step_avg:48.25ms
+step:1081/1490 train_time:52191ms step_avg:48.28ms
+step:1082/1490 train_time:52276ms step_avg:48.31ms
+step:1083/1490 train_time:52356ms step_avg:48.34ms
+step:1084/1490 train_time:52442ms step_avg:48.38ms
+step:1085/1490 train_time:52523ms step_avg:48.41ms
+step:1086/1490 train_time:52608ms step_avg:48.44ms
+step:1087/1490 train_time:52688ms step_avg:48.47ms
+step:1088/1490 train_time:52773ms step_avg:48.50ms
+step:1089/1490 train_time:52853ms step_avg:48.53ms
+step:1090/1490 train_time:52939ms step_avg:48.57ms
+step:1091/1490 train_time:53020ms step_avg:48.60ms
+step:1092/1490 train_time:53106ms step_avg:48.63ms
+step:1093/1490 train_time:53186ms step_avg:48.66ms
+step:1094/1490 train_time:53271ms step_avg:48.69ms
+step:1095/1490 train_time:53350ms step_avg:48.72ms
+step:1096/1490 train_time:53437ms step_avg:48.76ms
+step:1097/1490 train_time:53517ms step_avg:48.78ms
+step:1098/1490 train_time:53602ms step_avg:48.82ms
+step:1099/1490 train_time:53683ms step_avg:48.85ms
+step:1100/1490 train_time:53768ms step_avg:48.88ms
+step:1101/1490 train_time:53849ms step_avg:48.91ms
+step:1102/1490 train_time:53935ms step_avg:48.94ms
+step:1103/1490 train_time:54016ms step_avg:48.97ms
+step:1104/1490 train_time:54103ms step_avg:49.01ms
+step:1105/1490 train_time:54184ms step_avg:49.03ms
+step:1106/1490 train_time:54269ms step_avg:49.07ms
+step:1107/1490 train_time:54349ms step_avg:49.10ms
+step:1108/1490 train_time:54433ms step_avg:49.13ms
+step:1109/1490 train_time:54515ms step_avg:49.16ms
+step:1110/1490 train_time:54601ms step_avg:49.19ms
+step:1111/1490 train_time:54680ms step_avg:49.22ms
+step:1112/1490 train_time:54766ms step_avg:49.25ms
+step:1113/1490 train_time:54848ms step_avg:49.28ms
+step:1114/1490 train_time:54933ms step_avg:49.31ms
+step:1115/1490 train_time:55012ms step_avg:49.34ms
+step:1116/1490 train_time:55097ms step_avg:49.37ms
+step:1117/1490 train_time:55178ms step_avg:49.40ms
+step:1118/1490 train_time:55263ms step_avg:49.43ms
+step:1119/1490 train_time:55343ms step_avg:49.46ms
+step:1120/1490 train_time:55429ms step_avg:49.49ms
+step:1121/1490 train_time:55509ms step_avg:49.52ms
+step:1122/1490 train_time:55594ms step_avg:49.55ms
+step:1123/1490 train_time:55674ms step_avg:49.58ms
+step:1124/1490 train_time:55760ms step_avg:49.61ms
+step:1125/1490 train_time:55840ms step_avg:49.64ms
+step:1126/1490 train_time:55927ms step_avg:49.67ms
+step:1127/1490 train_time:56006ms step_avg:49.69ms
+step:1128/1490 train_time:56091ms step_avg:49.73ms
+step:1129/1490 train_time:56173ms step_avg:49.75ms
+step:1130/1490 train_time:56257ms step_avg:49.79ms
+step:1131/1490 train_time:56338ms step_avg:49.81ms
+step:1132/1490 train_time:56425ms step_avg:49.85ms
+step:1133/1490 train_time:56504ms step_avg:49.87ms
+step:1134/1490 train_time:56589ms step_avg:49.90ms
+step:1135/1490 train_time:56669ms step_avg:49.93ms
+step:1136/1490 train_time:56754ms step_avg:49.96ms
+step:1137/1490 train_time:56835ms step_avg:49.99ms
+step:1138/1490 train_time:56921ms step_avg:50.02ms
+step:1139/1490 train_time:57001ms step_avg:50.04ms
+step:1140/1490 train_time:57087ms step_avg:50.08ms
+step:1141/1490 train_time:57167ms step_avg:50.10ms
+step:1142/1490 train_time:57253ms step_avg:50.13ms
+step:1143/1490 train_time:57334ms step_avg:50.16ms
+step:1144/1490 train_time:57420ms step_avg:50.19ms
+step:1145/1490 train_time:57500ms step_avg:50.22ms
+step:1146/1490 train_time:57585ms step_avg:50.25ms
+step:1147/1490 train_time:57666ms step_avg:50.28ms
+step:1148/1490 train_time:57749ms step_avg:50.30ms
+step:1149/1490 train_time:57831ms step_avg:50.33ms
+step:1150/1490 train_time:57918ms step_avg:50.36ms
+step:1151/1490 train_time:57998ms step_avg:50.39ms
+step:1152/1490 train_time:58083ms step_avg:50.42ms
+step:1153/1490 train_time:58165ms step_avg:50.45ms
+step:1154/1490 train_time:58251ms step_avg:50.48ms
+step:1155/1490 train_time:58331ms step_avg:50.50ms
+step:1156/1490 train_time:58416ms step_avg:50.53ms
+step:1157/1490 train_time:58497ms step_avg:50.56ms
+step:1158/1490 train_time:58582ms step_avg:50.59ms
+step:1159/1490 train_time:58663ms step_avg:50.62ms
+step:1160/1490 train_time:58748ms step_avg:50.64ms
+step:1161/1490 train_time:58829ms step_avg:50.67ms
+step:1162/1490 train_time:58914ms step_avg:50.70ms
+step:1163/1490 train_time:58994ms step_avg:50.73ms
+step:1164/1490 train_time:59080ms step_avg:50.76ms
+step:1165/1490 train_time:59160ms step_avg:50.78ms
+step:1166/1490 train_time:59245ms step_avg:50.81ms
+step:1167/1490 train_time:59326ms step_avg:50.84ms
+step:1168/1490 train_time:59410ms step_avg:50.87ms
+step:1169/1490 train_time:59490ms step_avg:50.89ms
+step:1170/1490 train_time:59577ms step_avg:50.92ms
+step:1171/1490 train_time:59658ms step_avg:50.95ms
+step:1172/1490 train_time:59742ms step_avg:50.97ms
+step:1173/1490 train_time:59822ms step_avg:51.00ms
+step:1174/1490 train_time:59909ms step_avg:51.03ms
+step:1175/1490 train_time:59989ms step_avg:51.05ms
+step:1176/1490 train_time:60074ms step_avg:51.08ms
+step:1177/1490 train_time:60154ms step_avg:51.11ms
+step:1178/1490 train_time:60239ms step_avg:51.14ms
+step:1179/1490 train_time:60321ms step_avg:51.16ms
+step:1180/1490 train_time:60407ms step_avg:51.19ms
+step:1181/1490 train_time:60487ms step_avg:51.22ms
+step:1182/1490 train_time:60572ms step_avg:51.25ms
+step:1183/1490 train_time:60651ms step_avg:51.27ms
+step:1184/1490 train_time:60736ms step_avg:51.30ms
+step:1185/1490 train_time:60817ms step_avg:51.32ms
+step:1186/1490 train_time:60904ms step_avg:51.35ms
+step:1187/1490 train_time:60983ms step_avg:51.38ms
+step:1188/1490 train_time:61069ms step_avg:51.41ms
+step:1189/1490 train_time:61149ms step_avg:51.43ms
+step:1190/1490 train_time:61235ms step_avg:51.46ms
+step:1191/1490 train_time:61315ms step_avg:51.48ms
+step:1192/1490 train_time:61402ms step_avg:51.51ms
+step:1193/1490 train_time:61481ms step_avg:51.53ms
+step:1194/1490 train_time:61567ms step_avg:51.56ms
+step:1195/1490 train_time:61646ms step_avg:51.59ms
+step:1196/1490 train_time:61732ms step_avg:51.62ms
+step:1197/1490 train_time:61812ms step_avg:51.64ms
+step:1198/1490 train_time:61898ms step_avg:51.67ms
+step:1199/1490 train_time:61979ms step_avg:51.69ms
+step:1200/1490 train_time:62067ms step_avg:51.72ms
+step:1201/1490 train_time:62147ms step_avg:51.75ms
+step:1202/1490 train_time:62233ms step_avg:51.77ms
+step:1203/1490 train_time:62313ms step_avg:51.80ms
+step:1204/1490 train_time:62400ms step_avg:51.83ms
+step:1205/1490 train_time:62479ms step_avg:51.85ms
+step:1206/1490 train_time:62567ms step_avg:51.88ms
+step:1207/1490 train_time:62648ms step_avg:51.90ms
+step:1208/1490 train_time:62733ms step_avg:51.93ms
+step:1209/1490 train_time:62812ms step_avg:51.95ms
+step:1210/1490 train_time:62897ms step_avg:51.98ms
+step:1211/1490 train_time:62977ms step_avg:52.00ms
+step:1212/1490 train_time:63062ms step_avg:52.03ms
+step:1213/1490 train_time:63142ms step_avg:52.05ms
+step:1214/1490 train_time:63229ms step_avg:52.08ms
+step:1215/1490 train_time:63308ms step_avg:52.11ms
+step:1216/1490 train_time:63394ms step_avg:52.13ms
+step:1217/1490 train_time:63473ms step_avg:52.16ms
+step:1218/1490 train_time:63558ms step_avg:52.18ms
+step:1219/1490 train_time:63639ms step_avg:52.21ms
+step:1220/1490 train_time:63726ms step_avg:52.23ms
+step:1221/1490 train_time:63804ms step_avg:52.26ms
+step:1222/1490 train_time:63889ms step_avg:52.28ms
+step:1223/1490 train_time:63970ms step_avg:52.31ms
+step:1224/1490 train_time:64056ms step_avg:52.33ms
+step:1225/1490 train_time:64137ms step_avg:52.36ms
+step:1226/1490 train_time:64224ms step_avg:52.39ms
+step:1227/1490 train_time:64304ms step_avg:52.41ms
+step:1228/1490 train_time:64389ms step_avg:52.43ms
+step:1229/1490 train_time:64469ms step_avg:52.46ms
+step:1230/1490 train_time:64553ms step_avg:52.48ms
+step:1231/1490 train_time:64634ms step_avg:52.51ms
+step:1232/1490 train_time:64720ms step_avg:52.53ms
+step:1233/1490 train_time:64801ms step_avg:52.56ms
+step:1234/1490 train_time:64885ms step_avg:52.58ms
+step:1235/1490 train_time:64965ms step_avg:52.60ms
+step:1236/1490 train_time:65050ms step_avg:52.63ms
+step:1237/1490 train_time:65133ms step_avg:52.65ms
+step:1238/1490 train_time:65219ms step_avg:52.68ms
+step:1239/1490 train_time:65299ms step_avg:52.70ms
+step:1240/1490 train_time:65385ms step_avg:52.73ms
+step:1241/1490 train_time:65464ms step_avg:52.75ms
+step:1242/1490 train_time:65549ms step_avg:52.78ms
+step:1243/1490 train_time:65631ms step_avg:52.80ms
+step:1244/1490 train_time:65716ms step_avg:52.83ms
+step:1245/1490 train_time:65797ms step_avg:52.85ms
+step:1246/1490 train_time:65882ms step_avg:52.88ms
+step:1247/1490 train_time:65962ms step_avg:52.90ms
+step:1248/1490 train_time:66048ms step_avg:52.92ms
+step:1249/1490 train_time:66129ms step_avg:52.95ms
+step:1250/1490 train_time:66214ms step_avg:52.97ms
+step:1250/1490 val_loss:3.3727 train_time:66317ms step_avg:53.05ms
+step:1251/1490 train_time:66337ms step_avg:53.03ms
+step:1252/1490 train_time:66387ms step_avg:53.02ms
+step:1253/1490 train_time:66471ms step_avg:53.05ms
+step:1254/1490 train_time:66557ms step_avg:53.08ms
+step:1255/1490 train_time:66639ms step_avg:53.10ms
+step:1256/1490 train_time:66722ms step_avg:53.12ms
+step:1257/1490 train_time:66802ms step_avg:53.14ms
+step:1258/1490 train_time:66886ms step_avg:53.17ms
+step:1259/1490 train_time:66965ms step_avg:53.19ms
+step:1260/1490 train_time:67049ms step_avg:53.21ms
+step:1261/1490 train_time:67129ms step_avg:53.24ms
+step:1262/1490 train_time:67213ms step_avg:53.26ms
+step:1263/1490 train_time:67295ms step_avg:53.28ms
+step:1264/1490 train_time:67383ms step_avg:53.31ms
+step:1265/1490 train_time:67466ms step_avg:53.33ms
+step:1266/1490 train_time:67554ms step_avg:53.36ms
+step:1267/1490 train_time:67635ms step_avg:53.38ms
+step:1268/1490 train_time:67719ms step_avg:53.41ms
+step:1269/1490 train_time:67798ms step_avg:53.43ms
+step:1270/1490 train_time:67883ms step_avg:53.45ms
+step:1271/1490 train_time:67961ms step_avg:53.47ms
+step:1272/1490 train_time:68045ms step_avg:53.49ms
+step:1273/1490 train_time:68124ms step_avg:53.51ms
+step:1274/1490 train_time:68209ms step_avg:53.54ms
+step:1275/1490 train_time:68290ms step_avg:53.56ms
+step:1276/1490 train_time:68378ms step_avg:53.59ms
+step:1277/1490 train_time:68459ms step_avg:53.61ms
+step:1278/1490 train_time:68546ms step_avg:53.64ms
+step:1279/1490 train_time:68626ms step_avg:53.66ms
+step:1280/1490 train_time:68713ms step_avg:53.68ms
+step:1281/1490 train_time:68794ms step_avg:53.70ms
+step:1282/1490 train_time:68879ms step_avg:53.73ms
+step:1283/1490 train_time:68958ms step_avg:53.75ms
+step:1284/1490 train_time:69042ms step_avg:53.77ms
+step:1285/1490 train_time:69121ms step_avg:53.79ms
+step:1286/1490 train_time:69206ms step_avg:53.82ms
+step:1287/1490 train_time:69288ms step_avg:53.84ms
+step:1288/1490 train_time:69376ms step_avg:53.86ms
+step:1289/1490 train_time:69458ms step_avg:53.89ms
+step:1290/1490 train_time:69544ms step_avg:53.91ms
+step:1291/1490 train_time:69625ms step_avg:53.93ms
+step:1292/1490 train_time:69710ms step_avg:53.96ms
+step:1293/1490 train_time:69790ms step_avg:53.98ms
+step:1294/1490 train_time:69875ms step_avg:54.00ms
+step:1295/1490 train_time:69954ms step_avg:54.02ms
+step:1296/1490 train_time:70039ms step_avg:54.04ms
+step:1297/1490 train_time:70118ms step_avg:54.06ms
+step:1298/1490 train_time:70204ms step_avg:54.09ms
+step:1299/1490 train_time:70285ms step_avg:54.11ms
+step:1300/1490 train_time:70371ms step_avg:54.13ms
+step:1301/1490 train_time:70453ms step_avg:54.15ms
+step:1302/1490 train_time:70538ms step_avg:54.18ms
+step:1303/1490 train_time:70618ms step_avg:54.20ms
+step:1304/1490 train_time:70705ms step_avg:54.22ms
+step:1305/1490 train_time:70785ms step_avg:54.24ms
+step:1306/1490 train_time:70871ms step_avg:54.27ms
+step:1307/1490 train_time:70953ms step_avg:54.29ms
+step:1308/1490 train_time:71038ms step_avg:54.31ms
+step:1309/1490 train_time:71117ms step_avg:54.33ms
+step:1310/1490 train_time:71201ms step_avg:54.35ms
+step:1311/1490 train_time:71283ms step_avg:54.37ms
+step:1312/1490 train_time:71369ms step_avg:54.40ms
+step:1313/1490 train_time:71451ms step_avg:54.42ms
+step:1314/1490 train_time:71537ms step_avg:54.44ms
+step:1315/1490 train_time:71618ms step_avg:54.46ms
+step:1316/1490 train_time:71704ms step_avg:54.49ms
+step:1317/1490 train_time:71785ms step_avg:54.51ms
+step:1318/1490 train_time:71871ms step_avg:54.53ms
+step:1319/1490 train_time:71950ms step_avg:54.55ms
+step:1320/1490 train_time:72036ms step_avg:54.57ms
+step:1321/1490 train_time:72116ms step_avg:54.59ms
+step:1322/1490 train_time:72202ms step_avg:54.62ms
+step:1323/1490 train_time:72281ms step_avg:54.63ms
+step:1324/1490 train_time:72366ms step_avg:54.66ms
+step:1325/1490 train_time:72447ms step_avg:54.68ms
+step:1326/1490 train_time:72533ms step_avg:54.70ms
+step:1327/1490 train_time:72614ms step_avg:54.72ms
+step:1328/1490 train_time:72699ms step_avg:54.74ms
+step:1329/1490 train_time:72779ms step_avg:54.76ms
+step:1330/1490 train_time:72864ms step_avg:54.79ms
+step:1331/1490 train_time:72945ms step_avg:54.80ms
+step:1332/1490 train_time:73030ms step_avg:54.83ms
+step:1333/1490 train_time:73110ms step_avg:54.85ms
+step:1334/1490 train_time:73196ms step_avg:54.87ms
+step:1335/1490 train_time:73278ms step_avg:54.89ms
+step:1336/1490 train_time:73364ms step_avg:54.91ms
+step:1337/1490 train_time:73444ms step_avg:54.93ms
+step:1338/1490 train_time:73530ms step_avg:54.96ms
+step:1339/1490 train_time:73610ms step_avg:54.97ms
+step:1340/1490 train_time:73697ms step_avg:55.00ms
+step:1341/1490 train_time:73778ms step_avg:55.02ms
+step:1342/1490 train_time:73864ms step_avg:55.04ms
+step:1343/1490 train_time:73945ms step_avg:55.06ms
+step:1344/1490 train_time:74030ms step_avg:55.08ms
+step:1345/1490 train_time:74110ms step_avg:55.10ms
+step:1346/1490 train_time:74197ms step_avg:55.12ms
+step:1347/1490 train_time:74276ms step_avg:55.14ms
+step:1348/1490 train_time:74362ms step_avg:55.16ms
+step:1349/1490 train_time:74442ms step_avg:55.18ms
+step:1350/1490 train_time:74529ms step_avg:55.21ms
+step:1351/1490 train_time:74611ms step_avg:55.23ms
+step:1352/1490 train_time:74696ms step_avg:55.25ms
+step:1353/1490 train_time:74775ms step_avg:55.27ms
+step:1354/1490 train_time:74861ms step_avg:55.29ms
+step:1355/1490 train_time:74940ms step_avg:55.31ms
+step:1356/1490 train_time:75026ms step_avg:55.33ms
+step:1357/1490 train_time:75106ms step_avg:55.35ms
+step:1358/1490 train_time:75192ms step_avg:55.37ms
+step:1359/1490 train_time:75271ms step_avg:55.39ms
+step:1360/1490 train_time:75359ms step_avg:55.41ms
+step:1361/1490 train_time:75439ms step_avg:55.43ms
+step:1362/1490 train_time:75524ms step_avg:55.45ms
+step:1363/1490 train_time:75606ms step_avg:55.47ms
+step:1364/1490 train_time:75691ms step_avg:55.49ms
+step:1365/1490 train_time:75770ms step_avg:55.51ms
+step:1366/1490 train_time:75857ms step_avg:55.53ms
+step:1367/1490 train_time:75938ms step_avg:55.55ms
+step:1368/1490 train_time:76023ms step_avg:55.57ms
+step:1369/1490 train_time:76103ms step_avg:55.59ms
+step:1370/1490 train_time:76189ms step_avg:55.61ms
+step:1371/1490 train_time:76269ms step_avg:55.63ms
+step:1372/1490 train_time:76356ms step_avg:55.65ms
+step:1373/1490 train_time:76437ms step_avg:55.67ms
+step:1374/1490 train_time:76523ms step_avg:55.69ms
+step:1375/1490 train_time:76603ms step_avg:55.71ms
+step:1376/1490 train_time:76689ms step_avg:55.73ms
+step:1377/1490 train_time:76769ms step_avg:55.75ms
+step:1378/1490 train_time:76857ms step_avg:55.77ms
+step:1379/1490 train_time:76938ms step_avg:55.79ms
+step:1380/1490 train_time:77022ms step_avg:55.81ms
+step:1381/1490 train_time:77102ms step_avg:55.83ms
+step:1382/1490 train_time:77187ms step_avg:55.85ms
+step:1383/1490 train_time:77268ms step_avg:55.87ms
+step:1384/1490 train_time:77354ms step_avg:55.89ms
+step:1385/1490 train_time:77436ms step_avg:55.91ms
+step:1386/1490 train_time:77521ms step_avg:55.93ms
+step:1387/1490 train_time:77600ms step_avg:55.95ms
+step:1388/1490 train_time:77687ms step_avg:55.97ms
+step:1389/1490 train_time:77767ms step_avg:55.99ms
+step:1390/1490 train_time:77852ms step_avg:56.01ms
+step:1391/1490 train_time:77933ms step_avg:56.03ms
+step:1392/1490 train_time:78018ms step_avg:56.05ms
+step:1393/1490 train_time:78098ms step_avg:56.06ms
+step:1394/1490 train_time:78184ms step_avg:56.09ms
+step:1395/1490 train_time:78263ms step_avg:56.10ms
+step:1396/1490 train_time:78350ms step_avg:56.12ms
+step:1397/1490 train_time:78431ms step_avg:56.14ms
+step:1398/1490 train_time:78517ms step_avg:56.16ms
+step:1399/1490 train_time:78597ms step_avg:56.18ms
+step:1400/1490 train_time:78682ms step_avg:56.20ms
+step:1401/1490 train_time:78762ms step_avg:56.22ms
+step:1402/1490 train_time:78849ms step_avg:56.24ms
+step:1403/1490 train_time:78929ms step_avg:56.26ms
+step:1404/1490 train_time:79014ms step_avg:56.28ms
+step:1405/1490 train_time:79094ms step_avg:56.29ms
+step:1406/1490 train_time:79179ms step_avg:56.32ms
+step:1407/1490 train_time:79259ms step_avg:56.33ms
+step:1408/1490 train_time:79346ms step_avg:56.35ms
+step:1409/1490 train_time:79427ms step_avg:56.37ms
+step:1410/1490 train_time:79513ms step_avg:56.39ms
+step:1411/1490 train_time:79594ms step_avg:56.41ms
+step:1412/1490 train_time:79678ms step_avg:56.43ms
+step:1413/1490 train_time:79758ms step_avg:56.45ms
+step:1414/1490 train_time:79843ms step_avg:56.47ms
+step:1415/1490 train_time:79923ms step_avg:56.48ms
+step:1416/1490 train_time:80009ms step_avg:56.50ms
+step:1417/1490 train_time:80089ms step_avg:56.52ms
+step:1418/1490 train_time:80174ms step_avg:56.54ms
+step:1419/1490 train_time:80255ms step_avg:56.56ms
+step:1420/1490 train_time:80341ms step_avg:56.58ms
+step:1421/1490 train_time:80420ms step_avg:56.59ms
+step:1422/1490 train_time:80506ms step_avg:56.61ms
+step:1423/1490 train_time:80587ms step_avg:56.63ms
+step:1424/1490 train_time:80674ms step_avg:56.65ms
+step:1425/1490 train_time:80754ms step_avg:56.67ms
+step:1426/1490 train_time:80839ms step_avg:56.69ms
+step:1427/1490 train_time:80918ms step_avg:56.71ms
+step:1428/1490 train_time:81004ms step_avg:56.73ms
+step:1429/1490 train_time:81085ms step_avg:56.74ms
+step:1430/1490 train_time:81171ms step_avg:56.76ms
+step:1431/1490 train_time:81252ms step_avg:56.78ms
+step:1432/1490 train_time:81339ms step_avg:56.80ms
+step:1433/1490 train_time:81418ms step_avg:56.82ms
+step:1434/1490 train_time:81503ms step_avg:56.84ms
+step:1435/1490 train_time:81583ms step_avg:56.85ms
+step:1436/1490 train_time:81671ms step_avg:56.87ms
+step:1437/1490 train_time:81752ms step_avg:56.89ms
+step:1438/1490 train_time:81837ms step_avg:56.91ms
+step:1439/1490 train_time:81918ms step_avg:56.93ms
+step:1440/1490 train_time:82003ms step_avg:56.95ms
+step:1441/1490 train_time:82085ms step_avg:56.96ms
+step:1442/1490 train_time:82171ms step_avg:56.98ms
+step:1443/1490 train_time:82250ms step_avg:57.00ms
+step:1444/1490 train_time:82336ms step_avg:57.02ms
+step:1445/1490 train_time:82417ms step_avg:57.04ms
+step:1446/1490 train_time:82503ms step_avg:57.06ms
+step:1447/1490 train_time:82584ms step_avg:57.07ms
+step:1448/1490 train_time:82670ms step_avg:57.09ms
+step:1449/1490 train_time:82750ms step_avg:57.11ms
+step:1450/1490 train_time:82836ms step_avg:57.13ms
+step:1451/1490 train_time:82920ms step_avg:57.15ms
+step:1452/1490 train_time:83009ms step_avg:57.17ms
+step:1453/1490 train_time:83090ms step_avg:57.18ms
+step:1454/1490 train_time:83176ms step_avg:57.21ms
+step:1455/1490 train_time:83258ms step_avg:57.22ms
+step:1456/1490 train_time:83345ms step_avg:57.24ms
+step:1457/1490 train_time:83425ms step_avg:57.26ms
+step:1458/1490 train_time:83511ms step_avg:57.28ms
+step:1459/1490 train_time:83591ms step_avg:57.29ms
+step:1460/1490 train_time:83678ms step_avg:57.31ms
+step:1461/1490 train_time:83759ms step_avg:57.33ms
+step:1462/1490 train_time:83845ms step_avg:57.35ms
+step:1463/1490 train_time:83925ms step_avg:57.37ms
+step:1464/1490 train_time:84012ms step_avg:57.39ms
+step:1465/1490 train_time:84094ms step_avg:57.40ms
+step:1466/1490 train_time:84181ms step_avg:57.42ms
+step:1467/1490 train_time:84261ms step_avg:57.44ms
+step:1468/1490 train_time:84348ms step_avg:57.46ms
+step:1469/1490 train_time:84428ms step_avg:57.47ms
+step:1470/1490 train_time:84515ms step_avg:57.49ms
+step:1471/1490 train_time:84594ms step_avg:57.51ms
+step:1472/1490 train_time:84680ms step_avg:57.53ms
+step:1473/1490 train_time:84761ms step_avg:57.54ms
+step:1474/1490 train_time:84847ms step_avg:57.56ms
+step:1475/1490 train_time:84927ms step_avg:57.58ms
+step:1476/1490 train_time:85014ms step_avg:57.60ms
+step:1477/1490 train_time:85095ms step_avg:57.61ms
+step:1478/1490 train_time:85180ms step_avg:57.63ms
+step:1479/1490 train_time:85259ms step_avg:57.65ms
+step:1480/1490 train_time:85346ms step_avg:57.67ms
+step:1481/1490 train_time:85427ms step_avg:57.68ms
+step:1482/1490 train_time:85513ms step_avg:57.70ms
+step:1483/1490 train_time:85592ms step_avg:57.72ms
+step:1484/1490 train_time:85680ms step_avg:57.74ms
+step:1485/1490 train_time:85760ms step_avg:57.75ms
+step:1486/1490 train_time:85846ms step_avg:57.77ms
+step:1487/1490 train_time:85927ms step_avg:57.79ms
+step:1488/1490 train_time:86015ms step_avg:57.81ms
+step:1489/1490 train_time:86095ms step_avg:57.82ms
+step:1490/1490 train_time:86181ms step_avg:57.84ms
+step:1490/1490 val_loss:3.2792 train_time:86282ms step_avg:57.91ms
+peak memory allocated: 31296 MiB reserved: 47042 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/combined/2026-03-22_20-10-40_time-186_secs_06-mbeta2-max-docs_d4539c.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/combined/2026-03-22_20-10-40_time-186_secs_06-mbeta2-max-docs_d4539c.txt
@@ -1,0 +1,4457 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 20:10:55 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            133W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   40C    P0            124W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1843444      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1843445      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1843446      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1843447      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1843448      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1843449      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1843450      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1843451      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8278 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:73ms step_avg:73.06ms
+step:2/1490 train_time:102ms step_avg:51.20ms
+step:3/1490 train_time:119ms step_avg:39.78ms
+step:4/1490 train_time:148ms step_avg:37.08ms
+step:5/1490 train_time:175ms step_avg:35.04ms
+step:6/1490 train_time:210ms step_avg:35.02ms
+step:7/1490 train_time:237ms step_avg:33.88ms
+step:8/1490 train_time:272ms step_avg:33.98ms
+step:9/1490 train_time:300ms step_avg:33.28ms
+step:10/1490 train_time:335ms step_avg:33.45ms
+step:11/1490 train_time:362ms step_avg:32.90ms
+step:12/1490 train_time:396ms step_avg:33.01ms
+step:13/1490 train_time:424ms step_avg:32.61ms
+step:14/1490 train_time:459ms step_avg:32.76ms
+step:15/1490 train_time:486ms step_avg:32.42ms
+step:16/1490 train_time:521ms step_avg:32.56ms
+step:17/1490 train_time:549ms step_avg:32.30ms
+step:18/1490 train_time:583ms step_avg:32.41ms
+step:19/1490 train_time:612ms step_avg:32.19ms
+step:20/1490 train_time:646ms step_avg:32.30ms
+step:21/1490 train_time:674ms step_avg:32.09ms
+step:22/1490 train_time:708ms step_avg:32.19ms
+step:23/1490 train_time:736ms step_avg:32.01ms
+step:24/1490 train_time:771ms step_avg:32.11ms
+step:25/1490 train_time:799ms step_avg:31.96ms
+step:26/1490 train_time:833ms step_avg:32.05ms
+step:27/1490 train_time:861ms step_avg:31.90ms
+step:28/1490 train_time:895ms step_avg:31.98ms
+step:29/1490 train_time:924ms step_avg:31.85ms
+step:30/1490 train_time:958ms step_avg:31.94ms
+step:31/1490 train_time:987ms step_avg:31.84ms
+step:32/1490 train_time:1023ms step_avg:31.98ms
+step:33/1490 train_time:1054ms step_avg:31.92ms
+step:34/1490 train_time:1089ms step_avg:32.02ms
+step:35/1490 train_time:1117ms step_avg:31.92ms
+step:36/1490 train_time:1152ms step_avg:32.00ms
+step:37/1490 train_time:1181ms step_avg:31.91ms
+step:38/1490 train_time:1215ms step_avg:31.98ms
+step:39/1490 train_time:1243ms step_avg:31.87ms
+step:40/1490 train_time:1278ms step_avg:31.94ms
+step:41/1490 train_time:1306ms step_avg:31.85ms
+step:42/1490 train_time:1341ms step_avg:31.92ms
+step:43/1490 train_time:1369ms step_avg:31.83ms
+step:44/1490 train_time:1403ms step_avg:31.89ms
+step:45/1490 train_time:1431ms step_avg:31.81ms
+step:46/1490 train_time:1466ms step_avg:31.87ms
+step:47/1490 train_time:1494ms step_avg:31.78ms
+step:48/1490 train_time:1528ms step_avg:31.83ms
+step:49/1490 train_time:1556ms step_avg:31.75ms
+step:50/1490 train_time:1590ms step_avg:31.80ms
+step:51/1490 train_time:1618ms step_avg:31.72ms
+step:52/1490 train_time:1652ms step_avg:31.78ms
+step:53/1490 train_time:1680ms step_avg:31.70ms
+step:54/1490 train_time:1715ms step_avg:31.76ms
+step:55/1490 train_time:1743ms step_avg:31.69ms
+step:56/1490 train_time:1777ms step_avg:31.74ms
+step:57/1490 train_time:1805ms step_avg:31.67ms
+step:58/1490 train_time:1840ms step_avg:31.72ms
+step:59/1490 train_time:1868ms step_avg:31.65ms
+step:60/1490 train_time:1902ms step_avg:31.70ms
+step:61/1490 train_time:1930ms step_avg:31.65ms
+step:62/1490 train_time:1965ms step_avg:31.70ms
+step:63/1490 train_time:1994ms step_avg:31.64ms
+step:64/1490 train_time:2028ms step_avg:31.69ms
+step:65/1490 train_time:2057ms step_avg:31.65ms
+step:66/1490 train_time:2091ms step_avg:31.69ms
+step:67/1490 train_time:2120ms step_avg:31.64ms
+step:68/1490 train_time:2155ms step_avg:31.69ms
+step:69/1490 train_time:2183ms step_avg:31.64ms
+step:70/1490 train_time:2218ms step_avg:31.69ms
+step:71/1490 train_time:2247ms step_avg:31.64ms
+step:72/1490 train_time:2281ms step_avg:31.69ms
+step:73/1490 train_time:2310ms step_avg:31.64ms
+step:74/1490 train_time:2344ms step_avg:31.68ms
+step:75/1490 train_time:2373ms step_avg:31.64ms
+step:76/1490 train_time:2407ms step_avg:31.67ms
+step:77/1490 train_time:2435ms step_avg:31.63ms
+step:78/1490 train_time:2470ms step_avg:31.67ms
+step:79/1490 train_time:2498ms step_avg:31.62ms
+step:80/1490 train_time:2533ms step_avg:31.66ms
+step:81/1490 train_time:2561ms step_avg:31.61ms
+step:82/1490 train_time:2595ms step_avg:31.65ms
+step:83/1490 train_time:2623ms step_avg:31.61ms
+step:84/1490 train_time:2658ms step_avg:31.64ms
+step:85/1490 train_time:2686ms step_avg:31.59ms
+step:86/1490 train_time:2720ms step_avg:31.63ms
+step:87/1490 train_time:2748ms step_avg:31.59ms
+step:88/1490 train_time:2783ms step_avg:31.62ms
+step:89/1490 train_time:2811ms step_avg:31.58ms
+step:90/1490 train_time:2845ms step_avg:31.62ms
+step:91/1490 train_time:2873ms step_avg:31.57ms
+step:92/1490 train_time:2908ms step_avg:31.60ms
+step:93/1490 train_time:2936ms step_avg:31.57ms
+step:94/1490 train_time:2970ms step_avg:31.60ms
+step:95/1490 train_time:2998ms step_avg:31.56ms
+step:96/1490 train_time:3033ms step_avg:31.59ms
+step:97/1490 train_time:3061ms step_avg:31.56ms
+step:98/1490 train_time:3096ms step_avg:31.59ms
+step:99/1490 train_time:3124ms step_avg:31.55ms
+step:100/1490 train_time:3159ms step_avg:31.59ms
+step:101/1490 train_time:3188ms step_avg:31.56ms
+step:102/1490 train_time:3222ms step_avg:31.59ms
+step:103/1490 train_time:3251ms step_avg:31.56ms
+step:104/1490 train_time:3285ms step_avg:31.59ms
+step:105/1490 train_time:3313ms step_avg:31.55ms
+step:106/1490 train_time:3348ms step_avg:31.58ms
+step:107/1490 train_time:3376ms step_avg:31.55ms
+step:108/1490 train_time:3411ms step_avg:31.58ms
+step:109/1490 train_time:3439ms step_avg:31.55ms
+step:110/1490 train_time:3473ms step_avg:31.58ms
+step:111/1490 train_time:3501ms step_avg:31.54ms
+step:112/1490 train_time:3536ms step_avg:31.57ms
+step:113/1490 train_time:3564ms step_avg:31.54ms
+step:114/1490 train_time:3599ms step_avg:31.57ms
+step:115/1490 train_time:3627ms step_avg:31.54ms
+step:116/1490 train_time:3661ms step_avg:31.56ms
+step:117/1490 train_time:3689ms step_avg:31.53ms
+step:118/1490 train_time:3724ms step_avg:31.56ms
+step:119/1490 train_time:3752ms step_avg:31.53ms
+step:120/1490 train_time:3786ms step_avg:31.55ms
+step:121/1490 train_time:3815ms step_avg:31.53ms
+step:122/1490 train_time:3849ms step_avg:31.55ms
+step:123/1490 train_time:3877ms step_avg:31.52ms
+step:124/1490 train_time:3911ms step_avg:31.54ms
+step:125/1490 train_time:3940ms step_avg:31.52ms
+step:126/1490 train_time:3974ms step_avg:31.54ms
+step:127/1490 train_time:4002ms step_avg:31.51ms
+step:128/1490 train_time:4037ms step_avg:31.54ms
+step:129/1490 train_time:4065ms step_avg:31.51ms
+step:130/1490 train_time:4099ms step_avg:31.53ms
+step:131/1490 train_time:4128ms step_avg:31.51ms
+step:132/1490 train_time:4163ms step_avg:31.54ms
+step:133/1490 train_time:4191ms step_avg:31.51ms
+step:134/1490 train_time:4226ms step_avg:31.54ms
+step:135/1490 train_time:4254ms step_avg:31.51ms
+step:136/1490 train_time:4288ms step_avg:31.53ms
+step:137/1490 train_time:4317ms step_avg:31.51ms
+step:138/1490 train_time:4351ms step_avg:31.53ms
+step:139/1490 train_time:4380ms step_avg:31.51ms
+step:140/1490 train_time:4414ms step_avg:31.53ms
+step:141/1490 train_time:4442ms step_avg:31.51ms
+step:142/1490 train_time:4477ms step_avg:31.53ms
+step:143/1490 train_time:4505ms step_avg:31.50ms
+step:144/1490 train_time:4540ms step_avg:31.52ms
+step:145/1490 train_time:4568ms step_avg:31.50ms
+step:146/1490 train_time:4603ms step_avg:31.52ms
+step:147/1490 train_time:4631ms step_avg:31.50ms
+step:148/1490 train_time:4666ms step_avg:31.52ms
+step:149/1490 train_time:4694ms step_avg:31.50ms
+step:150/1490 train_time:4728ms step_avg:31.52ms
+step:151/1490 train_time:4756ms step_avg:31.50ms
+step:152/1490 train_time:4790ms step_avg:31.51ms
+step:153/1490 train_time:4818ms step_avg:31.49ms
+step:154/1490 train_time:4853ms step_avg:31.51ms
+step:155/1490 train_time:4881ms step_avg:31.49ms
+step:156/1490 train_time:4915ms step_avg:31.51ms
+step:157/1490 train_time:4943ms step_avg:31.48ms
+step:158/1490 train_time:4978ms step_avg:31.50ms
+step:159/1490 train_time:5006ms step_avg:31.48ms
+step:160/1490 train_time:5040ms step_avg:31.50ms
+step:161/1490 train_time:5068ms step_avg:31.48ms
+step:162/1490 train_time:5103ms step_avg:31.50ms
+step:163/1490 train_time:5131ms step_avg:31.48ms
+step:164/1490 train_time:5166ms step_avg:31.50ms
+step:165/1490 train_time:5194ms step_avg:31.48ms
+step:166/1490 train_time:5229ms step_avg:31.50ms
+step:167/1490 train_time:5257ms step_avg:31.48ms
+step:168/1490 train_time:5291ms step_avg:31.50ms
+step:169/1490 train_time:5319ms step_avg:31.47ms
+step:170/1490 train_time:5354ms step_avg:31.50ms
+step:171/1490 train_time:5382ms step_avg:31.48ms
+step:172/1490 train_time:5417ms step_avg:31.50ms
+step:173/1490 train_time:5445ms step_avg:31.47ms
+step:174/1490 train_time:5480ms step_avg:31.49ms
+step:175/1490 train_time:5508ms step_avg:31.47ms
+step:176/1490 train_time:5542ms step_avg:31.49ms
+step:177/1490 train_time:5571ms step_avg:31.47ms
+step:178/1490 train_time:5605ms step_avg:31.49ms
+step:179/1490 train_time:5634ms step_avg:31.47ms
+step:180/1490 train_time:5668ms step_avg:31.49ms
+step:181/1490 train_time:5696ms step_avg:31.47ms
+step:182/1490 train_time:5731ms step_avg:31.49ms
+step:183/1490 train_time:5759ms step_avg:31.47ms
+step:184/1490 train_time:5794ms step_avg:31.49ms
+step:185/1490 train_time:5822ms step_avg:31.47ms
+step:186/1490 train_time:5856ms step_avg:31.49ms
+step:187/1490 train_time:5885ms step_avg:31.47ms
+step:188/1490 train_time:5919ms step_avg:31.49ms
+step:189/1490 train_time:5947ms step_avg:31.47ms
+step:190/1490 train_time:5982ms step_avg:31.48ms
+step:191/1490 train_time:6010ms step_avg:31.47ms
+step:192/1490 train_time:6044ms step_avg:31.48ms
+step:193/1490 train_time:6073ms step_avg:31.46ms
+step:194/1490 train_time:6107ms step_avg:31.48ms
+step:195/1490 train_time:6135ms step_avg:31.46ms
+step:196/1490 train_time:6170ms step_avg:31.48ms
+step:197/1490 train_time:6198ms step_avg:31.46ms
+step:198/1490 train_time:6232ms step_avg:31.48ms
+step:199/1490 train_time:6261ms step_avg:31.46ms
+step:200/1490 train_time:6296ms step_avg:31.48ms
+step:201/1490 train_time:6323ms step_avg:31.46ms
+step:202/1490 train_time:6358ms step_avg:31.48ms
+step:203/1490 train_time:6386ms step_avg:31.46ms
+step:204/1490 train_time:6421ms step_avg:31.48ms
+step:205/1490 train_time:6449ms step_avg:31.46ms
+step:206/1490 train_time:6483ms step_avg:31.47ms
+step:207/1490 train_time:6512ms step_avg:31.46ms
+step:208/1490 train_time:6546ms step_avg:31.47ms
+step:209/1490 train_time:6575ms step_avg:31.46ms
+step:210/1490 train_time:6609ms step_avg:31.47ms
+step:211/1490 train_time:6638ms step_avg:31.46ms
+step:212/1490 train_time:6672ms step_avg:31.47ms
+step:213/1490 train_time:6700ms step_avg:31.46ms
+step:214/1490 train_time:6735ms step_avg:31.47ms
+step:215/1490 train_time:6763ms step_avg:31.46ms
+step:216/1490 train_time:6798ms step_avg:31.47ms
+step:217/1490 train_time:6826ms step_avg:31.46ms
+step:218/1490 train_time:6861ms step_avg:31.47ms
+step:219/1490 train_time:6889ms step_avg:31.45ms
+step:220/1490 train_time:6923ms step_avg:31.47ms
+step:221/1490 train_time:6951ms step_avg:31.45ms
+step:222/1490 train_time:6986ms step_avg:31.47ms
+step:223/1490 train_time:7014ms step_avg:31.45ms
+step:224/1490 train_time:7048ms step_avg:31.47ms
+step:225/1490 train_time:7077ms step_avg:31.45ms
+step:226/1490 train_time:7111ms step_avg:31.47ms
+step:227/1490 train_time:7139ms step_avg:31.45ms
+step:228/1490 train_time:7174ms step_avg:31.46ms
+step:229/1490 train_time:7202ms step_avg:31.45ms
+step:230/1490 train_time:7236ms step_avg:31.46ms
+step:231/1490 train_time:7264ms step_avg:31.45ms
+step:232/1490 train_time:7298ms step_avg:31.46ms
+step:233/1490 train_time:7327ms step_avg:31.44ms
+step:234/1490 train_time:7361ms step_avg:31.46ms
+step:235/1490 train_time:7389ms step_avg:31.44ms
+step:236/1490 train_time:7424ms step_avg:31.46ms
+step:237/1490 train_time:7452ms step_avg:31.44ms
+step:238/1490 train_time:7487ms step_avg:31.46ms
+step:239/1490 train_time:7515ms step_avg:31.44ms
+step:240/1490 train_time:7549ms step_avg:31.46ms
+step:241/1490 train_time:7577ms step_avg:31.44ms
+step:242/1490 train_time:7612ms step_avg:31.45ms
+step:243/1490 train_time:7640ms step_avg:31.44ms
+step:244/1490 train_time:7674ms step_avg:31.45ms
+step:245/1490 train_time:7702ms step_avg:31.44ms
+step:246/1490 train_time:7737ms step_avg:31.45ms
+step:247/1490 train_time:7765ms step_avg:31.44ms
+step:248/1490 train_time:7800ms step_avg:31.45ms
+step:249/1490 train_time:7827ms step_avg:31.44ms
+step:250/1490 train_time:7862ms step_avg:31.45ms
+step:250/1490 val_loss:4.5100 train_time:7905ms step_avg:31.62ms
+step:251/1490 train_time:7920ms step_avg:31.56ms
+step:252/1490 train_time:7938ms step_avg:31.50ms
+step:253/1490 train_time:7958ms step_avg:31.45ms
+step:254/1490 train_time:7992ms step_avg:31.47ms
+step:255/1490 train_time:8021ms step_avg:31.45ms
+step:256/1490 train_time:8056ms step_avg:31.47ms
+step:257/1490 train_time:8085ms step_avg:31.46ms
+step:258/1490 train_time:8120ms step_avg:31.47ms
+step:259/1490 train_time:8148ms step_avg:31.46ms
+step:260/1490 train_time:8183ms step_avg:31.47ms
+step:261/1490 train_time:8212ms step_avg:31.46ms
+step:262/1490 train_time:8246ms step_avg:31.47ms
+step:263/1490 train_time:8274ms step_avg:31.46ms
+step:264/1490 train_time:8308ms step_avg:31.47ms
+step:265/1490 train_time:8336ms step_avg:31.46ms
+step:266/1490 train_time:8370ms step_avg:31.47ms
+step:267/1490 train_time:8398ms step_avg:31.45ms
+step:268/1490 train_time:8432ms step_avg:31.46ms
+step:269/1490 train_time:8460ms step_avg:31.45ms
+step:270/1490 train_time:8494ms step_avg:31.46ms
+step:271/1490 train_time:8522ms step_avg:31.45ms
+step:272/1490 train_time:8556ms step_avg:31.46ms
+step:273/1490 train_time:8584ms step_avg:31.44ms
+step:274/1490 train_time:8618ms step_avg:31.45ms
+step:275/1490 train_time:8646ms step_avg:31.44ms
+step:276/1490 train_time:8680ms step_avg:31.45ms
+step:277/1490 train_time:8708ms step_avg:31.44ms
+step:278/1490 train_time:8742ms step_avg:31.45ms
+step:279/1490 train_time:8770ms step_avg:31.44ms
+step:280/1490 train_time:8805ms step_avg:31.45ms
+step:281/1490 train_time:8833ms step_avg:31.43ms
+step:282/1490 train_time:8867ms step_avg:31.44ms
+step:283/1490 train_time:8896ms step_avg:31.44ms
+step:284/1490 train_time:8931ms step_avg:31.45ms
+step:285/1490 train_time:8959ms step_avg:31.43ms
+step:286/1490 train_time:8994ms step_avg:31.45ms
+step:287/1490 train_time:9022ms step_avg:31.44ms
+step:288/1490 train_time:9057ms step_avg:31.45ms
+step:289/1490 train_time:9086ms step_avg:31.44ms
+step:290/1490 train_time:9120ms step_avg:31.45ms
+step:291/1490 train_time:9149ms step_avg:31.44ms
+step:292/1490 train_time:9183ms step_avg:31.45ms
+step:293/1490 train_time:9212ms step_avg:31.44ms
+step:294/1490 train_time:9246ms step_avg:31.45ms
+step:295/1490 train_time:9274ms step_avg:31.44ms
+step:296/1490 train_time:9309ms step_avg:31.45ms
+step:297/1490 train_time:9337ms step_avg:31.44ms
+step:298/1490 train_time:9371ms step_avg:31.45ms
+step:299/1490 train_time:9399ms step_avg:31.44ms
+step:300/1490 train_time:9433ms step_avg:31.44ms
+step:301/1490 train_time:9461ms step_avg:31.43ms
+step:302/1490 train_time:9496ms step_avg:31.44ms
+step:303/1490 train_time:9524ms step_avg:31.43ms
+step:304/1490 train_time:9558ms step_avg:31.44ms
+step:305/1490 train_time:9586ms step_avg:31.43ms
+step:306/1490 train_time:9620ms step_avg:31.44ms
+step:307/1490 train_time:9648ms step_avg:31.43ms
+step:308/1490 train_time:9683ms step_avg:31.44ms
+step:309/1490 train_time:9711ms step_avg:31.43ms
+step:310/1490 train_time:9745ms step_avg:31.44ms
+step:311/1490 train_time:9773ms step_avg:31.43ms
+step:312/1490 train_time:9808ms step_avg:31.44ms
+step:313/1490 train_time:9836ms step_avg:31.42ms
+step:314/1490 train_time:9870ms step_avg:31.43ms
+step:315/1490 train_time:9898ms step_avg:31.42ms
+step:316/1490 train_time:9933ms step_avg:31.43ms
+step:317/1490 train_time:9961ms step_avg:31.42ms
+step:318/1490 train_time:9996ms step_avg:31.43ms
+step:319/1490 train_time:10025ms step_avg:31.43ms
+step:320/1490 train_time:10059ms step_avg:31.44ms
+step:321/1490 train_time:10088ms step_avg:31.43ms
+step:322/1490 train_time:10123ms step_avg:31.44ms
+step:323/1490 train_time:10151ms step_avg:31.43ms
+step:324/1490 train_time:10185ms step_avg:31.44ms
+step:325/1490 train_time:10213ms step_avg:31.43ms
+step:326/1490 train_time:10248ms step_avg:31.43ms
+step:327/1490 train_time:10276ms step_avg:31.42ms
+step:328/1490 train_time:10310ms step_avg:31.43ms
+step:329/1490 train_time:10338ms step_avg:31.42ms
+step:330/1490 train_time:10373ms step_avg:31.43ms
+step:331/1490 train_time:10401ms step_avg:31.42ms
+step:332/1490 train_time:10435ms step_avg:31.43ms
+step:333/1490 train_time:10463ms step_avg:31.42ms
+step:334/1490 train_time:10497ms step_avg:31.43ms
+step:335/1490 train_time:10526ms step_avg:31.42ms
+step:336/1490 train_time:10561ms step_avg:31.43ms
+step:337/1490 train_time:10588ms step_avg:31.42ms
+step:338/1490 train_time:10623ms step_avg:31.43ms
+step:339/1490 train_time:10651ms step_avg:31.42ms
+step:340/1490 train_time:10685ms step_avg:31.43ms
+step:341/1490 train_time:10713ms step_avg:31.42ms
+step:342/1490 train_time:10747ms step_avg:31.42ms
+step:343/1490 train_time:10775ms step_avg:31.41ms
+step:344/1490 train_time:10809ms step_avg:31.42ms
+step:345/1490 train_time:10837ms step_avg:31.41ms
+step:346/1490 train_time:10872ms step_avg:31.42ms
+step:347/1490 train_time:10900ms step_avg:31.41ms
+step:348/1490 train_time:10935ms step_avg:31.42ms
+step:349/1490 train_time:10963ms step_avg:31.41ms
+step:350/1490 train_time:10998ms step_avg:31.42ms
+step:351/1490 train_time:11027ms step_avg:31.41ms
+step:352/1490 train_time:11061ms step_avg:31.42ms
+step:353/1490 train_time:11090ms step_avg:31.42ms
+step:354/1490 train_time:11124ms step_avg:31.42ms
+step:355/1490 train_time:11152ms step_avg:31.41ms
+step:356/1490 train_time:11187ms step_avg:31.42ms
+step:357/1490 train_time:11215ms step_avg:31.41ms
+step:358/1490 train_time:11249ms step_avg:31.42ms
+step:359/1490 train_time:11277ms step_avg:31.41ms
+step:360/1490 train_time:11312ms step_avg:31.42ms
+step:361/1490 train_time:11341ms step_avg:31.41ms
+step:362/1490 train_time:11375ms step_avg:31.42ms
+step:363/1490 train_time:11403ms step_avg:31.41ms
+step:364/1490 train_time:11438ms step_avg:31.42ms
+step:365/1490 train_time:11466ms step_avg:31.41ms
+step:366/1490 train_time:11501ms step_avg:31.42ms
+step:367/1490 train_time:11529ms step_avg:31.41ms
+step:368/1490 train_time:11563ms step_avg:31.42ms
+step:369/1490 train_time:11591ms step_avg:31.41ms
+step:370/1490 train_time:11625ms step_avg:31.42ms
+step:371/1490 train_time:11653ms step_avg:31.41ms
+step:372/1490 train_time:11687ms step_avg:31.42ms
+step:373/1490 train_time:11715ms step_avg:31.41ms
+step:374/1490 train_time:11750ms step_avg:31.42ms
+step:375/1490 train_time:11778ms step_avg:31.41ms
+step:376/1490 train_time:11812ms step_avg:31.41ms
+step:377/1490 train_time:11840ms step_avg:31.40ms
+step:378/1490 train_time:11874ms step_avg:31.41ms
+step:379/1490 train_time:11903ms step_avg:31.41ms
+step:380/1490 train_time:11937ms step_avg:31.41ms
+step:381/1490 train_time:11965ms step_avg:31.40ms
+step:382/1490 train_time:12000ms step_avg:31.41ms
+step:383/1490 train_time:12028ms step_avg:31.41ms
+step:384/1490 train_time:12062ms step_avg:31.41ms
+step:385/1490 train_time:12091ms step_avg:31.41ms
+step:386/1490 train_time:12125ms step_avg:31.41ms
+step:387/1490 train_time:12153ms step_avg:31.40ms
+step:388/1490 train_time:12188ms step_avg:31.41ms
+step:389/1490 train_time:12216ms step_avg:31.40ms
+step:390/1490 train_time:12251ms step_avg:31.41ms
+step:391/1490 train_time:12279ms step_avg:31.40ms
+step:392/1490 train_time:12313ms step_avg:31.41ms
+step:393/1490 train_time:12341ms step_avg:31.40ms
+step:394/1490 train_time:12376ms step_avg:31.41ms
+step:395/1490 train_time:12405ms step_avg:31.40ms
+step:396/1490 train_time:12439ms step_avg:31.41ms
+step:397/1490 train_time:12467ms step_avg:31.40ms
+step:398/1490 train_time:12502ms step_avg:31.41ms
+step:399/1490 train_time:12530ms step_avg:31.40ms
+step:400/1490 train_time:12564ms step_avg:31.41ms
+step:401/1490 train_time:12592ms step_avg:31.40ms
+step:402/1490 train_time:12626ms step_avg:31.41ms
+step:403/1490 train_time:12654ms step_avg:31.40ms
+step:404/1490 train_time:12688ms step_avg:31.41ms
+step:405/1490 train_time:12716ms step_avg:31.40ms
+step:406/1490 train_time:12751ms step_avg:31.41ms
+step:407/1490 train_time:12779ms step_avg:31.40ms
+step:408/1490 train_time:12814ms step_avg:31.41ms
+step:409/1490 train_time:12842ms step_avg:31.40ms
+step:410/1490 train_time:12877ms step_avg:31.41ms
+step:411/1490 train_time:12905ms step_avg:31.40ms
+step:412/1490 train_time:12939ms step_avg:31.41ms
+step:413/1490 train_time:12967ms step_avg:31.40ms
+step:414/1490 train_time:13002ms step_avg:31.40ms
+step:415/1490 train_time:13030ms step_avg:31.40ms
+step:416/1490 train_time:13064ms step_avg:31.40ms
+step:417/1490 train_time:13092ms step_avg:31.40ms
+step:418/1490 train_time:13127ms step_avg:31.40ms
+step:419/1490 train_time:13154ms step_avg:31.39ms
+step:420/1490 train_time:13189ms step_avg:31.40ms
+step:421/1490 train_time:13217ms step_avg:31.39ms
+step:422/1490 train_time:13252ms step_avg:31.40ms
+step:423/1490 train_time:13280ms step_avg:31.39ms
+step:424/1490 train_time:13315ms step_avg:31.40ms
+step:425/1490 train_time:13343ms step_avg:31.40ms
+step:426/1490 train_time:13378ms step_avg:31.40ms
+step:427/1490 train_time:13407ms step_avg:31.40ms
+step:428/1490 train_time:13441ms step_avg:31.41ms
+step:429/1490 train_time:13470ms step_avg:31.40ms
+step:430/1490 train_time:13504ms step_avg:31.40ms
+step:431/1490 train_time:13532ms step_avg:31.40ms
+step:432/1490 train_time:13566ms step_avg:31.40ms
+step:433/1490 train_time:13594ms step_avg:31.39ms
+step:434/1490 train_time:13628ms step_avg:31.40ms
+step:435/1490 train_time:13656ms step_avg:31.39ms
+step:436/1490 train_time:13690ms step_avg:31.40ms
+step:437/1490 train_time:13718ms step_avg:31.39ms
+step:438/1490 train_time:13753ms step_avg:31.40ms
+step:439/1490 train_time:13781ms step_avg:31.39ms
+step:440/1490 train_time:13816ms step_avg:31.40ms
+step:441/1490 train_time:13844ms step_avg:31.39ms
+step:442/1490 train_time:13878ms step_avg:31.40ms
+step:443/1490 train_time:13907ms step_avg:31.39ms
+step:444/1490 train_time:13942ms step_avg:31.40ms
+step:445/1490 train_time:13970ms step_avg:31.39ms
+step:446/1490 train_time:14005ms step_avg:31.40ms
+step:447/1490 train_time:14033ms step_avg:31.39ms
+step:448/1490 train_time:14067ms step_avg:31.40ms
+step:449/1490 train_time:14095ms step_avg:31.39ms
+step:450/1490 train_time:14129ms step_avg:31.40ms
+step:451/1490 train_time:14157ms step_avg:31.39ms
+step:452/1490 train_time:14192ms step_avg:31.40ms
+step:453/1490 train_time:14220ms step_avg:31.39ms
+step:454/1490 train_time:14254ms step_avg:31.40ms
+step:455/1490 train_time:14282ms step_avg:31.39ms
+step:456/1490 train_time:14317ms step_avg:31.40ms
+step:457/1490 train_time:14345ms step_avg:31.39ms
+step:458/1490 train_time:14379ms step_avg:31.40ms
+step:459/1490 train_time:14408ms step_avg:31.39ms
+step:460/1490 train_time:14442ms step_avg:31.40ms
+step:461/1490 train_time:14471ms step_avg:31.39ms
+step:462/1490 train_time:14505ms step_avg:31.40ms
+step:463/1490 train_time:14533ms step_avg:31.39ms
+step:464/1490 train_time:14567ms step_avg:31.40ms
+step:465/1490 train_time:14596ms step_avg:31.39ms
+step:466/1490 train_time:14630ms step_avg:31.40ms
+step:467/1490 train_time:14658ms step_avg:31.39ms
+step:468/1490 train_time:14692ms step_avg:31.39ms
+step:469/1490 train_time:14721ms step_avg:31.39ms
+step:470/1490 train_time:14755ms step_avg:31.39ms
+step:471/1490 train_time:14783ms step_avg:31.39ms
+step:472/1490 train_time:14818ms step_avg:31.39ms
+step:473/1490 train_time:14846ms step_avg:31.39ms
+step:474/1490 train_time:14881ms step_avg:31.39ms
+step:475/1490 train_time:14909ms step_avg:31.39ms
+step:476/1490 train_time:14944ms step_avg:31.39ms
+step:477/1490 train_time:14972ms step_avg:31.39ms
+step:478/1490 train_time:15007ms step_avg:31.39ms
+step:479/1490 train_time:15035ms step_avg:31.39ms
+step:480/1490 train_time:15069ms step_avg:31.39ms
+step:481/1490 train_time:15097ms step_avg:31.39ms
+step:482/1490 train_time:15132ms step_avg:31.39ms
+step:483/1490 train_time:15160ms step_avg:31.39ms
+step:484/1490 train_time:15197ms step_avg:31.40ms
+step:485/1490 train_time:15249ms step_avg:31.44ms
+step:486/1490 train_time:15308ms step_avg:31.50ms
+step:487/1490 train_time:15362ms step_avg:31.54ms
+step:488/1490 train_time:15422ms step_avg:31.60ms
+step:489/1490 train_time:15476ms step_avg:31.65ms
+step:490/1490 train_time:15536ms step_avg:31.71ms
+step:491/1490 train_time:15591ms step_avg:31.75ms
+step:492/1490 train_time:15650ms step_avg:31.81ms
+step:493/1490 train_time:15704ms step_avg:31.85ms
+step:494/1490 train_time:15763ms step_avg:31.91ms
+step:495/1490 train_time:15818ms step_avg:31.96ms
+step:496/1490 train_time:15878ms step_avg:32.01ms
+step:497/1490 train_time:15933ms step_avg:32.06ms
+step:498/1490 train_time:15992ms step_avg:32.11ms
+step:499/1490 train_time:16048ms step_avg:32.16ms
+step:500/1490 train_time:16106ms step_avg:32.21ms
+step:500/1490 val_loss:4.2246 train_time:16178ms step_avg:32.36ms
+step:501/1490 train_time:16195ms step_avg:32.33ms
+step:502/1490 train_time:16221ms step_avg:32.31ms
+step:503/1490 train_time:16279ms step_avg:32.36ms
+step:504/1490 train_time:16341ms step_avg:32.42ms
+step:505/1490 train_time:16396ms step_avg:32.47ms
+step:506/1490 train_time:16456ms step_avg:32.52ms
+step:507/1490 train_time:16510ms step_avg:32.56ms
+step:508/1490 train_time:16570ms step_avg:32.62ms
+step:509/1490 train_time:16624ms step_avg:32.66ms
+step:510/1490 train_time:16683ms step_avg:32.71ms
+step:511/1490 train_time:16736ms step_avg:32.75ms
+step:512/1490 train_time:16795ms step_avg:32.80ms
+step:513/1490 train_time:16848ms step_avg:32.84ms
+step:514/1490 train_time:16906ms step_avg:32.89ms
+step:515/1490 train_time:16959ms step_avg:32.93ms
+step:516/1490 train_time:17019ms step_avg:32.98ms
+step:517/1490 train_time:17074ms step_avg:33.03ms
+step:518/1490 train_time:17134ms step_avg:33.08ms
+step:519/1490 train_time:17189ms step_avg:33.12ms
+step:520/1490 train_time:17250ms step_avg:33.17ms
+step:521/1490 train_time:17305ms step_avg:33.21ms
+step:522/1490 train_time:17366ms step_avg:33.27ms
+step:523/1490 train_time:17420ms step_avg:33.31ms
+step:524/1490 train_time:17480ms step_avg:33.36ms
+step:525/1490 train_time:17536ms step_avg:33.40ms
+step:526/1490 train_time:17595ms step_avg:33.45ms
+step:527/1490 train_time:17648ms step_avg:33.49ms
+step:528/1490 train_time:17707ms step_avg:33.54ms
+step:529/1490 train_time:17761ms step_avg:33.57ms
+step:530/1490 train_time:17820ms step_avg:33.62ms
+step:531/1490 train_time:17874ms step_avg:33.66ms
+step:532/1490 train_time:17932ms step_avg:33.71ms
+step:533/1490 train_time:17986ms step_avg:33.74ms
+step:534/1490 train_time:18045ms step_avg:33.79ms
+step:535/1490 train_time:18098ms step_avg:33.83ms
+step:536/1490 train_time:18159ms step_avg:33.88ms
+step:537/1490 train_time:18214ms step_avg:33.92ms
+step:538/1490 train_time:18274ms step_avg:33.97ms
+step:539/1490 train_time:18328ms step_avg:34.00ms
+step:540/1490 train_time:18389ms step_avg:34.05ms
+step:541/1490 train_time:18444ms step_avg:34.09ms
+step:542/1490 train_time:18504ms step_avg:34.14ms
+step:543/1490 train_time:18558ms step_avg:34.18ms
+step:544/1490 train_time:18618ms step_avg:34.22ms
+step:545/1490 train_time:18671ms step_avg:34.26ms
+step:546/1490 train_time:18730ms step_avg:34.30ms
+step:547/1490 train_time:18784ms step_avg:34.34ms
+step:548/1490 train_time:18844ms step_avg:34.39ms
+step:549/1490 train_time:18898ms step_avg:34.42ms
+step:550/1490 train_time:18958ms step_avg:34.47ms
+step:551/1490 train_time:19011ms step_avg:34.50ms
+step:552/1490 train_time:19070ms step_avg:34.55ms
+step:553/1490 train_time:19124ms step_avg:34.58ms
+step:554/1490 train_time:19184ms step_avg:34.63ms
+step:555/1490 train_time:19239ms step_avg:34.66ms
+step:556/1490 train_time:19298ms step_avg:34.71ms
+step:557/1490 train_time:19352ms step_avg:34.74ms
+step:558/1490 train_time:19412ms step_avg:34.79ms
+step:559/1490 train_time:19467ms step_avg:34.82ms
+step:560/1490 train_time:19526ms step_avg:34.87ms
+step:561/1490 train_time:19581ms step_avg:34.90ms
+step:562/1490 train_time:19641ms step_avg:34.95ms
+step:563/1490 train_time:19695ms step_avg:34.98ms
+step:564/1490 train_time:19755ms step_avg:35.03ms
+step:565/1490 train_time:19808ms step_avg:35.06ms
+step:566/1490 train_time:19868ms step_avg:35.10ms
+step:567/1490 train_time:19921ms step_avg:35.13ms
+step:568/1490 train_time:19981ms step_avg:35.18ms
+step:569/1490 train_time:20034ms step_avg:35.21ms
+step:570/1490 train_time:20093ms step_avg:35.25ms
+step:571/1490 train_time:20147ms step_avg:35.28ms
+step:572/1490 train_time:20207ms step_avg:35.33ms
+step:573/1490 train_time:20261ms step_avg:35.36ms
+step:574/1490 train_time:20322ms step_avg:35.40ms
+step:575/1490 train_time:20376ms step_avg:35.44ms
+step:576/1490 train_time:20437ms step_avg:35.48ms
+step:577/1490 train_time:20492ms step_avg:35.51ms
+step:578/1490 train_time:20552ms step_avg:35.56ms
+step:579/1490 train_time:20605ms step_avg:35.59ms
+step:580/1490 train_time:20665ms step_avg:35.63ms
+step:581/1490 train_time:20719ms step_avg:35.66ms
+step:582/1490 train_time:20778ms step_avg:35.70ms
+step:583/1490 train_time:20832ms step_avg:35.73ms
+step:584/1490 train_time:20891ms step_avg:35.77ms
+step:585/1490 train_time:20945ms step_avg:35.80ms
+step:586/1490 train_time:21004ms step_avg:35.84ms
+step:587/1490 train_time:21057ms step_avg:35.87ms
+step:588/1490 train_time:21117ms step_avg:35.91ms
+step:589/1490 train_time:21171ms step_avg:35.94ms
+step:590/1490 train_time:21231ms step_avg:35.98ms
+step:591/1490 train_time:21286ms step_avg:36.02ms
+step:592/1490 train_time:21346ms step_avg:36.06ms
+step:593/1490 train_time:21401ms step_avg:36.09ms
+step:594/1490 train_time:21461ms step_avg:36.13ms
+step:595/1490 train_time:21515ms step_avg:36.16ms
+step:596/1490 train_time:21575ms step_avg:36.20ms
+step:597/1490 train_time:21629ms step_avg:36.23ms
+step:598/1490 train_time:21689ms step_avg:36.27ms
+step:599/1490 train_time:21742ms step_avg:36.30ms
+step:600/1490 train_time:21801ms step_avg:36.34ms
+step:601/1490 train_time:21855ms step_avg:36.37ms
+step:602/1490 train_time:21914ms step_avg:36.40ms
+step:603/1490 train_time:21969ms step_avg:36.43ms
+step:604/1490 train_time:22028ms step_avg:36.47ms
+step:605/1490 train_time:22081ms step_avg:36.50ms
+step:606/1490 train_time:22141ms step_avg:36.54ms
+step:607/1490 train_time:22195ms step_avg:36.56ms
+step:608/1490 train_time:22255ms step_avg:36.60ms
+step:609/1490 train_time:22309ms step_avg:36.63ms
+step:610/1490 train_time:22368ms step_avg:36.67ms
+step:611/1490 train_time:22423ms step_avg:36.70ms
+step:612/1490 train_time:22483ms step_avg:36.74ms
+step:613/1490 train_time:22536ms step_avg:36.76ms
+step:614/1490 train_time:22596ms step_avg:36.80ms
+step:615/1490 train_time:22650ms step_avg:36.83ms
+step:616/1490 train_time:22709ms step_avg:36.86ms
+step:617/1490 train_time:22763ms step_avg:36.89ms
+step:618/1490 train_time:22822ms step_avg:36.93ms
+step:619/1490 train_time:22876ms step_avg:36.96ms
+step:620/1490 train_time:22936ms step_avg:36.99ms
+step:621/1490 train_time:22990ms step_avg:37.02ms
+step:622/1490 train_time:23050ms step_avg:37.06ms
+step:623/1490 train_time:23103ms step_avg:37.08ms
+step:624/1490 train_time:23162ms step_avg:37.12ms
+step:625/1490 train_time:23217ms step_avg:37.15ms
+step:626/1490 train_time:23278ms step_avg:37.18ms
+step:627/1490 train_time:23332ms step_avg:37.21ms
+step:628/1490 train_time:23392ms step_avg:37.25ms
+step:629/1490 train_time:23446ms step_avg:37.27ms
+step:630/1490 train_time:23505ms step_avg:37.31ms
+step:631/1490 train_time:23560ms step_avg:37.34ms
+step:632/1490 train_time:23620ms step_avg:37.37ms
+step:633/1490 train_time:23674ms step_avg:37.40ms
+step:634/1490 train_time:23733ms step_avg:37.43ms
+step:635/1490 train_time:23787ms step_avg:37.46ms
+step:636/1490 train_time:23847ms step_avg:37.50ms
+step:637/1490 train_time:23900ms step_avg:37.52ms
+step:638/1490 train_time:23961ms step_avg:37.56ms
+step:639/1490 train_time:24016ms step_avg:37.58ms
+step:640/1490 train_time:24075ms step_avg:37.62ms
+step:641/1490 train_time:24129ms step_avg:37.64ms
+step:642/1490 train_time:24188ms step_avg:37.68ms
+step:643/1490 train_time:24242ms step_avg:37.70ms
+step:644/1490 train_time:24302ms step_avg:37.74ms
+step:645/1490 train_time:24356ms step_avg:37.76ms
+step:646/1490 train_time:24414ms step_avg:37.79ms
+step:647/1490 train_time:24469ms step_avg:37.82ms
+step:648/1490 train_time:24529ms step_avg:37.85ms
+step:649/1490 train_time:24583ms step_avg:37.88ms
+step:650/1490 train_time:24643ms step_avg:37.91ms
+step:651/1490 train_time:24697ms step_avg:37.94ms
+step:652/1490 train_time:24757ms step_avg:37.97ms
+step:653/1490 train_time:24810ms step_avg:37.99ms
+step:654/1490 train_time:24869ms step_avg:38.03ms
+step:655/1490 train_time:24924ms step_avg:38.05ms
+step:656/1490 train_time:24984ms step_avg:38.08ms
+step:657/1490 train_time:25038ms step_avg:38.11ms
+step:658/1490 train_time:25097ms step_avg:38.14ms
+step:659/1490 train_time:25151ms step_avg:38.17ms
+step:660/1490 train_time:25210ms step_avg:38.20ms
+step:661/1490 train_time:25264ms step_avg:38.22ms
+step:662/1490 train_time:25324ms step_avg:38.25ms
+step:663/1490 train_time:25378ms step_avg:38.28ms
+step:664/1490 train_time:25437ms step_avg:38.31ms
+step:665/1490 train_time:25492ms step_avg:38.33ms
+step:666/1490 train_time:25551ms step_avg:38.37ms
+step:667/1490 train_time:25605ms step_avg:38.39ms
+step:668/1490 train_time:25664ms step_avg:38.42ms
+step:669/1490 train_time:25719ms step_avg:38.44ms
+step:670/1490 train_time:25779ms step_avg:38.48ms
+step:671/1490 train_time:25834ms step_avg:38.50ms
+step:672/1490 train_time:25893ms step_avg:38.53ms
+step:673/1490 train_time:25948ms step_avg:38.56ms
+step:674/1490 train_time:26006ms step_avg:38.58ms
+step:675/1490 train_time:26060ms step_avg:38.61ms
+step:676/1490 train_time:26120ms step_avg:38.64ms
+step:677/1490 train_time:26174ms step_avg:38.66ms
+step:678/1490 train_time:26233ms step_avg:38.69ms
+step:679/1490 train_time:26288ms step_avg:38.72ms
+step:680/1490 train_time:26347ms step_avg:38.75ms
+step:681/1490 train_time:26401ms step_avg:38.77ms
+step:682/1490 train_time:26461ms step_avg:38.80ms
+step:683/1490 train_time:26516ms step_avg:38.82ms
+step:684/1490 train_time:26575ms step_avg:38.85ms
+step:685/1490 train_time:26628ms step_avg:38.87ms
+step:686/1490 train_time:26688ms step_avg:38.90ms
+step:687/1490 train_time:26743ms step_avg:38.93ms
+step:688/1490 train_time:26802ms step_avg:38.96ms
+step:689/1490 train_time:26856ms step_avg:38.98ms
+step:690/1490 train_time:26916ms step_avg:39.01ms
+step:691/1490 train_time:26970ms step_avg:39.03ms
+step:692/1490 train_time:27029ms step_avg:39.06ms
+step:693/1490 train_time:27084ms step_avg:39.08ms
+step:694/1490 train_time:27144ms step_avg:39.11ms
+step:695/1490 train_time:27197ms step_avg:39.13ms
+step:696/1490 train_time:27258ms step_avg:39.16ms
+step:697/1490 train_time:27311ms step_avg:39.18ms
+step:698/1490 train_time:27370ms step_avg:39.21ms
+step:699/1490 train_time:27425ms step_avg:39.23ms
+step:700/1490 train_time:27485ms step_avg:39.26ms
+step:701/1490 train_time:27539ms step_avg:39.29ms
+step:702/1490 train_time:27598ms step_avg:39.31ms
+step:703/1490 train_time:27652ms step_avg:39.33ms
+step:704/1490 train_time:27711ms step_avg:39.36ms
+step:705/1490 train_time:27766ms step_avg:39.38ms
+step:706/1490 train_time:27825ms step_avg:39.41ms
+step:707/1490 train_time:27879ms step_avg:39.43ms
+step:708/1490 train_time:27940ms step_avg:39.46ms
+step:709/1490 train_time:27994ms step_avg:39.48ms
+step:710/1490 train_time:28054ms step_avg:39.51ms
+step:711/1490 train_time:28107ms step_avg:39.53ms
+step:712/1490 train_time:28167ms step_avg:39.56ms
+step:713/1490 train_time:28221ms step_avg:39.58ms
+step:714/1490 train_time:28282ms step_avg:39.61ms
+step:715/1490 train_time:28336ms step_avg:39.63ms
+step:716/1490 train_time:28396ms step_avg:39.66ms
+step:717/1490 train_time:28450ms step_avg:39.68ms
+step:718/1490 train_time:28509ms step_avg:39.71ms
+step:719/1490 train_time:28564ms step_avg:39.73ms
+step:720/1490 train_time:28624ms step_avg:39.76ms
+step:721/1490 train_time:28678ms step_avg:39.78ms
+step:722/1490 train_time:28739ms step_avg:39.80ms
+step:723/1490 train_time:28793ms step_avg:39.82ms
+step:724/1490 train_time:28852ms step_avg:39.85ms
+step:725/1490 train_time:28905ms step_avg:39.87ms
+step:726/1490 train_time:28965ms step_avg:39.90ms
+step:727/1490 train_time:29019ms step_avg:39.92ms
+step:728/1490 train_time:29079ms step_avg:39.94ms
+step:729/1490 train_time:29133ms step_avg:39.96ms
+step:730/1490 train_time:29193ms step_avg:39.99ms
+step:731/1490 train_time:29247ms step_avg:40.01ms
+step:732/1490 train_time:29307ms step_avg:40.04ms
+step:733/1490 train_time:29361ms step_avg:40.06ms
+step:734/1490 train_time:29421ms step_avg:40.08ms
+step:735/1490 train_time:29475ms step_avg:40.10ms
+step:736/1490 train_time:29534ms step_avg:40.13ms
+step:737/1490 train_time:29589ms step_avg:40.15ms
+step:738/1490 train_time:29649ms step_avg:40.17ms
+step:739/1490 train_time:29703ms step_avg:40.19ms
+step:740/1490 train_time:29762ms step_avg:40.22ms
+step:741/1490 train_time:29816ms step_avg:40.24ms
+step:742/1490 train_time:29876ms step_avg:40.26ms
+step:743/1490 train_time:29930ms step_avg:40.28ms
+step:744/1490 train_time:29989ms step_avg:40.31ms
+step:745/1490 train_time:30044ms step_avg:40.33ms
+step:746/1490 train_time:30103ms step_avg:40.35ms
+step:747/1490 train_time:30158ms step_avg:40.37ms
+step:748/1490 train_time:30217ms step_avg:40.40ms
+step:749/1490 train_time:30272ms step_avg:40.42ms
+step:750/1490 train_time:30331ms step_avg:40.44ms
+step:750/1490 val_loss:3.8027 train_time:30404ms step_avg:40.54ms
+step:751/1490 train_time:30423ms step_avg:40.51ms
+step:752/1490 train_time:30447ms step_avg:40.49ms
+step:753/1490 train_time:30507ms step_avg:40.51ms
+step:754/1490 train_time:30569ms step_avg:40.54ms
+step:755/1490 train_time:30627ms step_avg:40.57ms
+step:756/1490 train_time:30689ms step_avg:40.59ms
+step:757/1490 train_time:30744ms step_avg:40.61ms
+step:758/1490 train_time:30803ms step_avg:40.64ms
+step:759/1490 train_time:30856ms step_avg:40.65ms
+step:760/1490 train_time:30915ms step_avg:40.68ms
+step:761/1490 train_time:30969ms step_avg:40.69ms
+step:762/1490 train_time:31028ms step_avg:40.72ms
+step:763/1490 train_time:31080ms step_avg:40.73ms
+step:764/1490 train_time:31139ms step_avg:40.76ms
+step:765/1490 train_time:31193ms step_avg:40.78ms
+step:766/1490 train_time:31252ms step_avg:40.80ms
+step:767/1490 train_time:31305ms step_avg:40.82ms
+step:768/1490 train_time:31365ms step_avg:40.84ms
+step:769/1490 train_time:31421ms step_avg:40.86ms
+step:770/1490 train_time:31481ms step_avg:40.88ms
+step:771/1490 train_time:31536ms step_avg:40.90ms
+step:772/1490 train_time:31597ms step_avg:40.93ms
+step:773/1490 train_time:31652ms step_avg:40.95ms
+step:774/1490 train_time:31713ms step_avg:40.97ms
+step:775/1490 train_time:31768ms step_avg:40.99ms
+step:776/1490 train_time:31828ms step_avg:41.02ms
+step:777/1490 train_time:31882ms step_avg:41.03ms
+step:778/1490 train_time:31941ms step_avg:41.06ms
+step:779/1490 train_time:31994ms step_avg:41.07ms
+step:780/1490 train_time:32053ms step_avg:41.09ms
+step:781/1490 train_time:32107ms step_avg:41.11ms
+step:782/1490 train_time:32167ms step_avg:41.13ms
+step:783/1490 train_time:32221ms step_avg:41.15ms
+step:784/1490 train_time:32280ms step_avg:41.17ms
+step:785/1490 train_time:32334ms step_avg:41.19ms
+step:786/1490 train_time:32394ms step_avg:41.21ms
+step:787/1490 train_time:32448ms step_avg:41.23ms
+step:788/1490 train_time:32510ms step_avg:41.26ms
+step:789/1490 train_time:32565ms step_avg:41.27ms
+step:790/1490 train_time:32626ms step_avg:41.30ms
+step:791/1490 train_time:32681ms step_avg:41.32ms
+step:792/1490 train_time:32741ms step_avg:41.34ms
+step:793/1490 train_time:32795ms step_avg:41.36ms
+step:794/1490 train_time:32855ms step_avg:41.38ms
+step:795/1490 train_time:32909ms step_avg:41.39ms
+step:796/1490 train_time:32968ms step_avg:41.42ms
+step:797/1490 train_time:33022ms step_avg:41.43ms
+step:798/1490 train_time:33081ms step_avg:41.45ms
+step:799/1490 train_time:33134ms step_avg:41.47ms
+step:800/1490 train_time:33193ms step_avg:41.49ms
+step:801/1490 train_time:33247ms step_avg:41.51ms
+step:802/1490 train_time:33307ms step_avg:41.53ms
+step:803/1490 train_time:33362ms step_avg:41.55ms
+step:804/1490 train_time:33421ms step_avg:41.57ms
+step:805/1490 train_time:33476ms step_avg:41.59ms
+step:806/1490 train_time:33535ms step_avg:41.61ms
+step:807/1490 train_time:33590ms step_avg:41.62ms
+step:808/1490 train_time:33650ms step_avg:41.65ms
+step:809/1490 train_time:33706ms step_avg:41.66ms
+step:810/1490 train_time:33767ms step_avg:41.69ms
+step:811/1490 train_time:33822ms step_avg:41.70ms
+step:812/1490 train_time:33881ms step_avg:41.73ms
+step:813/1490 train_time:33935ms step_avg:41.74ms
+step:814/1490 train_time:33994ms step_avg:41.76ms
+step:815/1490 train_time:34047ms step_avg:41.78ms
+step:816/1490 train_time:34107ms step_avg:41.80ms
+step:817/1490 train_time:34161ms step_avg:41.81ms
+step:818/1490 train_time:34220ms step_avg:41.83ms
+step:819/1490 train_time:34274ms step_avg:41.85ms
+step:820/1490 train_time:34333ms step_avg:41.87ms
+step:821/1490 train_time:34388ms step_avg:41.89ms
+step:822/1490 train_time:34448ms step_avg:41.91ms
+step:823/1490 train_time:34503ms step_avg:41.92ms
+step:824/1490 train_time:34563ms step_avg:41.95ms
+step:825/1490 train_time:34617ms step_avg:41.96ms
+step:826/1490 train_time:34677ms step_avg:41.98ms
+step:827/1490 train_time:34730ms step_avg:42.00ms
+step:828/1490 train_time:34790ms step_avg:42.02ms
+step:829/1490 train_time:34845ms step_avg:42.03ms
+step:830/1490 train_time:34905ms step_avg:42.05ms
+step:831/1490 train_time:34959ms step_avg:42.07ms
+step:832/1490 train_time:35019ms step_avg:42.09ms
+step:833/1490 train_time:35073ms step_avg:42.10ms
+step:834/1490 train_time:35132ms step_avg:42.12ms
+step:835/1490 train_time:35186ms step_avg:42.14ms
+step:836/1490 train_time:35245ms step_avg:42.16ms
+step:837/1490 train_time:35299ms step_avg:42.17ms
+step:838/1490 train_time:35358ms step_avg:42.19ms
+step:839/1490 train_time:35412ms step_avg:42.21ms
+step:840/1490 train_time:35473ms step_avg:42.23ms
+step:841/1490 train_time:35527ms step_avg:42.24ms
+step:842/1490 train_time:35587ms step_avg:42.26ms
+step:843/1490 train_time:35642ms step_avg:42.28ms
+step:844/1490 train_time:35702ms step_avg:42.30ms
+step:845/1490 train_time:35756ms step_avg:42.31ms
+step:846/1490 train_time:35815ms step_avg:42.33ms
+step:847/1490 train_time:35869ms step_avg:42.35ms
+step:848/1490 train_time:35928ms step_avg:42.37ms
+step:849/1490 train_time:35983ms step_avg:42.38ms
+step:850/1490 train_time:36043ms step_avg:42.40ms
+step:851/1490 train_time:36097ms step_avg:42.42ms
+step:852/1490 train_time:36156ms step_avg:42.44ms
+step:853/1490 train_time:36210ms step_avg:42.45ms
+step:854/1490 train_time:36271ms step_avg:42.47ms
+step:855/1490 train_time:36325ms step_avg:42.48ms
+step:856/1490 train_time:36385ms step_avg:42.51ms
+step:857/1490 train_time:36438ms step_avg:42.52ms
+step:858/1490 train_time:36497ms step_avg:42.54ms
+step:859/1490 train_time:36551ms step_avg:42.55ms
+step:860/1490 train_time:36612ms step_avg:42.57ms
+step:861/1490 train_time:36666ms step_avg:42.59ms
+step:862/1490 train_time:36726ms step_avg:42.61ms
+step:863/1490 train_time:36780ms step_avg:42.62ms
+step:864/1490 train_time:36839ms step_avg:42.64ms
+step:865/1490 train_time:36893ms step_avg:42.65ms
+step:866/1490 train_time:36953ms step_avg:42.67ms
+step:867/1490 train_time:37006ms step_avg:42.68ms
+step:868/1490 train_time:37067ms step_avg:42.70ms
+step:869/1490 train_time:37121ms step_avg:42.72ms
+step:870/1490 train_time:37181ms step_avg:42.74ms
+step:871/1490 train_time:37234ms step_avg:42.75ms
+step:872/1490 train_time:37294ms step_avg:42.77ms
+step:873/1490 train_time:37348ms step_avg:42.78ms
+step:874/1490 train_time:37408ms step_avg:42.80ms
+step:875/1490 train_time:37462ms step_avg:42.81ms
+step:876/1490 train_time:37522ms step_avg:42.83ms
+step:877/1490 train_time:37576ms step_avg:42.85ms
+step:878/1490 train_time:37636ms step_avg:42.87ms
+step:879/1490 train_time:37690ms step_avg:42.88ms
+step:880/1490 train_time:37751ms step_avg:42.90ms
+step:881/1490 train_time:37806ms step_avg:42.91ms
+step:882/1490 train_time:37866ms step_avg:42.93ms
+step:883/1490 train_time:37920ms step_avg:42.94ms
+step:884/1490 train_time:37979ms step_avg:42.96ms
+step:885/1490 train_time:38032ms step_avg:42.97ms
+step:886/1490 train_time:38092ms step_avg:42.99ms
+step:887/1490 train_time:38146ms step_avg:43.01ms
+step:888/1490 train_time:38207ms step_avg:43.03ms
+step:889/1490 train_time:38262ms step_avg:43.04ms
+step:890/1490 train_time:38321ms step_avg:43.06ms
+step:891/1490 train_time:38375ms step_avg:43.07ms
+step:892/1490 train_time:38435ms step_avg:43.09ms
+step:893/1490 train_time:38488ms step_avg:43.10ms
+step:894/1490 train_time:38548ms step_avg:43.12ms
+step:895/1490 train_time:38602ms step_avg:43.13ms
+step:896/1490 train_time:38661ms step_avg:43.15ms
+step:897/1490 train_time:38715ms step_avg:43.16ms
+step:898/1490 train_time:38774ms step_avg:43.18ms
+step:899/1490 train_time:38828ms step_avg:43.19ms
+step:900/1490 train_time:38888ms step_avg:43.21ms
+step:901/1490 train_time:38942ms step_avg:43.22ms
+step:902/1490 train_time:39002ms step_avg:43.24ms
+step:903/1490 train_time:39055ms step_avg:43.25ms
+step:904/1490 train_time:39114ms step_avg:43.27ms
+step:905/1490 train_time:39168ms step_avg:43.28ms
+step:906/1490 train_time:39227ms step_avg:43.30ms
+step:907/1490 train_time:39283ms step_avg:43.31ms
+step:908/1490 train_time:39343ms step_avg:43.33ms
+step:909/1490 train_time:39397ms step_avg:43.34ms
+step:910/1490 train_time:39456ms step_avg:43.36ms
+step:911/1490 train_time:39511ms step_avg:43.37ms
+step:912/1490 train_time:39572ms step_avg:43.39ms
+step:913/1490 train_time:39625ms step_avg:43.40ms
+step:914/1490 train_time:39685ms step_avg:43.42ms
+step:915/1490 train_time:39739ms step_avg:43.43ms
+step:916/1490 train_time:39799ms step_avg:43.45ms
+step:917/1490 train_time:39853ms step_avg:43.46ms
+step:918/1490 train_time:39912ms step_avg:43.48ms
+step:919/1490 train_time:39966ms step_avg:43.49ms
+step:920/1490 train_time:40026ms step_avg:43.51ms
+step:921/1490 train_time:40079ms step_avg:43.52ms
+step:922/1490 train_time:40138ms step_avg:43.53ms
+step:923/1490 train_time:40192ms step_avg:43.55ms
+step:924/1490 train_time:40253ms step_avg:43.56ms
+step:925/1490 train_time:40306ms step_avg:43.57ms
+step:926/1490 train_time:40368ms step_avg:43.59ms
+step:927/1490 train_time:40422ms step_avg:43.61ms
+step:928/1490 train_time:40482ms step_avg:43.62ms
+step:929/1490 train_time:40535ms step_avg:43.63ms
+step:930/1490 train_time:40594ms step_avg:43.65ms
+step:931/1490 train_time:40649ms step_avg:43.66ms
+step:932/1490 train_time:40709ms step_avg:43.68ms
+step:933/1490 train_time:40762ms step_avg:43.69ms
+step:934/1490 train_time:40823ms step_avg:43.71ms
+step:935/1490 train_time:40877ms step_avg:43.72ms
+step:936/1490 train_time:40936ms step_avg:43.74ms
+step:937/1490 train_time:40990ms step_avg:43.75ms
+step:938/1490 train_time:41050ms step_avg:43.76ms
+step:939/1490 train_time:41105ms step_avg:43.78ms
+step:940/1490 train_time:41165ms step_avg:43.79ms
+step:941/1490 train_time:41219ms step_avg:43.80ms
+step:942/1490 train_time:41279ms step_avg:43.82ms
+step:943/1490 train_time:41332ms step_avg:43.83ms
+step:944/1490 train_time:41392ms step_avg:43.85ms
+step:945/1490 train_time:41446ms step_avg:43.86ms
+step:946/1490 train_time:41505ms step_avg:43.87ms
+step:947/1490 train_time:41559ms step_avg:43.88ms
+step:948/1490 train_time:41619ms step_avg:43.90ms
+step:949/1490 train_time:41672ms step_avg:43.91ms
+step:950/1490 train_time:41732ms step_avg:43.93ms
+step:951/1490 train_time:41786ms step_avg:43.94ms
+step:952/1490 train_time:41846ms step_avg:43.96ms
+step:953/1490 train_time:41901ms step_avg:43.97ms
+step:954/1490 train_time:41960ms step_avg:43.98ms
+step:955/1490 train_time:42014ms step_avg:43.99ms
+step:956/1490 train_time:42074ms step_avg:44.01ms
+step:957/1490 train_time:42127ms step_avg:44.02ms
+step:958/1490 train_time:42187ms step_avg:44.04ms
+step:959/1490 train_time:42241ms step_avg:44.05ms
+step:960/1490 train_time:42301ms step_avg:44.06ms
+step:961/1490 train_time:42355ms step_avg:44.07ms
+step:962/1490 train_time:42415ms step_avg:44.09ms
+step:963/1490 train_time:42469ms step_avg:44.10ms
+step:964/1490 train_time:42529ms step_avg:44.12ms
+step:965/1490 train_time:42583ms step_avg:44.13ms
+step:966/1490 train_time:42643ms step_avg:44.14ms
+step:967/1490 train_time:42696ms step_avg:44.15ms
+step:968/1490 train_time:42759ms step_avg:44.17ms
+step:969/1490 train_time:42837ms step_avg:44.21ms
+step:970/1490 train_time:42922ms step_avg:44.25ms
+step:971/1490 train_time:43003ms step_avg:44.29ms
+step:972/1490 train_time:43089ms step_avg:44.33ms
+step:973/1490 train_time:43169ms step_avg:44.37ms
+step:974/1490 train_time:43254ms step_avg:44.41ms
+step:975/1490 train_time:43335ms step_avg:44.45ms
+step:976/1490 train_time:43420ms step_avg:44.49ms
+step:977/1490 train_time:43502ms step_avg:44.53ms
+step:978/1490 train_time:43588ms step_avg:44.57ms
+step:979/1490 train_time:43668ms step_avg:44.60ms
+step:980/1490 train_time:43755ms step_avg:44.65ms
+step:981/1490 train_time:43834ms step_avg:44.68ms
+step:982/1490 train_time:43919ms step_avg:44.72ms
+step:983/1490 train_time:44000ms step_avg:44.76ms
+step:984/1490 train_time:44086ms step_avg:44.80ms
+step:985/1490 train_time:44165ms step_avg:44.84ms
+step:986/1490 train_time:44250ms step_avg:44.88ms
+step:987/1490 train_time:44331ms step_avg:44.91ms
+step:988/1490 train_time:44416ms step_avg:44.96ms
+step:989/1490 train_time:44497ms step_avg:44.99ms
+step:990/1490 train_time:44582ms step_avg:45.03ms
+step:991/1490 train_time:44663ms step_avg:45.07ms
+step:992/1490 train_time:44749ms step_avg:45.11ms
+step:993/1490 train_time:44829ms step_avg:45.14ms
+step:994/1490 train_time:44913ms step_avg:45.18ms
+step:995/1490 train_time:44994ms step_avg:45.22ms
+step:996/1490 train_time:45078ms step_avg:45.26ms
+step:997/1490 train_time:45156ms step_avg:45.29ms
+step:998/1490 train_time:45242ms step_avg:45.33ms
+step:999/1490 train_time:45323ms step_avg:45.37ms
+step:1000/1490 train_time:45412ms step_avg:45.41ms
+step:1000/1490 val_loss:3.5152 train_time:45514ms step_avg:45.51ms
+step:1001/1490 train_time:45533ms step_avg:45.49ms
+step:1002/1490 train_time:45581ms step_avg:45.49ms
+step:1003/1490 train_time:45665ms step_avg:45.53ms
+step:1004/1490 train_time:45751ms step_avg:45.57ms
+step:1005/1490 train_time:45832ms step_avg:45.60ms
+step:1006/1490 train_time:45917ms step_avg:45.64ms
+step:1007/1490 train_time:45998ms step_avg:45.68ms
+step:1008/1490 train_time:46083ms step_avg:45.72ms
+step:1009/1490 train_time:46161ms step_avg:45.75ms
+step:1010/1490 train_time:46246ms step_avg:45.79ms
+step:1011/1490 train_time:46325ms step_avg:45.82ms
+step:1012/1490 train_time:46409ms step_avg:45.86ms
+step:1013/1490 train_time:46490ms step_avg:45.89ms
+step:1014/1490 train_time:46578ms step_avg:45.93ms
+step:1015/1490 train_time:46661ms step_avg:45.97ms
+step:1016/1490 train_time:46749ms step_avg:46.01ms
+step:1017/1490 train_time:46830ms step_avg:46.05ms
+step:1018/1490 train_time:46917ms step_avg:46.09ms
+step:1019/1490 train_time:46999ms step_avg:46.12ms
+step:1020/1490 train_time:47083ms step_avg:46.16ms
+step:1021/1490 train_time:47163ms step_avg:46.19ms
+step:1022/1490 train_time:47247ms step_avg:46.23ms
+step:1023/1490 train_time:47326ms step_avg:46.26ms
+step:1024/1490 train_time:47410ms step_avg:46.30ms
+step:1025/1490 train_time:47492ms step_avg:46.33ms
+step:1026/1490 train_time:47579ms step_avg:46.37ms
+step:1027/1490 train_time:47661ms step_avg:46.41ms
+step:1028/1490 train_time:47747ms step_avg:46.45ms
+step:1029/1490 train_time:47827ms step_avg:46.48ms
+step:1030/1490 train_time:47913ms step_avg:46.52ms
+step:1031/1490 train_time:47994ms step_avg:46.55ms
+step:1032/1490 train_time:48078ms step_avg:46.59ms
+step:1033/1490 train_time:48158ms step_avg:46.62ms
+step:1034/1490 train_time:48243ms step_avg:46.66ms
+step:1035/1490 train_time:48321ms step_avg:46.69ms
+step:1036/1490 train_time:48407ms step_avg:46.72ms
+step:1037/1490 train_time:48486ms step_avg:46.76ms
+step:1038/1490 train_time:48572ms step_avg:46.79ms
+step:1039/1490 train_time:48653ms step_avg:46.83ms
+step:1040/1490 train_time:48740ms step_avg:46.86ms
+step:1041/1490 train_time:48820ms step_avg:46.90ms
+step:1042/1490 train_time:48907ms step_avg:46.94ms
+step:1043/1490 train_time:48988ms step_avg:46.97ms
+step:1044/1490 train_time:49073ms step_avg:47.00ms
+step:1045/1490 train_time:49154ms step_avg:47.04ms
+step:1046/1490 train_time:49240ms step_avg:47.07ms
+step:1047/1490 train_time:49319ms step_avg:47.11ms
+step:1048/1490 train_time:49404ms step_avg:47.14ms
+step:1049/1490 train_time:49483ms step_avg:47.17ms
+step:1050/1490 train_time:49567ms step_avg:47.21ms
+step:1051/1490 train_time:49649ms step_avg:47.24ms
+step:1052/1490 train_time:49734ms step_avg:47.28ms
+step:1053/1490 train_time:49816ms step_avg:47.31ms
+step:1054/1490 train_time:49902ms step_avg:47.35ms
+step:1055/1490 train_time:49983ms step_avg:47.38ms
+step:1056/1490 train_time:50067ms step_avg:47.41ms
+step:1057/1490 train_time:50147ms step_avg:47.44ms
+step:1058/1490 train_time:50232ms step_avg:47.48ms
+step:1059/1490 train_time:50314ms step_avg:47.51ms
+step:1060/1490 train_time:50399ms step_avg:47.55ms
+step:1061/1490 train_time:50478ms step_avg:47.58ms
+step:1062/1490 train_time:50564ms step_avg:47.61ms
+step:1063/1490 train_time:50644ms step_avg:47.64ms
+step:1064/1490 train_time:50730ms step_avg:47.68ms
+step:1065/1490 train_time:50812ms step_avg:47.71ms
+step:1066/1490 train_time:50897ms step_avg:47.75ms
+step:1067/1490 train_time:50977ms step_avg:47.78ms
+step:1068/1490 train_time:51063ms step_avg:47.81ms
+step:1069/1490 train_time:51143ms step_avg:47.84ms
+step:1070/1490 train_time:51228ms step_avg:47.88ms
+step:1071/1490 train_time:51309ms step_avg:47.91ms
+step:1072/1490 train_time:51394ms step_avg:47.94ms
+step:1073/1490 train_time:51473ms step_avg:47.97ms
+step:1074/1490 train_time:51559ms step_avg:48.01ms
+step:1075/1490 train_time:51639ms step_avg:48.04ms
+step:1076/1490 train_time:51724ms step_avg:48.07ms
+step:1077/1490 train_time:51804ms step_avg:48.10ms
+step:1078/1490 train_time:51890ms step_avg:48.13ms
+step:1079/1490 train_time:51970ms step_avg:48.16ms
+step:1080/1490 train_time:52055ms step_avg:48.20ms
+step:1081/1490 train_time:52135ms step_avg:48.23ms
+step:1082/1490 train_time:52221ms step_avg:48.26ms
+step:1083/1490 train_time:52301ms step_avg:48.29ms
+step:1084/1490 train_time:52386ms step_avg:48.33ms
+step:1085/1490 train_time:52465ms step_avg:48.35ms
+step:1086/1490 train_time:52550ms step_avg:48.39ms
+step:1087/1490 train_time:52631ms step_avg:48.42ms
+step:1088/1490 train_time:52717ms step_avg:48.45ms
+step:1089/1490 train_time:52798ms step_avg:48.48ms
+step:1090/1490 train_time:52883ms step_avg:48.52ms
+step:1091/1490 train_time:52963ms step_avg:48.55ms
+step:1092/1490 train_time:53048ms step_avg:48.58ms
+step:1093/1490 train_time:53128ms step_avg:48.61ms
+step:1094/1490 train_time:53215ms step_avg:48.64ms
+step:1095/1490 train_time:53295ms step_avg:48.67ms
+step:1096/1490 train_time:53381ms step_avg:48.71ms
+step:1097/1490 train_time:53460ms step_avg:48.73ms
+step:1098/1490 train_time:53545ms step_avg:48.77ms
+step:1099/1490 train_time:53625ms step_avg:48.79ms
+step:1100/1490 train_time:53711ms step_avg:48.83ms
+step:1101/1490 train_time:53791ms step_avg:48.86ms
+step:1102/1490 train_time:53876ms step_avg:48.89ms
+step:1103/1490 train_time:53957ms step_avg:48.92ms
+step:1104/1490 train_time:54042ms step_avg:48.95ms
+step:1105/1490 train_time:54122ms step_avg:48.98ms
+step:1106/1490 train_time:54206ms step_avg:49.01ms
+step:1107/1490 train_time:54287ms step_avg:49.04ms
+step:1108/1490 train_time:54373ms step_avg:49.07ms
+step:1109/1490 train_time:54454ms step_avg:49.10ms
+step:1110/1490 train_time:54540ms step_avg:49.14ms
+step:1111/1490 train_time:54620ms step_avg:49.16ms
+step:1112/1490 train_time:54705ms step_avg:49.20ms
+step:1113/1490 train_time:54784ms step_avg:49.22ms
+step:1114/1490 train_time:54870ms step_avg:49.25ms
+step:1115/1490 train_time:54951ms step_avg:49.28ms
+step:1116/1490 train_time:55037ms step_avg:49.32ms
+step:1117/1490 train_time:55118ms step_avg:49.34ms
+step:1118/1490 train_time:55205ms step_avg:49.38ms
+step:1119/1490 train_time:55283ms step_avg:49.40ms
+step:1120/1490 train_time:55369ms step_avg:49.44ms
+step:1121/1490 train_time:55450ms step_avg:49.46ms
+step:1122/1490 train_time:55535ms step_avg:49.50ms
+step:1123/1490 train_time:55615ms step_avg:49.52ms
+step:1124/1490 train_time:55701ms step_avg:49.56ms
+step:1125/1490 train_time:55780ms step_avg:49.58ms
+step:1126/1490 train_time:55865ms step_avg:49.61ms
+step:1127/1490 train_time:55945ms step_avg:49.64ms
+step:1128/1490 train_time:56031ms step_avg:49.67ms
+step:1129/1490 train_time:56113ms step_avg:49.70ms
+step:1130/1490 train_time:56199ms step_avg:49.73ms
+step:1131/1490 train_time:56279ms step_avg:49.76ms
+step:1132/1490 train_time:56364ms step_avg:49.79ms
+step:1133/1490 train_time:56444ms step_avg:49.82ms
+step:1134/1490 train_time:56529ms step_avg:49.85ms
+step:1135/1490 train_time:56610ms step_avg:49.88ms
+step:1136/1490 train_time:56696ms step_avg:49.91ms
+step:1137/1490 train_time:56778ms step_avg:49.94ms
+step:1138/1490 train_time:56863ms step_avg:49.97ms
+step:1139/1490 train_time:56943ms step_avg:49.99ms
+step:1140/1490 train_time:57029ms step_avg:50.03ms
+step:1141/1490 train_time:57110ms step_avg:50.05ms
+step:1142/1490 train_time:57195ms step_avg:50.08ms
+step:1143/1490 train_time:57275ms step_avg:50.11ms
+step:1144/1490 train_time:57362ms step_avg:50.14ms
+step:1145/1490 train_time:57441ms step_avg:50.17ms
+step:1146/1490 train_time:57526ms step_avg:50.20ms
+step:1147/1490 train_time:57606ms step_avg:50.22ms
+step:1148/1490 train_time:57691ms step_avg:50.25ms
+step:1149/1490 train_time:57772ms step_avg:50.28ms
+step:1150/1490 train_time:57857ms step_avg:50.31ms
+step:1151/1490 train_time:57938ms step_avg:50.34ms
+step:1152/1490 train_time:58023ms step_avg:50.37ms
+step:1153/1490 train_time:58104ms step_avg:50.39ms
+step:1154/1490 train_time:58189ms step_avg:50.42ms
+step:1155/1490 train_time:58270ms step_avg:50.45ms
+step:1156/1490 train_time:58357ms step_avg:50.48ms
+step:1157/1490 train_time:58437ms step_avg:50.51ms
+step:1158/1490 train_time:58522ms step_avg:50.54ms
+step:1159/1490 train_time:58602ms step_avg:50.56ms
+step:1160/1490 train_time:58687ms step_avg:50.59ms
+step:1161/1490 train_time:58767ms step_avg:50.62ms
+step:1162/1490 train_time:58854ms step_avg:50.65ms
+step:1163/1490 train_time:58935ms step_avg:50.67ms
+step:1164/1490 train_time:59020ms step_avg:50.70ms
+step:1165/1490 train_time:59101ms step_avg:50.73ms
+step:1166/1490 train_time:59185ms step_avg:50.76ms
+step:1167/1490 train_time:59265ms step_avg:50.78ms
+step:1168/1490 train_time:59350ms step_avg:50.81ms
+step:1169/1490 train_time:59430ms step_avg:50.84ms
+step:1170/1490 train_time:59516ms step_avg:50.87ms
+step:1171/1490 train_time:59597ms step_avg:50.89ms
+step:1172/1490 train_time:59683ms step_avg:50.92ms
+step:1173/1490 train_time:59762ms step_avg:50.95ms
+step:1174/1490 train_time:59848ms step_avg:50.98ms
+step:1175/1490 train_time:59928ms step_avg:51.00ms
+step:1176/1490 train_time:60015ms step_avg:51.03ms
+step:1177/1490 train_time:60096ms step_avg:51.06ms
+step:1178/1490 train_time:60181ms step_avg:51.09ms
+step:1179/1490 train_time:60260ms step_avg:51.11ms
+step:1180/1490 train_time:60346ms step_avg:51.14ms
+step:1181/1490 train_time:60425ms step_avg:51.16ms
+step:1182/1490 train_time:60512ms step_avg:51.19ms
+step:1183/1490 train_time:60593ms step_avg:51.22ms
+step:1184/1490 train_time:60678ms step_avg:51.25ms
+step:1185/1490 train_time:60758ms step_avg:51.27ms
+step:1186/1490 train_time:60844ms step_avg:51.30ms
+step:1187/1490 train_time:60923ms step_avg:51.33ms
+step:1188/1490 train_time:61009ms step_avg:51.35ms
+step:1189/1490 train_time:61090ms step_avg:51.38ms
+step:1190/1490 train_time:61176ms step_avg:51.41ms
+step:1191/1490 train_time:61256ms step_avg:51.43ms
+step:1192/1490 train_time:61341ms step_avg:51.46ms
+step:1193/1490 train_time:61421ms step_avg:51.48ms
+step:1194/1490 train_time:61507ms step_avg:51.51ms
+step:1195/1490 train_time:61587ms step_avg:51.54ms
+step:1196/1490 train_time:61673ms step_avg:51.57ms
+step:1197/1490 train_time:61753ms step_avg:51.59ms
+step:1198/1490 train_time:61839ms step_avg:51.62ms
+step:1199/1490 train_time:61919ms step_avg:51.64ms
+step:1200/1490 train_time:62005ms step_avg:51.67ms
+step:1201/1490 train_time:62084ms step_avg:51.69ms
+step:1202/1490 train_time:62170ms step_avg:51.72ms
+step:1203/1490 train_time:62251ms step_avg:51.75ms
+step:1204/1490 train_time:62337ms step_avg:51.77ms
+step:1205/1490 train_time:62416ms step_avg:51.80ms
+step:1206/1490 train_time:62502ms step_avg:51.83ms
+step:1207/1490 train_time:62582ms step_avg:51.85ms
+step:1208/1490 train_time:62666ms step_avg:51.88ms
+step:1209/1490 train_time:62746ms step_avg:51.90ms
+step:1210/1490 train_time:62831ms step_avg:51.93ms
+step:1211/1490 train_time:62912ms step_avg:51.95ms
+step:1212/1490 train_time:62997ms step_avg:51.98ms
+step:1213/1490 train_time:63078ms step_avg:52.00ms
+step:1214/1490 train_time:63164ms step_avg:52.03ms
+step:1215/1490 train_time:63244ms step_avg:52.05ms
+step:1216/1490 train_time:63330ms step_avg:52.08ms
+step:1217/1490 train_time:63410ms step_avg:52.10ms
+step:1218/1490 train_time:63496ms step_avg:52.13ms
+step:1219/1490 train_time:63575ms step_avg:52.15ms
+step:1220/1490 train_time:63662ms step_avg:52.18ms
+step:1221/1490 train_time:63742ms step_avg:52.21ms
+step:1222/1490 train_time:63828ms step_avg:52.23ms
+step:1223/1490 train_time:63909ms step_avg:52.26ms
+step:1224/1490 train_time:63995ms step_avg:52.28ms
+step:1225/1490 train_time:64076ms step_avg:52.31ms
+step:1226/1490 train_time:64160ms step_avg:52.33ms
+step:1227/1490 train_time:64241ms step_avg:52.36ms
+step:1228/1490 train_time:64326ms step_avg:52.38ms
+step:1229/1490 train_time:64405ms step_avg:52.40ms
+step:1230/1490 train_time:64491ms step_avg:52.43ms
+step:1231/1490 train_time:64571ms step_avg:52.45ms
+step:1232/1490 train_time:64657ms step_avg:52.48ms
+step:1233/1490 train_time:64737ms step_avg:52.50ms
+step:1234/1490 train_time:64823ms step_avg:52.53ms
+step:1235/1490 train_time:64904ms step_avg:52.55ms
+step:1236/1490 train_time:64989ms step_avg:52.58ms
+step:1237/1490 train_time:65070ms step_avg:52.60ms
+step:1238/1490 train_time:65154ms step_avg:52.63ms
+step:1239/1490 train_time:65236ms step_avg:52.65ms
+step:1240/1490 train_time:65321ms step_avg:52.68ms
+step:1241/1490 train_time:65403ms step_avg:52.70ms
+step:1242/1490 train_time:65488ms step_avg:52.73ms
+step:1243/1490 train_time:65569ms step_avg:52.75ms
+step:1244/1490 train_time:65656ms step_avg:52.78ms
+step:1245/1490 train_time:65735ms step_avg:52.80ms
+step:1246/1490 train_time:65820ms step_avg:52.83ms
+step:1247/1490 train_time:65902ms step_avg:52.85ms
+step:1248/1490 train_time:65988ms step_avg:52.88ms
+step:1249/1490 train_time:66069ms step_avg:52.90ms
+step:1250/1490 train_time:66154ms step_avg:52.92ms
+step:1250/1490 val_loss:3.3692 train_time:66256ms step_avg:53.00ms
+step:1251/1490 train_time:66276ms step_avg:52.98ms
+step:1252/1490 train_time:66325ms step_avg:52.98ms
+step:1253/1490 train_time:66410ms step_avg:53.00ms
+step:1254/1490 train_time:66496ms step_avg:53.03ms
+step:1255/1490 train_time:66576ms step_avg:53.05ms
+step:1256/1490 train_time:66660ms step_avg:53.07ms
+step:1257/1490 train_time:66740ms step_avg:53.09ms
+step:1258/1490 train_time:66824ms step_avg:53.12ms
+step:1259/1490 train_time:66904ms step_avg:53.14ms
+step:1260/1490 train_time:66988ms step_avg:53.16ms
+step:1261/1490 train_time:67067ms step_avg:53.19ms
+step:1262/1490 train_time:67152ms step_avg:53.21ms
+step:1263/1490 train_time:67231ms step_avg:53.23ms
+step:1264/1490 train_time:67320ms step_avg:53.26ms
+step:1265/1490 train_time:67402ms step_avg:53.28ms
+step:1266/1490 train_time:67489ms step_avg:53.31ms
+step:1267/1490 train_time:67571ms step_avg:53.33ms
+step:1268/1490 train_time:67657ms step_avg:53.36ms
+step:1269/1490 train_time:67736ms step_avg:53.38ms
+step:1270/1490 train_time:67820ms step_avg:53.40ms
+step:1271/1490 train_time:67898ms step_avg:53.42ms
+step:1272/1490 train_time:67983ms step_avg:53.45ms
+step:1273/1490 train_time:68063ms step_avg:53.47ms
+step:1274/1490 train_time:68148ms step_avg:53.49ms
+step:1275/1490 train_time:68228ms step_avg:53.51ms
+step:1276/1490 train_time:68317ms step_avg:53.54ms
+step:1277/1490 train_time:68398ms step_avg:53.56ms
+step:1278/1490 train_time:68484ms step_avg:53.59ms
+step:1279/1490 train_time:68564ms step_avg:53.61ms
+step:1280/1490 train_time:68650ms step_avg:53.63ms
+step:1281/1490 train_time:68730ms step_avg:53.65ms
+step:1282/1490 train_time:68815ms step_avg:53.68ms
+step:1283/1490 train_time:68895ms step_avg:53.70ms
+step:1284/1490 train_time:68980ms step_avg:53.72ms
+step:1285/1490 train_time:69059ms step_avg:53.74ms
+step:1286/1490 train_time:69144ms step_avg:53.77ms
+step:1287/1490 train_time:69225ms step_avg:53.79ms
+step:1288/1490 train_time:69312ms step_avg:53.81ms
+step:1289/1490 train_time:69393ms step_avg:53.83ms
+step:1290/1490 train_time:69479ms step_avg:53.86ms
+step:1291/1490 train_time:69560ms step_avg:53.88ms
+step:1292/1490 train_time:69645ms step_avg:53.91ms
+step:1293/1490 train_time:69727ms step_avg:53.93ms
+step:1294/1490 train_time:69812ms step_avg:53.95ms
+step:1295/1490 train_time:69892ms step_avg:53.97ms
+step:1296/1490 train_time:69976ms step_avg:53.99ms
+step:1297/1490 train_time:70055ms step_avg:54.01ms
+step:1298/1490 train_time:70142ms step_avg:54.04ms
+step:1299/1490 train_time:70222ms step_avg:54.06ms
+step:1300/1490 train_time:70308ms step_avg:54.08ms
+step:1301/1490 train_time:70389ms step_avg:54.10ms
+step:1302/1490 train_time:70475ms step_avg:54.13ms
+step:1303/1490 train_time:70556ms step_avg:54.15ms
+step:1304/1490 train_time:70642ms step_avg:54.17ms
+step:1305/1490 train_time:70722ms step_avg:54.19ms
+step:1306/1490 train_time:70809ms step_avg:54.22ms
+step:1307/1490 train_time:70888ms step_avg:54.24ms
+step:1308/1490 train_time:70973ms step_avg:54.26ms
+step:1309/1490 train_time:71051ms step_avg:54.28ms
+step:1310/1490 train_time:71135ms step_avg:54.30ms
+step:1311/1490 train_time:71216ms step_avg:54.32ms
+step:1312/1490 train_time:71302ms step_avg:54.35ms
+step:1313/1490 train_time:71382ms step_avg:54.37ms
+step:1314/1490 train_time:71467ms step_avg:54.39ms
+step:1315/1490 train_time:71547ms step_avg:54.41ms
+step:1316/1490 train_time:71635ms step_avg:54.43ms
+step:1317/1490 train_time:71716ms step_avg:54.45ms
+step:1318/1490 train_time:71801ms step_avg:54.48ms
+step:1319/1490 train_time:71881ms step_avg:54.50ms
+step:1320/1490 train_time:71965ms step_avg:54.52ms
+step:1321/1490 train_time:72044ms step_avg:54.54ms
+step:1322/1490 train_time:72130ms step_avg:54.56ms
+step:1323/1490 train_time:72210ms step_avg:54.58ms
+step:1324/1490 train_time:72297ms step_avg:54.60ms
+step:1325/1490 train_time:72375ms step_avg:54.62ms
+step:1326/1490 train_time:72462ms step_avg:54.65ms
+step:1327/1490 train_time:72542ms step_avg:54.67ms
+step:1328/1490 train_time:72629ms step_avg:54.69ms
+step:1329/1490 train_time:72710ms step_avg:54.71ms
+step:1330/1490 train_time:72795ms step_avg:54.73ms
+step:1331/1490 train_time:72874ms step_avg:54.75ms
+step:1332/1490 train_time:72959ms step_avg:54.77ms
+step:1333/1490 train_time:73039ms step_avg:54.79ms
+step:1334/1490 train_time:73124ms step_avg:54.82ms
+step:1335/1490 train_time:73204ms step_avg:54.83ms
+step:1336/1490 train_time:73291ms step_avg:54.86ms
+step:1337/1490 train_time:73372ms step_avg:54.88ms
+step:1338/1490 train_time:73456ms step_avg:54.90ms
+step:1339/1490 train_time:73537ms step_avg:54.92ms
+step:1340/1490 train_time:73623ms step_avg:54.94ms
+step:1341/1490 train_time:73704ms step_avg:54.96ms
+step:1342/1490 train_time:73790ms step_avg:54.98ms
+step:1343/1490 train_time:73870ms step_avg:55.00ms
+step:1344/1490 train_time:73956ms step_avg:55.03ms
+step:1345/1490 train_time:74036ms step_avg:55.05ms
+step:1346/1490 train_time:74121ms step_avg:55.07ms
+step:1347/1490 train_time:74200ms step_avg:55.09ms
+step:1348/1490 train_time:74286ms step_avg:55.11ms
+step:1349/1490 train_time:74368ms step_avg:55.13ms
+step:1350/1490 train_time:74454ms step_avg:55.15ms
+step:1351/1490 train_time:74533ms step_avg:55.17ms
+step:1352/1490 train_time:74619ms step_avg:55.19ms
+step:1353/1490 train_time:74698ms step_avg:55.21ms
+step:1354/1490 train_time:74784ms step_avg:55.23ms
+step:1355/1490 train_time:74866ms step_avg:55.25ms
+step:1356/1490 train_time:74951ms step_avg:55.27ms
+step:1357/1490 train_time:75030ms step_avg:55.29ms
+step:1358/1490 train_time:75116ms step_avg:55.31ms
+step:1359/1490 train_time:75195ms step_avg:55.33ms
+step:1360/1490 train_time:75282ms step_avg:55.35ms
+step:1361/1490 train_time:75363ms step_avg:55.37ms
+step:1362/1490 train_time:75450ms step_avg:55.40ms
+step:1363/1490 train_time:75530ms step_avg:55.41ms
+step:1364/1490 train_time:75616ms step_avg:55.44ms
+step:1365/1490 train_time:75695ms step_avg:55.45ms
+step:1366/1490 train_time:75779ms step_avg:55.48ms
+step:1367/1490 train_time:75860ms step_avg:55.49ms
+step:1368/1490 train_time:75946ms step_avg:55.52ms
+step:1369/1490 train_time:76027ms step_avg:55.53ms
+step:1370/1490 train_time:76113ms step_avg:55.56ms
+step:1371/1490 train_time:76194ms step_avg:55.58ms
+step:1372/1490 train_time:76278ms step_avg:55.60ms
+step:1373/1490 train_time:76357ms step_avg:55.61ms
+step:1374/1490 train_time:76444ms step_avg:55.64ms
+step:1375/1490 train_time:76525ms step_avg:55.65ms
+step:1376/1490 train_time:76611ms step_avg:55.68ms
+step:1377/1490 train_time:76690ms step_avg:55.69ms
+step:1378/1490 train_time:76776ms step_avg:55.72ms
+step:1379/1490 train_time:76855ms step_avg:55.73ms
+step:1380/1490 train_time:76941ms step_avg:55.75ms
+step:1381/1490 train_time:77022ms step_avg:55.77ms
+step:1382/1490 train_time:77108ms step_avg:55.79ms
+step:1383/1490 train_time:77189ms step_avg:55.81ms
+step:1384/1490 train_time:77275ms step_avg:55.83ms
+step:1385/1490 train_time:77355ms step_avg:55.85ms
+step:1386/1490 train_time:77442ms step_avg:55.87ms
+step:1387/1490 train_time:77522ms step_avg:55.89ms
+step:1388/1490 train_time:77609ms step_avg:55.91ms
+step:1389/1490 train_time:77690ms step_avg:55.93ms
+step:1390/1490 train_time:77777ms step_avg:55.95ms
+step:1391/1490 train_time:77857ms step_avg:55.97ms
+step:1392/1490 train_time:77941ms step_avg:55.99ms
+step:1393/1490 train_time:78022ms step_avg:56.01ms
+step:1394/1490 train_time:78108ms step_avg:56.03ms
+step:1395/1490 train_time:78189ms step_avg:56.05ms
+step:1396/1490 train_time:78276ms step_avg:56.07ms
+step:1397/1490 train_time:78356ms step_avg:56.09ms
+step:1398/1490 train_time:78441ms step_avg:56.11ms
+step:1399/1490 train_time:78521ms step_avg:56.13ms
+step:1400/1490 train_time:78607ms step_avg:56.15ms
+step:1401/1490 train_time:78688ms step_avg:56.17ms
+step:1402/1490 train_time:78773ms step_avg:56.19ms
+step:1403/1490 train_time:78854ms step_avg:56.20ms
+step:1404/1490 train_time:78940ms step_avg:56.23ms
+step:1405/1490 train_time:79021ms step_avg:56.24ms
+step:1406/1490 train_time:79106ms step_avg:56.26ms
+step:1407/1490 train_time:79186ms step_avg:56.28ms
+step:1408/1490 train_time:79273ms step_avg:56.30ms
+step:1409/1490 train_time:79353ms step_avg:56.32ms
+step:1410/1490 train_time:79438ms step_avg:56.34ms
+step:1411/1490 train_time:79517ms step_avg:56.36ms
+step:1412/1490 train_time:79602ms step_avg:56.38ms
+step:1413/1490 train_time:79683ms step_avg:56.39ms
+step:1414/1490 train_time:79769ms step_avg:56.41ms
+step:1415/1490 train_time:79851ms step_avg:56.43ms
+step:1416/1490 train_time:79936ms step_avg:56.45ms
+step:1417/1490 train_time:80017ms step_avg:56.47ms
+step:1418/1490 train_time:80101ms step_avg:56.49ms
+step:1419/1490 train_time:80182ms step_avg:56.51ms
+step:1420/1490 train_time:80269ms step_avg:56.53ms
+step:1421/1490 train_time:80350ms step_avg:56.54ms
+step:1422/1490 train_time:80436ms step_avg:56.57ms
+step:1423/1490 train_time:80516ms step_avg:56.58ms
+step:1424/1490 train_time:80602ms step_avg:56.60ms
+step:1425/1490 train_time:80683ms step_avg:56.62ms
+step:1426/1490 train_time:80769ms step_avg:56.64ms
+step:1427/1490 train_time:80848ms step_avg:56.66ms
+step:1428/1490 train_time:80933ms step_avg:56.68ms
+step:1429/1490 train_time:81015ms step_avg:56.69ms
+step:1430/1490 train_time:81099ms step_avg:56.71ms
+step:1431/1490 train_time:81180ms step_avg:56.73ms
+step:1432/1490 train_time:81265ms step_avg:56.75ms
+step:1433/1490 train_time:81346ms step_avg:56.77ms
+step:1434/1490 train_time:81432ms step_avg:56.79ms
+step:1435/1490 train_time:81513ms step_avg:56.80ms
+step:1436/1490 train_time:81598ms step_avg:56.82ms
+step:1437/1490 train_time:81677ms step_avg:56.84ms
+step:1438/1490 train_time:81762ms step_avg:56.86ms
+step:1439/1490 train_time:81843ms step_avg:56.87ms
+step:1440/1490 train_time:81928ms step_avg:56.89ms
+step:1441/1490 train_time:82009ms step_avg:56.91ms
+step:1442/1490 train_time:82095ms step_avg:56.93ms
+step:1443/1490 train_time:82175ms step_avg:56.95ms
+step:1444/1490 train_time:82261ms step_avg:56.97ms
+step:1445/1490 train_time:82340ms step_avg:56.98ms
+step:1446/1490 train_time:82427ms step_avg:57.00ms
+step:1447/1490 train_time:82508ms step_avg:57.02ms
+step:1448/1490 train_time:82594ms step_avg:57.04ms
+step:1449/1490 train_time:82674ms step_avg:57.06ms
+step:1450/1490 train_time:82760ms step_avg:57.08ms
+step:1451/1490 train_time:82843ms step_avg:57.09ms
+step:1452/1490 train_time:82930ms step_avg:57.11ms
+step:1453/1490 train_time:83009ms step_avg:57.13ms
+step:1454/1490 train_time:83095ms step_avg:57.15ms
+step:1455/1490 train_time:83176ms step_avg:57.17ms
+step:1456/1490 train_time:83261ms step_avg:57.18ms
+step:1457/1490 train_time:83342ms step_avg:57.20ms
+step:1458/1490 train_time:83428ms step_avg:57.22ms
+step:1459/1490 train_time:83509ms step_avg:57.24ms
+step:1460/1490 train_time:83596ms step_avg:57.26ms
+step:1461/1490 train_time:83675ms step_avg:57.27ms
+step:1462/1490 train_time:83760ms step_avg:57.29ms
+step:1463/1490 train_time:83841ms step_avg:57.31ms
+step:1464/1490 train_time:83927ms step_avg:57.33ms
+step:1465/1490 train_time:84009ms step_avg:57.34ms
+step:1466/1490 train_time:84094ms step_avg:57.36ms
+step:1467/1490 train_time:84174ms step_avg:57.38ms
+step:1468/1490 train_time:84261ms step_avg:57.40ms
+step:1469/1490 train_time:84342ms step_avg:57.41ms
+step:1470/1490 train_time:84428ms step_avg:57.43ms
+step:1471/1490 train_time:84508ms step_avg:57.45ms
+step:1472/1490 train_time:84595ms step_avg:57.47ms
+step:1473/1490 train_time:84677ms step_avg:57.49ms
+step:1474/1490 train_time:84763ms step_avg:57.51ms
+step:1475/1490 train_time:84844ms step_avg:57.52ms
+step:1476/1490 train_time:84931ms step_avg:57.54ms
+step:1477/1490 train_time:85013ms step_avg:57.56ms
+step:1478/1490 train_time:85099ms step_avg:57.58ms
+step:1479/1490 train_time:85178ms step_avg:57.59ms
+step:1480/1490 train_time:85264ms step_avg:57.61ms
+step:1481/1490 train_time:85344ms step_avg:57.63ms
+step:1482/1490 train_time:85429ms step_avg:57.64ms
+step:1483/1490 train_time:85510ms step_avg:57.66ms
+step:1484/1490 train_time:85595ms step_avg:57.68ms
+step:1485/1490 train_time:85676ms step_avg:57.69ms
+step:1486/1490 train_time:85763ms step_avg:57.71ms
+step:1487/1490 train_time:85844ms step_avg:57.73ms
+step:1488/1490 train_time:85931ms step_avg:57.75ms
+step:1489/1490 train_time:86012ms step_avg:57.77ms
+step:1490/1490 train_time:86098ms step_avg:57.78ms
+step:1490/1490 val_loss:3.2762 train_time:86202ms step_avg:57.85ms
+peak memory allocated: 31277 MiB reserved: 47162 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/combined/2026-03-22_20-13-47_time-185_secs_06-mbeta2-max-docs_45c4f7.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/combined/2026-03-22_20-13-47_time-185_secs_06-mbeta2-max-docs_45c4f7.txt
@@ -1,0 +1,4457 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 20:14:02 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   36C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            132W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   41C    P0            124W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1858475      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1858476      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1858477      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1858478      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1858479      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1858480      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1858481      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1858482      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8319 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:80ms step_avg:80.19ms
+step:2/1490 train_time:100ms step_avg:50.25ms
+step:3/1490 train_time:117ms step_avg:38.89ms
+step:4/1490 train_time:150ms step_avg:37.50ms
+step:5/1490 train_time:177ms step_avg:35.49ms
+step:6/1490 train_time:212ms step_avg:35.39ms
+step:7/1490 train_time:240ms step_avg:34.28ms
+step:8/1490 train_time:274ms step_avg:34.30ms
+step:9/1490 train_time:302ms step_avg:33.54ms
+step:10/1490 train_time:336ms step_avg:33.58ms
+step:11/1490 train_time:364ms step_avg:33.06ms
+step:12/1490 train_time:398ms step_avg:33.19ms
+step:13/1490 train_time:426ms step_avg:32.79ms
+step:14/1490 train_time:460ms step_avg:32.89ms
+step:15/1490 train_time:488ms step_avg:32.56ms
+step:16/1490 train_time:523ms step_avg:32.68ms
+step:17/1490 train_time:551ms step_avg:32.42ms
+step:18/1490 train_time:585ms step_avg:32.51ms
+step:19/1490 train_time:613ms step_avg:32.28ms
+step:20/1490 train_time:648ms step_avg:32.38ms
+step:21/1490 train_time:676ms step_avg:32.18ms
+step:22/1490 train_time:710ms step_avg:32.27ms
+step:23/1490 train_time:738ms step_avg:32.09ms
+step:24/1490 train_time:772ms step_avg:32.17ms
+step:25/1490 train_time:800ms step_avg:32.02ms
+step:26/1490 train_time:835ms step_avg:32.10ms
+step:27/1490 train_time:863ms step_avg:31.96ms
+step:28/1490 train_time:897ms step_avg:32.03ms
+step:29/1490 train_time:925ms step_avg:31.90ms
+step:30/1490 train_time:959ms step_avg:31.98ms
+step:31/1490 train_time:989ms step_avg:31.91ms
+step:32/1490 train_time:1025ms step_avg:32.04ms
+step:33/1490 train_time:1055ms step_avg:31.97ms
+step:34/1490 train_time:1091ms step_avg:32.09ms
+step:35/1490 train_time:1120ms step_avg:31.99ms
+step:36/1490 train_time:1154ms step_avg:32.07ms
+step:37/1490 train_time:1183ms step_avg:31.96ms
+step:38/1490 train_time:1217ms step_avg:32.02ms
+step:39/1490 train_time:1245ms step_avg:31.93ms
+step:40/1490 train_time:1280ms step_avg:31.99ms
+step:41/1490 train_time:1308ms step_avg:31.90ms
+step:42/1490 train_time:1343ms step_avg:31.97ms
+step:43/1490 train_time:1371ms step_avg:31.88ms
+step:44/1490 train_time:1406ms step_avg:31.94ms
+step:45/1490 train_time:1434ms step_avg:31.86ms
+step:46/1490 train_time:1468ms step_avg:31.91ms
+step:47/1490 train_time:1496ms step_avg:31.83ms
+step:48/1490 train_time:1530ms step_avg:31.88ms
+step:49/1490 train_time:1559ms step_avg:31.82ms
+step:50/1490 train_time:1593ms step_avg:31.87ms
+step:51/1490 train_time:1622ms step_avg:31.80ms
+step:52/1490 train_time:1656ms step_avg:31.84ms
+step:53/1490 train_time:1684ms step_avg:31.77ms
+step:54/1490 train_time:1718ms step_avg:31.82ms
+step:55/1490 train_time:1747ms step_avg:31.76ms
+step:56/1490 train_time:1781ms step_avg:31.81ms
+step:57/1490 train_time:1810ms step_avg:31.75ms
+step:58/1490 train_time:1844ms step_avg:31.79ms
+step:59/1490 train_time:1872ms step_avg:31.73ms
+step:60/1490 train_time:1906ms step_avg:31.77ms
+step:61/1490 train_time:1935ms step_avg:31.71ms
+step:62/1490 train_time:1969ms step_avg:31.76ms
+step:63/1490 train_time:1998ms step_avg:31.71ms
+step:64/1490 train_time:2032ms step_avg:31.75ms
+step:65/1490 train_time:2061ms step_avg:31.71ms
+step:66/1490 train_time:2096ms step_avg:31.75ms
+step:67/1490 train_time:2124ms step_avg:31.70ms
+step:68/1490 train_time:2158ms step_avg:31.74ms
+step:69/1490 train_time:2187ms step_avg:31.69ms
+step:70/1490 train_time:2221ms step_avg:31.73ms
+step:71/1490 train_time:2250ms step_avg:31.69ms
+step:72/1490 train_time:2285ms step_avg:31.73ms
+step:73/1490 train_time:2313ms step_avg:31.69ms
+step:74/1490 train_time:2348ms step_avg:31.72ms
+step:75/1490 train_time:2376ms step_avg:31.68ms
+step:76/1490 train_time:2411ms step_avg:31.72ms
+step:77/1490 train_time:2439ms step_avg:31.67ms
+step:78/1490 train_time:2473ms step_avg:31.71ms
+step:79/1490 train_time:2501ms step_avg:31.66ms
+step:80/1490 train_time:2536ms step_avg:31.70ms
+step:81/1490 train_time:2564ms step_avg:31.65ms
+step:82/1490 train_time:2598ms step_avg:31.69ms
+step:83/1490 train_time:2627ms step_avg:31.64ms
+step:84/1490 train_time:2661ms step_avg:31.68ms
+step:85/1490 train_time:2689ms step_avg:31.64ms
+step:86/1490 train_time:2723ms step_avg:31.67ms
+step:87/1490 train_time:2751ms step_avg:31.62ms
+step:88/1490 train_time:2786ms step_avg:31.66ms
+step:89/1490 train_time:2814ms step_avg:31.62ms
+step:90/1490 train_time:2849ms step_avg:31.65ms
+step:91/1490 train_time:2877ms step_avg:31.62ms
+step:92/1490 train_time:2912ms step_avg:31.65ms
+step:93/1490 train_time:2940ms step_avg:31.61ms
+step:94/1490 train_time:2974ms step_avg:31.64ms
+step:95/1490 train_time:3003ms step_avg:31.61ms
+step:96/1490 train_time:3037ms step_avg:31.64ms
+step:97/1490 train_time:3065ms step_avg:31.60ms
+step:98/1490 train_time:3100ms step_avg:31.63ms
+step:99/1490 train_time:3128ms step_avg:31.60ms
+step:100/1490 train_time:3163ms step_avg:31.63ms
+step:101/1490 train_time:3191ms step_avg:31.60ms
+step:102/1490 train_time:3226ms step_avg:31.63ms
+step:103/1490 train_time:3254ms step_avg:31.59ms
+step:104/1490 train_time:3289ms step_avg:31.62ms
+step:105/1490 train_time:3317ms step_avg:31.59ms
+step:106/1490 train_time:3352ms step_avg:31.62ms
+step:107/1490 train_time:3380ms step_avg:31.59ms
+step:108/1490 train_time:3415ms step_avg:31.62ms
+step:109/1490 train_time:3443ms step_avg:31.59ms
+step:110/1490 train_time:3477ms step_avg:31.61ms
+step:111/1490 train_time:3505ms step_avg:31.58ms
+step:112/1490 train_time:3540ms step_avg:31.60ms
+step:113/1490 train_time:3568ms step_avg:31.57ms
+step:114/1490 train_time:3603ms step_avg:31.60ms
+step:115/1490 train_time:3631ms step_avg:31.57ms
+step:116/1490 train_time:3665ms step_avg:31.60ms
+step:117/1490 train_time:3694ms step_avg:31.57ms
+step:118/1490 train_time:3728ms step_avg:31.59ms
+step:119/1490 train_time:3756ms step_avg:31.57ms
+step:120/1490 train_time:3791ms step_avg:31.59ms
+step:121/1490 train_time:3819ms step_avg:31.56ms
+step:122/1490 train_time:3853ms step_avg:31.59ms
+step:123/1490 train_time:3882ms step_avg:31.56ms
+step:124/1490 train_time:3916ms step_avg:31.58ms
+step:125/1490 train_time:3944ms step_avg:31.55ms
+step:126/1490 train_time:3978ms step_avg:31.57ms
+step:127/1490 train_time:4007ms step_avg:31.55ms
+step:128/1490 train_time:4041ms step_avg:31.57ms
+step:129/1490 train_time:4069ms step_avg:31.54ms
+step:130/1490 train_time:4104ms step_avg:31.57ms
+step:131/1490 train_time:4133ms step_avg:31.55ms
+step:132/1490 train_time:4167ms step_avg:31.57ms
+step:133/1490 train_time:4196ms step_avg:31.55ms
+step:134/1490 train_time:4230ms step_avg:31.57ms
+step:135/1490 train_time:4259ms step_avg:31.55ms
+step:136/1490 train_time:4293ms step_avg:31.57ms
+step:137/1490 train_time:4321ms step_avg:31.54ms
+step:138/1490 train_time:4356ms step_avg:31.56ms
+step:139/1490 train_time:4385ms step_avg:31.54ms
+step:140/1490 train_time:4419ms step_avg:31.57ms
+step:141/1490 train_time:4447ms step_avg:31.54ms
+step:142/1490 train_time:4482ms step_avg:31.56ms
+step:143/1490 train_time:4510ms step_avg:31.54ms
+step:144/1490 train_time:4544ms step_avg:31.56ms
+step:145/1490 train_time:4572ms step_avg:31.53ms
+step:146/1490 train_time:4607ms step_avg:31.55ms
+step:147/1490 train_time:4635ms step_avg:31.53ms
+step:148/1490 train_time:4669ms step_avg:31.55ms
+step:149/1490 train_time:4698ms step_avg:31.53ms
+step:150/1490 train_time:4732ms step_avg:31.55ms
+step:151/1490 train_time:4761ms step_avg:31.53ms
+step:152/1490 train_time:4795ms step_avg:31.55ms
+step:153/1490 train_time:4823ms step_avg:31.52ms
+step:154/1490 train_time:4857ms step_avg:31.54ms
+step:155/1490 train_time:4885ms step_avg:31.52ms
+step:156/1490 train_time:4920ms step_avg:31.54ms
+step:157/1490 train_time:4948ms step_avg:31.52ms
+step:158/1490 train_time:4982ms step_avg:31.53ms
+step:159/1490 train_time:5011ms step_avg:31.51ms
+step:160/1490 train_time:5045ms step_avg:31.53ms
+step:161/1490 train_time:5073ms step_avg:31.51ms
+step:162/1490 train_time:5108ms step_avg:31.53ms
+step:163/1490 train_time:5136ms step_avg:31.51ms
+step:164/1490 train_time:5170ms step_avg:31.53ms
+step:165/1490 train_time:5199ms step_avg:31.51ms
+step:166/1490 train_time:5233ms step_avg:31.52ms
+step:167/1490 train_time:5261ms step_avg:31.51ms
+step:168/1490 train_time:5296ms step_avg:31.52ms
+step:169/1490 train_time:5324ms step_avg:31.50ms
+step:170/1490 train_time:5358ms step_avg:31.52ms
+step:171/1490 train_time:5387ms step_avg:31.50ms
+step:172/1490 train_time:5421ms step_avg:31.52ms
+step:173/1490 train_time:5450ms step_avg:31.50ms
+step:174/1490 train_time:5484ms step_avg:31.52ms
+step:175/1490 train_time:5512ms step_avg:31.50ms
+step:176/1490 train_time:5547ms step_avg:31.51ms
+step:177/1490 train_time:5575ms step_avg:31.50ms
+step:178/1490 train_time:5610ms step_avg:31.52ms
+step:179/1490 train_time:5638ms step_avg:31.50ms
+step:180/1490 train_time:5672ms step_avg:31.51ms
+step:181/1490 train_time:5701ms step_avg:31.49ms
+step:182/1490 train_time:5735ms step_avg:31.51ms
+step:183/1490 train_time:5763ms step_avg:31.49ms
+step:184/1490 train_time:5797ms step_avg:31.51ms
+step:185/1490 train_time:5825ms step_avg:31.49ms
+step:186/1490 train_time:5859ms step_avg:31.50ms
+step:187/1490 train_time:5888ms step_avg:31.48ms
+step:188/1490 train_time:5922ms step_avg:31.50ms
+step:189/1490 train_time:5950ms step_avg:31.48ms
+step:190/1490 train_time:5984ms step_avg:31.50ms
+step:191/1490 train_time:6013ms step_avg:31.48ms
+step:192/1490 train_time:6047ms step_avg:31.50ms
+step:193/1490 train_time:6076ms step_avg:31.48ms
+step:194/1490 train_time:6110ms step_avg:31.49ms
+step:195/1490 train_time:6138ms step_avg:31.48ms
+step:196/1490 train_time:6173ms step_avg:31.49ms
+step:197/1490 train_time:6201ms step_avg:31.48ms
+step:198/1490 train_time:6235ms step_avg:31.49ms
+step:199/1490 train_time:6264ms step_avg:31.48ms
+step:200/1490 train_time:6298ms step_avg:31.49ms
+step:201/1490 train_time:6326ms step_avg:31.47ms
+step:202/1490 train_time:6361ms step_avg:31.49ms
+step:203/1490 train_time:6389ms step_avg:31.47ms
+step:204/1490 train_time:6423ms step_avg:31.49ms
+step:205/1490 train_time:6451ms step_avg:31.47ms
+step:206/1490 train_time:6486ms step_avg:31.49ms
+step:207/1490 train_time:6515ms step_avg:31.47ms
+step:208/1490 train_time:6550ms step_avg:31.49ms
+step:209/1490 train_time:6578ms step_avg:31.47ms
+step:210/1490 train_time:6612ms step_avg:31.49ms
+step:211/1490 train_time:6640ms step_avg:31.47ms
+step:212/1490 train_time:6674ms step_avg:31.48ms
+step:213/1490 train_time:6703ms step_avg:31.47ms
+step:214/1490 train_time:6737ms step_avg:31.48ms
+step:215/1490 train_time:6765ms step_avg:31.46ms
+step:216/1490 train_time:6800ms step_avg:31.48ms
+step:217/1490 train_time:6827ms step_avg:31.46ms
+step:218/1490 train_time:6862ms step_avg:31.48ms
+step:219/1490 train_time:6890ms step_avg:31.46ms
+step:220/1490 train_time:6925ms step_avg:31.48ms
+step:221/1490 train_time:6953ms step_avg:31.46ms
+step:222/1490 train_time:6988ms step_avg:31.48ms
+step:223/1490 train_time:7016ms step_avg:31.46ms
+step:224/1490 train_time:7050ms step_avg:31.47ms
+step:225/1490 train_time:7079ms step_avg:31.46ms
+step:226/1490 train_time:7113ms step_avg:31.47ms
+step:227/1490 train_time:7141ms step_avg:31.46ms
+step:228/1490 train_time:7175ms step_avg:31.47ms
+step:229/1490 train_time:7203ms step_avg:31.45ms
+step:230/1490 train_time:7237ms step_avg:31.47ms
+step:231/1490 train_time:7266ms step_avg:31.45ms
+step:232/1490 train_time:7301ms step_avg:31.47ms
+step:233/1490 train_time:7329ms step_avg:31.46ms
+step:234/1490 train_time:7364ms step_avg:31.47ms
+step:235/1490 train_time:7393ms step_avg:31.46ms
+step:236/1490 train_time:7427ms step_avg:31.47ms
+step:237/1490 train_time:7456ms step_avg:31.46ms
+step:238/1490 train_time:7490ms step_avg:31.47ms
+step:239/1490 train_time:7519ms step_avg:31.46ms
+step:240/1490 train_time:7553ms step_avg:31.47ms
+step:241/1490 train_time:7581ms step_avg:31.46ms
+step:242/1490 train_time:7615ms step_avg:31.47ms
+step:243/1490 train_time:7644ms step_avg:31.46ms
+step:244/1490 train_time:7678ms step_avg:31.47ms
+step:245/1490 train_time:7706ms step_avg:31.45ms
+step:246/1490 train_time:7740ms step_avg:31.46ms
+step:247/1490 train_time:7768ms step_avg:31.45ms
+step:248/1490 train_time:7803ms step_avg:31.46ms
+step:249/1490 train_time:7831ms step_avg:31.45ms
+step:250/1490 train_time:7865ms step_avg:31.46ms
+step:250/1490 val_loss:4.5228 train_time:7908ms step_avg:31.63ms
+step:251/1490 train_time:7923ms step_avg:31.57ms
+step:252/1490 train_time:7941ms step_avg:31.51ms
+step:253/1490 train_time:7959ms step_avg:31.46ms
+step:254/1490 train_time:7993ms step_avg:31.47ms
+step:255/1490 train_time:8023ms step_avg:31.46ms
+step:256/1490 train_time:8058ms step_avg:31.48ms
+step:257/1490 train_time:8088ms step_avg:31.47ms
+step:258/1490 train_time:8122ms step_avg:31.48ms
+step:259/1490 train_time:8150ms step_avg:31.47ms
+step:260/1490 train_time:8185ms step_avg:31.48ms
+step:261/1490 train_time:8213ms step_avg:31.47ms
+step:262/1490 train_time:8248ms step_avg:31.48ms
+step:263/1490 train_time:8276ms step_avg:31.47ms
+step:264/1490 train_time:8310ms step_avg:31.48ms
+step:265/1490 train_time:8338ms step_avg:31.46ms
+step:266/1490 train_time:8372ms step_avg:31.47ms
+step:267/1490 train_time:8400ms step_avg:31.46ms
+step:268/1490 train_time:8434ms step_avg:31.47ms
+step:269/1490 train_time:8462ms step_avg:31.46ms
+step:270/1490 train_time:8496ms step_avg:31.46ms
+step:271/1490 train_time:8524ms step_avg:31.45ms
+step:272/1490 train_time:8558ms step_avg:31.46ms
+step:273/1490 train_time:8586ms step_avg:31.45ms
+step:274/1490 train_time:8620ms step_avg:31.46ms
+step:275/1490 train_time:8648ms step_avg:31.45ms
+step:276/1490 train_time:8683ms step_avg:31.46ms
+step:277/1490 train_time:8711ms step_avg:31.45ms
+step:278/1490 train_time:8745ms step_avg:31.46ms
+step:279/1490 train_time:8774ms step_avg:31.45ms
+step:280/1490 train_time:8808ms step_avg:31.46ms
+step:281/1490 train_time:8837ms step_avg:31.45ms
+step:282/1490 train_time:8871ms step_avg:31.46ms
+step:283/1490 train_time:8900ms step_avg:31.45ms
+step:284/1490 train_time:8934ms step_avg:31.46ms
+step:285/1490 train_time:8963ms step_avg:31.45ms
+step:286/1490 train_time:8997ms step_avg:31.46ms
+step:287/1490 train_time:9026ms step_avg:31.45ms
+step:288/1490 train_time:9061ms step_avg:31.46ms
+step:289/1490 train_time:9090ms step_avg:31.45ms
+step:290/1490 train_time:9125ms step_avg:31.47ms
+step:291/1490 train_time:9154ms step_avg:31.46ms
+step:292/1490 train_time:9188ms step_avg:31.47ms
+step:293/1490 train_time:9217ms step_avg:31.46ms
+step:294/1490 train_time:9251ms step_avg:31.47ms
+step:295/1490 train_time:9280ms step_avg:31.46ms
+step:296/1490 train_time:9313ms step_avg:31.46ms
+step:297/1490 train_time:9342ms step_avg:31.45ms
+step:298/1490 train_time:9376ms step_avg:31.46ms
+step:299/1490 train_time:9404ms step_avg:31.45ms
+step:300/1490 train_time:9438ms step_avg:31.46ms
+step:301/1490 train_time:9466ms step_avg:31.45ms
+step:302/1490 train_time:9500ms step_avg:31.46ms
+step:303/1490 train_time:9528ms step_avg:31.45ms
+step:304/1490 train_time:9563ms step_avg:31.46ms
+step:305/1490 train_time:9591ms step_avg:31.45ms
+step:306/1490 train_time:9625ms step_avg:31.46ms
+step:307/1490 train_time:9654ms step_avg:31.45ms
+step:308/1490 train_time:9688ms step_avg:31.45ms
+step:309/1490 train_time:9716ms step_avg:31.44ms
+step:310/1490 train_time:9750ms step_avg:31.45ms
+step:311/1490 train_time:9779ms step_avg:31.44ms
+step:312/1490 train_time:9813ms step_avg:31.45ms
+step:313/1490 train_time:9841ms step_avg:31.44ms
+step:314/1490 train_time:9875ms step_avg:31.45ms
+step:315/1490 train_time:9903ms step_avg:31.44ms
+step:316/1490 train_time:9938ms step_avg:31.45ms
+step:317/1490 train_time:9966ms step_avg:31.44ms
+step:318/1490 train_time:10001ms step_avg:31.45ms
+step:319/1490 train_time:10029ms step_avg:31.44ms
+step:320/1490 train_time:10064ms step_avg:31.45ms
+step:321/1490 train_time:10093ms step_avg:31.44ms
+step:322/1490 train_time:10127ms step_avg:31.45ms
+step:323/1490 train_time:10156ms step_avg:31.44ms
+step:324/1490 train_time:10191ms step_avg:31.45ms
+step:325/1490 train_time:10219ms step_avg:31.44ms
+step:326/1490 train_time:10254ms step_avg:31.45ms
+step:327/1490 train_time:10282ms step_avg:31.44ms
+step:328/1490 train_time:10316ms step_avg:31.45ms
+step:329/1490 train_time:10344ms step_avg:31.44ms
+step:330/1490 train_time:10378ms step_avg:31.45ms
+step:331/1490 train_time:10406ms step_avg:31.44ms
+step:332/1490 train_time:10441ms step_avg:31.45ms
+step:333/1490 train_time:10469ms step_avg:31.44ms
+step:334/1490 train_time:10503ms step_avg:31.45ms
+step:335/1490 train_time:10532ms step_avg:31.44ms
+step:336/1490 train_time:10566ms step_avg:31.45ms
+step:337/1490 train_time:10595ms step_avg:31.44ms
+step:338/1490 train_time:10630ms step_avg:31.45ms
+step:339/1490 train_time:10658ms step_avg:31.44ms
+step:340/1490 train_time:10692ms step_avg:31.45ms
+step:341/1490 train_time:10720ms step_avg:31.44ms
+step:342/1490 train_time:10754ms step_avg:31.45ms
+step:343/1490 train_time:10783ms step_avg:31.44ms
+step:344/1490 train_time:10817ms step_avg:31.44ms
+step:345/1490 train_time:10845ms step_avg:31.43ms
+step:346/1490 train_time:10879ms step_avg:31.44ms
+step:347/1490 train_time:10907ms step_avg:31.43ms
+step:348/1490 train_time:10942ms step_avg:31.44ms
+step:349/1490 train_time:10970ms step_avg:31.43ms
+step:350/1490 train_time:11005ms step_avg:31.44ms
+step:351/1490 train_time:11033ms step_avg:31.43ms
+step:352/1490 train_time:11069ms step_avg:31.45ms
+step:353/1490 train_time:11098ms step_avg:31.44ms
+step:354/1490 train_time:11132ms step_avg:31.45ms
+step:355/1490 train_time:11160ms step_avg:31.44ms
+step:356/1490 train_time:11195ms step_avg:31.45ms
+step:357/1490 train_time:11223ms step_avg:31.44ms
+step:358/1490 train_time:11257ms step_avg:31.44ms
+step:359/1490 train_time:11285ms step_avg:31.44ms
+step:360/1490 train_time:11320ms step_avg:31.44ms
+step:361/1490 train_time:11348ms step_avg:31.44ms
+step:362/1490 train_time:11383ms step_avg:31.44ms
+step:363/1490 train_time:11411ms step_avg:31.44ms
+step:364/1490 train_time:11445ms step_avg:31.44ms
+step:365/1490 train_time:11474ms step_avg:31.44ms
+step:366/1490 train_time:11508ms step_avg:31.44ms
+step:367/1490 train_time:11536ms step_avg:31.43ms
+step:368/1490 train_time:11571ms step_avg:31.44ms
+step:369/1490 train_time:11599ms step_avg:31.43ms
+step:370/1490 train_time:11634ms step_avg:31.44ms
+step:371/1490 train_time:11662ms step_avg:31.43ms
+step:372/1490 train_time:11696ms step_avg:31.44ms
+step:373/1490 train_time:11724ms step_avg:31.43ms
+step:374/1490 train_time:11759ms step_avg:31.44ms
+step:375/1490 train_time:11787ms step_avg:31.43ms
+step:376/1490 train_time:11822ms step_avg:31.44ms
+step:377/1490 train_time:11850ms step_avg:31.43ms
+step:378/1490 train_time:11884ms step_avg:31.44ms
+step:379/1490 train_time:11912ms step_avg:31.43ms
+step:380/1490 train_time:11947ms step_avg:31.44ms
+step:381/1490 train_time:11975ms step_avg:31.43ms
+step:382/1490 train_time:12010ms step_avg:31.44ms
+step:383/1490 train_time:12038ms step_avg:31.43ms
+step:384/1490 train_time:12072ms step_avg:31.44ms
+step:385/1490 train_time:12101ms step_avg:31.43ms
+step:386/1490 train_time:12135ms step_avg:31.44ms
+step:387/1490 train_time:12163ms step_avg:31.43ms
+step:388/1490 train_time:12197ms step_avg:31.44ms
+step:389/1490 train_time:12225ms step_avg:31.43ms
+step:390/1490 train_time:12261ms step_avg:31.44ms
+step:391/1490 train_time:12289ms step_avg:31.43ms
+step:392/1490 train_time:12324ms step_avg:31.44ms
+step:393/1490 train_time:12352ms step_avg:31.43ms
+step:394/1490 train_time:12386ms step_avg:31.44ms
+step:395/1490 train_time:12415ms step_avg:31.43ms
+step:396/1490 train_time:12449ms step_avg:31.44ms
+step:397/1490 train_time:12477ms step_avg:31.43ms
+step:398/1490 train_time:12513ms step_avg:31.44ms
+step:399/1490 train_time:12540ms step_avg:31.43ms
+step:400/1490 train_time:12574ms step_avg:31.43ms
+step:401/1490 train_time:12602ms step_avg:31.43ms
+step:402/1490 train_time:12636ms step_avg:31.43ms
+step:403/1490 train_time:12664ms step_avg:31.42ms
+step:404/1490 train_time:12698ms step_avg:31.43ms
+step:405/1490 train_time:12726ms step_avg:31.42ms
+step:406/1490 train_time:12761ms step_avg:31.43ms
+step:407/1490 train_time:12789ms step_avg:31.42ms
+step:408/1490 train_time:12824ms step_avg:31.43ms
+step:409/1490 train_time:12852ms step_avg:31.42ms
+step:410/1490 train_time:12887ms step_avg:31.43ms
+step:411/1490 train_time:12915ms step_avg:31.42ms
+step:412/1490 train_time:12950ms step_avg:31.43ms
+step:413/1490 train_time:12978ms step_avg:31.42ms
+step:414/1490 train_time:13012ms step_avg:31.43ms
+step:415/1490 train_time:13040ms step_avg:31.42ms
+step:416/1490 train_time:13075ms step_avg:31.43ms
+step:417/1490 train_time:13103ms step_avg:31.42ms
+step:418/1490 train_time:13137ms step_avg:31.43ms
+step:419/1490 train_time:13166ms step_avg:31.42ms
+step:420/1490 train_time:13200ms step_avg:31.43ms
+step:421/1490 train_time:13228ms step_avg:31.42ms
+step:422/1490 train_time:13263ms step_avg:31.43ms
+step:423/1490 train_time:13291ms step_avg:31.42ms
+step:424/1490 train_time:13326ms step_avg:31.43ms
+step:425/1490 train_time:13354ms step_avg:31.42ms
+step:426/1490 train_time:13389ms step_avg:31.43ms
+step:427/1490 train_time:13417ms step_avg:31.42ms
+step:428/1490 train_time:13451ms step_avg:31.43ms
+step:429/1490 train_time:13479ms step_avg:31.42ms
+step:430/1490 train_time:13513ms step_avg:31.43ms
+step:431/1490 train_time:13541ms step_avg:31.42ms
+step:432/1490 train_time:13575ms step_avg:31.42ms
+step:433/1490 train_time:13604ms step_avg:31.42ms
+step:434/1490 train_time:13638ms step_avg:31.42ms
+step:435/1490 train_time:13666ms step_avg:31.42ms
+step:436/1490 train_time:13701ms step_avg:31.42ms
+step:437/1490 train_time:13729ms step_avg:31.42ms
+step:438/1490 train_time:13763ms step_avg:31.42ms
+step:439/1490 train_time:13792ms step_avg:31.42ms
+step:440/1490 train_time:13826ms step_avg:31.42ms
+step:441/1490 train_time:13855ms step_avg:31.42ms
+step:442/1490 train_time:13889ms step_avg:31.42ms
+step:443/1490 train_time:13917ms step_avg:31.42ms
+step:444/1490 train_time:13952ms step_avg:31.42ms
+step:445/1490 train_time:13980ms step_avg:31.42ms
+step:446/1490 train_time:14014ms step_avg:31.42ms
+step:447/1490 train_time:14042ms step_avg:31.41ms
+step:448/1490 train_time:14076ms step_avg:31.42ms
+step:449/1490 train_time:14105ms step_avg:31.41ms
+step:450/1490 train_time:14139ms step_avg:31.42ms
+step:451/1490 train_time:14167ms step_avg:31.41ms
+step:452/1490 train_time:14201ms step_avg:31.42ms
+step:453/1490 train_time:14230ms step_avg:31.41ms
+step:454/1490 train_time:14265ms step_avg:31.42ms
+step:455/1490 train_time:14293ms step_avg:31.41ms
+step:456/1490 train_time:14328ms step_avg:31.42ms
+step:457/1490 train_time:14356ms step_avg:31.41ms
+step:458/1490 train_time:14391ms step_avg:31.42ms
+step:459/1490 train_time:14419ms step_avg:31.41ms
+step:460/1490 train_time:14453ms step_avg:31.42ms
+step:461/1490 train_time:14481ms step_avg:31.41ms
+step:462/1490 train_time:14515ms step_avg:31.42ms
+step:463/1490 train_time:14543ms step_avg:31.41ms
+step:464/1490 train_time:14577ms step_avg:31.42ms
+step:465/1490 train_time:14606ms step_avg:31.41ms
+step:466/1490 train_time:14640ms step_avg:31.42ms
+step:467/1490 train_time:14668ms step_avg:31.41ms
+step:468/1490 train_time:14702ms step_avg:31.41ms
+step:469/1490 train_time:14730ms step_avg:31.41ms
+step:470/1490 train_time:14765ms step_avg:31.41ms
+step:471/1490 train_time:14793ms step_avg:31.41ms
+step:472/1490 train_time:14828ms step_avg:31.41ms
+step:473/1490 train_time:14856ms step_avg:31.41ms
+step:474/1490 train_time:14891ms step_avg:31.41ms
+step:475/1490 train_time:14919ms step_avg:31.41ms
+step:476/1490 train_time:14953ms step_avg:31.41ms
+step:477/1490 train_time:14981ms step_avg:31.41ms
+step:478/1490 train_time:15015ms step_avg:31.41ms
+step:479/1490 train_time:15043ms step_avg:31.41ms
+step:480/1490 train_time:15077ms step_avg:31.41ms
+step:481/1490 train_time:15105ms step_avg:31.40ms
+step:482/1490 train_time:15140ms step_avg:31.41ms
+step:483/1490 train_time:15168ms step_avg:31.40ms
+step:484/1490 train_time:15206ms step_avg:31.42ms
+step:485/1490 train_time:15258ms step_avg:31.46ms
+step:486/1490 train_time:15317ms step_avg:31.52ms
+step:487/1490 train_time:15371ms step_avg:31.56ms
+step:488/1490 train_time:15431ms step_avg:31.62ms
+step:489/1490 train_time:15485ms step_avg:31.67ms
+step:490/1490 train_time:15545ms step_avg:31.73ms
+step:491/1490 train_time:15600ms step_avg:31.77ms
+step:492/1490 train_time:15659ms step_avg:31.83ms
+step:493/1490 train_time:15713ms step_avg:31.87ms
+step:494/1490 train_time:15773ms step_avg:31.93ms
+step:495/1490 train_time:15827ms step_avg:31.97ms
+step:496/1490 train_time:15887ms step_avg:32.03ms
+step:497/1490 train_time:15942ms step_avg:32.08ms
+step:498/1490 train_time:16002ms step_avg:32.13ms
+step:499/1490 train_time:16056ms step_avg:32.18ms
+step:500/1490 train_time:16116ms step_avg:32.23ms
+step:500/1490 val_loss:4.2096 train_time:16187ms step_avg:32.37ms
+step:501/1490 train_time:16203ms step_avg:32.34ms
+step:502/1490 train_time:16230ms step_avg:32.33ms
+step:503/1490 train_time:16287ms step_avg:32.38ms
+step:504/1490 train_time:16350ms step_avg:32.44ms
+step:505/1490 train_time:16405ms step_avg:32.49ms
+step:506/1490 train_time:16465ms step_avg:32.54ms
+step:507/1490 train_time:16517ms step_avg:32.58ms
+step:508/1490 train_time:16576ms step_avg:32.63ms
+step:509/1490 train_time:16631ms step_avg:32.67ms
+step:510/1490 train_time:16690ms step_avg:32.72ms
+step:511/1490 train_time:16743ms step_avg:32.76ms
+step:512/1490 train_time:16802ms step_avg:32.82ms
+step:513/1490 train_time:16856ms step_avg:32.86ms
+step:514/1490 train_time:16914ms step_avg:32.91ms
+step:515/1490 train_time:16968ms step_avg:32.95ms
+step:516/1490 train_time:17027ms step_avg:33.00ms
+step:517/1490 train_time:17082ms step_avg:33.04ms
+step:518/1490 train_time:17142ms step_avg:33.09ms
+step:519/1490 train_time:17197ms step_avg:33.14ms
+step:520/1490 train_time:17258ms step_avg:33.19ms
+step:521/1490 train_time:17314ms step_avg:33.23ms
+step:522/1490 train_time:17376ms step_avg:33.29ms
+step:523/1490 train_time:17429ms step_avg:33.32ms
+step:524/1490 train_time:17489ms step_avg:33.38ms
+step:525/1490 train_time:17543ms step_avg:33.41ms
+step:526/1490 train_time:17602ms step_avg:33.46ms
+step:527/1490 train_time:17655ms step_avg:33.50ms
+step:528/1490 train_time:17714ms step_avg:33.55ms
+step:529/1490 train_time:17768ms step_avg:33.59ms
+step:530/1490 train_time:17827ms step_avg:33.64ms
+step:531/1490 train_time:17881ms step_avg:33.67ms
+step:532/1490 train_time:17940ms step_avg:33.72ms
+step:533/1490 train_time:17994ms step_avg:33.76ms
+step:534/1490 train_time:18053ms step_avg:33.81ms
+step:535/1490 train_time:18107ms step_avg:33.84ms
+step:536/1490 train_time:18167ms step_avg:33.89ms
+step:537/1490 train_time:18223ms step_avg:33.94ms
+step:538/1490 train_time:18283ms step_avg:33.98ms
+step:539/1490 train_time:18338ms step_avg:34.02ms
+step:540/1490 train_time:18398ms step_avg:34.07ms
+step:541/1490 train_time:18453ms step_avg:34.11ms
+step:542/1490 train_time:18512ms step_avg:34.15ms
+step:543/1490 train_time:18566ms step_avg:34.19ms
+step:544/1490 train_time:18626ms step_avg:34.24ms
+step:545/1490 train_time:18680ms step_avg:34.28ms
+step:546/1490 train_time:18740ms step_avg:34.32ms
+step:547/1490 train_time:18793ms step_avg:34.36ms
+step:548/1490 train_time:18851ms step_avg:34.40ms
+step:549/1490 train_time:18905ms step_avg:34.44ms
+step:550/1490 train_time:18964ms step_avg:34.48ms
+step:551/1490 train_time:19019ms step_avg:34.52ms
+step:552/1490 train_time:19078ms step_avg:34.56ms
+step:553/1490 train_time:19133ms step_avg:34.60ms
+step:554/1490 train_time:19192ms step_avg:34.64ms
+step:555/1490 train_time:19246ms step_avg:34.68ms
+step:556/1490 train_time:19307ms step_avg:34.72ms
+step:557/1490 train_time:19362ms step_avg:34.76ms
+step:558/1490 train_time:19422ms step_avg:34.81ms
+step:559/1490 train_time:19476ms step_avg:34.84ms
+step:560/1490 train_time:19536ms step_avg:34.89ms
+step:561/1490 train_time:19589ms step_avg:34.92ms
+step:562/1490 train_time:19649ms step_avg:34.96ms
+step:563/1490 train_time:19703ms step_avg:35.00ms
+step:564/1490 train_time:19763ms step_avg:35.04ms
+step:565/1490 train_time:19816ms step_avg:35.07ms
+step:566/1490 train_time:19875ms step_avg:35.12ms
+step:567/1490 train_time:19929ms step_avg:35.15ms
+step:568/1490 train_time:19989ms step_avg:35.19ms
+step:569/1490 train_time:20042ms step_avg:35.22ms
+step:570/1490 train_time:20102ms step_avg:35.27ms
+step:571/1490 train_time:20155ms step_avg:35.30ms
+step:572/1490 train_time:20215ms step_avg:35.34ms
+step:573/1490 train_time:20270ms step_avg:35.37ms
+step:574/1490 train_time:20331ms step_avg:35.42ms
+step:575/1490 train_time:20385ms step_avg:35.45ms
+step:576/1490 train_time:20445ms step_avg:35.50ms
+step:577/1490 train_time:20500ms step_avg:35.53ms
+step:578/1490 train_time:20560ms step_avg:35.57ms
+step:579/1490 train_time:20613ms step_avg:35.60ms
+step:580/1490 train_time:20672ms step_avg:35.64ms
+step:581/1490 train_time:20726ms step_avg:35.67ms
+step:582/1490 train_time:20786ms step_avg:35.71ms
+step:583/1490 train_time:20839ms step_avg:35.75ms
+step:584/1490 train_time:20898ms step_avg:35.78ms
+step:585/1490 train_time:20953ms step_avg:35.82ms
+step:586/1490 train_time:21012ms step_avg:35.86ms
+step:587/1490 train_time:21066ms step_avg:35.89ms
+step:588/1490 train_time:21127ms step_avg:35.93ms
+step:589/1490 train_time:21182ms step_avg:35.96ms
+step:590/1490 train_time:21241ms step_avg:36.00ms
+step:591/1490 train_time:21295ms step_avg:36.03ms
+step:592/1490 train_time:21354ms step_avg:36.07ms
+step:593/1490 train_time:21408ms step_avg:36.10ms
+step:594/1490 train_time:21468ms step_avg:36.14ms
+step:595/1490 train_time:21522ms step_avg:36.17ms
+step:596/1490 train_time:21583ms step_avg:36.21ms
+step:597/1490 train_time:21636ms step_avg:36.24ms
+step:598/1490 train_time:21695ms step_avg:36.28ms
+step:599/1490 train_time:21749ms step_avg:36.31ms
+step:600/1490 train_time:21808ms step_avg:36.35ms
+step:601/1490 train_time:21863ms step_avg:36.38ms
+step:602/1490 train_time:21923ms step_avg:36.42ms
+step:603/1490 train_time:21976ms step_avg:36.44ms
+step:604/1490 train_time:22035ms step_avg:36.48ms
+step:605/1490 train_time:22090ms step_avg:36.51ms
+step:606/1490 train_time:22149ms step_avg:36.55ms
+step:607/1490 train_time:22203ms step_avg:36.58ms
+step:608/1490 train_time:22264ms step_avg:36.62ms
+step:609/1490 train_time:22318ms step_avg:36.65ms
+step:610/1490 train_time:22377ms step_avg:36.68ms
+step:611/1490 train_time:22432ms step_avg:36.71ms
+step:612/1490 train_time:22491ms step_avg:36.75ms
+step:613/1490 train_time:22545ms step_avg:36.78ms
+step:614/1490 train_time:22605ms step_avg:36.82ms
+step:615/1490 train_time:22659ms step_avg:36.84ms
+step:616/1490 train_time:22718ms step_avg:36.88ms
+step:617/1490 train_time:22773ms step_avg:36.91ms
+step:618/1490 train_time:22832ms step_avg:36.95ms
+step:619/1490 train_time:22886ms step_avg:36.97ms
+step:620/1490 train_time:22947ms step_avg:37.01ms
+step:621/1490 train_time:23002ms step_avg:37.04ms
+step:622/1490 train_time:23060ms step_avg:37.07ms
+step:623/1490 train_time:23114ms step_avg:37.10ms
+step:624/1490 train_time:23174ms step_avg:37.14ms
+step:625/1490 train_time:23228ms step_avg:37.17ms
+step:626/1490 train_time:23288ms step_avg:37.20ms
+step:627/1490 train_time:23342ms step_avg:37.23ms
+step:628/1490 train_time:23402ms step_avg:37.26ms
+step:629/1490 train_time:23456ms step_avg:37.29ms
+step:630/1490 train_time:23516ms step_avg:37.33ms
+step:631/1490 train_time:23571ms step_avg:37.35ms
+step:632/1490 train_time:23632ms step_avg:37.39ms
+step:633/1490 train_time:23685ms step_avg:37.42ms
+step:634/1490 train_time:23745ms step_avg:37.45ms
+step:635/1490 train_time:23800ms step_avg:37.48ms
+step:636/1490 train_time:23859ms step_avg:37.51ms
+step:637/1490 train_time:23914ms step_avg:37.54ms
+step:638/1490 train_time:23974ms step_avg:37.58ms
+step:639/1490 train_time:24028ms step_avg:37.60ms
+step:640/1490 train_time:24087ms step_avg:37.64ms
+step:641/1490 train_time:24141ms step_avg:37.66ms
+step:642/1490 train_time:24200ms step_avg:37.69ms
+step:643/1490 train_time:24254ms step_avg:37.72ms
+step:644/1490 train_time:24314ms step_avg:37.75ms
+step:645/1490 train_time:24368ms step_avg:37.78ms
+step:646/1490 train_time:24428ms step_avg:37.81ms
+step:647/1490 train_time:24483ms step_avg:37.84ms
+step:648/1490 train_time:24544ms step_avg:37.88ms
+step:649/1490 train_time:24597ms step_avg:37.90ms
+step:650/1490 train_time:24656ms step_avg:37.93ms
+step:651/1490 train_time:24711ms step_avg:37.96ms
+step:652/1490 train_time:24770ms step_avg:37.99ms
+step:653/1490 train_time:24825ms step_avg:38.02ms
+step:654/1490 train_time:24884ms step_avg:38.05ms
+step:655/1490 train_time:24938ms step_avg:38.07ms
+step:656/1490 train_time:24997ms step_avg:38.10ms
+step:657/1490 train_time:25050ms step_avg:38.13ms
+step:658/1490 train_time:25110ms step_avg:38.16ms
+step:659/1490 train_time:25165ms step_avg:38.19ms
+step:660/1490 train_time:25225ms step_avg:38.22ms
+step:661/1490 train_time:25279ms step_avg:38.24ms
+step:662/1490 train_time:25337ms step_avg:38.27ms
+step:663/1490 train_time:25392ms step_avg:38.30ms
+step:664/1490 train_time:25452ms step_avg:38.33ms
+step:665/1490 train_time:25506ms step_avg:38.36ms
+step:666/1490 train_time:25567ms step_avg:38.39ms
+step:667/1490 train_time:25622ms step_avg:38.41ms
+step:668/1490 train_time:25681ms step_avg:38.44ms
+step:669/1490 train_time:25734ms step_avg:38.47ms
+step:670/1490 train_time:25794ms step_avg:38.50ms
+step:671/1490 train_time:25847ms step_avg:38.52ms
+step:672/1490 train_time:25908ms step_avg:38.55ms
+step:673/1490 train_time:25963ms step_avg:38.58ms
+step:674/1490 train_time:26023ms step_avg:38.61ms
+step:675/1490 train_time:26076ms step_avg:38.63ms
+step:676/1490 train_time:26136ms step_avg:38.66ms
+step:677/1490 train_time:26190ms step_avg:38.68ms
+step:678/1490 train_time:26249ms step_avg:38.72ms
+step:679/1490 train_time:26304ms step_avg:38.74ms
+step:680/1490 train_time:26364ms step_avg:38.77ms
+step:681/1490 train_time:26418ms step_avg:38.79ms
+step:682/1490 train_time:26477ms step_avg:38.82ms
+step:683/1490 train_time:26532ms step_avg:38.85ms
+step:684/1490 train_time:26592ms step_avg:38.88ms
+step:685/1490 train_time:26646ms step_avg:38.90ms
+step:686/1490 train_time:26707ms step_avg:38.93ms
+step:687/1490 train_time:26761ms step_avg:38.95ms
+step:688/1490 train_time:26821ms step_avg:38.98ms
+step:689/1490 train_time:26875ms step_avg:39.01ms
+step:690/1490 train_time:26935ms step_avg:39.04ms
+step:691/1490 train_time:26989ms step_avg:39.06ms
+step:692/1490 train_time:27048ms step_avg:39.09ms
+step:693/1490 train_time:27102ms step_avg:39.11ms
+step:694/1490 train_time:27161ms step_avg:39.14ms
+step:695/1490 train_time:27215ms step_avg:39.16ms
+step:696/1490 train_time:27275ms step_avg:39.19ms
+step:697/1490 train_time:27330ms step_avg:39.21ms
+step:698/1490 train_time:27389ms step_avg:39.24ms
+step:699/1490 train_time:27443ms step_avg:39.26ms
+step:700/1490 train_time:27503ms step_avg:39.29ms
+step:701/1490 train_time:27557ms step_avg:39.31ms
+step:702/1490 train_time:27616ms step_avg:39.34ms
+step:703/1490 train_time:27671ms step_avg:39.36ms
+step:704/1490 train_time:27732ms step_avg:39.39ms
+step:705/1490 train_time:27786ms step_avg:39.41ms
+step:706/1490 train_time:27846ms step_avg:39.44ms
+step:707/1490 train_time:27901ms step_avg:39.46ms
+step:708/1490 train_time:27960ms step_avg:39.49ms
+step:709/1490 train_time:28014ms step_avg:39.51ms
+step:710/1490 train_time:28073ms step_avg:39.54ms
+step:711/1490 train_time:28127ms step_avg:39.56ms
+step:712/1490 train_time:28188ms step_avg:39.59ms
+step:713/1490 train_time:28243ms step_avg:39.61ms
+step:714/1490 train_time:28303ms step_avg:39.64ms
+step:715/1490 train_time:28356ms step_avg:39.66ms
+step:716/1490 train_time:28416ms step_avg:39.69ms
+step:717/1490 train_time:28469ms step_avg:39.71ms
+step:718/1490 train_time:28530ms step_avg:39.74ms
+step:719/1490 train_time:28584ms step_avg:39.75ms
+step:720/1490 train_time:28643ms step_avg:39.78ms
+step:721/1490 train_time:28697ms step_avg:39.80ms
+step:722/1490 train_time:28756ms step_avg:39.83ms
+step:723/1490 train_time:28811ms step_avg:39.85ms
+step:724/1490 train_time:28871ms step_avg:39.88ms
+step:725/1490 train_time:28925ms step_avg:39.90ms
+step:726/1490 train_time:28985ms step_avg:39.92ms
+step:727/1490 train_time:29039ms step_avg:39.94ms
+step:728/1490 train_time:29098ms step_avg:39.97ms
+step:729/1490 train_time:29152ms step_avg:39.99ms
+step:730/1490 train_time:29211ms step_avg:40.02ms
+step:731/1490 train_time:29266ms step_avg:40.04ms
+step:732/1490 train_time:29326ms step_avg:40.06ms
+step:733/1490 train_time:29381ms step_avg:40.08ms
+step:734/1490 train_time:29440ms step_avg:40.11ms
+step:735/1490 train_time:29494ms step_avg:40.13ms
+step:736/1490 train_time:29553ms step_avg:40.15ms
+step:737/1490 train_time:29607ms step_avg:40.17ms
+step:738/1490 train_time:29666ms step_avg:40.20ms
+step:739/1490 train_time:29721ms step_avg:40.22ms
+step:740/1490 train_time:29780ms step_avg:40.24ms
+step:741/1490 train_time:29835ms step_avg:40.26ms
+step:742/1490 train_time:29894ms step_avg:40.29ms
+step:743/1490 train_time:29948ms step_avg:40.31ms
+step:744/1490 train_time:30008ms step_avg:40.33ms
+step:745/1490 train_time:30064ms step_avg:40.35ms
+step:746/1490 train_time:30123ms step_avg:40.38ms
+step:747/1490 train_time:30177ms step_avg:40.40ms
+step:748/1490 train_time:30237ms step_avg:40.42ms
+step:749/1490 train_time:30290ms step_avg:40.44ms
+step:750/1490 train_time:30350ms step_avg:40.47ms
+step:750/1490 val_loss:3.8007 train_time:30422ms step_avg:40.56ms
+step:751/1490 train_time:30438ms step_avg:40.53ms
+step:752/1490 train_time:30466ms step_avg:40.51ms
+step:753/1490 train_time:30525ms step_avg:40.54ms
+step:754/1490 train_time:30586ms step_avg:40.56ms
+step:755/1490 train_time:30641ms step_avg:40.58ms
+step:756/1490 train_time:30701ms step_avg:40.61ms
+step:757/1490 train_time:30755ms step_avg:40.63ms
+step:758/1490 train_time:30814ms step_avg:40.65ms
+step:759/1490 train_time:30868ms step_avg:40.67ms
+step:760/1490 train_time:30927ms step_avg:40.69ms
+step:761/1490 train_time:30980ms step_avg:40.71ms
+step:762/1490 train_time:31039ms step_avg:40.73ms
+step:763/1490 train_time:31093ms step_avg:40.75ms
+step:764/1490 train_time:31152ms step_avg:40.77ms
+step:765/1490 train_time:31205ms step_avg:40.79ms
+step:766/1490 train_time:31264ms step_avg:40.82ms
+step:767/1490 train_time:31318ms step_avg:40.83ms
+step:768/1490 train_time:31379ms step_avg:40.86ms
+step:769/1490 train_time:31434ms step_avg:40.88ms
+step:770/1490 train_time:31495ms step_avg:40.90ms
+step:771/1490 train_time:31551ms step_avg:40.92ms
+step:772/1490 train_time:31612ms step_avg:40.95ms
+step:773/1490 train_time:31666ms step_avg:40.97ms
+step:774/1490 train_time:31726ms step_avg:40.99ms
+step:775/1490 train_time:31780ms step_avg:41.01ms
+step:776/1490 train_time:31839ms step_avg:41.03ms
+step:777/1490 train_time:31894ms step_avg:41.05ms
+step:778/1490 train_time:31954ms step_avg:41.07ms
+step:779/1490 train_time:32007ms step_avg:41.09ms
+step:780/1490 train_time:32066ms step_avg:41.11ms
+step:781/1490 train_time:32119ms step_avg:41.13ms
+step:782/1490 train_time:32179ms step_avg:41.15ms
+step:783/1490 train_time:32233ms step_avg:41.17ms
+step:784/1490 train_time:32292ms step_avg:41.19ms
+step:785/1490 train_time:32345ms step_avg:41.20ms
+step:786/1490 train_time:32405ms step_avg:41.23ms
+step:787/1490 train_time:32460ms step_avg:41.25ms
+step:788/1490 train_time:32520ms step_avg:41.27ms
+step:789/1490 train_time:32575ms step_avg:41.29ms
+step:790/1490 train_time:32635ms step_avg:41.31ms
+step:791/1490 train_time:32690ms step_avg:41.33ms
+step:792/1490 train_time:32750ms step_avg:41.35ms
+step:793/1490 train_time:32804ms step_avg:41.37ms
+step:794/1490 train_time:32864ms step_avg:41.39ms
+step:795/1490 train_time:32918ms step_avg:41.41ms
+step:796/1490 train_time:32977ms step_avg:41.43ms
+step:797/1490 train_time:33030ms step_avg:41.44ms
+step:798/1490 train_time:33090ms step_avg:41.47ms
+step:799/1490 train_time:33143ms step_avg:41.48ms
+step:800/1490 train_time:33203ms step_avg:41.50ms
+step:801/1490 train_time:33257ms step_avg:41.52ms
+step:802/1490 train_time:33317ms step_avg:41.54ms
+step:803/1490 train_time:33372ms step_avg:41.56ms
+step:804/1490 train_time:33432ms step_avg:41.58ms
+step:805/1490 train_time:33487ms step_avg:41.60ms
+step:806/1490 train_time:33546ms step_avg:41.62ms
+step:807/1490 train_time:33601ms step_avg:41.64ms
+step:808/1490 train_time:33661ms step_avg:41.66ms
+step:809/1490 train_time:33715ms step_avg:41.68ms
+step:810/1490 train_time:33776ms step_avg:41.70ms
+step:811/1490 train_time:33831ms step_avg:41.72ms
+step:812/1490 train_time:33890ms step_avg:41.74ms
+step:813/1490 train_time:33944ms step_avg:41.75ms
+step:814/1490 train_time:34003ms step_avg:41.77ms
+step:815/1490 train_time:34057ms step_avg:41.79ms
+step:816/1490 train_time:34116ms step_avg:41.81ms
+step:817/1490 train_time:34169ms step_avg:41.82ms
+step:818/1490 train_time:34228ms step_avg:41.84ms
+step:819/1490 train_time:34283ms step_avg:41.86ms
+step:820/1490 train_time:34343ms step_avg:41.88ms
+step:821/1490 train_time:34398ms step_avg:41.90ms
+step:822/1490 train_time:34459ms step_avg:41.92ms
+step:823/1490 train_time:34513ms step_avg:41.94ms
+step:824/1490 train_time:34573ms step_avg:41.96ms
+step:825/1490 train_time:34627ms step_avg:41.97ms
+step:826/1490 train_time:34687ms step_avg:41.99ms
+step:827/1490 train_time:34741ms step_avg:42.01ms
+step:828/1490 train_time:34801ms step_avg:42.03ms
+step:829/1490 train_time:34856ms step_avg:42.05ms
+step:830/1490 train_time:34916ms step_avg:42.07ms
+step:831/1490 train_time:34969ms step_avg:42.08ms
+step:832/1490 train_time:35029ms step_avg:42.10ms
+step:833/1490 train_time:35082ms step_avg:42.12ms
+step:834/1490 train_time:35141ms step_avg:42.14ms
+step:835/1490 train_time:35195ms step_avg:42.15ms
+step:836/1490 train_time:35255ms step_avg:42.17ms
+step:837/1490 train_time:35310ms step_avg:42.19ms
+step:838/1490 train_time:35369ms step_avg:42.21ms
+step:839/1490 train_time:35423ms step_avg:42.22ms
+step:840/1490 train_time:35483ms step_avg:42.24ms
+step:841/1490 train_time:35538ms step_avg:42.26ms
+step:842/1490 train_time:35598ms step_avg:42.28ms
+step:843/1490 train_time:35652ms step_avg:42.29ms
+step:844/1490 train_time:35713ms step_avg:42.31ms
+step:845/1490 train_time:35768ms step_avg:42.33ms
+step:846/1490 train_time:35827ms step_avg:42.35ms
+step:847/1490 train_time:35881ms step_avg:42.36ms
+step:848/1490 train_time:35940ms step_avg:42.38ms
+step:849/1490 train_time:35994ms step_avg:42.40ms
+step:850/1490 train_time:36056ms step_avg:42.42ms
+step:851/1490 train_time:36110ms step_avg:42.43ms
+step:852/1490 train_time:36169ms step_avg:42.45ms
+step:853/1490 train_time:36223ms step_avg:42.47ms
+step:854/1490 train_time:36283ms step_avg:42.49ms
+step:855/1490 train_time:36337ms step_avg:42.50ms
+step:856/1490 train_time:36397ms step_avg:42.52ms
+step:857/1490 train_time:36451ms step_avg:42.53ms
+step:858/1490 train_time:36512ms step_avg:42.56ms
+step:859/1490 train_time:36567ms step_avg:42.57ms
+step:860/1490 train_time:36626ms step_avg:42.59ms
+step:861/1490 train_time:36681ms step_avg:42.60ms
+step:862/1490 train_time:36740ms step_avg:42.62ms
+step:863/1490 train_time:36795ms step_avg:42.64ms
+step:864/1490 train_time:36855ms step_avg:42.66ms
+step:865/1490 train_time:36909ms step_avg:42.67ms
+step:866/1490 train_time:36968ms step_avg:42.69ms
+step:867/1490 train_time:37022ms step_avg:42.70ms
+step:868/1490 train_time:37081ms step_avg:42.72ms
+step:869/1490 train_time:37134ms step_avg:42.73ms
+step:870/1490 train_time:37195ms step_avg:42.75ms
+step:871/1490 train_time:37249ms step_avg:42.77ms
+step:872/1490 train_time:37309ms step_avg:42.78ms
+step:873/1490 train_time:37362ms step_avg:42.80ms
+step:874/1490 train_time:37422ms step_avg:42.82ms
+step:875/1490 train_time:37476ms step_avg:42.83ms
+step:876/1490 train_time:37536ms step_avg:42.85ms
+step:877/1490 train_time:37593ms step_avg:42.87ms
+step:878/1490 train_time:37653ms step_avg:42.88ms
+step:879/1490 train_time:37707ms step_avg:42.90ms
+step:880/1490 train_time:37766ms step_avg:42.92ms
+step:881/1490 train_time:37820ms step_avg:42.93ms
+step:882/1490 train_time:37880ms step_avg:42.95ms
+step:883/1490 train_time:37933ms step_avg:42.96ms
+step:884/1490 train_time:37993ms step_avg:42.98ms
+step:885/1490 train_time:38047ms step_avg:42.99ms
+step:886/1490 train_time:38106ms step_avg:43.01ms
+step:887/1490 train_time:38161ms step_avg:43.02ms
+step:888/1490 train_time:38220ms step_avg:43.04ms
+step:889/1490 train_time:38274ms step_avg:43.05ms
+step:890/1490 train_time:38334ms step_avg:43.07ms
+step:891/1490 train_time:38390ms step_avg:43.09ms
+step:892/1490 train_time:38449ms step_avg:43.10ms
+step:893/1490 train_time:38504ms step_avg:43.12ms
+step:894/1490 train_time:38563ms step_avg:43.14ms
+step:895/1490 train_time:38618ms step_avg:43.15ms
+step:896/1490 train_time:38678ms step_avg:43.17ms
+step:897/1490 train_time:38731ms step_avg:43.18ms
+step:898/1490 train_time:38791ms step_avg:43.20ms
+step:899/1490 train_time:38845ms step_avg:43.21ms
+step:900/1490 train_time:38905ms step_avg:43.23ms
+step:901/1490 train_time:38959ms step_avg:43.24ms
+step:902/1490 train_time:39019ms step_avg:43.26ms
+step:903/1490 train_time:39072ms step_avg:43.27ms
+step:904/1490 train_time:39133ms step_avg:43.29ms
+step:905/1490 train_time:39187ms step_avg:43.30ms
+step:906/1490 train_time:39247ms step_avg:43.32ms
+step:907/1490 train_time:39301ms step_avg:43.33ms
+step:908/1490 train_time:39361ms step_avg:43.35ms
+step:909/1490 train_time:39415ms step_avg:43.36ms
+step:910/1490 train_time:39475ms step_avg:43.38ms
+step:911/1490 train_time:39528ms step_avg:43.39ms
+step:912/1490 train_time:39589ms step_avg:43.41ms
+step:913/1490 train_time:39643ms step_avg:43.42ms
+step:914/1490 train_time:39702ms step_avg:43.44ms
+step:915/1490 train_time:39756ms step_avg:43.45ms
+step:916/1490 train_time:39816ms step_avg:43.47ms
+step:917/1490 train_time:39870ms step_avg:43.48ms
+step:918/1490 train_time:39930ms step_avg:43.50ms
+step:919/1490 train_time:39983ms step_avg:43.51ms
+step:920/1490 train_time:40042ms step_avg:43.52ms
+step:921/1490 train_time:40096ms step_avg:43.54ms
+step:922/1490 train_time:40157ms step_avg:43.55ms
+step:923/1490 train_time:40212ms step_avg:43.57ms
+step:924/1490 train_time:40272ms step_avg:43.58ms
+step:925/1490 train_time:40326ms step_avg:43.60ms
+step:926/1490 train_time:40385ms step_avg:43.61ms
+step:927/1490 train_time:40440ms step_avg:43.62ms
+step:928/1490 train_time:40500ms step_avg:43.64ms
+step:929/1490 train_time:40554ms step_avg:43.65ms
+step:930/1490 train_time:40614ms step_avg:43.67ms
+step:931/1490 train_time:40669ms step_avg:43.68ms
+step:932/1490 train_time:40728ms step_avg:43.70ms
+step:933/1490 train_time:40783ms step_avg:43.71ms
+step:934/1490 train_time:40843ms step_avg:43.73ms
+step:935/1490 train_time:40896ms step_avg:43.74ms
+step:936/1490 train_time:40956ms step_avg:43.76ms
+step:937/1490 train_time:41010ms step_avg:43.77ms
+step:938/1490 train_time:41070ms step_avg:43.78ms
+step:939/1490 train_time:41124ms step_avg:43.80ms
+step:940/1490 train_time:41183ms step_avg:43.81ms
+step:941/1490 train_time:41237ms step_avg:43.82ms
+step:942/1490 train_time:41298ms step_avg:43.84ms
+step:943/1490 train_time:41351ms step_avg:43.85ms
+step:944/1490 train_time:41411ms step_avg:43.87ms
+step:945/1490 train_time:41464ms step_avg:43.88ms
+step:946/1490 train_time:41524ms step_avg:43.89ms
+step:947/1490 train_time:41577ms step_avg:43.90ms
+step:948/1490 train_time:41637ms step_avg:43.92ms
+step:949/1490 train_time:41693ms step_avg:43.93ms
+step:950/1490 train_time:41753ms step_avg:43.95ms
+step:951/1490 train_time:41807ms step_avg:43.96ms
+step:952/1490 train_time:41867ms step_avg:43.98ms
+step:953/1490 train_time:41921ms step_avg:43.99ms
+step:954/1490 train_time:41981ms step_avg:44.00ms
+step:955/1490 train_time:42034ms step_avg:44.01ms
+step:956/1490 train_time:42094ms step_avg:44.03ms
+step:957/1490 train_time:42148ms step_avg:44.04ms
+step:958/1490 train_time:42207ms step_avg:44.06ms
+step:959/1490 train_time:42262ms step_avg:44.07ms
+step:960/1490 train_time:42321ms step_avg:44.08ms
+step:961/1490 train_time:42375ms step_avg:44.09ms
+step:962/1490 train_time:42435ms step_avg:44.11ms
+step:963/1490 train_time:42489ms step_avg:44.12ms
+step:964/1490 train_time:42548ms step_avg:44.14ms
+step:965/1490 train_time:42602ms step_avg:44.15ms
+step:966/1490 train_time:42662ms step_avg:44.16ms
+step:967/1490 train_time:42716ms step_avg:44.17ms
+step:968/1490 train_time:42779ms step_avg:44.19ms
+step:969/1490 train_time:42858ms step_avg:44.23ms
+step:970/1490 train_time:42943ms step_avg:44.27ms
+step:971/1490 train_time:43023ms step_avg:44.31ms
+step:972/1490 train_time:43109ms step_avg:44.35ms
+step:973/1490 train_time:43190ms step_avg:44.39ms
+step:974/1490 train_time:43277ms step_avg:44.43ms
+step:975/1490 train_time:43356ms step_avg:44.47ms
+step:976/1490 train_time:43442ms step_avg:44.51ms
+step:977/1490 train_time:43523ms step_avg:44.55ms
+step:978/1490 train_time:43609ms step_avg:44.59ms
+step:979/1490 train_time:43690ms step_avg:44.63ms
+step:980/1490 train_time:43776ms step_avg:44.67ms
+step:981/1490 train_time:43855ms step_avg:44.70ms
+step:982/1490 train_time:43940ms step_avg:44.75ms
+step:983/1490 train_time:44021ms step_avg:44.78ms
+step:984/1490 train_time:44107ms step_avg:44.82ms
+step:985/1490 train_time:44188ms step_avg:44.86ms
+step:986/1490 train_time:44273ms step_avg:44.90ms
+step:987/1490 train_time:44354ms step_avg:44.94ms
+step:988/1490 train_time:44438ms step_avg:44.98ms
+step:989/1490 train_time:44519ms step_avg:45.01ms
+step:990/1490 train_time:44605ms step_avg:45.06ms
+step:991/1490 train_time:44685ms step_avg:45.09ms
+step:992/1490 train_time:44770ms step_avg:45.13ms
+step:993/1490 train_time:44850ms step_avg:45.17ms
+step:994/1490 train_time:44935ms step_avg:45.21ms
+step:995/1490 train_time:45016ms step_avg:45.24ms
+step:996/1490 train_time:45101ms step_avg:45.28ms
+step:997/1490 train_time:45180ms step_avg:45.32ms
+step:998/1490 train_time:45265ms step_avg:45.36ms
+step:999/1490 train_time:45345ms step_avg:45.39ms
+step:1000/1490 train_time:45431ms step_avg:45.43ms
+step:1000/1490 val_loss:3.5167 train_time:45534ms step_avg:45.53ms
+step:1001/1490 train_time:45551ms step_avg:45.51ms
+step:1002/1490 train_time:45601ms step_avg:45.51ms
+step:1003/1490 train_time:45682ms step_avg:45.55ms
+step:1004/1490 train_time:45770ms step_avg:45.59ms
+step:1005/1490 train_time:45851ms step_avg:45.62ms
+step:1006/1490 train_time:45936ms step_avg:45.66ms
+step:1007/1490 train_time:46015ms step_avg:45.69ms
+step:1008/1490 train_time:46100ms step_avg:45.73ms
+step:1009/1490 train_time:46180ms step_avg:45.77ms
+step:1010/1490 train_time:46263ms step_avg:45.81ms
+step:1011/1490 train_time:46343ms step_avg:45.84ms
+step:1012/1490 train_time:46428ms step_avg:45.88ms
+step:1013/1490 train_time:46511ms step_avg:45.91ms
+step:1014/1490 train_time:46598ms step_avg:45.95ms
+step:1015/1490 train_time:46681ms step_avg:45.99ms
+step:1016/1490 train_time:46769ms step_avg:46.03ms
+step:1017/1490 train_time:46850ms step_avg:46.07ms
+step:1018/1490 train_time:46935ms step_avg:46.11ms
+step:1019/1490 train_time:47015ms step_avg:46.14ms
+step:1020/1490 train_time:47100ms step_avg:46.18ms
+step:1021/1490 train_time:47179ms step_avg:46.21ms
+step:1022/1490 train_time:47264ms step_avg:46.25ms
+step:1023/1490 train_time:47344ms step_avg:46.28ms
+step:1024/1490 train_time:47430ms step_avg:46.32ms
+step:1025/1490 train_time:47512ms step_avg:46.35ms
+step:1026/1490 train_time:47599ms step_avg:46.39ms
+step:1027/1490 train_time:47679ms step_avg:46.43ms
+step:1028/1490 train_time:47765ms step_avg:46.46ms
+step:1029/1490 train_time:47846ms step_avg:46.50ms
+step:1030/1490 train_time:47931ms step_avg:46.53ms
+step:1031/1490 train_time:48011ms step_avg:46.57ms
+step:1032/1490 train_time:48098ms step_avg:46.61ms
+step:1033/1490 train_time:48176ms step_avg:46.64ms
+step:1034/1490 train_time:48260ms step_avg:46.67ms
+step:1035/1490 train_time:48341ms step_avg:46.71ms
+step:1036/1490 train_time:48427ms step_avg:46.74ms
+step:1037/1490 train_time:48507ms step_avg:46.78ms
+step:1038/1490 train_time:48593ms step_avg:46.81ms
+step:1039/1490 train_time:48674ms step_avg:46.85ms
+step:1040/1490 train_time:48761ms step_avg:46.89ms
+step:1041/1490 train_time:48843ms step_avg:46.92ms
+step:1042/1490 train_time:48931ms step_avg:46.96ms
+step:1043/1490 train_time:49011ms step_avg:46.99ms
+step:1044/1490 train_time:49096ms step_avg:47.03ms
+step:1045/1490 train_time:49175ms step_avg:47.06ms
+step:1046/1490 train_time:49258ms step_avg:47.09ms
+step:1047/1490 train_time:49337ms step_avg:47.12ms
+step:1048/1490 train_time:49423ms step_avg:47.16ms
+step:1049/1490 train_time:49504ms step_avg:47.19ms
+step:1050/1490 train_time:49591ms step_avg:47.23ms
+step:1051/1490 train_time:49671ms step_avg:47.26ms
+step:1052/1490 train_time:49756ms step_avg:47.30ms
+step:1053/1490 train_time:49837ms step_avg:47.33ms
+step:1054/1490 train_time:49923ms step_avg:47.37ms
+step:1055/1490 train_time:50004ms step_avg:47.40ms
+step:1056/1490 train_time:50089ms step_avg:47.43ms
+step:1057/1490 train_time:50168ms step_avg:47.46ms
+step:1058/1490 train_time:50253ms step_avg:47.50ms
+step:1059/1490 train_time:50333ms step_avg:47.53ms
+step:1060/1490 train_time:50417ms step_avg:47.56ms
+step:1061/1490 train_time:50498ms step_avg:47.60ms
+step:1062/1490 train_time:50584ms step_avg:47.63ms
+step:1063/1490 train_time:50665ms step_avg:47.66ms
+step:1064/1490 train_time:50751ms step_avg:47.70ms
+step:1065/1490 train_time:50833ms step_avg:47.73ms
+step:1066/1490 train_time:50918ms step_avg:47.77ms
+step:1067/1490 train_time:50998ms step_avg:47.80ms
+step:1068/1490 train_time:51083ms step_avg:47.83ms
+step:1069/1490 train_time:51163ms step_avg:47.86ms
+step:1070/1490 train_time:51248ms step_avg:47.89ms
+step:1071/1490 train_time:51328ms step_avg:47.93ms
+step:1072/1490 train_time:51414ms step_avg:47.96ms
+step:1073/1490 train_time:51495ms step_avg:47.99ms
+step:1074/1490 train_time:51580ms step_avg:48.03ms
+step:1075/1490 train_time:51660ms step_avg:48.06ms
+step:1076/1490 train_time:51746ms step_avg:48.09ms
+step:1077/1490 train_time:51826ms step_avg:48.12ms
+step:1078/1490 train_time:51913ms step_avg:48.16ms
+step:1079/1490 train_time:51992ms step_avg:48.19ms
+step:1080/1490 train_time:52076ms step_avg:48.22ms
+step:1081/1490 train_time:52156ms step_avg:48.25ms
+step:1082/1490 train_time:52242ms step_avg:48.28ms
+step:1083/1490 train_time:52321ms step_avg:48.31ms
+step:1084/1490 train_time:52406ms step_avg:48.35ms
+step:1085/1490 train_time:52486ms step_avg:48.37ms
+step:1086/1490 train_time:52572ms step_avg:48.41ms
+step:1087/1490 train_time:52652ms step_avg:48.44ms
+step:1088/1490 train_time:52737ms step_avg:48.47ms
+step:1089/1490 train_time:52817ms step_avg:48.50ms
+step:1090/1490 train_time:52903ms step_avg:48.53ms
+step:1091/1490 train_time:52984ms step_avg:48.56ms
+step:1092/1490 train_time:53070ms step_avg:48.60ms
+step:1093/1490 train_time:53151ms step_avg:48.63ms
+step:1094/1490 train_time:53237ms step_avg:48.66ms
+step:1095/1490 train_time:53317ms step_avg:48.69ms
+step:1096/1490 train_time:53402ms step_avg:48.72ms
+step:1097/1490 train_time:53483ms step_avg:48.75ms
+step:1098/1490 train_time:53569ms step_avg:48.79ms
+step:1099/1490 train_time:53649ms step_avg:48.82ms
+step:1100/1490 train_time:53735ms step_avg:48.85ms
+step:1101/1490 train_time:53815ms step_avg:48.88ms
+step:1102/1490 train_time:53901ms step_avg:48.91ms
+step:1103/1490 train_time:53981ms step_avg:48.94ms
+step:1104/1490 train_time:54067ms step_avg:48.97ms
+step:1105/1490 train_time:54148ms step_avg:49.00ms
+step:1106/1490 train_time:54235ms step_avg:49.04ms
+step:1107/1490 train_time:54315ms step_avg:49.07ms
+step:1108/1490 train_time:54400ms step_avg:49.10ms
+step:1109/1490 train_time:54480ms step_avg:49.13ms
+step:1110/1490 train_time:54565ms step_avg:49.16ms
+step:1111/1490 train_time:54646ms step_avg:49.19ms
+step:1112/1490 train_time:54732ms step_avg:49.22ms
+step:1113/1490 train_time:54814ms step_avg:49.25ms
+step:1114/1490 train_time:54899ms step_avg:49.28ms
+step:1115/1490 train_time:54979ms step_avg:49.31ms
+step:1116/1490 train_time:55065ms step_avg:49.34ms
+step:1117/1490 train_time:55147ms step_avg:49.37ms
+step:1118/1490 train_time:55232ms step_avg:49.40ms
+step:1119/1490 train_time:55312ms step_avg:49.43ms
+step:1120/1490 train_time:55397ms step_avg:49.46ms
+step:1121/1490 train_time:55476ms step_avg:49.49ms
+step:1122/1490 train_time:55561ms step_avg:49.52ms
+step:1123/1490 train_time:55642ms step_avg:49.55ms
+step:1124/1490 train_time:55727ms step_avg:49.58ms
+step:1125/1490 train_time:55807ms step_avg:49.61ms
+step:1126/1490 train_time:55894ms step_avg:49.64ms
+step:1127/1490 train_time:55972ms step_avg:49.66ms
+step:1128/1490 train_time:56057ms step_avg:49.70ms
+step:1129/1490 train_time:56138ms step_avg:49.72ms
+step:1130/1490 train_time:56223ms step_avg:49.75ms
+step:1131/1490 train_time:56305ms step_avg:49.78ms
+step:1132/1490 train_time:56391ms step_avg:49.82ms
+step:1133/1490 train_time:56471ms step_avg:49.84ms
+step:1134/1490 train_time:56556ms step_avg:49.87ms
+step:1135/1490 train_time:56636ms step_avg:49.90ms
+step:1136/1490 train_time:56721ms step_avg:49.93ms
+step:1137/1490 train_time:56802ms step_avg:49.96ms
+step:1138/1490 train_time:56889ms step_avg:49.99ms
+step:1139/1490 train_time:56970ms step_avg:50.02ms
+step:1140/1490 train_time:57055ms step_avg:50.05ms
+step:1141/1490 train_time:57136ms step_avg:50.08ms
+step:1142/1490 train_time:57222ms step_avg:50.11ms
+step:1143/1490 train_time:57302ms step_avg:50.13ms
+step:1144/1490 train_time:57388ms step_avg:50.16ms
+step:1145/1490 train_time:57467ms step_avg:50.19ms
+step:1146/1490 train_time:57553ms step_avg:50.22ms
+step:1147/1490 train_time:57633ms step_avg:50.25ms
+step:1148/1490 train_time:57717ms step_avg:50.28ms
+step:1149/1490 train_time:57798ms step_avg:50.30ms
+step:1150/1490 train_time:57884ms step_avg:50.33ms
+step:1151/1490 train_time:57965ms step_avg:50.36ms
+step:1152/1490 train_time:58050ms step_avg:50.39ms
+step:1153/1490 train_time:58130ms step_avg:50.42ms
+step:1154/1490 train_time:58215ms step_avg:50.45ms
+step:1155/1490 train_time:58296ms step_avg:50.47ms
+step:1156/1490 train_time:58380ms step_avg:50.50ms
+step:1157/1490 train_time:58461ms step_avg:50.53ms
+step:1158/1490 train_time:58547ms step_avg:50.56ms
+step:1159/1490 train_time:58627ms step_avg:50.58ms
+step:1160/1490 train_time:58712ms step_avg:50.61ms
+step:1161/1490 train_time:58794ms step_avg:50.64ms
+step:1162/1490 train_time:58879ms step_avg:50.67ms
+step:1163/1490 train_time:58960ms step_avg:50.70ms
+step:1164/1490 train_time:59046ms step_avg:50.73ms
+step:1165/1490 train_time:59127ms step_avg:50.75ms
+step:1166/1490 train_time:59212ms step_avg:50.78ms
+step:1167/1490 train_time:59294ms step_avg:50.81ms
+step:1168/1490 train_time:59380ms step_avg:50.84ms
+step:1169/1490 train_time:59460ms step_avg:50.86ms
+step:1170/1490 train_time:59545ms step_avg:50.89ms
+step:1171/1490 train_time:59626ms step_avg:50.92ms
+step:1172/1490 train_time:59712ms step_avg:50.95ms
+step:1173/1490 train_time:59794ms step_avg:50.98ms
+step:1174/1490 train_time:59879ms step_avg:51.00ms
+step:1175/1490 train_time:59958ms step_avg:51.03ms
+step:1176/1490 train_time:60043ms step_avg:51.06ms
+step:1177/1490 train_time:60124ms step_avg:51.08ms
+step:1178/1490 train_time:60209ms step_avg:51.11ms
+step:1179/1490 train_time:60289ms step_avg:51.14ms
+step:1180/1490 train_time:60376ms step_avg:51.17ms
+step:1181/1490 train_time:60456ms step_avg:51.19ms
+step:1182/1490 train_time:60541ms step_avg:51.22ms
+step:1183/1490 train_time:60622ms step_avg:51.24ms
+step:1184/1490 train_time:60708ms step_avg:51.27ms
+step:1185/1490 train_time:60787ms step_avg:51.30ms
+step:1186/1490 train_time:60873ms step_avg:51.33ms
+step:1187/1490 train_time:60953ms step_avg:51.35ms
+step:1188/1490 train_time:61039ms step_avg:51.38ms
+step:1189/1490 train_time:61118ms step_avg:51.40ms
+step:1190/1490 train_time:61203ms step_avg:51.43ms
+step:1191/1490 train_time:61283ms step_avg:51.46ms
+step:1192/1490 train_time:61368ms step_avg:51.48ms
+step:1193/1490 train_time:61447ms step_avg:51.51ms
+step:1194/1490 train_time:61534ms step_avg:51.54ms
+step:1195/1490 train_time:61614ms step_avg:51.56ms
+step:1196/1490 train_time:61701ms step_avg:51.59ms
+step:1197/1490 train_time:61782ms step_avg:51.61ms
+step:1198/1490 train_time:61867ms step_avg:51.64ms
+step:1199/1490 train_time:61948ms step_avg:51.67ms
+step:1200/1490 train_time:62033ms step_avg:51.69ms
+step:1201/1490 train_time:62113ms step_avg:51.72ms
+step:1202/1490 train_time:62199ms step_avg:51.75ms
+step:1203/1490 train_time:62279ms step_avg:51.77ms
+step:1204/1490 train_time:62365ms step_avg:51.80ms
+step:1205/1490 train_time:62447ms step_avg:51.82ms
+step:1206/1490 train_time:62533ms step_avg:51.85ms
+step:1207/1490 train_time:62615ms step_avg:51.88ms
+step:1208/1490 train_time:62699ms step_avg:51.90ms
+step:1209/1490 train_time:62779ms step_avg:51.93ms
+step:1210/1490 train_time:62866ms step_avg:51.96ms
+step:1211/1490 train_time:62947ms step_avg:51.98ms
+step:1212/1490 train_time:63032ms step_avg:52.01ms
+step:1213/1490 train_time:63112ms step_avg:52.03ms
+step:1214/1490 train_time:63197ms step_avg:52.06ms
+step:1215/1490 train_time:63276ms step_avg:52.08ms
+step:1216/1490 train_time:63361ms step_avg:52.11ms
+step:1217/1490 train_time:63442ms step_avg:52.13ms
+step:1218/1490 train_time:63529ms step_avg:52.16ms
+step:1219/1490 train_time:63611ms step_avg:52.18ms
+step:1220/1490 train_time:63696ms step_avg:52.21ms
+step:1221/1490 train_time:63775ms step_avg:52.23ms
+step:1222/1490 train_time:63861ms step_avg:52.26ms
+step:1223/1490 train_time:63942ms step_avg:52.28ms
+step:1224/1490 train_time:64028ms step_avg:52.31ms
+step:1225/1490 train_time:64107ms step_avg:52.33ms
+step:1226/1490 train_time:64193ms step_avg:52.36ms
+step:1227/1490 train_time:64273ms step_avg:52.38ms
+step:1228/1490 train_time:64357ms step_avg:52.41ms
+step:1229/1490 train_time:64437ms step_avg:52.43ms
+step:1230/1490 train_time:64523ms step_avg:52.46ms
+step:1231/1490 train_time:64604ms step_avg:52.48ms
+step:1232/1490 train_time:64690ms step_avg:52.51ms
+step:1233/1490 train_time:64770ms step_avg:52.53ms
+step:1234/1490 train_time:64856ms step_avg:52.56ms
+step:1235/1490 train_time:64935ms step_avg:52.58ms
+step:1236/1490 train_time:65021ms step_avg:52.61ms
+step:1237/1490 train_time:65104ms step_avg:52.63ms
+step:1238/1490 train_time:65189ms step_avg:52.66ms
+step:1239/1490 train_time:65268ms step_avg:52.68ms
+step:1240/1490 train_time:65355ms step_avg:52.71ms
+step:1241/1490 train_time:65435ms step_avg:52.73ms
+step:1242/1490 train_time:65520ms step_avg:52.75ms
+step:1243/1490 train_time:65600ms step_avg:52.78ms
+step:1244/1490 train_time:65685ms step_avg:52.80ms
+step:1245/1490 train_time:65767ms step_avg:52.82ms
+step:1246/1490 train_time:65852ms step_avg:52.85ms
+step:1247/1490 train_time:65933ms step_avg:52.87ms
+step:1248/1490 train_time:66019ms step_avg:52.90ms
+step:1249/1490 train_time:66099ms step_avg:52.92ms
+step:1250/1490 train_time:66183ms step_avg:52.95ms
+step:1250/1490 val_loss:3.3713 train_time:66287ms step_avg:53.03ms
+step:1251/1490 train_time:66304ms step_avg:53.00ms
+step:1252/1490 train_time:66355ms step_avg:53.00ms
+step:1253/1490 train_time:66438ms step_avg:53.02ms
+step:1254/1490 train_time:66524ms step_avg:53.05ms
+step:1255/1490 train_time:66604ms step_avg:53.07ms
+step:1256/1490 train_time:66690ms step_avg:53.10ms
+step:1257/1490 train_time:66770ms step_avg:53.12ms
+step:1258/1490 train_time:66853ms step_avg:53.14ms
+step:1259/1490 train_time:66932ms step_avg:53.16ms
+step:1260/1490 train_time:67018ms step_avg:53.19ms
+step:1261/1490 train_time:67097ms step_avg:53.21ms
+step:1262/1490 train_time:67182ms step_avg:53.23ms
+step:1263/1490 train_time:67263ms step_avg:53.26ms
+step:1264/1490 train_time:67352ms step_avg:53.28ms
+step:1265/1490 train_time:67434ms step_avg:53.31ms
+step:1266/1490 train_time:67520ms step_avg:53.33ms
+step:1267/1490 train_time:67601ms step_avg:53.36ms
+step:1268/1490 train_time:67686ms step_avg:53.38ms
+step:1269/1490 train_time:67767ms step_avg:53.40ms
+step:1270/1490 train_time:67851ms step_avg:53.43ms
+step:1271/1490 train_time:67930ms step_avg:53.45ms
+step:1272/1490 train_time:68015ms step_avg:53.47ms
+step:1273/1490 train_time:68094ms step_avg:53.49ms
+step:1274/1490 train_time:68180ms step_avg:53.52ms
+step:1275/1490 train_time:68261ms step_avg:53.54ms
+step:1276/1490 train_time:68349ms step_avg:53.57ms
+step:1277/1490 train_time:68430ms step_avg:53.59ms
+step:1278/1490 train_time:68517ms step_avg:53.61ms
+step:1279/1490 train_time:68598ms step_avg:53.63ms
+step:1280/1490 train_time:68685ms step_avg:53.66ms
+step:1281/1490 train_time:68765ms step_avg:53.68ms
+step:1282/1490 train_time:68850ms step_avg:53.71ms
+step:1283/1490 train_time:68929ms step_avg:53.73ms
+step:1284/1490 train_time:69015ms step_avg:53.75ms
+step:1285/1490 train_time:69093ms step_avg:53.77ms
+step:1286/1490 train_time:69178ms step_avg:53.79ms
+step:1287/1490 train_time:69260ms step_avg:53.81ms
+step:1288/1490 train_time:69347ms step_avg:53.84ms
+step:1289/1490 train_time:69429ms step_avg:53.86ms
+step:1290/1490 train_time:69515ms step_avg:53.89ms
+step:1291/1490 train_time:69596ms step_avg:53.91ms
+step:1292/1490 train_time:69683ms step_avg:53.93ms
+step:1293/1490 train_time:69763ms step_avg:53.95ms
+step:1294/1490 train_time:69848ms step_avg:53.98ms
+step:1295/1490 train_time:69930ms step_avg:54.00ms
+step:1296/1490 train_time:70013ms step_avg:54.02ms
+step:1297/1490 train_time:70093ms step_avg:54.04ms
+step:1298/1490 train_time:70179ms step_avg:54.07ms
+step:1299/1490 train_time:70259ms step_avg:54.09ms
+step:1300/1490 train_time:70344ms step_avg:54.11ms
+step:1301/1490 train_time:70426ms step_avg:54.13ms
+step:1302/1490 train_time:70513ms step_avg:54.16ms
+step:1303/1490 train_time:70593ms step_avg:54.18ms
+step:1304/1490 train_time:70678ms step_avg:54.20ms
+step:1305/1490 train_time:70760ms step_avg:54.22ms
+step:1306/1490 train_time:70845ms step_avg:54.25ms
+step:1307/1490 train_time:70927ms step_avg:54.27ms
+step:1308/1490 train_time:71011ms step_avg:54.29ms
+step:1309/1490 train_time:71090ms step_avg:54.31ms
+step:1310/1490 train_time:71174ms step_avg:54.33ms
+step:1311/1490 train_time:71253ms step_avg:54.35ms
+step:1312/1490 train_time:71339ms step_avg:54.37ms
+step:1313/1490 train_time:71421ms step_avg:54.40ms
+step:1314/1490 train_time:71507ms step_avg:54.42ms
+step:1315/1490 train_time:71588ms step_avg:54.44ms
+step:1316/1490 train_time:71673ms step_avg:54.46ms
+step:1317/1490 train_time:71753ms step_avg:54.48ms
+step:1318/1490 train_time:71838ms step_avg:54.51ms
+step:1319/1490 train_time:71919ms step_avg:54.53ms
+step:1320/1490 train_time:72005ms step_avg:54.55ms
+step:1321/1490 train_time:72085ms step_avg:54.57ms
+step:1322/1490 train_time:72170ms step_avg:54.59ms
+step:1323/1490 train_time:72250ms step_avg:54.61ms
+step:1324/1490 train_time:72334ms step_avg:54.63ms
+step:1325/1490 train_time:72414ms step_avg:54.65ms
+step:1326/1490 train_time:72500ms step_avg:54.68ms
+step:1327/1490 train_time:72582ms step_avg:54.70ms
+step:1328/1490 train_time:72668ms step_avg:54.72ms
+step:1329/1490 train_time:72748ms step_avg:54.74ms
+step:1330/1490 train_time:72835ms step_avg:54.76ms
+step:1331/1490 train_time:72914ms step_avg:54.78ms
+step:1332/1490 train_time:72999ms step_avg:54.80ms
+step:1333/1490 train_time:73079ms step_avg:54.82ms
+step:1334/1490 train_time:73166ms step_avg:54.85ms
+step:1335/1490 train_time:73245ms step_avg:54.87ms
+step:1336/1490 train_time:73331ms step_avg:54.89ms
+step:1337/1490 train_time:73412ms step_avg:54.91ms
+step:1338/1490 train_time:73497ms step_avg:54.93ms
+step:1339/1490 train_time:73577ms step_avg:54.95ms
+step:1340/1490 train_time:73664ms step_avg:54.97ms
+step:1341/1490 train_time:73745ms step_avg:54.99ms
+step:1342/1490 train_time:73832ms step_avg:55.02ms
+step:1343/1490 train_time:73912ms step_avg:55.04ms
+step:1344/1490 train_time:73997ms step_avg:55.06ms
+step:1345/1490 train_time:74077ms step_avg:55.08ms
+step:1346/1490 train_time:74163ms step_avg:55.10ms
+step:1347/1490 train_time:74242ms step_avg:55.12ms
+step:1348/1490 train_time:74328ms step_avg:55.14ms
+step:1349/1490 train_time:74407ms step_avg:55.16ms
+step:1350/1490 train_time:74492ms step_avg:55.18ms
+step:1351/1490 train_time:74572ms step_avg:55.20ms
+step:1352/1490 train_time:74657ms step_avg:55.22ms
+step:1353/1490 train_time:74739ms step_avg:55.24ms
+step:1354/1490 train_time:74824ms step_avg:55.26ms
+step:1355/1490 train_time:74904ms step_avg:55.28ms
+step:1356/1490 train_time:74989ms step_avg:55.30ms
+step:1357/1490 train_time:75069ms step_avg:55.32ms
+step:1358/1490 train_time:75153ms step_avg:55.34ms
+step:1359/1490 train_time:75233ms step_avg:55.36ms
+step:1360/1490 train_time:75320ms step_avg:55.38ms
+step:1361/1490 train_time:75399ms step_avg:55.40ms
+step:1362/1490 train_time:75485ms step_avg:55.42ms
+step:1363/1490 train_time:75564ms step_avg:55.44ms
+step:1364/1490 train_time:75651ms step_avg:55.46ms
+step:1365/1490 train_time:75732ms step_avg:55.48ms
+step:1366/1490 train_time:75816ms step_avg:55.50ms
+step:1367/1490 train_time:75897ms step_avg:55.52ms
+step:1368/1490 train_time:75983ms step_avg:55.54ms
+step:1369/1490 train_time:76063ms step_avg:55.56ms
+step:1370/1490 train_time:76149ms step_avg:55.58ms
+step:1371/1490 train_time:76230ms step_avg:55.60ms
+step:1372/1490 train_time:76316ms step_avg:55.62ms
+step:1373/1490 train_time:76396ms step_avg:55.64ms
+step:1374/1490 train_time:76482ms step_avg:55.66ms
+step:1375/1490 train_time:76562ms step_avg:55.68ms
+step:1376/1490 train_time:76649ms step_avg:55.70ms
+step:1377/1490 train_time:76731ms step_avg:55.72ms
+step:1378/1490 train_time:76816ms step_avg:55.74ms
+step:1379/1490 train_time:76896ms step_avg:55.76ms
+step:1380/1490 train_time:76982ms step_avg:55.78ms
+step:1381/1490 train_time:77063ms step_avg:55.80ms
+step:1382/1490 train_time:77149ms step_avg:55.82ms
+step:1383/1490 train_time:77229ms step_avg:55.84ms
+step:1384/1490 train_time:77315ms step_avg:55.86ms
+step:1385/1490 train_time:77394ms step_avg:55.88ms
+step:1386/1490 train_time:77481ms step_avg:55.90ms
+step:1387/1490 train_time:77562ms step_avg:55.92ms
+step:1388/1490 train_time:77649ms step_avg:55.94ms
+step:1389/1490 train_time:77731ms step_avg:55.96ms
+step:1390/1490 train_time:77816ms step_avg:55.98ms
+step:1391/1490 train_time:77895ms step_avg:56.00ms
+step:1392/1490 train_time:77982ms step_avg:56.02ms
+step:1393/1490 train_time:78063ms step_avg:56.04ms
+step:1394/1490 train_time:78148ms step_avg:56.06ms
+step:1395/1490 train_time:78228ms step_avg:56.08ms
+step:1396/1490 train_time:78314ms step_avg:56.10ms
+step:1397/1490 train_time:78392ms step_avg:56.11ms
+step:1398/1490 train_time:78478ms step_avg:56.14ms
+step:1399/1490 train_time:78558ms step_avg:56.15ms
+step:1400/1490 train_time:78644ms step_avg:56.17ms
+step:1401/1490 train_time:78724ms step_avg:56.19ms
+step:1402/1490 train_time:78810ms step_avg:56.21ms
+step:1403/1490 train_time:78889ms step_avg:56.23ms
+step:1404/1490 train_time:78974ms step_avg:56.25ms
+step:1405/1490 train_time:79055ms step_avg:56.27ms
+step:1406/1490 train_time:79141ms step_avg:56.29ms
+step:1407/1490 train_time:79222ms step_avg:56.31ms
+step:1408/1490 train_time:79308ms step_avg:56.33ms
+step:1409/1490 train_time:79387ms step_avg:56.34ms
+step:1410/1490 train_time:79473ms step_avg:56.36ms
+step:1411/1490 train_time:79553ms step_avg:56.38ms
+step:1412/1490 train_time:79639ms step_avg:56.40ms
+step:1413/1490 train_time:79720ms step_avg:56.42ms
+step:1414/1490 train_time:79806ms step_avg:56.44ms
+step:1415/1490 train_time:79885ms step_avg:56.46ms
+step:1416/1490 train_time:79971ms step_avg:56.48ms
+step:1417/1490 train_time:80051ms step_avg:56.49ms
+step:1418/1490 train_time:80135ms step_avg:56.51ms
+step:1419/1490 train_time:80216ms step_avg:56.53ms
+step:1420/1490 train_time:80303ms step_avg:56.55ms
+step:1421/1490 train_time:80383ms step_avg:56.57ms
+step:1422/1490 train_time:80470ms step_avg:56.59ms
+step:1423/1490 train_time:80550ms step_avg:56.61ms
+step:1424/1490 train_time:80637ms step_avg:56.63ms
+step:1425/1490 train_time:80718ms step_avg:56.64ms
+step:1426/1490 train_time:80803ms step_avg:56.66ms
+step:1427/1490 train_time:80884ms step_avg:56.68ms
+step:1428/1490 train_time:80970ms step_avg:56.70ms
+step:1429/1490 train_time:81048ms step_avg:56.72ms
+step:1430/1490 train_time:81134ms step_avg:56.74ms
+step:1431/1490 train_time:81214ms step_avg:56.75ms
+step:1432/1490 train_time:81299ms step_avg:56.77ms
+step:1433/1490 train_time:81379ms step_avg:56.79ms
+step:1434/1490 train_time:81465ms step_avg:56.81ms
+step:1435/1490 train_time:81545ms step_avg:56.83ms
+step:1436/1490 train_time:81631ms step_avg:56.85ms
+step:1437/1490 train_time:81710ms step_avg:56.86ms
+step:1438/1490 train_time:81795ms step_avg:56.88ms
+step:1439/1490 train_time:81876ms step_avg:56.90ms
+step:1440/1490 train_time:81963ms step_avg:56.92ms
+step:1441/1490 train_time:82044ms step_avg:56.94ms
+step:1442/1490 train_time:82130ms step_avg:56.96ms
+step:1443/1490 train_time:82209ms step_avg:56.97ms
+step:1444/1490 train_time:82294ms step_avg:56.99ms
+step:1445/1490 train_time:82375ms step_avg:57.01ms
+step:1446/1490 train_time:82461ms step_avg:57.03ms
+step:1447/1490 train_time:82543ms step_avg:57.04ms
+step:1448/1490 train_time:82628ms step_avg:57.06ms
+step:1449/1490 train_time:82708ms step_avg:57.08ms
+step:1450/1490 train_time:82793ms step_avg:57.10ms
+step:1451/1490 train_time:82876ms step_avg:57.12ms
+step:1452/1490 train_time:82963ms step_avg:57.14ms
+step:1453/1490 train_time:83043ms step_avg:57.15ms
+step:1454/1490 train_time:83128ms step_avg:57.17ms
+step:1455/1490 train_time:83209ms step_avg:57.19ms
+step:1456/1490 train_time:83294ms step_avg:57.21ms
+step:1457/1490 train_time:83375ms step_avg:57.22ms
+step:1458/1490 train_time:83462ms step_avg:57.24ms
+step:1459/1490 train_time:83544ms step_avg:57.26ms
+step:1460/1490 train_time:83629ms step_avg:57.28ms
+step:1461/1490 train_time:83710ms step_avg:57.30ms
+step:1462/1490 train_time:83795ms step_avg:57.32ms
+step:1463/1490 train_time:83875ms step_avg:57.33ms
+step:1464/1490 train_time:83961ms step_avg:57.35ms
+step:1465/1490 train_time:84043ms step_avg:57.37ms
+step:1466/1490 train_time:84130ms step_avg:57.39ms
+step:1467/1490 train_time:84212ms step_avg:57.40ms
+step:1468/1490 train_time:84297ms step_avg:57.42ms
+step:1469/1490 train_time:84376ms step_avg:57.44ms
+step:1470/1490 train_time:84463ms step_avg:57.46ms
+step:1471/1490 train_time:84543ms step_avg:57.47ms
+step:1472/1490 train_time:84630ms step_avg:57.49ms
+step:1473/1490 train_time:84711ms step_avg:57.51ms
+step:1474/1490 train_time:84797ms step_avg:57.53ms
+step:1475/1490 train_time:84877ms step_avg:57.54ms
+step:1476/1490 train_time:84964ms step_avg:57.56ms
+step:1477/1490 train_time:85043ms step_avg:57.58ms
+step:1478/1490 train_time:85131ms step_avg:57.60ms
+step:1479/1490 train_time:85213ms step_avg:57.62ms
+step:1480/1490 train_time:85299ms step_avg:57.63ms
+step:1481/1490 train_time:85378ms step_avg:57.65ms
+step:1482/1490 train_time:85463ms step_avg:57.67ms
+step:1483/1490 train_time:85547ms step_avg:57.68ms
+step:1484/1490 train_time:85632ms step_avg:57.70ms
+step:1485/1490 train_time:85712ms step_avg:57.72ms
+step:1486/1490 train_time:85798ms step_avg:57.74ms
+step:1487/1490 train_time:85879ms step_avg:57.75ms
+step:1488/1490 train_time:85967ms step_avg:57.77ms
+step:1489/1490 train_time:86048ms step_avg:57.79ms
+step:1490/1490 train_time:86133ms step_avg:57.81ms
+step:1490/1490 val_loss:3.2785 train_time:86236ms step_avg:57.88ms
+peak memory allocated: 31296 MiB reserved: 47042 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/combined/2026-03-22_20-16-54_time-186_secs_06-mbeta2-max-docs_3a1fa2.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/combined/2026-03-22_20-16-54_time-186_secs_06-mbeta2-max-docs_3a1fa2.txt
@@ -1,0 +1,4457 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 20:17:09 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   36C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            132W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   41C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1873539      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1873540      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1873541      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1873542      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1873543      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1873544      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1873545      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1873546      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8290 train_time:0ms step_avg:0.04ms
+step:1/1490 train_time:75ms step_avg:75.20ms
+step:2/1490 train_time:96ms step_avg:47.87ms
+step:3/1490 train_time:112ms step_avg:37.46ms
+step:4/1490 train_time:139ms step_avg:34.83ms
+step:5/1490 train_time:166ms step_avg:33.26ms
+step:6/1490 train_time:201ms step_avg:33.47ms
+step:7/1490 train_time:228ms step_avg:32.58ms
+step:8/1490 train_time:263ms step_avg:32.86ms
+step:9/1490 train_time:290ms step_avg:32.23ms
+step:10/1490 train_time:325ms step_avg:32.46ms
+step:11/1490 train_time:352ms step_avg:32.02ms
+step:12/1490 train_time:387ms step_avg:32.21ms
+step:13/1490 train_time:415ms step_avg:31.89ms
+step:14/1490 train_time:449ms step_avg:32.05ms
+step:15/1490 train_time:477ms step_avg:31.80ms
+step:16/1490 train_time:511ms step_avg:31.95ms
+step:17/1490 train_time:539ms step_avg:31.73ms
+step:18/1490 train_time:574ms step_avg:31.89ms
+step:19/1490 train_time:602ms step_avg:31.69ms
+step:20/1490 train_time:636ms step_avg:31.81ms
+step:21/1490 train_time:664ms step_avg:31.63ms
+step:22/1490 train_time:698ms step_avg:31.73ms
+step:23/1490 train_time:727ms step_avg:31.60ms
+step:24/1490 train_time:761ms step_avg:31.70ms
+step:25/1490 train_time:789ms step_avg:31.54ms
+step:26/1490 train_time:823ms step_avg:31.66ms
+step:27/1490 train_time:851ms step_avg:31.53ms
+step:28/1490 train_time:886ms step_avg:31.63ms
+step:29/1490 train_time:914ms step_avg:31.51ms
+step:30/1490 train_time:949ms step_avg:31.62ms
+step:31/1490 train_time:978ms step_avg:31.54ms
+step:32/1490 train_time:1013ms step_avg:31.67ms
+step:33/1490 train_time:1043ms step_avg:31.61ms
+step:34/1490 train_time:1078ms step_avg:31.71ms
+step:35/1490 train_time:1107ms step_avg:31.61ms
+step:36/1490 train_time:1141ms step_avg:31.70ms
+step:37/1490 train_time:1170ms step_avg:31.61ms
+step:38/1490 train_time:1204ms step_avg:31.69ms
+step:39/1490 train_time:1233ms step_avg:31.62ms
+step:40/1490 train_time:1267ms step_avg:31.68ms
+step:41/1490 train_time:1295ms step_avg:31.59ms
+step:42/1490 train_time:1330ms step_avg:31.66ms
+step:43/1490 train_time:1358ms step_avg:31.58ms
+step:44/1490 train_time:1392ms step_avg:31.64ms
+step:45/1490 train_time:1420ms step_avg:31.57ms
+step:46/1490 train_time:1454ms step_avg:31.62ms
+step:47/1490 train_time:1483ms step_avg:31.55ms
+step:48/1490 train_time:1517ms step_avg:31.61ms
+step:49/1490 train_time:1545ms step_avg:31.53ms
+step:50/1490 train_time:1579ms step_avg:31.58ms
+step:51/1490 train_time:1607ms step_avg:31.52ms
+step:52/1490 train_time:1641ms step_avg:31.56ms
+step:53/1490 train_time:1669ms step_avg:31.50ms
+step:54/1490 train_time:1704ms step_avg:31.55ms
+step:55/1490 train_time:1732ms step_avg:31.49ms
+step:56/1490 train_time:1767ms step_avg:31.55ms
+step:57/1490 train_time:1795ms step_avg:31.49ms
+step:58/1490 train_time:1829ms step_avg:31.54ms
+step:59/1490 train_time:1858ms step_avg:31.49ms
+step:60/1490 train_time:1892ms step_avg:31.54ms
+step:61/1490 train_time:1921ms step_avg:31.49ms
+step:62/1490 train_time:1955ms step_avg:31.54ms
+step:63/1490 train_time:1984ms step_avg:31.49ms
+step:64/1490 train_time:2019ms step_avg:31.54ms
+step:65/1490 train_time:2047ms step_avg:31.50ms
+step:66/1490 train_time:2082ms step_avg:31.55ms
+step:67/1490 train_time:2110ms step_avg:31.50ms
+step:68/1490 train_time:2145ms step_avg:31.54ms
+step:69/1490 train_time:2173ms step_avg:31.50ms
+step:70/1490 train_time:2208ms step_avg:31.54ms
+step:71/1490 train_time:2236ms step_avg:31.49ms
+step:72/1490 train_time:2271ms step_avg:31.54ms
+step:73/1490 train_time:2299ms step_avg:31.50ms
+step:74/1490 train_time:2334ms step_avg:31.54ms
+step:75/1490 train_time:2362ms step_avg:31.49ms
+step:76/1490 train_time:2396ms step_avg:31.53ms
+step:77/1490 train_time:2425ms step_avg:31.50ms
+step:78/1490 train_time:2459ms step_avg:31.53ms
+step:79/1490 train_time:2488ms step_avg:31.49ms
+step:80/1490 train_time:2522ms step_avg:31.52ms
+step:81/1490 train_time:2550ms step_avg:31.48ms
+step:82/1490 train_time:2585ms step_avg:31.52ms
+step:83/1490 train_time:2613ms step_avg:31.48ms
+step:84/1490 train_time:2647ms step_avg:31.51ms
+step:85/1490 train_time:2675ms step_avg:31.47ms
+step:86/1490 train_time:2709ms step_avg:31.50ms
+step:87/1490 train_time:2737ms step_avg:31.46ms
+step:88/1490 train_time:2772ms step_avg:31.50ms
+step:89/1490 train_time:2800ms step_avg:31.46ms
+step:90/1490 train_time:2834ms step_avg:31.49ms
+step:91/1490 train_time:2862ms step_avg:31.45ms
+step:92/1490 train_time:2897ms step_avg:31.48ms
+step:93/1490 train_time:2925ms step_avg:31.45ms
+step:94/1490 train_time:2959ms step_avg:31.48ms
+step:95/1490 train_time:2988ms step_avg:31.45ms
+step:96/1490 train_time:3022ms step_avg:31.48ms
+step:97/1490 train_time:3050ms step_avg:31.45ms
+step:98/1490 train_time:3085ms step_avg:31.48ms
+step:99/1490 train_time:3113ms step_avg:31.45ms
+step:100/1490 train_time:3148ms step_avg:31.48ms
+step:101/1490 train_time:3177ms step_avg:31.45ms
+step:102/1490 train_time:3211ms step_avg:31.48ms
+step:103/1490 train_time:3240ms step_avg:31.45ms
+step:104/1490 train_time:3274ms step_avg:31.49ms
+step:105/1490 train_time:3303ms step_avg:31.46ms
+step:106/1490 train_time:3337ms step_avg:31.48ms
+step:107/1490 train_time:3366ms step_avg:31.46ms
+step:108/1490 train_time:3400ms step_avg:31.48ms
+step:109/1490 train_time:3428ms step_avg:31.45ms
+step:110/1490 train_time:3463ms step_avg:31.48ms
+step:111/1490 train_time:3491ms step_avg:31.45ms
+step:112/1490 train_time:3525ms step_avg:31.48ms
+step:113/1490 train_time:3553ms step_avg:31.45ms
+step:114/1490 train_time:3588ms step_avg:31.47ms
+step:115/1490 train_time:3616ms step_avg:31.44ms
+step:116/1490 train_time:3650ms step_avg:31.47ms
+step:117/1490 train_time:3678ms step_avg:31.44ms
+step:118/1490 train_time:3713ms step_avg:31.47ms
+step:119/1490 train_time:3741ms step_avg:31.44ms
+step:120/1490 train_time:3776ms step_avg:31.46ms
+step:121/1490 train_time:3804ms step_avg:31.44ms
+step:122/1490 train_time:3838ms step_avg:31.46ms
+step:123/1490 train_time:3866ms step_avg:31.43ms
+step:124/1490 train_time:3901ms step_avg:31.46ms
+step:125/1490 train_time:3929ms step_avg:31.43ms
+step:126/1490 train_time:3963ms step_avg:31.45ms
+step:127/1490 train_time:3992ms step_avg:31.43ms
+step:128/1490 train_time:4027ms step_avg:31.46ms
+step:129/1490 train_time:4056ms step_avg:31.44ms
+step:130/1490 train_time:4090ms step_avg:31.46ms
+step:131/1490 train_time:4118ms step_avg:31.44ms
+step:132/1490 train_time:4153ms step_avg:31.46ms
+step:133/1490 train_time:4181ms step_avg:31.44ms
+step:134/1490 train_time:4215ms step_avg:31.46ms
+step:135/1490 train_time:4244ms step_avg:31.44ms
+step:136/1490 train_time:4278ms step_avg:31.46ms
+step:137/1490 train_time:4306ms step_avg:31.43ms
+step:138/1490 train_time:4341ms step_avg:31.45ms
+step:139/1490 train_time:4369ms step_avg:31.43ms
+step:140/1490 train_time:4404ms step_avg:31.46ms
+step:141/1490 train_time:4432ms step_avg:31.44ms
+step:142/1490 train_time:4467ms step_avg:31.46ms
+step:143/1490 train_time:4495ms step_avg:31.44ms
+step:144/1490 train_time:4530ms step_avg:31.46ms
+step:145/1490 train_time:4558ms step_avg:31.44ms
+step:146/1490 train_time:4592ms step_avg:31.45ms
+step:147/1490 train_time:4621ms step_avg:31.43ms
+step:148/1490 train_time:4655ms step_avg:31.45ms
+step:149/1490 train_time:4683ms step_avg:31.43ms
+step:150/1490 train_time:4717ms step_avg:31.45ms
+step:151/1490 train_time:4746ms step_avg:31.43ms
+step:152/1490 train_time:4780ms step_avg:31.45ms
+step:153/1490 train_time:4808ms step_avg:31.42ms
+step:154/1490 train_time:4842ms step_avg:31.44ms
+step:155/1490 train_time:4870ms step_avg:31.42ms
+step:156/1490 train_time:4904ms step_avg:31.44ms
+step:157/1490 train_time:4933ms step_avg:31.42ms
+step:158/1490 train_time:4967ms step_avg:31.44ms
+step:159/1490 train_time:4995ms step_avg:31.41ms
+step:160/1490 train_time:5030ms step_avg:31.43ms
+step:161/1490 train_time:5058ms step_avg:31.42ms
+step:162/1490 train_time:5093ms step_avg:31.44ms
+step:163/1490 train_time:5121ms step_avg:31.42ms
+step:164/1490 train_time:5155ms step_avg:31.44ms
+step:165/1490 train_time:5184ms step_avg:31.42ms
+step:166/1490 train_time:5218ms step_avg:31.43ms
+step:167/1490 train_time:5246ms step_avg:31.41ms
+step:168/1490 train_time:5281ms step_avg:31.43ms
+step:169/1490 train_time:5309ms step_avg:31.41ms
+step:170/1490 train_time:5343ms step_avg:31.43ms
+step:171/1490 train_time:5372ms step_avg:31.41ms
+step:172/1490 train_time:5406ms step_avg:31.43ms
+step:173/1490 train_time:5435ms step_avg:31.41ms
+step:174/1490 train_time:5469ms step_avg:31.43ms
+step:175/1490 train_time:5497ms step_avg:31.41ms
+step:176/1490 train_time:5532ms step_avg:31.43ms
+step:177/1490 train_time:5560ms step_avg:31.41ms
+step:178/1490 train_time:5594ms step_avg:31.43ms
+step:179/1490 train_time:5623ms step_avg:31.41ms
+step:180/1490 train_time:5657ms step_avg:31.43ms
+step:181/1490 train_time:5685ms step_avg:31.41ms
+step:182/1490 train_time:5720ms step_avg:31.43ms
+step:183/1490 train_time:5748ms step_avg:31.41ms
+step:184/1490 train_time:5782ms step_avg:31.43ms
+step:185/1490 train_time:5810ms step_avg:31.41ms
+step:186/1490 train_time:5845ms step_avg:31.42ms
+step:187/1490 train_time:5873ms step_avg:31.41ms
+step:188/1490 train_time:5907ms step_avg:31.42ms
+step:189/1490 train_time:5935ms step_avg:31.40ms
+step:190/1490 train_time:5970ms step_avg:31.42ms
+step:191/1490 train_time:5999ms step_avg:31.41ms
+step:192/1490 train_time:6033ms step_avg:31.42ms
+step:193/1490 train_time:6062ms step_avg:31.41ms
+step:194/1490 train_time:6096ms step_avg:31.42ms
+step:195/1490 train_time:6124ms step_avg:31.41ms
+step:196/1490 train_time:6158ms step_avg:31.42ms
+step:197/1490 train_time:6186ms step_avg:31.40ms
+step:198/1490 train_time:6220ms step_avg:31.42ms
+step:199/1490 train_time:6249ms step_avg:31.40ms
+step:200/1490 train_time:6283ms step_avg:31.42ms
+step:201/1490 train_time:6311ms step_avg:31.40ms
+step:202/1490 train_time:6346ms step_avg:31.41ms
+step:203/1490 train_time:6374ms step_avg:31.40ms
+step:204/1490 train_time:6408ms step_avg:31.41ms
+step:205/1490 train_time:6437ms step_avg:31.40ms
+step:206/1490 train_time:6472ms step_avg:31.42ms
+step:207/1490 train_time:6500ms step_avg:31.40ms
+step:208/1490 train_time:6535ms step_avg:31.42ms
+step:209/1490 train_time:6563ms step_avg:31.40ms
+step:210/1490 train_time:6597ms step_avg:31.41ms
+step:211/1490 train_time:6625ms step_avg:31.40ms
+step:212/1490 train_time:6659ms step_avg:31.41ms
+step:213/1490 train_time:6687ms step_avg:31.40ms
+step:214/1490 train_time:6722ms step_avg:31.41ms
+step:215/1490 train_time:6750ms step_avg:31.39ms
+step:216/1490 train_time:6784ms step_avg:31.41ms
+step:217/1490 train_time:6812ms step_avg:31.39ms
+step:218/1490 train_time:6846ms step_avg:31.40ms
+step:219/1490 train_time:6874ms step_avg:31.39ms
+step:220/1490 train_time:6909ms step_avg:31.40ms
+step:221/1490 train_time:6937ms step_avg:31.39ms
+step:222/1490 train_time:6972ms step_avg:31.40ms
+step:223/1490 train_time:7000ms step_avg:31.39ms
+step:224/1490 train_time:7035ms step_avg:31.40ms
+step:225/1490 train_time:7063ms step_avg:31.39ms
+step:226/1490 train_time:7097ms step_avg:31.40ms
+step:227/1490 train_time:7125ms step_avg:31.39ms
+step:228/1490 train_time:7159ms step_avg:31.40ms
+step:229/1490 train_time:7187ms step_avg:31.38ms
+step:230/1490 train_time:7221ms step_avg:31.40ms
+step:231/1490 train_time:7250ms step_avg:31.38ms
+step:232/1490 train_time:7285ms step_avg:31.40ms
+step:233/1490 train_time:7313ms step_avg:31.39ms
+step:234/1490 train_time:7347ms step_avg:31.40ms
+step:235/1490 train_time:7375ms step_avg:31.38ms
+step:236/1490 train_time:7410ms step_avg:31.40ms
+step:237/1490 train_time:7438ms step_avg:31.39ms
+step:238/1490 train_time:7473ms step_avg:31.40ms
+step:239/1490 train_time:7501ms step_avg:31.39ms
+step:240/1490 train_time:7536ms step_avg:31.40ms
+step:241/1490 train_time:7564ms step_avg:31.39ms
+step:242/1490 train_time:7598ms step_avg:31.40ms
+step:243/1490 train_time:7626ms step_avg:31.38ms
+step:244/1490 train_time:7660ms step_avg:31.39ms
+step:245/1490 train_time:7689ms step_avg:31.38ms
+step:246/1490 train_time:7723ms step_avg:31.39ms
+step:247/1490 train_time:7751ms step_avg:31.38ms
+step:248/1490 train_time:7785ms step_avg:31.39ms
+step:249/1490 train_time:7813ms step_avg:31.38ms
+step:250/1490 train_time:7847ms step_avg:31.39ms
+step:250/1490 val_loss:4.5042 train_time:7890ms step_avg:31.56ms
+step:251/1490 train_time:7906ms step_avg:31.50ms
+step:252/1490 train_time:7923ms step_avg:31.44ms
+step:253/1490 train_time:7941ms step_avg:31.39ms
+step:254/1490 train_time:7976ms step_avg:31.40ms
+step:255/1490 train_time:8006ms step_avg:31.40ms
+step:256/1490 train_time:8042ms step_avg:31.42ms
+step:257/1490 train_time:8071ms step_avg:31.41ms
+step:258/1490 train_time:8106ms step_avg:31.42ms
+step:259/1490 train_time:8134ms step_avg:31.41ms
+step:260/1490 train_time:8169ms step_avg:31.42ms
+step:261/1490 train_time:8197ms step_avg:31.41ms
+step:262/1490 train_time:8232ms step_avg:31.42ms
+step:263/1490 train_time:8260ms step_avg:31.41ms
+step:264/1490 train_time:8294ms step_avg:31.41ms
+step:265/1490 train_time:8322ms step_avg:31.40ms
+step:266/1490 train_time:8355ms step_avg:31.41ms
+step:267/1490 train_time:8384ms step_avg:31.40ms
+step:268/1490 train_time:8417ms step_avg:31.41ms
+step:269/1490 train_time:8445ms step_avg:31.40ms
+step:270/1490 train_time:8479ms step_avg:31.41ms
+step:271/1490 train_time:8508ms step_avg:31.40ms
+step:272/1490 train_time:8543ms step_avg:31.41ms
+step:273/1490 train_time:8570ms step_avg:31.39ms
+step:274/1490 train_time:8605ms step_avg:31.40ms
+step:275/1490 train_time:8632ms step_avg:31.39ms
+step:276/1490 train_time:8667ms step_avg:31.40ms
+step:277/1490 train_time:8695ms step_avg:31.39ms
+step:278/1490 train_time:8729ms step_avg:31.40ms
+step:279/1490 train_time:8757ms step_avg:31.39ms
+step:280/1490 train_time:8791ms step_avg:31.40ms
+step:281/1490 train_time:8819ms step_avg:31.39ms
+step:282/1490 train_time:8853ms step_avg:31.39ms
+step:283/1490 train_time:8882ms step_avg:31.38ms
+step:284/1490 train_time:8916ms step_avg:31.39ms
+step:285/1490 train_time:8945ms step_avg:31.39ms
+step:286/1490 train_time:8980ms step_avg:31.40ms
+step:287/1490 train_time:9009ms step_avg:31.39ms
+step:288/1490 train_time:9043ms step_avg:31.40ms
+step:289/1490 train_time:9072ms step_avg:31.39ms
+step:290/1490 train_time:9107ms step_avg:31.40ms
+step:291/1490 train_time:9135ms step_avg:31.39ms
+step:292/1490 train_time:9170ms step_avg:31.40ms
+step:293/1490 train_time:9199ms step_avg:31.39ms
+step:294/1490 train_time:9233ms step_avg:31.40ms
+step:295/1490 train_time:9261ms step_avg:31.39ms
+step:296/1490 train_time:9295ms step_avg:31.40ms
+step:297/1490 train_time:9324ms step_avg:31.39ms
+step:298/1490 train_time:9358ms step_avg:31.40ms
+step:299/1490 train_time:9386ms step_avg:31.39ms
+step:300/1490 train_time:9420ms step_avg:31.40ms
+step:301/1490 train_time:9448ms step_avg:31.39ms
+step:302/1490 train_time:9482ms step_avg:31.40ms
+step:303/1490 train_time:9510ms step_avg:31.39ms
+step:304/1490 train_time:9545ms step_avg:31.40ms
+step:305/1490 train_time:9573ms step_avg:31.39ms
+step:306/1490 train_time:9608ms step_avg:31.40ms
+step:307/1490 train_time:9636ms step_avg:31.39ms
+step:308/1490 train_time:9670ms step_avg:31.40ms
+step:309/1490 train_time:9698ms step_avg:31.39ms
+step:310/1490 train_time:9732ms step_avg:31.39ms
+step:311/1490 train_time:9761ms step_avg:31.38ms
+step:312/1490 train_time:9794ms step_avg:31.39ms
+step:313/1490 train_time:9823ms step_avg:31.38ms
+step:314/1490 train_time:9857ms step_avg:31.39ms
+step:315/1490 train_time:9885ms step_avg:31.38ms
+step:316/1490 train_time:9920ms step_avg:31.39ms
+step:317/1490 train_time:9948ms step_avg:31.38ms
+step:318/1490 train_time:9983ms step_avg:31.39ms
+step:319/1490 train_time:10011ms step_avg:31.38ms
+step:320/1490 train_time:10046ms step_avg:31.39ms
+step:321/1490 train_time:10075ms step_avg:31.38ms
+step:322/1490 train_time:10109ms step_avg:31.39ms
+step:323/1490 train_time:10138ms step_avg:31.39ms
+step:324/1490 train_time:10172ms step_avg:31.40ms
+step:325/1490 train_time:10201ms step_avg:31.39ms
+step:326/1490 train_time:10235ms step_avg:31.40ms
+step:327/1490 train_time:10263ms step_avg:31.39ms
+step:328/1490 train_time:10297ms step_avg:31.39ms
+step:329/1490 train_time:10325ms step_avg:31.38ms
+step:330/1490 train_time:10360ms step_avg:31.39ms
+step:331/1490 train_time:10388ms step_avg:31.38ms
+step:332/1490 train_time:10423ms step_avg:31.39ms
+step:333/1490 train_time:10451ms step_avg:31.38ms
+step:334/1490 train_time:10486ms step_avg:31.39ms
+step:335/1490 train_time:10514ms step_avg:31.39ms
+step:336/1490 train_time:10549ms step_avg:31.39ms
+step:337/1490 train_time:10577ms step_avg:31.39ms
+step:338/1490 train_time:10611ms step_avg:31.39ms
+step:339/1490 train_time:10639ms step_avg:31.38ms
+step:340/1490 train_time:10674ms step_avg:31.39ms
+step:341/1490 train_time:10702ms step_avg:31.38ms
+step:342/1490 train_time:10736ms step_avg:31.39ms
+step:343/1490 train_time:10764ms step_avg:31.38ms
+step:344/1490 train_time:10798ms step_avg:31.39ms
+step:345/1490 train_time:10826ms step_avg:31.38ms
+step:346/1490 train_time:10861ms step_avg:31.39ms
+step:347/1490 train_time:10890ms step_avg:31.38ms
+step:348/1490 train_time:10924ms step_avg:31.39ms
+step:349/1490 train_time:10952ms step_avg:31.38ms
+step:350/1490 train_time:10986ms step_avg:31.39ms
+step:351/1490 train_time:11015ms step_avg:31.38ms
+step:352/1490 train_time:11050ms step_avg:31.39ms
+step:353/1490 train_time:11078ms step_avg:31.38ms
+step:354/1490 train_time:11113ms step_avg:31.39ms
+step:355/1490 train_time:11141ms step_avg:31.38ms
+step:356/1490 train_time:11175ms step_avg:31.39ms
+step:357/1490 train_time:11203ms step_avg:31.38ms
+step:358/1490 train_time:11237ms step_avg:31.39ms
+step:359/1490 train_time:11266ms step_avg:31.38ms
+step:360/1490 train_time:11300ms step_avg:31.39ms
+step:361/1490 train_time:11328ms step_avg:31.38ms
+step:362/1490 train_time:11363ms step_avg:31.39ms
+step:363/1490 train_time:11391ms step_avg:31.38ms
+step:364/1490 train_time:11426ms step_avg:31.39ms
+step:365/1490 train_time:11454ms step_avg:31.38ms
+step:366/1490 train_time:11488ms step_avg:31.39ms
+step:367/1490 train_time:11516ms step_avg:31.38ms
+step:368/1490 train_time:11551ms step_avg:31.39ms
+step:369/1490 train_time:11579ms step_avg:31.38ms
+step:370/1490 train_time:11613ms step_avg:31.39ms
+step:371/1490 train_time:11642ms step_avg:31.38ms
+step:372/1490 train_time:11676ms step_avg:31.39ms
+step:373/1490 train_time:11704ms step_avg:31.38ms
+step:374/1490 train_time:11738ms step_avg:31.39ms
+step:375/1490 train_time:11766ms step_avg:31.38ms
+step:376/1490 train_time:11800ms step_avg:31.38ms
+step:377/1490 train_time:11829ms step_avg:31.38ms
+step:378/1490 train_time:11863ms step_avg:31.38ms
+step:379/1490 train_time:11892ms step_avg:31.38ms
+step:380/1490 train_time:11926ms step_avg:31.38ms
+step:381/1490 train_time:11954ms step_avg:31.38ms
+step:382/1490 train_time:11989ms step_avg:31.38ms
+step:383/1490 train_time:12018ms step_avg:31.38ms
+step:384/1490 train_time:12052ms step_avg:31.39ms
+step:385/1490 train_time:12081ms step_avg:31.38ms
+step:386/1490 train_time:12115ms step_avg:31.39ms
+step:387/1490 train_time:12143ms step_avg:31.38ms
+step:388/1490 train_time:12177ms step_avg:31.38ms
+step:389/1490 train_time:12205ms step_avg:31.38ms
+step:390/1490 train_time:12239ms step_avg:31.38ms
+step:391/1490 train_time:12268ms step_avg:31.38ms
+step:392/1490 train_time:12302ms step_avg:31.38ms
+step:393/1490 train_time:12330ms step_avg:31.37ms
+step:394/1490 train_time:12365ms step_avg:31.38ms
+step:395/1490 train_time:12393ms step_avg:31.37ms
+step:396/1490 train_time:12428ms step_avg:31.38ms
+step:397/1490 train_time:12455ms step_avg:31.37ms
+step:398/1490 train_time:12490ms step_avg:31.38ms
+step:399/1490 train_time:12518ms step_avg:31.37ms
+step:400/1490 train_time:12553ms step_avg:31.38ms
+step:401/1490 train_time:12581ms step_avg:31.37ms
+step:402/1490 train_time:12615ms step_avg:31.38ms
+step:403/1490 train_time:12643ms step_avg:31.37ms
+step:404/1490 train_time:12677ms step_avg:31.38ms
+step:405/1490 train_time:12705ms step_avg:31.37ms
+step:406/1490 train_time:12740ms step_avg:31.38ms
+step:407/1490 train_time:12768ms step_avg:31.37ms
+step:408/1490 train_time:12802ms step_avg:31.38ms
+step:409/1490 train_time:12831ms step_avg:31.37ms
+step:410/1490 train_time:12865ms step_avg:31.38ms
+step:411/1490 train_time:12893ms step_avg:31.37ms
+step:412/1490 train_time:12928ms step_avg:31.38ms
+step:413/1490 train_time:12956ms step_avg:31.37ms
+step:414/1490 train_time:12990ms step_avg:31.38ms
+step:415/1490 train_time:13019ms step_avg:31.37ms
+step:416/1490 train_time:13053ms step_avg:31.38ms
+step:417/1490 train_time:13082ms step_avg:31.37ms
+step:418/1490 train_time:13116ms step_avg:31.38ms
+step:419/1490 train_time:13144ms step_avg:31.37ms
+step:420/1490 train_time:13178ms step_avg:31.38ms
+step:421/1490 train_time:13207ms step_avg:31.37ms
+step:422/1490 train_time:13242ms step_avg:31.38ms
+step:423/1490 train_time:13270ms step_avg:31.37ms
+step:424/1490 train_time:13304ms step_avg:31.38ms
+step:425/1490 train_time:13333ms step_avg:31.37ms
+step:426/1490 train_time:13367ms step_avg:31.38ms
+step:427/1490 train_time:13395ms step_avg:31.37ms
+step:428/1490 train_time:13430ms step_avg:31.38ms
+step:429/1490 train_time:13458ms step_avg:31.37ms
+step:430/1490 train_time:13492ms step_avg:31.38ms
+step:431/1490 train_time:13521ms step_avg:31.37ms
+step:432/1490 train_time:13555ms step_avg:31.38ms
+step:433/1490 train_time:13583ms step_avg:31.37ms
+step:434/1490 train_time:13617ms step_avg:31.38ms
+step:435/1490 train_time:13646ms step_avg:31.37ms
+step:436/1490 train_time:13680ms step_avg:31.38ms
+step:437/1490 train_time:13708ms step_avg:31.37ms
+step:438/1490 train_time:13743ms step_avg:31.38ms
+step:439/1490 train_time:13771ms step_avg:31.37ms
+step:440/1490 train_time:13806ms step_avg:31.38ms
+step:441/1490 train_time:13833ms step_avg:31.37ms
+step:442/1490 train_time:13868ms step_avg:31.38ms
+step:443/1490 train_time:13897ms step_avg:31.37ms
+step:444/1490 train_time:13931ms step_avg:31.38ms
+step:445/1490 train_time:13959ms step_avg:31.37ms
+step:446/1490 train_time:13993ms step_avg:31.37ms
+step:447/1490 train_time:14021ms step_avg:31.37ms
+step:448/1490 train_time:14055ms step_avg:31.37ms
+step:449/1490 train_time:14083ms step_avg:31.37ms
+step:450/1490 train_time:14117ms step_avg:31.37ms
+step:451/1490 train_time:14146ms step_avg:31.37ms
+step:452/1490 train_time:14180ms step_avg:31.37ms
+step:453/1490 train_time:14208ms step_avg:31.36ms
+step:454/1490 train_time:14243ms step_avg:31.37ms
+step:455/1490 train_time:14271ms step_avg:31.36ms
+step:456/1490 train_time:14305ms step_avg:31.37ms
+step:457/1490 train_time:14334ms step_avg:31.36ms
+step:458/1490 train_time:14368ms step_avg:31.37ms
+step:459/1490 train_time:14396ms step_avg:31.36ms
+step:460/1490 train_time:14431ms step_avg:31.37ms
+step:461/1490 train_time:14459ms step_avg:31.36ms
+step:462/1490 train_time:14493ms step_avg:31.37ms
+step:463/1490 train_time:14521ms step_avg:31.36ms
+step:464/1490 train_time:14555ms step_avg:31.37ms
+step:465/1490 train_time:14583ms step_avg:31.36ms
+step:466/1490 train_time:14617ms step_avg:31.37ms
+step:467/1490 train_time:14645ms step_avg:31.36ms
+step:468/1490 train_time:14679ms step_avg:31.37ms
+step:469/1490 train_time:14708ms step_avg:31.36ms
+step:470/1490 train_time:14742ms step_avg:31.37ms
+step:471/1490 train_time:14771ms step_avg:31.36ms
+step:472/1490 train_time:14805ms step_avg:31.37ms
+step:473/1490 train_time:14833ms step_avg:31.36ms
+step:474/1490 train_time:14867ms step_avg:31.37ms
+step:475/1490 train_time:14895ms step_avg:31.36ms
+step:476/1490 train_time:14929ms step_avg:31.36ms
+step:477/1490 train_time:14958ms step_avg:31.36ms
+step:478/1490 train_time:14992ms step_avg:31.36ms
+step:479/1490 train_time:15020ms step_avg:31.36ms
+step:480/1490 train_time:15054ms step_avg:31.36ms
+step:481/1490 train_time:15083ms step_avg:31.36ms
+step:482/1490 train_time:15117ms step_avg:31.36ms
+step:483/1490 train_time:15145ms step_avg:31.36ms
+step:484/1490 train_time:15182ms step_avg:31.37ms
+step:485/1490 train_time:15233ms step_avg:31.41ms
+step:486/1490 train_time:15292ms step_avg:31.47ms
+step:487/1490 train_time:15347ms step_avg:31.51ms
+step:488/1490 train_time:15407ms step_avg:31.57ms
+step:489/1490 train_time:15460ms step_avg:31.62ms
+step:490/1490 train_time:15520ms step_avg:31.67ms
+step:491/1490 train_time:15573ms step_avg:31.72ms
+step:492/1490 train_time:15632ms step_avg:31.77ms
+step:493/1490 train_time:15687ms step_avg:31.82ms
+step:494/1490 train_time:15747ms step_avg:31.88ms
+step:495/1490 train_time:15801ms step_avg:31.92ms
+step:496/1490 train_time:15861ms step_avg:31.98ms
+step:497/1490 train_time:15917ms step_avg:32.03ms
+step:498/1490 train_time:15976ms step_avg:32.08ms
+step:499/1490 train_time:16030ms step_avg:32.12ms
+step:500/1490 train_time:16090ms step_avg:32.18ms
+step:500/1490 val_loss:4.2356 train_time:16161ms step_avg:32.32ms
+step:501/1490 train_time:16177ms step_avg:32.29ms
+step:502/1490 train_time:16204ms step_avg:32.28ms
+step:503/1490 train_time:16263ms step_avg:32.33ms
+step:504/1490 train_time:16327ms step_avg:32.39ms
+step:505/1490 train_time:16382ms step_avg:32.44ms
+step:506/1490 train_time:16442ms step_avg:32.49ms
+step:507/1490 train_time:16495ms step_avg:32.53ms
+step:508/1490 train_time:16554ms step_avg:32.59ms
+step:509/1490 train_time:16607ms step_avg:32.63ms
+step:510/1490 train_time:16666ms step_avg:32.68ms
+step:511/1490 train_time:16719ms step_avg:32.72ms
+step:512/1490 train_time:16778ms step_avg:32.77ms
+step:513/1490 train_time:16831ms step_avg:32.81ms
+step:514/1490 train_time:16890ms step_avg:32.86ms
+step:515/1490 train_time:16944ms step_avg:32.90ms
+step:516/1490 train_time:17002ms step_avg:32.95ms
+step:517/1490 train_time:17055ms step_avg:32.99ms
+step:518/1490 train_time:17116ms step_avg:33.04ms
+step:519/1490 train_time:17170ms step_avg:33.08ms
+step:520/1490 train_time:17231ms step_avg:33.14ms
+step:521/1490 train_time:17287ms step_avg:33.18ms
+step:522/1490 train_time:17349ms step_avg:33.24ms
+step:523/1490 train_time:17404ms step_avg:33.28ms
+step:524/1490 train_time:17465ms step_avg:33.33ms
+step:525/1490 train_time:17519ms step_avg:33.37ms
+step:526/1490 train_time:17578ms step_avg:33.42ms
+step:527/1490 train_time:17631ms step_avg:33.46ms
+step:528/1490 train_time:17690ms step_avg:33.50ms
+step:529/1490 train_time:17744ms step_avg:33.54ms
+step:530/1490 train_time:17804ms step_avg:33.59ms
+step:531/1490 train_time:17857ms step_avg:33.63ms
+step:532/1490 train_time:17916ms step_avg:33.68ms
+step:533/1490 train_time:17968ms step_avg:33.71ms
+step:534/1490 train_time:18028ms step_avg:33.76ms
+step:535/1490 train_time:18081ms step_avg:33.80ms
+step:536/1490 train_time:18141ms step_avg:33.84ms
+step:537/1490 train_time:18195ms step_avg:33.88ms
+step:538/1490 train_time:18256ms step_avg:33.93ms
+step:539/1490 train_time:18311ms step_avg:33.97ms
+step:540/1490 train_time:18371ms step_avg:34.02ms
+step:541/1490 train_time:18426ms step_avg:34.06ms
+step:542/1490 train_time:18485ms step_avg:34.11ms
+step:543/1490 train_time:18540ms step_avg:34.14ms
+step:544/1490 train_time:18599ms step_avg:34.19ms
+step:545/1490 train_time:18652ms step_avg:34.22ms
+step:546/1490 train_time:18712ms step_avg:34.27ms
+step:547/1490 train_time:18766ms step_avg:34.31ms
+step:548/1490 train_time:18825ms step_avg:34.35ms
+step:549/1490 train_time:18878ms step_avg:34.39ms
+step:550/1490 train_time:18937ms step_avg:34.43ms
+step:551/1490 train_time:18991ms step_avg:34.47ms
+step:552/1490 train_time:19050ms step_avg:34.51ms
+step:553/1490 train_time:19104ms step_avg:34.55ms
+step:554/1490 train_time:19163ms step_avg:34.59ms
+step:555/1490 train_time:19218ms step_avg:34.63ms
+step:556/1490 train_time:19277ms step_avg:34.67ms
+step:557/1490 train_time:19332ms step_avg:34.71ms
+step:558/1490 train_time:19392ms step_avg:34.75ms
+step:559/1490 train_time:19447ms step_avg:34.79ms
+step:560/1490 train_time:19507ms step_avg:34.83ms
+step:561/1490 train_time:19561ms step_avg:34.87ms
+step:562/1490 train_time:19621ms step_avg:34.91ms
+step:563/1490 train_time:19674ms step_avg:34.95ms
+step:564/1490 train_time:19734ms step_avg:34.99ms
+step:565/1490 train_time:19787ms step_avg:35.02ms
+step:566/1490 train_time:19847ms step_avg:35.07ms
+step:567/1490 train_time:19902ms step_avg:35.10ms
+step:568/1490 train_time:19961ms step_avg:35.14ms
+step:569/1490 train_time:20014ms step_avg:35.17ms
+step:570/1490 train_time:20073ms step_avg:35.22ms
+step:571/1490 train_time:20127ms step_avg:35.25ms
+step:572/1490 train_time:20187ms step_avg:35.29ms
+step:573/1490 train_time:20241ms step_avg:35.33ms
+step:574/1490 train_time:20301ms step_avg:35.37ms
+step:575/1490 train_time:20355ms step_avg:35.40ms
+step:576/1490 train_time:20416ms step_avg:35.44ms
+step:577/1490 train_time:20470ms step_avg:35.48ms
+step:578/1490 train_time:20530ms step_avg:35.52ms
+step:579/1490 train_time:20584ms step_avg:35.55ms
+step:580/1490 train_time:20644ms step_avg:35.59ms
+step:581/1490 train_time:20697ms step_avg:35.62ms
+step:582/1490 train_time:20757ms step_avg:35.66ms
+step:583/1490 train_time:20811ms step_avg:35.70ms
+step:584/1490 train_time:20870ms step_avg:35.74ms
+step:585/1490 train_time:20924ms step_avg:35.77ms
+step:586/1490 train_time:20984ms step_avg:35.81ms
+step:587/1490 train_time:21037ms step_avg:35.84ms
+step:588/1490 train_time:21096ms step_avg:35.88ms
+step:589/1490 train_time:21150ms step_avg:35.91ms
+step:590/1490 train_time:21211ms step_avg:35.95ms
+step:591/1490 train_time:21264ms step_avg:35.98ms
+step:592/1490 train_time:21324ms step_avg:36.02ms
+step:593/1490 train_time:21379ms step_avg:36.05ms
+step:594/1490 train_time:21439ms step_avg:36.09ms
+step:595/1490 train_time:21493ms step_avg:36.12ms
+step:596/1490 train_time:21553ms step_avg:36.16ms
+step:597/1490 train_time:21607ms step_avg:36.19ms
+step:598/1490 train_time:21667ms step_avg:36.23ms
+step:599/1490 train_time:21721ms step_avg:36.26ms
+step:600/1490 train_time:21781ms step_avg:36.30ms
+step:601/1490 train_time:21835ms step_avg:36.33ms
+step:602/1490 train_time:21894ms step_avg:36.37ms
+step:603/1490 train_time:21949ms step_avg:36.40ms
+step:604/1490 train_time:22009ms step_avg:36.44ms
+step:605/1490 train_time:22063ms step_avg:36.47ms
+step:606/1490 train_time:22122ms step_avg:36.51ms
+step:607/1490 train_time:22175ms step_avg:36.53ms
+step:608/1490 train_time:22235ms step_avg:36.57ms
+step:609/1490 train_time:22289ms step_avg:36.60ms
+step:610/1490 train_time:22350ms step_avg:36.64ms
+step:611/1490 train_time:22404ms step_avg:36.67ms
+step:612/1490 train_time:22464ms step_avg:36.71ms
+step:613/1490 train_time:22518ms step_avg:36.73ms
+step:614/1490 train_time:22577ms step_avg:36.77ms
+step:615/1490 train_time:22632ms step_avg:36.80ms
+step:616/1490 train_time:22691ms step_avg:36.84ms
+step:617/1490 train_time:22745ms step_avg:36.86ms
+step:618/1490 train_time:22806ms step_avg:36.90ms
+step:619/1490 train_time:22860ms step_avg:36.93ms
+step:620/1490 train_time:22919ms step_avg:36.97ms
+step:621/1490 train_time:22973ms step_avg:36.99ms
+step:622/1490 train_time:23033ms step_avg:37.03ms
+step:623/1490 train_time:23087ms step_avg:37.06ms
+step:624/1490 train_time:23147ms step_avg:37.10ms
+step:625/1490 train_time:23202ms step_avg:37.12ms
+step:626/1490 train_time:23261ms step_avg:37.16ms
+step:627/1490 train_time:23314ms step_avg:37.18ms
+step:628/1490 train_time:23373ms step_avg:37.22ms
+step:629/1490 train_time:23428ms step_avg:37.25ms
+step:630/1490 train_time:23487ms step_avg:37.28ms
+step:631/1490 train_time:23542ms step_avg:37.31ms
+step:632/1490 train_time:23601ms step_avg:37.34ms
+step:633/1490 train_time:23655ms step_avg:37.37ms
+step:634/1490 train_time:23715ms step_avg:37.40ms
+step:635/1490 train_time:23769ms step_avg:37.43ms
+step:636/1490 train_time:23829ms step_avg:37.47ms
+step:637/1490 train_time:23882ms step_avg:37.49ms
+step:638/1490 train_time:23942ms step_avg:37.53ms
+step:639/1490 train_time:23996ms step_avg:37.55ms
+step:640/1490 train_time:24056ms step_avg:37.59ms
+step:641/1490 train_time:24111ms step_avg:37.61ms
+step:642/1490 train_time:24171ms step_avg:37.65ms
+step:643/1490 train_time:24224ms step_avg:37.67ms
+step:644/1490 train_time:24284ms step_avg:37.71ms
+step:645/1490 train_time:24338ms step_avg:37.73ms
+step:646/1490 train_time:24397ms step_avg:37.77ms
+step:647/1490 train_time:24451ms step_avg:37.79ms
+step:648/1490 train_time:24511ms step_avg:37.83ms
+step:649/1490 train_time:24565ms step_avg:37.85ms
+step:650/1490 train_time:24624ms step_avg:37.88ms
+step:651/1490 train_time:24679ms step_avg:37.91ms
+step:652/1490 train_time:24738ms step_avg:37.94ms
+step:653/1490 train_time:24792ms step_avg:37.97ms
+step:654/1490 train_time:24851ms step_avg:38.00ms
+step:655/1490 train_time:24906ms step_avg:38.02ms
+step:656/1490 train_time:24966ms step_avg:38.06ms
+step:657/1490 train_time:25019ms step_avg:38.08ms
+step:658/1490 train_time:25078ms step_avg:38.11ms
+step:659/1490 train_time:25132ms step_avg:38.14ms
+step:660/1490 train_time:25191ms step_avg:38.17ms
+step:661/1490 train_time:25246ms step_avg:38.19ms
+step:662/1490 train_time:25305ms step_avg:38.23ms
+step:663/1490 train_time:25359ms step_avg:38.25ms
+step:664/1490 train_time:25418ms step_avg:38.28ms
+step:665/1490 train_time:25472ms step_avg:38.30ms
+step:666/1490 train_time:25532ms step_avg:38.34ms
+step:667/1490 train_time:25585ms step_avg:38.36ms
+step:668/1490 train_time:25645ms step_avg:38.39ms
+step:669/1490 train_time:25700ms step_avg:38.42ms
+step:670/1490 train_time:25760ms step_avg:38.45ms
+step:671/1490 train_time:25814ms step_avg:38.47ms
+step:672/1490 train_time:25873ms step_avg:38.50ms
+step:673/1490 train_time:25927ms step_avg:38.52ms
+step:674/1490 train_time:25987ms step_avg:38.56ms
+step:675/1490 train_time:26041ms step_avg:38.58ms
+step:676/1490 train_time:26101ms step_avg:38.61ms
+step:677/1490 train_time:26154ms step_avg:38.63ms
+step:678/1490 train_time:26215ms step_avg:38.66ms
+step:679/1490 train_time:26268ms step_avg:38.69ms
+step:680/1490 train_time:26328ms step_avg:38.72ms
+step:681/1490 train_time:26381ms step_avg:38.74ms
+step:682/1490 train_time:26441ms step_avg:38.77ms
+step:683/1490 train_time:26495ms step_avg:38.79ms
+step:684/1490 train_time:26555ms step_avg:38.82ms
+step:685/1490 train_time:26609ms step_avg:38.85ms
+step:686/1490 train_time:26668ms step_avg:38.88ms
+step:687/1490 train_time:26722ms step_avg:38.90ms
+step:688/1490 train_time:26782ms step_avg:38.93ms
+step:689/1490 train_time:26836ms step_avg:38.95ms
+step:690/1490 train_time:26895ms step_avg:38.98ms
+step:691/1490 train_time:26949ms step_avg:39.00ms
+step:692/1490 train_time:27010ms step_avg:39.03ms
+step:693/1490 train_time:27065ms step_avg:39.05ms
+step:694/1490 train_time:27124ms step_avg:39.08ms
+step:695/1490 train_time:27178ms step_avg:39.10ms
+step:696/1490 train_time:27237ms step_avg:39.13ms
+step:697/1490 train_time:27291ms step_avg:39.16ms
+step:698/1490 train_time:27351ms step_avg:39.19ms
+step:699/1490 train_time:27405ms step_avg:39.21ms
+step:700/1490 train_time:27466ms step_avg:39.24ms
+step:701/1490 train_time:27519ms step_avg:39.26ms
+step:702/1490 train_time:27578ms step_avg:39.29ms
+step:703/1490 train_time:27632ms step_avg:39.31ms
+step:704/1490 train_time:27691ms step_avg:39.33ms
+step:705/1490 train_time:27747ms step_avg:39.36ms
+step:706/1490 train_time:27807ms step_avg:39.39ms
+step:707/1490 train_time:27862ms step_avg:39.41ms
+step:708/1490 train_time:27922ms step_avg:39.44ms
+step:709/1490 train_time:27975ms step_avg:39.46ms
+step:710/1490 train_time:28034ms step_avg:39.48ms
+step:711/1490 train_time:28088ms step_avg:39.51ms
+step:712/1490 train_time:28149ms step_avg:39.53ms
+step:713/1490 train_time:28203ms step_avg:39.55ms
+step:714/1490 train_time:28262ms step_avg:39.58ms
+step:715/1490 train_time:28316ms step_avg:39.60ms
+step:716/1490 train_time:28375ms step_avg:39.63ms
+step:717/1490 train_time:28429ms step_avg:39.65ms
+step:718/1490 train_time:28489ms step_avg:39.68ms
+step:719/1490 train_time:28544ms step_avg:39.70ms
+step:720/1490 train_time:28605ms step_avg:39.73ms
+step:721/1490 train_time:28658ms step_avg:39.75ms
+step:722/1490 train_time:28718ms step_avg:39.78ms
+step:723/1490 train_time:28772ms step_avg:39.80ms
+step:724/1490 train_time:28832ms step_avg:39.82ms
+step:725/1490 train_time:28886ms step_avg:39.84ms
+step:726/1490 train_time:28945ms step_avg:39.87ms
+step:727/1490 train_time:28999ms step_avg:39.89ms
+step:728/1490 train_time:29057ms step_avg:39.91ms
+step:729/1490 train_time:29112ms step_avg:39.93ms
+step:730/1490 train_time:29172ms step_avg:39.96ms
+step:731/1490 train_time:29226ms step_avg:39.98ms
+step:732/1490 train_time:29286ms step_avg:40.01ms
+step:733/1490 train_time:29339ms step_avg:40.03ms
+step:734/1490 train_time:29398ms step_avg:40.05ms
+step:735/1490 train_time:29453ms step_avg:40.07ms
+step:736/1490 train_time:29513ms step_avg:40.10ms
+step:737/1490 train_time:29567ms step_avg:40.12ms
+step:738/1490 train_time:29626ms step_avg:40.14ms
+step:739/1490 train_time:29680ms step_avg:40.16ms
+step:740/1490 train_time:29740ms step_avg:40.19ms
+step:741/1490 train_time:29793ms step_avg:40.21ms
+step:742/1490 train_time:29853ms step_avg:40.23ms
+step:743/1490 train_time:29908ms step_avg:40.25ms
+step:744/1490 train_time:29967ms step_avg:40.28ms
+step:745/1490 train_time:30022ms step_avg:40.30ms
+step:746/1490 train_time:30082ms step_avg:40.32ms
+step:747/1490 train_time:30135ms step_avg:40.34ms
+step:748/1490 train_time:30195ms step_avg:40.37ms
+step:749/1490 train_time:30250ms step_avg:40.39ms
+step:750/1490 train_time:30309ms step_avg:40.41ms
+step:750/1490 val_loss:3.8069 train_time:30381ms step_avg:40.51ms
+step:751/1490 train_time:30397ms step_avg:40.48ms
+step:752/1490 train_time:30425ms step_avg:40.46ms
+step:753/1490 train_time:30485ms step_avg:40.48ms
+step:754/1490 train_time:30548ms step_avg:40.51ms
+step:755/1490 train_time:30603ms step_avg:40.53ms
+step:756/1490 train_time:30664ms step_avg:40.56ms
+step:757/1490 train_time:30718ms step_avg:40.58ms
+step:758/1490 train_time:30776ms step_avg:40.60ms
+step:759/1490 train_time:30830ms step_avg:40.62ms
+step:760/1490 train_time:30889ms step_avg:40.64ms
+step:761/1490 train_time:30942ms step_avg:40.66ms
+step:762/1490 train_time:31001ms step_avg:40.68ms
+step:763/1490 train_time:31054ms step_avg:40.70ms
+step:764/1490 train_time:31113ms step_avg:40.72ms
+step:765/1490 train_time:31167ms step_avg:40.74ms
+step:766/1490 train_time:31227ms step_avg:40.77ms
+step:767/1490 train_time:31281ms step_avg:40.78ms
+step:768/1490 train_time:31341ms step_avg:40.81ms
+step:769/1490 train_time:31396ms step_avg:40.83ms
+step:770/1490 train_time:31457ms step_avg:40.85ms
+step:771/1490 train_time:31512ms step_avg:40.87ms
+step:772/1490 train_time:31574ms step_avg:40.90ms
+step:773/1490 train_time:31629ms step_avg:40.92ms
+step:774/1490 train_time:31689ms step_avg:40.94ms
+step:775/1490 train_time:31743ms step_avg:40.96ms
+step:776/1490 train_time:31803ms step_avg:40.98ms
+step:777/1490 train_time:31857ms step_avg:41.00ms
+step:778/1490 train_time:31916ms step_avg:41.02ms
+step:779/1490 train_time:31970ms step_avg:41.04ms
+step:780/1490 train_time:32028ms step_avg:41.06ms
+step:781/1490 train_time:32082ms step_avg:41.08ms
+step:782/1490 train_time:32141ms step_avg:41.10ms
+step:783/1490 train_time:32194ms step_avg:41.12ms
+step:784/1490 train_time:32254ms step_avg:41.14ms
+step:785/1490 train_time:32308ms step_avg:41.16ms
+step:786/1490 train_time:32369ms step_avg:41.18ms
+step:787/1490 train_time:32424ms step_avg:41.20ms
+step:788/1490 train_time:32484ms step_avg:41.22ms
+step:789/1490 train_time:32540ms step_avg:41.24ms
+step:790/1490 train_time:32600ms step_avg:41.27ms
+step:791/1490 train_time:32654ms step_avg:41.28ms
+step:792/1490 train_time:32714ms step_avg:41.31ms
+step:793/1490 train_time:32769ms step_avg:41.32ms
+step:794/1490 train_time:32829ms step_avg:41.35ms
+step:795/1490 train_time:32883ms step_avg:41.36ms
+step:796/1490 train_time:32942ms step_avg:41.38ms
+step:797/1490 train_time:32995ms step_avg:41.40ms
+step:798/1490 train_time:33054ms step_avg:41.42ms
+step:799/1490 train_time:33108ms step_avg:41.44ms
+step:800/1490 train_time:33167ms step_avg:41.46ms
+step:801/1490 train_time:33222ms step_avg:41.48ms
+step:802/1490 train_time:33281ms step_avg:41.50ms
+step:803/1490 train_time:33334ms step_avg:41.51ms
+step:804/1490 train_time:33394ms step_avg:41.54ms
+step:805/1490 train_time:33449ms step_avg:41.55ms
+step:806/1490 train_time:33509ms step_avg:41.57ms
+step:807/1490 train_time:33564ms step_avg:41.59ms
+step:808/1490 train_time:33624ms step_avg:41.61ms
+step:809/1490 train_time:33679ms step_avg:41.63ms
+step:810/1490 train_time:33739ms step_avg:41.65ms
+step:811/1490 train_time:33792ms step_avg:41.67ms
+step:812/1490 train_time:33852ms step_avg:41.69ms
+step:813/1490 train_time:33905ms step_avg:41.70ms
+step:814/1490 train_time:33965ms step_avg:41.73ms
+step:815/1490 train_time:34018ms step_avg:41.74ms
+step:816/1490 train_time:34077ms step_avg:41.76ms
+step:817/1490 train_time:34132ms step_avg:41.78ms
+step:818/1490 train_time:34191ms step_avg:41.80ms
+step:819/1490 train_time:34245ms step_avg:41.81ms
+step:820/1490 train_time:34305ms step_avg:41.84ms
+step:821/1490 train_time:34359ms step_avg:41.85ms
+step:822/1490 train_time:34418ms step_avg:41.87ms
+step:823/1490 train_time:34472ms step_avg:41.89ms
+step:824/1490 train_time:34533ms step_avg:41.91ms
+step:825/1490 train_time:34587ms step_avg:41.92ms
+step:826/1490 train_time:34646ms step_avg:41.94ms
+step:827/1490 train_time:34700ms step_avg:41.96ms
+step:828/1490 train_time:34759ms step_avg:41.98ms
+step:829/1490 train_time:34813ms step_avg:41.99ms
+step:830/1490 train_time:34873ms step_avg:42.02ms
+step:831/1490 train_time:34926ms step_avg:42.03ms
+step:832/1490 train_time:34986ms step_avg:42.05ms
+step:833/1490 train_time:35039ms step_avg:42.06ms
+step:834/1490 train_time:35099ms step_avg:42.09ms
+step:835/1490 train_time:35153ms step_avg:42.10ms
+step:836/1490 train_time:35212ms step_avg:42.12ms
+step:837/1490 train_time:35266ms step_avg:42.13ms
+step:838/1490 train_time:35326ms step_avg:42.16ms
+step:839/1490 train_time:35380ms step_avg:42.17ms
+step:840/1490 train_time:35440ms step_avg:42.19ms
+step:841/1490 train_time:35494ms step_avg:42.20ms
+step:842/1490 train_time:35553ms step_avg:42.22ms
+step:843/1490 train_time:35608ms step_avg:42.24ms
+step:844/1490 train_time:35667ms step_avg:42.26ms
+step:845/1490 train_time:35722ms step_avg:42.27ms
+step:846/1490 train_time:35782ms step_avg:42.30ms
+step:847/1490 train_time:35835ms step_avg:42.31ms
+step:848/1490 train_time:35894ms step_avg:42.33ms
+step:849/1490 train_time:35948ms step_avg:42.34ms
+step:850/1490 train_time:36007ms step_avg:42.36ms
+step:851/1490 train_time:36061ms step_avg:42.38ms
+step:852/1490 train_time:36122ms step_avg:42.40ms
+step:853/1490 train_time:36175ms step_avg:42.41ms
+step:854/1490 train_time:36235ms step_avg:42.43ms
+step:855/1490 train_time:36289ms step_avg:42.44ms
+step:856/1490 train_time:36349ms step_avg:42.46ms
+step:857/1490 train_time:36403ms step_avg:42.48ms
+step:858/1490 train_time:36463ms step_avg:42.50ms
+step:859/1490 train_time:36518ms step_avg:42.51ms
+step:860/1490 train_time:36577ms step_avg:42.53ms
+step:861/1490 train_time:36631ms step_avg:42.54ms
+step:862/1490 train_time:36690ms step_avg:42.56ms
+step:863/1490 train_time:36744ms step_avg:42.58ms
+step:864/1490 train_time:36805ms step_avg:42.60ms
+step:865/1490 train_time:36860ms step_avg:42.61ms
+step:866/1490 train_time:36919ms step_avg:42.63ms
+step:867/1490 train_time:36973ms step_avg:42.65ms
+step:868/1490 train_time:37034ms step_avg:42.67ms
+step:869/1490 train_time:37088ms step_avg:42.68ms
+step:870/1490 train_time:37148ms step_avg:42.70ms
+step:871/1490 train_time:37201ms step_avg:42.71ms
+step:872/1490 train_time:37261ms step_avg:42.73ms
+step:873/1490 train_time:37315ms step_avg:42.74ms
+step:874/1490 train_time:37375ms step_avg:42.76ms
+step:875/1490 train_time:37429ms step_avg:42.78ms
+step:876/1490 train_time:37489ms step_avg:42.80ms
+step:877/1490 train_time:37543ms step_avg:42.81ms
+step:878/1490 train_time:37602ms step_avg:42.83ms
+step:879/1490 train_time:37656ms step_avg:42.84ms
+step:880/1490 train_time:37716ms step_avg:42.86ms
+step:881/1490 train_time:37771ms step_avg:42.87ms
+step:882/1490 train_time:37830ms step_avg:42.89ms
+step:883/1490 train_time:37884ms step_avg:42.90ms
+step:884/1490 train_time:37944ms step_avg:42.92ms
+step:885/1490 train_time:37999ms step_avg:42.94ms
+step:886/1490 train_time:38058ms step_avg:42.95ms
+step:887/1490 train_time:38112ms step_avg:42.97ms
+step:888/1490 train_time:38171ms step_avg:42.99ms
+step:889/1490 train_time:38225ms step_avg:43.00ms
+step:890/1490 train_time:38285ms step_avg:43.02ms
+step:891/1490 train_time:38339ms step_avg:43.03ms
+step:892/1490 train_time:38398ms step_avg:43.05ms
+step:893/1490 train_time:38452ms step_avg:43.06ms
+step:894/1490 train_time:38511ms step_avg:43.08ms
+step:895/1490 train_time:38566ms step_avg:43.09ms
+step:896/1490 train_time:38627ms step_avg:43.11ms
+step:897/1490 train_time:38681ms step_avg:43.12ms
+step:898/1490 train_time:38740ms step_avg:43.14ms
+step:899/1490 train_time:38794ms step_avg:43.15ms
+step:900/1490 train_time:38853ms step_avg:43.17ms
+step:901/1490 train_time:38907ms step_avg:43.18ms
+step:902/1490 train_time:38967ms step_avg:43.20ms
+step:903/1490 train_time:39022ms step_avg:43.21ms
+step:904/1490 train_time:39082ms step_avg:43.23ms
+step:905/1490 train_time:39135ms step_avg:43.24ms
+step:906/1490 train_time:39194ms step_avg:43.26ms
+step:907/1490 train_time:39249ms step_avg:43.27ms
+step:908/1490 train_time:39308ms step_avg:43.29ms
+step:909/1490 train_time:39363ms step_avg:43.30ms
+step:910/1490 train_time:39423ms step_avg:43.32ms
+step:911/1490 train_time:39477ms step_avg:43.33ms
+step:912/1490 train_time:39536ms step_avg:43.35ms
+step:913/1490 train_time:39591ms step_avg:43.36ms
+step:914/1490 train_time:39650ms step_avg:43.38ms
+step:915/1490 train_time:39705ms step_avg:43.39ms
+step:916/1490 train_time:39765ms step_avg:43.41ms
+step:917/1490 train_time:39819ms step_avg:43.42ms
+step:918/1490 train_time:39878ms step_avg:43.44ms
+step:919/1490 train_time:39933ms step_avg:43.45ms
+step:920/1490 train_time:39992ms step_avg:43.47ms
+step:921/1490 train_time:40046ms step_avg:43.48ms
+step:922/1490 train_time:40106ms step_avg:43.50ms
+step:923/1490 train_time:40160ms step_avg:43.51ms
+step:924/1490 train_time:40219ms step_avg:43.53ms
+step:925/1490 train_time:40273ms step_avg:43.54ms
+step:926/1490 train_time:40333ms step_avg:43.56ms
+step:927/1490 train_time:40386ms step_avg:43.57ms
+step:928/1490 train_time:40446ms step_avg:43.58ms
+step:929/1490 train_time:40500ms step_avg:43.59ms
+step:930/1490 train_time:40559ms step_avg:43.61ms
+step:931/1490 train_time:40613ms step_avg:43.62ms
+step:932/1490 train_time:40673ms step_avg:43.64ms
+step:933/1490 train_time:40727ms step_avg:43.65ms
+step:934/1490 train_time:40787ms step_avg:43.67ms
+step:935/1490 train_time:40841ms step_avg:43.68ms
+step:936/1490 train_time:40901ms step_avg:43.70ms
+step:937/1490 train_time:40955ms step_avg:43.71ms
+step:938/1490 train_time:41015ms step_avg:43.73ms
+step:939/1490 train_time:41069ms step_avg:43.74ms
+step:940/1490 train_time:41129ms step_avg:43.75ms
+step:941/1490 train_time:41183ms step_avg:43.76ms
+step:942/1490 train_time:41242ms step_avg:43.78ms
+step:943/1490 train_time:41295ms step_avg:43.79ms
+step:944/1490 train_time:41355ms step_avg:43.81ms
+step:945/1490 train_time:41410ms step_avg:43.82ms
+step:946/1490 train_time:41469ms step_avg:43.84ms
+step:947/1490 train_time:41523ms step_avg:43.85ms
+step:948/1490 train_time:41583ms step_avg:43.86ms
+step:949/1490 train_time:41636ms step_avg:43.87ms
+step:950/1490 train_time:41696ms step_avg:43.89ms
+step:951/1490 train_time:41750ms step_avg:43.90ms
+step:952/1490 train_time:41810ms step_avg:43.92ms
+step:953/1490 train_time:41864ms step_avg:43.93ms
+step:954/1490 train_time:41924ms step_avg:43.95ms
+step:955/1490 train_time:41979ms step_avg:43.96ms
+step:956/1490 train_time:42038ms step_avg:43.97ms
+step:957/1490 train_time:42092ms step_avg:43.98ms
+step:958/1490 train_time:42151ms step_avg:44.00ms
+step:959/1490 train_time:42205ms step_avg:44.01ms
+step:960/1490 train_time:42265ms step_avg:44.03ms
+step:961/1490 train_time:42320ms step_avg:44.04ms
+step:962/1490 train_time:42379ms step_avg:44.05ms
+step:963/1490 train_time:42433ms step_avg:44.06ms
+step:964/1490 train_time:42492ms step_avg:44.08ms
+step:965/1490 train_time:42546ms step_avg:44.09ms
+step:966/1490 train_time:42606ms step_avg:44.11ms
+step:967/1490 train_time:42661ms step_avg:44.12ms
+step:968/1490 train_time:42724ms step_avg:44.14ms
+step:969/1490 train_time:42802ms step_avg:44.17ms
+step:970/1490 train_time:42888ms step_avg:44.21ms
+step:971/1490 train_time:42969ms step_avg:44.25ms
+step:972/1490 train_time:43054ms step_avg:44.29ms
+step:973/1490 train_time:43133ms step_avg:44.33ms
+step:974/1490 train_time:43218ms step_avg:44.37ms
+step:975/1490 train_time:43298ms step_avg:44.41ms
+step:976/1490 train_time:43384ms step_avg:44.45ms
+step:977/1490 train_time:43465ms step_avg:44.49ms
+step:978/1490 train_time:43551ms step_avg:44.53ms
+step:979/1490 train_time:43632ms step_avg:44.57ms
+step:980/1490 train_time:43716ms step_avg:44.61ms
+step:981/1490 train_time:43797ms step_avg:44.65ms
+step:982/1490 train_time:43882ms step_avg:44.69ms
+step:983/1490 train_time:43963ms step_avg:44.72ms
+step:984/1490 train_time:44048ms step_avg:44.76ms
+step:985/1490 train_time:44129ms step_avg:44.80ms
+step:986/1490 train_time:44215ms step_avg:44.84ms
+step:987/1490 train_time:44294ms step_avg:44.88ms
+step:988/1490 train_time:44379ms step_avg:44.92ms
+step:989/1490 train_time:44460ms step_avg:44.95ms
+step:990/1490 train_time:44545ms step_avg:45.00ms
+step:991/1490 train_time:44626ms step_avg:45.03ms
+step:992/1490 train_time:44713ms step_avg:45.07ms
+step:993/1490 train_time:44793ms step_avg:45.11ms
+step:994/1490 train_time:44879ms step_avg:45.15ms
+step:995/1490 train_time:44960ms step_avg:45.19ms
+step:996/1490 train_time:45046ms step_avg:45.23ms
+step:997/1490 train_time:45125ms step_avg:45.26ms
+step:998/1490 train_time:45210ms step_avg:45.30ms
+step:999/1490 train_time:45291ms step_avg:45.34ms
+step:1000/1490 train_time:45376ms step_avg:45.38ms
+step:1000/1490 val_loss:3.5176 train_time:45478ms step_avg:45.48ms
+step:1001/1490 train_time:45494ms step_avg:45.45ms
+step:1002/1490 train_time:45545ms step_avg:45.45ms
+step:1003/1490 train_time:45633ms step_avg:45.50ms
+step:1004/1490 train_time:45720ms step_avg:45.54ms
+step:1005/1490 train_time:45800ms step_avg:45.57ms
+step:1006/1490 train_time:45884ms step_avg:45.61ms
+step:1007/1490 train_time:45965ms step_avg:45.64ms
+step:1008/1490 train_time:46050ms step_avg:45.68ms
+step:1009/1490 train_time:46128ms step_avg:45.72ms
+step:1010/1490 train_time:46211ms step_avg:45.75ms
+step:1011/1490 train_time:46291ms step_avg:45.79ms
+step:1012/1490 train_time:46375ms step_avg:45.83ms
+step:1013/1490 train_time:46458ms step_avg:45.86ms
+step:1014/1490 train_time:46547ms step_avg:45.90ms
+step:1015/1490 train_time:46629ms step_avg:45.94ms
+step:1016/1490 train_time:46717ms step_avg:45.98ms
+step:1017/1490 train_time:46797ms step_avg:46.02ms
+step:1018/1490 train_time:46882ms step_avg:46.05ms
+step:1019/1490 train_time:46961ms step_avg:46.09ms
+step:1020/1490 train_time:47047ms step_avg:46.12ms
+step:1021/1490 train_time:47126ms step_avg:46.16ms
+step:1022/1490 train_time:47210ms step_avg:46.19ms
+step:1023/1490 train_time:47289ms step_avg:46.23ms
+step:1024/1490 train_time:47375ms step_avg:46.26ms
+step:1025/1490 train_time:47456ms step_avg:46.30ms
+step:1026/1490 train_time:47544ms step_avg:46.34ms
+step:1027/1490 train_time:47628ms step_avg:46.38ms
+step:1028/1490 train_time:47716ms step_avg:46.42ms
+step:1029/1490 train_time:47797ms step_avg:46.45ms
+step:1030/1490 train_time:47882ms step_avg:46.49ms
+step:1031/1490 train_time:47962ms step_avg:46.52ms
+step:1032/1490 train_time:48047ms step_avg:46.56ms
+step:1033/1490 train_time:48127ms step_avg:46.59ms
+step:1034/1490 train_time:48213ms step_avg:46.63ms
+step:1035/1490 train_time:48292ms step_avg:46.66ms
+step:1036/1490 train_time:48377ms step_avg:46.70ms
+step:1037/1490 train_time:48458ms step_avg:46.73ms
+step:1038/1490 train_time:48544ms step_avg:46.77ms
+step:1039/1490 train_time:48627ms step_avg:46.80ms
+step:1040/1490 train_time:48715ms step_avg:46.84ms
+step:1041/1490 train_time:48796ms step_avg:46.87ms
+step:1042/1490 train_time:48881ms step_avg:46.91ms
+step:1043/1490 train_time:48962ms step_avg:46.94ms
+step:1044/1490 train_time:49047ms step_avg:46.98ms
+step:1045/1490 train_time:49127ms step_avg:47.01ms
+step:1046/1490 train_time:49211ms step_avg:47.05ms
+step:1047/1490 train_time:49291ms step_avg:47.08ms
+step:1048/1490 train_time:49377ms step_avg:47.11ms
+step:1049/1490 train_time:49457ms step_avg:47.15ms
+step:1050/1490 train_time:49542ms step_avg:47.18ms
+step:1051/1490 train_time:49623ms step_avg:47.22ms
+step:1052/1490 train_time:49709ms step_avg:47.25ms
+step:1053/1490 train_time:49789ms step_avg:47.28ms
+step:1054/1490 train_time:49876ms step_avg:47.32ms
+step:1055/1490 train_time:49956ms step_avg:47.35ms
+step:1056/1490 train_time:50041ms step_avg:47.39ms
+step:1057/1490 train_time:50120ms step_avg:47.42ms
+step:1058/1490 train_time:50206ms step_avg:47.45ms
+step:1059/1490 train_time:50285ms step_avg:47.48ms
+step:1060/1490 train_time:50370ms step_avg:47.52ms
+step:1061/1490 train_time:50452ms step_avg:47.55ms
+step:1062/1490 train_time:50537ms step_avg:47.59ms
+step:1063/1490 train_time:50618ms step_avg:47.62ms
+step:1064/1490 train_time:50703ms step_avg:47.65ms
+step:1065/1490 train_time:50783ms step_avg:47.68ms
+step:1066/1490 train_time:50868ms step_avg:47.72ms
+step:1067/1490 train_time:50948ms step_avg:47.75ms
+step:1068/1490 train_time:51034ms step_avg:47.78ms
+step:1069/1490 train_time:51114ms step_avg:47.81ms
+step:1070/1490 train_time:51200ms step_avg:47.85ms
+step:1071/1490 train_time:51280ms step_avg:47.88ms
+step:1072/1490 train_time:51366ms step_avg:47.92ms
+step:1073/1490 train_time:51446ms step_avg:47.95ms
+step:1074/1490 train_time:51532ms step_avg:47.98ms
+step:1075/1490 train_time:51614ms step_avg:48.01ms
+step:1076/1490 train_time:51700ms step_avg:48.05ms
+step:1077/1490 train_time:51780ms step_avg:48.08ms
+step:1078/1490 train_time:51868ms step_avg:48.11ms
+step:1079/1490 train_time:51947ms step_avg:48.14ms
+step:1080/1490 train_time:52032ms step_avg:48.18ms
+step:1081/1490 train_time:52113ms step_avg:48.21ms
+step:1082/1490 train_time:52198ms step_avg:48.24ms
+step:1083/1490 train_time:52276ms step_avg:48.27ms
+step:1084/1490 train_time:52363ms step_avg:48.31ms
+step:1085/1490 train_time:52444ms step_avg:48.34ms
+step:1086/1490 train_time:52531ms step_avg:48.37ms
+step:1087/1490 train_time:52612ms step_avg:48.40ms
+step:1088/1490 train_time:52697ms step_avg:48.43ms
+step:1089/1490 train_time:52777ms step_avg:48.46ms
+step:1090/1490 train_time:52863ms step_avg:48.50ms
+step:1091/1490 train_time:52942ms step_avg:48.53ms
+step:1092/1490 train_time:53027ms step_avg:48.56ms
+step:1093/1490 train_time:53108ms step_avg:48.59ms
+step:1094/1490 train_time:53193ms step_avg:48.62ms
+step:1095/1490 train_time:53273ms step_avg:48.65ms
+step:1096/1490 train_time:53360ms step_avg:48.69ms
+step:1097/1490 train_time:53440ms step_avg:48.71ms
+step:1098/1490 train_time:53526ms step_avg:48.75ms
+step:1099/1490 train_time:53608ms step_avg:48.78ms
+step:1100/1490 train_time:53694ms step_avg:48.81ms
+step:1101/1490 train_time:53773ms step_avg:48.84ms
+step:1102/1490 train_time:53858ms step_avg:48.87ms
+step:1103/1490 train_time:53937ms step_avg:48.90ms
+step:1104/1490 train_time:54023ms step_avg:48.93ms
+step:1105/1490 train_time:54104ms step_avg:48.96ms
+step:1106/1490 train_time:54189ms step_avg:49.00ms
+step:1107/1490 train_time:54270ms step_avg:49.02ms
+step:1108/1490 train_time:54355ms step_avg:49.06ms
+step:1109/1490 train_time:54436ms step_avg:49.09ms
+step:1110/1490 train_time:54521ms step_avg:49.12ms
+step:1111/1490 train_time:54603ms step_avg:49.15ms
+step:1112/1490 train_time:54687ms step_avg:49.18ms
+step:1113/1490 train_time:54768ms step_avg:49.21ms
+step:1114/1490 train_time:54855ms step_avg:49.24ms
+step:1115/1490 train_time:54934ms step_avg:49.27ms
+step:1116/1490 train_time:55019ms step_avg:49.30ms
+step:1117/1490 train_time:55099ms step_avg:49.33ms
+step:1118/1490 train_time:55185ms step_avg:49.36ms
+step:1119/1490 train_time:55266ms step_avg:49.39ms
+step:1120/1490 train_time:55354ms step_avg:49.42ms
+step:1121/1490 train_time:55434ms step_avg:49.45ms
+step:1122/1490 train_time:55519ms step_avg:49.48ms
+step:1123/1490 train_time:55599ms step_avg:49.51ms
+step:1124/1490 train_time:55685ms step_avg:49.54ms
+step:1125/1490 train_time:55766ms step_avg:49.57ms
+step:1126/1490 train_time:55853ms step_avg:49.60ms
+step:1127/1490 train_time:55932ms step_avg:49.63ms
+step:1128/1490 train_time:56018ms step_avg:49.66ms
+step:1129/1490 train_time:56097ms step_avg:49.69ms
+step:1130/1490 train_time:56182ms step_avg:49.72ms
+step:1131/1490 train_time:56263ms step_avg:49.75ms
+step:1132/1490 train_time:56350ms step_avg:49.78ms
+step:1133/1490 train_time:56428ms step_avg:49.80ms
+step:1134/1490 train_time:56515ms step_avg:49.84ms
+step:1135/1490 train_time:56596ms step_avg:49.86ms
+step:1136/1490 train_time:56682ms step_avg:49.90ms
+step:1137/1490 train_time:56764ms step_avg:49.92ms
+step:1138/1490 train_time:56850ms step_avg:49.96ms
+step:1139/1490 train_time:56929ms step_avg:49.98ms
+step:1140/1490 train_time:57015ms step_avg:50.01ms
+step:1141/1490 train_time:57095ms step_avg:50.04ms
+step:1142/1490 train_time:57180ms step_avg:50.07ms
+step:1143/1490 train_time:57260ms step_avg:50.10ms
+step:1144/1490 train_time:57346ms step_avg:50.13ms
+step:1145/1490 train_time:57428ms step_avg:50.16ms
+step:1146/1490 train_time:57512ms step_avg:50.19ms
+step:1147/1490 train_time:57591ms step_avg:50.21ms
+step:1148/1490 train_time:57677ms step_avg:50.24ms
+step:1149/1490 train_time:57758ms step_avg:50.27ms
+step:1150/1490 train_time:57843ms step_avg:50.30ms
+step:1151/1490 train_time:57923ms step_avg:50.32ms
+step:1152/1490 train_time:58007ms step_avg:50.35ms
+step:1153/1490 train_time:58088ms step_avg:50.38ms
+step:1154/1490 train_time:58174ms step_avg:50.41ms
+step:1155/1490 train_time:58254ms step_avg:50.44ms
+step:1156/1490 train_time:58339ms step_avg:50.47ms
+step:1157/1490 train_time:58419ms step_avg:50.49ms
+step:1158/1490 train_time:58505ms step_avg:50.52ms
+step:1159/1490 train_time:58585ms step_avg:50.55ms
+step:1160/1490 train_time:58672ms step_avg:50.58ms
+step:1161/1490 train_time:58753ms step_avg:50.61ms
+step:1162/1490 train_time:58839ms step_avg:50.64ms
+step:1163/1490 train_time:58918ms step_avg:50.66ms
+step:1164/1490 train_time:59003ms step_avg:50.69ms
+step:1165/1490 train_time:59084ms step_avg:50.72ms
+step:1166/1490 train_time:59169ms step_avg:50.75ms
+step:1167/1490 train_time:59249ms step_avg:50.77ms
+step:1168/1490 train_time:59336ms step_avg:50.80ms
+step:1169/1490 train_time:59416ms step_avg:50.83ms
+step:1170/1490 train_time:59501ms step_avg:50.86ms
+step:1171/1490 train_time:59580ms step_avg:50.88ms
+step:1172/1490 train_time:59667ms step_avg:50.91ms
+step:1173/1490 train_time:59750ms step_avg:50.94ms
+step:1174/1490 train_time:59835ms step_avg:50.97ms
+step:1175/1490 train_time:59915ms step_avg:50.99ms
+step:1176/1490 train_time:60000ms step_avg:51.02ms
+step:1177/1490 train_time:60080ms step_avg:51.04ms
+step:1178/1490 train_time:60167ms step_avg:51.08ms
+step:1179/1490 train_time:60248ms step_avg:51.10ms
+step:1180/1490 train_time:60334ms step_avg:51.13ms
+step:1181/1490 train_time:60415ms step_avg:51.16ms
+step:1182/1490 train_time:60500ms step_avg:51.18ms
+step:1183/1490 train_time:60580ms step_avg:51.21ms
+step:1184/1490 train_time:60667ms step_avg:51.24ms
+step:1185/1490 train_time:60748ms step_avg:51.26ms
+step:1186/1490 train_time:60833ms step_avg:51.29ms
+step:1187/1490 train_time:60914ms step_avg:51.32ms
+step:1188/1490 train_time:60999ms step_avg:51.35ms
+step:1189/1490 train_time:61078ms step_avg:51.37ms
+step:1190/1490 train_time:61164ms step_avg:51.40ms
+step:1191/1490 train_time:61244ms step_avg:51.42ms
+step:1192/1490 train_time:61331ms step_avg:51.45ms
+step:1193/1490 train_time:61411ms step_avg:51.48ms
+step:1194/1490 train_time:61497ms step_avg:51.51ms
+step:1195/1490 train_time:61576ms step_avg:51.53ms
+step:1196/1490 train_time:61663ms step_avg:51.56ms
+step:1197/1490 train_time:61744ms step_avg:51.58ms
+step:1198/1490 train_time:61831ms step_avg:51.61ms
+step:1199/1490 train_time:61911ms step_avg:51.64ms
+step:1200/1490 train_time:61996ms step_avg:51.66ms
+step:1201/1490 train_time:62076ms step_avg:51.69ms
+step:1202/1490 train_time:62162ms step_avg:51.72ms
+step:1203/1490 train_time:62242ms step_avg:51.74ms
+step:1204/1490 train_time:62327ms step_avg:51.77ms
+step:1205/1490 train_time:62408ms step_avg:51.79ms
+step:1206/1490 train_time:62494ms step_avg:51.82ms
+step:1207/1490 train_time:62574ms step_avg:51.84ms
+step:1208/1490 train_time:62659ms step_avg:51.87ms
+step:1209/1490 train_time:62738ms step_avg:51.89ms
+step:1210/1490 train_time:62823ms step_avg:51.92ms
+step:1211/1490 train_time:62906ms step_avg:51.95ms
+step:1212/1490 train_time:62991ms step_avg:51.97ms
+step:1213/1490 train_time:63071ms step_avg:52.00ms
+step:1214/1490 train_time:63158ms step_avg:52.02ms
+step:1215/1490 train_time:63237ms step_avg:52.05ms
+step:1216/1490 train_time:63323ms step_avg:52.07ms
+step:1217/1490 train_time:63403ms step_avg:52.10ms
+step:1218/1490 train_time:63489ms step_avg:52.13ms
+step:1219/1490 train_time:63571ms step_avg:52.15ms
+step:1220/1490 train_time:63657ms step_avg:52.18ms
+step:1221/1490 train_time:63736ms step_avg:52.20ms
+step:1222/1490 train_time:63821ms step_avg:52.23ms
+step:1223/1490 train_time:63901ms step_avg:52.25ms
+step:1224/1490 train_time:63987ms step_avg:52.28ms
+step:1225/1490 train_time:64067ms step_avg:52.30ms
+step:1226/1490 train_time:64153ms step_avg:52.33ms
+step:1227/1490 train_time:64233ms step_avg:52.35ms
+step:1228/1490 train_time:64316ms step_avg:52.37ms
+step:1229/1490 train_time:64396ms step_avg:52.40ms
+step:1230/1490 train_time:64482ms step_avg:52.42ms
+step:1231/1490 train_time:64563ms step_avg:52.45ms
+step:1232/1490 train_time:64648ms step_avg:52.47ms
+step:1233/1490 train_time:64731ms step_avg:52.50ms
+step:1234/1490 train_time:64817ms step_avg:52.53ms
+step:1235/1490 train_time:64897ms step_avg:52.55ms
+step:1236/1490 train_time:64982ms step_avg:52.57ms
+step:1237/1490 train_time:65063ms step_avg:52.60ms
+step:1238/1490 train_time:65150ms step_avg:52.63ms
+step:1239/1490 train_time:65230ms step_avg:52.65ms
+step:1240/1490 train_time:65314ms step_avg:52.67ms
+step:1241/1490 train_time:65394ms step_avg:52.69ms
+step:1242/1490 train_time:65479ms step_avg:52.72ms
+step:1243/1490 train_time:65560ms step_avg:52.74ms
+step:1244/1490 train_time:65645ms step_avg:52.77ms
+step:1245/1490 train_time:65726ms step_avg:52.79ms
+step:1246/1490 train_time:65811ms step_avg:52.82ms
+step:1247/1490 train_time:65890ms step_avg:52.84ms
+step:1248/1490 train_time:65976ms step_avg:52.87ms
+step:1249/1490 train_time:66057ms step_avg:52.89ms
+step:1250/1490 train_time:66143ms step_avg:52.91ms
+step:1250/1490 val_loss:3.3722 train_time:66246ms step_avg:53.00ms
+step:1251/1490 train_time:66263ms step_avg:52.97ms
+step:1252/1490 train_time:66313ms step_avg:52.97ms
+step:1253/1490 train_time:66399ms step_avg:52.99ms
+step:1254/1490 train_time:66487ms step_avg:53.02ms
+step:1255/1490 train_time:66568ms step_avg:53.04ms
+step:1256/1490 train_time:66653ms step_avg:53.07ms
+step:1257/1490 train_time:66732ms step_avg:53.09ms
+step:1258/1490 train_time:66816ms step_avg:53.11ms
+step:1259/1490 train_time:66895ms step_avg:53.13ms
+step:1260/1490 train_time:66979ms step_avg:53.16ms
+step:1261/1490 train_time:67059ms step_avg:53.18ms
+step:1262/1490 train_time:67145ms step_avg:53.21ms
+step:1263/1490 train_time:67227ms step_avg:53.23ms
+step:1264/1490 train_time:67314ms step_avg:53.25ms
+step:1265/1490 train_time:67399ms step_avg:53.28ms
+step:1266/1490 train_time:67487ms step_avg:53.31ms
+step:1267/1490 train_time:67569ms step_avg:53.33ms
+step:1268/1490 train_time:67654ms step_avg:53.35ms
+step:1269/1490 train_time:67733ms step_avg:53.37ms
+step:1270/1490 train_time:67816ms step_avg:53.40ms
+step:1271/1490 train_time:67895ms step_avg:53.42ms
+step:1272/1490 train_time:67980ms step_avg:53.44ms
+step:1273/1490 train_time:68058ms step_avg:53.46ms
+step:1274/1490 train_time:68144ms step_avg:53.49ms
+step:1275/1490 train_time:68225ms step_avg:53.51ms
+step:1276/1490 train_time:68312ms step_avg:53.54ms
+step:1277/1490 train_time:68396ms step_avg:53.56ms
+step:1278/1490 train_time:68483ms step_avg:53.59ms
+step:1279/1490 train_time:68564ms step_avg:53.61ms
+step:1280/1490 train_time:68649ms step_avg:53.63ms
+step:1281/1490 train_time:68728ms step_avg:53.65ms
+step:1282/1490 train_time:68814ms step_avg:53.68ms
+step:1283/1490 train_time:68893ms step_avg:53.70ms
+step:1284/1490 train_time:68979ms step_avg:53.72ms
+step:1285/1490 train_time:69060ms step_avg:53.74ms
+step:1286/1490 train_time:69144ms step_avg:53.77ms
+step:1287/1490 train_time:69225ms step_avg:53.79ms
+step:1288/1490 train_time:69311ms step_avg:53.81ms
+step:1289/1490 train_time:69392ms step_avg:53.83ms
+step:1290/1490 train_time:69478ms step_avg:53.86ms
+step:1291/1490 train_time:69558ms step_avg:53.88ms
+step:1292/1490 train_time:69645ms step_avg:53.90ms
+step:1293/1490 train_time:69726ms step_avg:53.93ms
+step:1294/1490 train_time:69810ms step_avg:53.95ms
+step:1295/1490 train_time:69891ms step_avg:53.97ms
+step:1296/1490 train_time:69975ms step_avg:53.99ms
+step:1297/1490 train_time:70055ms step_avg:54.01ms
+step:1298/1490 train_time:70142ms step_avg:54.04ms
+step:1299/1490 train_time:70221ms step_avg:54.06ms
+step:1300/1490 train_time:70308ms step_avg:54.08ms
+step:1301/1490 train_time:70390ms step_avg:54.10ms
+step:1302/1490 train_time:70477ms step_avg:54.13ms
+step:1303/1490 train_time:70556ms step_avg:54.15ms
+step:1304/1490 train_time:70643ms step_avg:54.17ms
+step:1305/1490 train_time:70722ms step_avg:54.19ms
+step:1306/1490 train_time:70808ms step_avg:54.22ms
+step:1307/1490 train_time:70890ms step_avg:54.24ms
+step:1308/1490 train_time:70975ms step_avg:54.26ms
+step:1309/1490 train_time:71056ms step_avg:54.28ms
+step:1310/1490 train_time:71141ms step_avg:54.31ms
+step:1311/1490 train_time:71221ms step_avg:54.33ms
+step:1312/1490 train_time:71306ms step_avg:54.35ms
+step:1313/1490 train_time:71387ms step_avg:54.37ms
+step:1314/1490 train_time:71472ms step_avg:54.39ms
+step:1315/1490 train_time:71552ms step_avg:54.41ms
+step:1316/1490 train_time:71640ms step_avg:54.44ms
+step:1317/1490 train_time:71719ms step_avg:54.46ms
+step:1318/1490 train_time:71804ms step_avg:54.48ms
+step:1319/1490 train_time:71884ms step_avg:54.50ms
+step:1320/1490 train_time:71970ms step_avg:54.52ms
+step:1321/1490 train_time:72050ms step_avg:54.54ms
+step:1322/1490 train_time:72135ms step_avg:54.56ms
+step:1323/1490 train_time:72215ms step_avg:54.58ms
+step:1324/1490 train_time:72302ms step_avg:54.61ms
+step:1325/1490 train_time:72381ms step_avg:54.63ms
+step:1326/1490 train_time:72467ms step_avg:54.65ms
+step:1327/1490 train_time:72548ms step_avg:54.67ms
+step:1328/1490 train_time:72635ms step_avg:54.69ms
+step:1329/1490 train_time:72715ms step_avg:54.71ms
+step:1330/1490 train_time:72799ms step_avg:54.74ms
+step:1331/1490 train_time:72879ms step_avg:54.76ms
+step:1332/1490 train_time:72965ms step_avg:54.78ms
+step:1333/1490 train_time:73045ms step_avg:54.80ms
+step:1334/1490 train_time:73131ms step_avg:54.82ms
+step:1335/1490 train_time:73211ms step_avg:54.84ms
+step:1336/1490 train_time:73298ms step_avg:54.86ms
+step:1337/1490 train_time:73377ms step_avg:54.88ms
+step:1338/1490 train_time:73463ms step_avg:54.91ms
+step:1339/1490 train_time:73543ms step_avg:54.92ms
+step:1340/1490 train_time:73631ms step_avg:54.95ms
+step:1341/1490 train_time:73711ms step_avg:54.97ms
+step:1342/1490 train_time:73797ms step_avg:54.99ms
+step:1343/1490 train_time:73876ms step_avg:55.01ms
+step:1344/1490 train_time:73962ms step_avg:55.03ms
+step:1345/1490 train_time:74041ms step_avg:55.05ms
+step:1346/1490 train_time:74125ms step_avg:55.07ms
+step:1347/1490 train_time:74207ms step_avg:55.09ms
+step:1348/1490 train_time:74293ms step_avg:55.11ms
+step:1349/1490 train_time:74373ms step_avg:55.13ms
+step:1350/1490 train_time:74460ms step_avg:55.16ms
+step:1351/1490 train_time:74539ms step_avg:55.17ms
+step:1352/1490 train_time:74624ms step_avg:55.20ms
+step:1353/1490 train_time:74705ms step_avg:55.21ms
+step:1354/1490 train_time:74791ms step_avg:55.24ms
+step:1355/1490 train_time:74872ms step_avg:55.26ms
+step:1356/1490 train_time:74959ms step_avg:55.28ms
+step:1357/1490 train_time:75038ms step_avg:55.30ms
+step:1358/1490 train_time:75123ms step_avg:55.32ms
+step:1359/1490 train_time:75203ms step_avg:55.34ms
+step:1360/1490 train_time:75289ms step_avg:55.36ms
+step:1361/1490 train_time:75369ms step_avg:55.38ms
+step:1362/1490 train_time:75455ms step_avg:55.40ms
+step:1363/1490 train_time:75535ms step_avg:55.42ms
+step:1364/1490 train_time:75619ms step_avg:55.44ms
+step:1365/1490 train_time:75699ms step_avg:55.46ms
+step:1366/1490 train_time:75785ms step_avg:55.48ms
+step:1367/1490 train_time:75866ms step_avg:55.50ms
+step:1368/1490 train_time:75952ms step_avg:55.52ms
+step:1369/1490 train_time:76032ms step_avg:55.54ms
+step:1370/1490 train_time:76119ms step_avg:55.56ms
+step:1371/1490 train_time:76198ms step_avg:55.58ms
+step:1372/1490 train_time:76284ms step_avg:55.60ms
+step:1373/1490 train_time:76363ms step_avg:55.62ms
+step:1374/1490 train_time:76448ms step_avg:55.64ms
+step:1375/1490 train_time:76530ms step_avg:55.66ms
+step:1376/1490 train_time:76617ms step_avg:55.68ms
+step:1377/1490 train_time:76699ms step_avg:55.70ms
+step:1378/1490 train_time:76784ms step_avg:55.72ms
+step:1379/1490 train_time:76864ms step_avg:55.74ms
+step:1380/1490 train_time:76949ms step_avg:55.76ms
+step:1381/1490 train_time:77030ms step_avg:55.78ms
+step:1382/1490 train_time:77115ms step_avg:55.80ms
+step:1383/1490 train_time:77195ms step_avg:55.82ms
+step:1384/1490 train_time:77280ms step_avg:55.84ms
+step:1385/1490 train_time:77360ms step_avg:55.86ms
+step:1386/1490 train_time:77445ms step_avg:55.88ms
+step:1387/1490 train_time:77525ms step_avg:55.89ms
+step:1388/1490 train_time:77611ms step_avg:55.92ms
+step:1389/1490 train_time:77692ms step_avg:55.93ms
+step:1390/1490 train_time:77778ms step_avg:55.96ms
+step:1391/1490 train_time:77857ms step_avg:55.97ms
+step:1392/1490 train_time:77942ms step_avg:55.99ms
+step:1393/1490 train_time:78022ms step_avg:56.01ms
+step:1394/1490 train_time:78108ms step_avg:56.03ms
+step:1395/1490 train_time:78190ms step_avg:56.05ms
+step:1396/1490 train_time:78276ms step_avg:56.07ms
+step:1397/1490 train_time:78356ms step_avg:56.09ms
+step:1398/1490 train_time:78440ms step_avg:56.11ms
+step:1399/1490 train_time:78520ms step_avg:56.13ms
+step:1400/1490 train_time:78605ms step_avg:56.15ms
+step:1401/1490 train_time:78686ms step_avg:56.16ms
+step:1402/1490 train_time:78772ms step_avg:56.19ms
+step:1403/1490 train_time:78852ms step_avg:56.20ms
+step:1404/1490 train_time:78938ms step_avg:56.22ms
+step:1405/1490 train_time:79018ms step_avg:56.24ms
+step:1406/1490 train_time:79103ms step_avg:56.26ms
+step:1407/1490 train_time:79184ms step_avg:56.28ms
+step:1408/1490 train_time:79271ms step_avg:56.30ms
+step:1409/1490 train_time:79352ms step_avg:56.32ms
+step:1410/1490 train_time:79439ms step_avg:56.34ms
+step:1411/1490 train_time:79519ms step_avg:56.36ms
+step:1412/1490 train_time:79603ms step_avg:56.38ms
+step:1413/1490 train_time:79683ms step_avg:56.39ms
+step:1414/1490 train_time:79771ms step_avg:56.41ms
+step:1415/1490 train_time:79852ms step_avg:56.43ms
+step:1416/1490 train_time:79936ms step_avg:56.45ms
+step:1417/1490 train_time:80017ms step_avg:56.47ms
+step:1418/1490 train_time:80103ms step_avg:56.49ms
+step:1419/1490 train_time:80182ms step_avg:56.51ms
+step:1420/1490 train_time:80268ms step_avg:56.53ms
+step:1421/1490 train_time:80350ms step_avg:56.55ms
+step:1422/1490 train_time:80435ms step_avg:56.56ms
+step:1423/1490 train_time:80515ms step_avg:56.58ms
+step:1424/1490 train_time:80601ms step_avg:56.60ms
+step:1425/1490 train_time:80681ms step_avg:56.62ms
+step:1426/1490 train_time:80767ms step_avg:56.64ms
+step:1427/1490 train_time:80848ms step_avg:56.66ms
+step:1428/1490 train_time:80934ms step_avg:56.68ms
+step:1429/1490 train_time:81013ms step_avg:56.69ms
+step:1430/1490 train_time:81099ms step_avg:56.71ms
+step:1431/1490 train_time:81180ms step_avg:56.73ms
+step:1432/1490 train_time:81265ms step_avg:56.75ms
+step:1433/1490 train_time:81346ms step_avg:56.77ms
+step:1434/1490 train_time:81431ms step_avg:56.79ms
+step:1435/1490 train_time:81511ms step_avg:56.80ms
+step:1436/1490 train_time:81597ms step_avg:56.82ms
+step:1437/1490 train_time:81679ms step_avg:56.84ms
+step:1438/1490 train_time:81764ms step_avg:56.86ms
+step:1439/1490 train_time:81845ms step_avg:56.88ms
+step:1440/1490 train_time:81930ms step_avg:56.90ms
+step:1441/1490 train_time:82010ms step_avg:56.91ms
+step:1442/1490 train_time:82096ms step_avg:56.93ms
+step:1443/1490 train_time:82177ms step_avg:56.95ms
+step:1444/1490 train_time:82262ms step_avg:56.97ms
+step:1445/1490 train_time:82342ms step_avg:56.98ms
+step:1446/1490 train_time:82427ms step_avg:57.00ms
+step:1447/1490 train_time:82508ms step_avg:57.02ms
+step:1448/1490 train_time:82595ms step_avg:57.04ms
+step:1449/1490 train_time:82674ms step_avg:57.06ms
+step:1450/1490 train_time:82761ms step_avg:57.08ms
+step:1451/1490 train_time:82844ms step_avg:57.09ms
+step:1452/1490 train_time:82931ms step_avg:57.11ms
+step:1453/1490 train_time:83012ms step_avg:57.13ms
+step:1454/1490 train_time:83098ms step_avg:57.15ms
+step:1455/1490 train_time:83180ms step_avg:57.17ms
+step:1456/1490 train_time:83266ms step_avg:57.19ms
+step:1457/1490 train_time:83347ms step_avg:57.20ms
+step:1458/1490 train_time:83432ms step_avg:57.22ms
+step:1459/1490 train_time:83512ms step_avg:57.24ms
+step:1460/1490 train_time:83599ms step_avg:57.26ms
+step:1461/1490 train_time:83679ms step_avg:57.27ms
+step:1462/1490 train_time:83765ms step_avg:57.30ms
+step:1463/1490 train_time:83845ms step_avg:57.31ms
+step:1464/1490 train_time:83932ms step_avg:57.33ms
+step:1465/1490 train_time:84013ms step_avg:57.35ms
+step:1466/1490 train_time:84098ms step_avg:57.37ms
+step:1467/1490 train_time:84179ms step_avg:57.38ms
+step:1468/1490 train_time:84265ms step_avg:57.40ms
+step:1469/1490 train_time:84346ms step_avg:57.42ms
+step:1470/1490 train_time:84431ms step_avg:57.44ms
+step:1471/1490 train_time:84512ms step_avg:57.45ms
+step:1472/1490 train_time:84597ms step_avg:57.47ms
+step:1473/1490 train_time:84679ms step_avg:57.49ms
+step:1474/1490 train_time:84765ms step_avg:57.51ms
+step:1475/1490 train_time:84846ms step_avg:57.52ms
+step:1476/1490 train_time:84934ms step_avg:57.54ms
+step:1477/1490 train_time:85014ms step_avg:57.56ms
+step:1478/1490 train_time:85101ms step_avg:57.58ms
+step:1479/1490 train_time:85181ms step_avg:57.59ms
+step:1480/1490 train_time:85267ms step_avg:57.61ms
+step:1481/1490 train_time:85348ms step_avg:57.63ms
+step:1482/1490 train_time:85433ms step_avg:57.65ms
+step:1483/1490 train_time:85515ms step_avg:57.66ms
+step:1484/1490 train_time:85601ms step_avg:57.68ms
+step:1485/1490 train_time:85682ms step_avg:57.70ms
+step:1486/1490 train_time:85768ms step_avg:57.72ms
+step:1487/1490 train_time:85848ms step_avg:57.73ms
+step:1488/1490 train_time:85934ms step_avg:57.75ms
+step:1489/1490 train_time:86015ms step_avg:57.77ms
+step:1490/1490 train_time:86100ms step_avg:57.79ms
+step:1490/1490 val_loss:3.2788 train_time:86203ms step_avg:57.85ms
+peak memory allocated: 31277 MiB reserved: 47162 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/combined/2026-03-22_20-20-02_time-186_secs_06-mbeta2-max-docs_b3fc62.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/combined/2026-03-22_20-20-02_time-186_secs_06-mbeta2-max-docs_b3fc62.txt
@@ -1,0 +1,4457 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 20:20:17 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            122W /  700W |    1520MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            131W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   40C    P0            124W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1888659      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1888660      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1888661      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1888662      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1888663      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1888664      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1888665      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1888666      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8304 train_time:0ms step_avg:0.04ms
+step:1/1490 train_time:91ms step_avg:91.11ms
+step:2/1490 train_time:115ms step_avg:57.40ms
+step:3/1490 train_time:132ms step_avg:44.08ms
+step:4/1490 train_time:156ms step_avg:38.94ms
+step:5/1490 train_time:183ms step_avg:36.53ms
+step:6/1490 train_time:217ms step_avg:36.24ms
+step:7/1490 train_time:245ms step_avg:34.95ms
+step:8/1490 train_time:279ms step_avg:34.93ms
+step:9/1490 train_time:307ms step_avg:34.09ms
+step:10/1490 train_time:343ms step_avg:34.35ms
+step:11/1490 train_time:369ms step_avg:33.57ms
+step:12/1490 train_time:404ms step_avg:33.66ms
+step:13/1490 train_time:432ms step_avg:33.21ms
+step:14/1490 train_time:466ms step_avg:33.30ms
+step:15/1490 train_time:494ms step_avg:32.93ms
+step:16/1490 train_time:529ms step_avg:33.04ms
+step:17/1490 train_time:557ms step_avg:32.74ms
+step:18/1490 train_time:591ms step_avg:32.84ms
+step:19/1490 train_time:619ms step_avg:32.58ms
+step:20/1490 train_time:654ms step_avg:32.69ms
+step:21/1490 train_time:682ms step_avg:32.46ms
+step:22/1490 train_time:716ms step_avg:32.53ms
+step:23/1490 train_time:744ms step_avg:32.35ms
+step:24/1490 train_time:778ms step_avg:32.42ms
+step:25/1490 train_time:806ms step_avg:32.25ms
+step:26/1490 train_time:841ms step_avg:32.34ms
+step:27/1490 train_time:869ms step_avg:32.17ms
+step:28/1490 train_time:903ms step_avg:32.26ms
+step:29/1490 train_time:931ms step_avg:32.11ms
+step:30/1490 train_time:966ms step_avg:32.21ms
+step:31/1490 train_time:996ms step_avg:32.12ms
+step:32/1490 train_time:1032ms step_avg:32.26ms
+step:33/1490 train_time:1062ms step_avg:32.19ms
+step:34/1490 train_time:1097ms step_avg:32.27ms
+step:35/1490 train_time:1126ms step_avg:32.16ms
+step:36/1490 train_time:1161ms step_avg:32.25ms
+step:37/1490 train_time:1189ms step_avg:32.14ms
+step:38/1490 train_time:1224ms step_avg:32.21ms
+step:39/1490 train_time:1252ms step_avg:32.10ms
+step:40/1490 train_time:1287ms step_avg:32.16ms
+step:41/1490 train_time:1315ms step_avg:32.06ms
+step:42/1490 train_time:1350ms step_avg:32.13ms
+step:43/1490 train_time:1378ms step_avg:32.05ms
+step:44/1490 train_time:1413ms step_avg:32.12ms
+step:45/1490 train_time:1440ms step_avg:32.01ms
+step:46/1490 train_time:1475ms step_avg:32.06ms
+step:47/1490 train_time:1503ms step_avg:31.97ms
+step:48/1490 train_time:1537ms step_avg:32.02ms
+step:49/1490 train_time:1565ms step_avg:31.94ms
+step:50/1490 train_time:1599ms step_avg:31.98ms
+step:51/1490 train_time:1628ms step_avg:31.92ms
+step:52/1490 train_time:1663ms step_avg:31.97ms
+step:53/1490 train_time:1691ms step_avg:31.90ms
+step:54/1490 train_time:1725ms step_avg:31.94ms
+step:55/1490 train_time:1753ms step_avg:31.87ms
+step:56/1490 train_time:1787ms step_avg:31.91ms
+step:57/1490 train_time:1815ms step_avg:31.84ms
+step:58/1490 train_time:1850ms step_avg:31.89ms
+step:59/1490 train_time:1878ms step_avg:31.83ms
+step:60/1490 train_time:1912ms step_avg:31.87ms
+step:61/1490 train_time:1941ms step_avg:31.83ms
+step:62/1490 train_time:1976ms step_avg:31.87ms
+step:63/1490 train_time:2004ms step_avg:31.81ms
+step:64/1490 train_time:2039ms step_avg:31.86ms
+step:65/1490 train_time:2067ms step_avg:31.80ms
+step:66/1490 train_time:2102ms step_avg:31.85ms
+step:67/1490 train_time:2130ms step_avg:31.80ms
+step:68/1490 train_time:2165ms step_avg:31.84ms
+step:69/1490 train_time:2193ms step_avg:31.78ms
+step:70/1490 train_time:2228ms step_avg:31.83ms
+step:71/1490 train_time:2257ms step_avg:31.78ms
+step:72/1490 train_time:2292ms step_avg:31.83ms
+step:73/1490 train_time:2320ms step_avg:31.78ms
+step:74/1490 train_time:2355ms step_avg:31.82ms
+step:75/1490 train_time:2383ms step_avg:31.77ms
+step:76/1490 train_time:2417ms step_avg:31.80ms
+step:77/1490 train_time:2445ms step_avg:31.75ms
+step:78/1490 train_time:2479ms step_avg:31.78ms
+step:79/1490 train_time:2507ms step_avg:31.74ms
+step:80/1490 train_time:2541ms step_avg:31.77ms
+step:81/1490 train_time:2570ms step_avg:31.72ms
+step:82/1490 train_time:2605ms step_avg:31.76ms
+step:83/1490 train_time:2633ms step_avg:31.72ms
+step:84/1490 train_time:2667ms step_avg:31.75ms
+step:85/1490 train_time:2695ms step_avg:31.71ms
+step:86/1490 train_time:2729ms step_avg:31.74ms
+step:87/1490 train_time:2758ms step_avg:31.70ms
+step:88/1490 train_time:2792ms step_avg:31.73ms
+step:89/1490 train_time:2821ms step_avg:31.69ms
+step:90/1490 train_time:2855ms step_avg:31.72ms
+step:91/1490 train_time:2883ms step_avg:31.68ms
+step:92/1490 train_time:2917ms step_avg:31.71ms
+step:93/1490 train_time:2946ms step_avg:31.68ms
+step:94/1490 train_time:2980ms step_avg:31.70ms
+step:95/1490 train_time:3009ms step_avg:31.67ms
+step:96/1490 train_time:3044ms step_avg:31.71ms
+step:97/1490 train_time:3072ms step_avg:31.67ms
+step:98/1490 train_time:3107ms step_avg:31.70ms
+step:99/1490 train_time:3135ms step_avg:31.66ms
+step:100/1490 train_time:3169ms step_avg:31.69ms
+step:101/1490 train_time:3197ms step_avg:31.66ms
+step:102/1490 train_time:3232ms step_avg:31.69ms
+step:103/1490 train_time:3261ms step_avg:31.66ms
+step:104/1490 train_time:3295ms step_avg:31.69ms
+step:105/1490 train_time:3324ms step_avg:31.66ms
+step:106/1490 train_time:3358ms step_avg:31.68ms
+step:107/1490 train_time:3386ms step_avg:31.65ms
+step:108/1490 train_time:3420ms step_avg:31.67ms
+step:109/1490 train_time:3449ms step_avg:31.64ms
+step:110/1490 train_time:3484ms step_avg:31.67ms
+step:111/1490 train_time:3512ms step_avg:31.64ms
+step:112/1490 train_time:3548ms step_avg:31.68ms
+step:113/1490 train_time:3575ms step_avg:31.64ms
+step:114/1490 train_time:3609ms step_avg:31.66ms
+step:115/1490 train_time:3637ms step_avg:31.63ms
+step:116/1490 train_time:3672ms step_avg:31.65ms
+step:117/1490 train_time:3700ms step_avg:31.62ms
+step:118/1490 train_time:3734ms step_avg:31.65ms
+step:119/1490 train_time:3762ms step_avg:31.62ms
+step:120/1490 train_time:3796ms step_avg:31.64ms
+step:121/1490 train_time:3824ms step_avg:31.61ms
+step:122/1490 train_time:3859ms step_avg:31.63ms
+step:123/1490 train_time:3887ms step_avg:31.60ms
+step:124/1490 train_time:3921ms step_avg:31.62ms
+step:125/1490 train_time:3950ms step_avg:31.60ms
+step:126/1490 train_time:3985ms step_avg:31.62ms
+step:127/1490 train_time:4013ms step_avg:31.60ms
+step:128/1490 train_time:4047ms step_avg:31.62ms
+step:129/1490 train_time:4076ms step_avg:31.59ms
+step:130/1490 train_time:4110ms step_avg:31.62ms
+step:131/1490 train_time:4139ms step_avg:31.59ms
+step:132/1490 train_time:4173ms step_avg:31.61ms
+step:133/1490 train_time:4201ms step_avg:31.59ms
+step:134/1490 train_time:4236ms step_avg:31.61ms
+step:135/1490 train_time:4264ms step_avg:31.58ms
+step:136/1490 train_time:4298ms step_avg:31.60ms
+step:137/1490 train_time:4327ms step_avg:31.58ms
+step:138/1490 train_time:4362ms step_avg:31.61ms
+step:139/1490 train_time:4390ms step_avg:31.58ms
+step:140/1490 train_time:4424ms step_avg:31.60ms
+step:141/1490 train_time:4452ms step_avg:31.58ms
+step:142/1490 train_time:4487ms step_avg:31.60ms
+step:143/1490 train_time:4515ms step_avg:31.58ms
+step:144/1490 train_time:4550ms step_avg:31.60ms
+step:145/1490 train_time:4578ms step_avg:31.57ms
+step:146/1490 train_time:4613ms step_avg:31.60ms
+step:147/1490 train_time:4641ms step_avg:31.57ms
+step:148/1490 train_time:4675ms step_avg:31.59ms
+step:149/1490 train_time:4703ms step_avg:31.56ms
+step:150/1490 train_time:4737ms step_avg:31.58ms
+step:151/1490 train_time:4765ms step_avg:31.56ms
+step:152/1490 train_time:4800ms step_avg:31.58ms
+step:153/1490 train_time:4828ms step_avg:31.55ms
+step:154/1490 train_time:4862ms step_avg:31.57ms
+step:155/1490 train_time:4890ms step_avg:31.55ms
+step:156/1490 train_time:4925ms step_avg:31.57ms
+step:157/1490 train_time:4953ms step_avg:31.55ms
+step:158/1490 train_time:4987ms step_avg:31.57ms
+step:159/1490 train_time:5015ms step_avg:31.54ms
+step:160/1490 train_time:5051ms step_avg:31.57ms
+step:161/1490 train_time:5078ms step_avg:31.54ms
+step:162/1490 train_time:5113ms step_avg:31.56ms
+step:163/1490 train_time:5141ms step_avg:31.54ms
+step:164/1490 train_time:5175ms step_avg:31.56ms
+step:165/1490 train_time:5204ms step_avg:31.54ms
+step:166/1490 train_time:5238ms step_avg:31.55ms
+step:167/1490 train_time:5266ms step_avg:31.53ms
+step:168/1490 train_time:5300ms step_avg:31.55ms
+step:169/1490 train_time:5329ms step_avg:31.53ms
+step:170/1490 train_time:5364ms step_avg:31.55ms
+step:171/1490 train_time:5392ms step_avg:31.53ms
+step:172/1490 train_time:5427ms step_avg:31.55ms
+step:173/1490 train_time:5455ms step_avg:31.53ms
+step:174/1490 train_time:5490ms step_avg:31.55ms
+step:175/1490 train_time:5518ms step_avg:31.53ms
+step:176/1490 train_time:5553ms step_avg:31.55ms
+step:177/1490 train_time:5581ms step_avg:31.53ms
+step:178/1490 train_time:5615ms step_avg:31.55ms
+step:179/1490 train_time:5643ms step_avg:31.53ms
+step:180/1490 train_time:5678ms step_avg:31.54ms
+step:181/1490 train_time:5705ms step_avg:31.52ms
+step:182/1490 train_time:5739ms step_avg:31.53ms
+step:183/1490 train_time:5768ms step_avg:31.52ms
+step:184/1490 train_time:5803ms step_avg:31.54ms
+step:185/1490 train_time:5830ms step_avg:31.52ms
+step:186/1490 train_time:5865ms step_avg:31.53ms
+step:187/1490 train_time:5893ms step_avg:31.51ms
+step:188/1490 train_time:5928ms step_avg:31.53ms
+step:189/1490 train_time:5956ms step_avg:31.51ms
+step:190/1490 train_time:5990ms step_avg:31.53ms
+step:191/1490 train_time:6018ms step_avg:31.51ms
+step:192/1490 train_time:6053ms step_avg:31.53ms
+step:193/1490 train_time:6081ms step_avg:31.51ms
+step:194/1490 train_time:6115ms step_avg:31.52ms
+step:195/1490 train_time:6144ms step_avg:31.51ms
+step:196/1490 train_time:6178ms step_avg:31.52ms
+step:197/1490 train_time:6205ms step_avg:31.50ms
+step:198/1490 train_time:6240ms step_avg:31.52ms
+step:199/1490 train_time:6268ms step_avg:31.50ms
+step:200/1490 train_time:6303ms step_avg:31.52ms
+step:201/1490 train_time:6331ms step_avg:31.50ms
+step:202/1490 train_time:6366ms step_avg:31.52ms
+step:203/1490 train_time:6394ms step_avg:31.50ms
+step:204/1490 train_time:6429ms step_avg:31.51ms
+step:205/1490 train_time:6457ms step_avg:31.50ms
+step:206/1490 train_time:6492ms step_avg:31.51ms
+step:207/1490 train_time:6520ms step_avg:31.50ms
+step:208/1490 train_time:6555ms step_avg:31.51ms
+step:209/1490 train_time:6583ms step_avg:31.50ms
+step:210/1490 train_time:6617ms step_avg:31.51ms
+step:211/1490 train_time:6646ms step_avg:31.50ms
+step:212/1490 train_time:6680ms step_avg:31.51ms
+step:213/1490 train_time:6708ms step_avg:31.49ms
+step:214/1490 train_time:6743ms step_avg:31.51ms
+step:215/1490 train_time:6771ms step_avg:31.49ms
+step:216/1490 train_time:6806ms step_avg:31.51ms
+step:217/1490 train_time:6834ms step_avg:31.49ms
+step:218/1490 train_time:6869ms step_avg:31.51ms
+step:219/1490 train_time:6897ms step_avg:31.49ms
+step:220/1490 train_time:6931ms step_avg:31.51ms
+step:221/1490 train_time:6959ms step_avg:31.49ms
+step:222/1490 train_time:6994ms step_avg:31.50ms
+step:223/1490 train_time:7022ms step_avg:31.49ms
+step:224/1490 train_time:7056ms step_avg:31.50ms
+step:225/1490 train_time:7085ms step_avg:31.49ms
+step:226/1490 train_time:7119ms step_avg:31.50ms
+step:227/1490 train_time:7147ms step_avg:31.48ms
+step:228/1490 train_time:7181ms step_avg:31.50ms
+step:229/1490 train_time:7209ms step_avg:31.48ms
+step:230/1490 train_time:7244ms step_avg:31.49ms
+step:231/1490 train_time:7272ms step_avg:31.48ms
+step:232/1490 train_time:7306ms step_avg:31.49ms
+step:233/1490 train_time:7334ms step_avg:31.48ms
+step:234/1490 train_time:7369ms step_avg:31.49ms
+step:235/1490 train_time:7397ms step_avg:31.48ms
+step:236/1490 train_time:7432ms step_avg:31.49ms
+step:237/1490 train_time:7460ms step_avg:31.48ms
+step:238/1490 train_time:7495ms step_avg:31.49ms
+step:239/1490 train_time:7523ms step_avg:31.48ms
+step:240/1490 train_time:7557ms step_avg:31.49ms
+step:241/1490 train_time:7585ms step_avg:31.47ms
+step:242/1490 train_time:7619ms step_avg:31.48ms
+step:243/1490 train_time:7648ms step_avg:31.47ms
+step:244/1490 train_time:7682ms step_avg:31.48ms
+step:245/1490 train_time:7710ms step_avg:31.47ms
+step:246/1490 train_time:7745ms step_avg:31.48ms
+step:247/1490 train_time:7773ms step_avg:31.47ms
+step:248/1490 train_time:7807ms step_avg:31.48ms
+step:249/1490 train_time:7835ms step_avg:31.47ms
+step:250/1490 train_time:7870ms step_avg:31.48ms
+step:250/1490 val_loss:4.5092 train_time:7912ms step_avg:31.65ms
+step:251/1490 train_time:7928ms step_avg:31.59ms
+step:252/1490 train_time:7946ms step_avg:31.53ms
+step:253/1490 train_time:7964ms step_avg:31.48ms
+step:254/1490 train_time:8000ms step_avg:31.50ms
+step:255/1490 train_time:8030ms step_avg:31.49ms
+step:256/1490 train_time:8066ms step_avg:31.51ms
+step:257/1490 train_time:8096ms step_avg:31.50ms
+step:258/1490 train_time:8130ms step_avg:31.51ms
+step:259/1490 train_time:8159ms step_avg:31.50ms
+step:260/1490 train_time:8193ms step_avg:31.51ms
+step:261/1490 train_time:8222ms step_avg:31.50ms
+step:262/1490 train_time:8256ms step_avg:31.51ms
+step:263/1490 train_time:8284ms step_avg:31.50ms
+step:264/1490 train_time:8318ms step_avg:31.51ms
+step:265/1490 train_time:8346ms step_avg:31.49ms
+step:266/1490 train_time:8381ms step_avg:31.51ms
+step:267/1490 train_time:8408ms step_avg:31.49ms
+step:268/1490 train_time:8442ms step_avg:31.50ms
+step:269/1490 train_time:8470ms step_avg:31.49ms
+step:270/1490 train_time:8504ms step_avg:31.50ms
+step:271/1490 train_time:8532ms step_avg:31.48ms
+step:272/1490 train_time:8566ms step_avg:31.49ms
+step:273/1490 train_time:8594ms step_avg:31.48ms
+step:274/1490 train_time:8628ms step_avg:31.49ms
+step:275/1490 train_time:8656ms step_avg:31.48ms
+step:276/1490 train_time:8690ms step_avg:31.48ms
+step:277/1490 train_time:8718ms step_avg:31.47ms
+step:278/1490 train_time:8752ms step_avg:31.48ms
+step:279/1490 train_time:8780ms step_avg:31.47ms
+step:280/1490 train_time:8814ms step_avg:31.48ms
+step:281/1490 train_time:8841ms step_avg:31.46ms
+step:282/1490 train_time:8875ms step_avg:31.47ms
+step:283/1490 train_time:8903ms step_avg:31.46ms
+step:284/1490 train_time:8938ms step_avg:31.47ms
+step:285/1490 train_time:8966ms step_avg:31.46ms
+step:286/1490 train_time:9001ms step_avg:31.47ms
+step:287/1490 train_time:9030ms step_avg:31.46ms
+step:288/1490 train_time:9065ms step_avg:31.48ms
+step:289/1490 train_time:9093ms step_avg:31.46ms
+step:290/1490 train_time:9128ms step_avg:31.48ms
+step:291/1490 train_time:9156ms step_avg:31.47ms
+step:292/1490 train_time:9191ms step_avg:31.48ms
+step:293/1490 train_time:9219ms step_avg:31.46ms
+step:294/1490 train_time:9253ms step_avg:31.47ms
+step:295/1490 train_time:9282ms step_avg:31.47ms
+step:296/1490 train_time:9317ms step_avg:31.47ms
+step:297/1490 train_time:9345ms step_avg:31.46ms
+step:298/1490 train_time:9379ms step_avg:31.47ms
+step:299/1490 train_time:9407ms step_avg:31.46ms
+step:300/1490 train_time:9442ms step_avg:31.47ms
+step:301/1490 train_time:9470ms step_avg:31.46ms
+step:302/1490 train_time:9505ms step_avg:31.47ms
+step:303/1490 train_time:9533ms step_avg:31.46ms
+step:304/1490 train_time:9567ms step_avg:31.47ms
+step:305/1490 train_time:9595ms step_avg:31.46ms
+step:306/1490 train_time:9630ms step_avg:31.47ms
+step:307/1490 train_time:9658ms step_avg:31.46ms
+step:308/1490 train_time:9692ms step_avg:31.47ms
+step:309/1490 train_time:9720ms step_avg:31.46ms
+step:310/1490 train_time:9753ms step_avg:31.46ms
+step:311/1490 train_time:9781ms step_avg:31.45ms
+step:312/1490 train_time:9815ms step_avg:31.46ms
+step:313/1490 train_time:9843ms step_avg:31.45ms
+step:314/1490 train_time:9877ms step_avg:31.46ms
+step:315/1490 train_time:9905ms step_avg:31.45ms
+step:316/1490 train_time:9940ms step_avg:31.45ms
+step:317/1490 train_time:9968ms step_avg:31.44ms
+step:318/1490 train_time:10002ms step_avg:31.45ms
+step:319/1490 train_time:10030ms step_avg:31.44ms
+step:320/1490 train_time:10065ms step_avg:31.45ms
+step:321/1490 train_time:10093ms step_avg:31.44ms
+step:322/1490 train_time:10127ms step_avg:31.45ms
+step:323/1490 train_time:10155ms step_avg:31.44ms
+step:324/1490 train_time:10190ms step_avg:31.45ms
+step:325/1490 train_time:10218ms step_avg:31.44ms
+step:326/1490 train_time:10252ms step_avg:31.45ms
+step:327/1490 train_time:10281ms step_avg:31.44ms
+step:328/1490 train_time:10315ms step_avg:31.45ms
+step:329/1490 train_time:10343ms step_avg:31.44ms
+step:330/1490 train_time:10378ms step_avg:31.45ms
+step:331/1490 train_time:10406ms step_avg:31.44ms
+step:332/1490 train_time:10440ms step_avg:31.45ms
+step:333/1490 train_time:10468ms step_avg:31.44ms
+step:334/1490 train_time:10503ms step_avg:31.45ms
+step:335/1490 train_time:10531ms step_avg:31.44ms
+step:336/1490 train_time:10565ms step_avg:31.44ms
+step:337/1490 train_time:10593ms step_avg:31.43ms
+step:338/1490 train_time:10628ms step_avg:31.44ms
+step:339/1490 train_time:10656ms step_avg:31.43ms
+step:340/1490 train_time:10690ms step_avg:31.44ms
+step:341/1490 train_time:10718ms step_avg:31.43ms
+step:342/1490 train_time:10752ms step_avg:31.44ms
+step:343/1490 train_time:10781ms step_avg:31.43ms
+step:344/1490 train_time:10815ms step_avg:31.44ms
+step:345/1490 train_time:10843ms step_avg:31.43ms
+step:346/1490 train_time:10877ms step_avg:31.44ms
+step:347/1490 train_time:10905ms step_avg:31.43ms
+step:348/1490 train_time:10939ms step_avg:31.44ms
+step:349/1490 train_time:10968ms step_avg:31.43ms
+step:350/1490 train_time:11002ms step_avg:31.44ms
+step:351/1490 train_time:11030ms step_avg:31.43ms
+step:352/1490 train_time:11065ms step_avg:31.43ms
+step:353/1490 train_time:11093ms step_avg:31.43ms
+step:354/1490 train_time:11128ms step_avg:31.44ms
+step:355/1490 train_time:11156ms step_avg:31.43ms
+step:356/1490 train_time:11191ms step_avg:31.44ms
+step:357/1490 train_time:11219ms step_avg:31.43ms
+step:358/1490 train_time:11253ms step_avg:31.43ms
+step:359/1490 train_time:11282ms step_avg:31.43ms
+step:360/1490 train_time:11317ms step_avg:31.43ms
+step:361/1490 train_time:11345ms step_avg:31.43ms
+step:362/1490 train_time:11380ms step_avg:31.44ms
+step:363/1490 train_time:11407ms step_avg:31.42ms
+step:364/1490 train_time:11442ms step_avg:31.43ms
+step:365/1490 train_time:11470ms step_avg:31.42ms
+step:366/1490 train_time:11505ms step_avg:31.43ms
+step:367/1490 train_time:11533ms step_avg:31.42ms
+step:368/1490 train_time:11567ms step_avg:31.43ms
+step:369/1490 train_time:11595ms step_avg:31.42ms
+step:370/1490 train_time:11630ms step_avg:31.43ms
+step:371/1490 train_time:11657ms step_avg:31.42ms
+step:372/1490 train_time:11692ms step_avg:31.43ms
+step:373/1490 train_time:11720ms step_avg:31.42ms
+step:374/1490 train_time:11754ms step_avg:31.43ms
+step:375/1490 train_time:11782ms step_avg:31.42ms
+step:376/1490 train_time:11816ms step_avg:31.43ms
+step:377/1490 train_time:11844ms step_avg:31.42ms
+step:378/1490 train_time:11878ms step_avg:31.42ms
+step:379/1490 train_time:11907ms step_avg:31.42ms
+step:380/1490 train_time:11942ms step_avg:31.43ms
+step:381/1490 train_time:11969ms step_avg:31.41ms
+step:382/1490 train_time:12004ms step_avg:31.42ms
+step:383/1490 train_time:12032ms step_avg:31.41ms
+step:384/1490 train_time:12066ms step_avg:31.42ms
+step:385/1490 train_time:12095ms step_avg:31.41ms
+step:386/1490 train_time:12129ms step_avg:31.42ms
+step:387/1490 train_time:12157ms step_avg:31.41ms
+step:388/1490 train_time:12191ms step_avg:31.42ms
+step:389/1490 train_time:12219ms step_avg:31.41ms
+step:390/1490 train_time:12253ms step_avg:31.42ms
+step:391/1490 train_time:12281ms step_avg:31.41ms
+step:392/1490 train_time:12316ms step_avg:31.42ms
+step:393/1490 train_time:12344ms step_avg:31.41ms
+step:394/1490 train_time:12379ms step_avg:31.42ms
+step:395/1490 train_time:12407ms step_avg:31.41ms
+step:396/1490 train_time:12442ms step_avg:31.42ms
+step:397/1490 train_time:12470ms step_avg:31.41ms
+step:398/1490 train_time:12504ms step_avg:31.42ms
+step:399/1490 train_time:12533ms step_avg:31.41ms
+step:400/1490 train_time:12568ms step_avg:31.42ms
+step:401/1490 train_time:12595ms step_avg:31.41ms
+step:402/1490 train_time:12630ms step_avg:31.42ms
+step:403/1490 train_time:12657ms step_avg:31.41ms
+step:404/1490 train_time:12692ms step_avg:31.42ms
+step:405/1490 train_time:12720ms step_avg:31.41ms
+step:406/1490 train_time:12754ms step_avg:31.41ms
+step:407/1490 train_time:12783ms step_avg:31.41ms
+step:408/1490 train_time:12817ms step_avg:31.41ms
+step:409/1490 train_time:12845ms step_avg:31.41ms
+step:410/1490 train_time:12880ms step_avg:31.41ms
+step:411/1490 train_time:12908ms step_avg:31.41ms
+step:412/1490 train_time:12942ms step_avg:31.41ms
+step:413/1490 train_time:12970ms step_avg:31.40ms
+step:414/1490 train_time:13005ms step_avg:31.41ms
+step:415/1490 train_time:13034ms step_avg:31.41ms
+step:416/1490 train_time:13068ms step_avg:31.41ms
+step:417/1490 train_time:13097ms step_avg:31.41ms
+step:418/1490 train_time:13131ms step_avg:31.41ms
+step:419/1490 train_time:13159ms step_avg:31.41ms
+step:420/1490 train_time:13194ms step_avg:31.41ms
+step:421/1490 train_time:13221ms step_avg:31.40ms
+step:422/1490 train_time:13255ms step_avg:31.41ms
+step:423/1490 train_time:13284ms step_avg:31.40ms
+step:424/1490 train_time:13318ms step_avg:31.41ms
+step:425/1490 train_time:13346ms step_avg:31.40ms
+step:426/1490 train_time:13381ms step_avg:31.41ms
+step:427/1490 train_time:13409ms step_avg:31.40ms
+step:428/1490 train_time:13444ms step_avg:31.41ms
+step:429/1490 train_time:13472ms step_avg:31.40ms
+step:430/1490 train_time:13507ms step_avg:31.41ms
+step:431/1490 train_time:13535ms step_avg:31.40ms
+step:432/1490 train_time:13569ms step_avg:31.41ms
+step:433/1490 train_time:13597ms step_avg:31.40ms
+step:434/1490 train_time:13631ms step_avg:31.41ms
+step:435/1490 train_time:13659ms step_avg:31.40ms
+step:436/1490 train_time:13694ms step_avg:31.41ms
+step:437/1490 train_time:13722ms step_avg:31.40ms
+step:438/1490 train_time:13756ms step_avg:31.41ms
+step:439/1490 train_time:13785ms step_avg:31.40ms
+step:440/1490 train_time:13820ms step_avg:31.41ms
+step:441/1490 train_time:13848ms step_avg:31.40ms
+step:442/1490 train_time:13882ms step_avg:31.41ms
+step:443/1490 train_time:13911ms step_avg:31.40ms
+step:444/1490 train_time:13945ms step_avg:31.41ms
+step:445/1490 train_time:13973ms step_avg:31.40ms
+step:446/1490 train_time:14007ms step_avg:31.41ms
+step:447/1490 train_time:14036ms step_avg:31.40ms
+step:448/1490 train_time:14070ms step_avg:31.41ms
+step:449/1490 train_time:14098ms step_avg:31.40ms
+step:450/1490 train_time:14132ms step_avg:31.40ms
+step:451/1490 train_time:14160ms step_avg:31.40ms
+step:452/1490 train_time:14194ms step_avg:31.40ms
+step:453/1490 train_time:14223ms step_avg:31.40ms
+step:454/1490 train_time:14257ms step_avg:31.40ms
+step:455/1490 train_time:14285ms step_avg:31.40ms
+step:456/1490 train_time:14320ms step_avg:31.40ms
+step:457/1490 train_time:14348ms step_avg:31.40ms
+step:458/1490 train_time:14383ms step_avg:31.40ms
+step:459/1490 train_time:14411ms step_avg:31.40ms
+step:460/1490 train_time:14446ms step_avg:31.40ms
+step:461/1490 train_time:14473ms step_avg:31.40ms
+step:462/1490 train_time:14508ms step_avg:31.40ms
+step:463/1490 train_time:14536ms step_avg:31.39ms
+step:464/1490 train_time:14570ms step_avg:31.40ms
+step:465/1490 train_time:14599ms step_avg:31.40ms
+step:466/1490 train_time:14633ms step_avg:31.40ms
+step:467/1490 train_time:14660ms step_avg:31.39ms
+step:468/1490 train_time:14694ms step_avg:31.40ms
+step:469/1490 train_time:14723ms step_avg:31.39ms
+step:470/1490 train_time:14757ms step_avg:31.40ms
+step:471/1490 train_time:14786ms step_avg:31.39ms
+step:472/1490 train_time:14821ms step_avg:31.40ms
+step:473/1490 train_time:14849ms step_avg:31.39ms
+step:474/1490 train_time:14884ms step_avg:31.40ms
+step:475/1490 train_time:14911ms step_avg:31.39ms
+step:476/1490 train_time:14946ms step_avg:31.40ms
+step:477/1490 train_time:14974ms step_avg:31.39ms
+step:478/1490 train_time:15009ms step_avg:31.40ms
+step:479/1490 train_time:15037ms step_avg:31.39ms
+step:480/1490 train_time:15071ms step_avg:31.40ms
+step:481/1490 train_time:15099ms step_avg:31.39ms
+step:482/1490 train_time:15133ms step_avg:31.40ms
+step:483/1490 train_time:15161ms step_avg:31.39ms
+step:484/1490 train_time:15199ms step_avg:31.40ms
+step:485/1490 train_time:15250ms step_avg:31.44ms
+step:486/1490 train_time:15310ms step_avg:31.50ms
+step:487/1490 train_time:15365ms step_avg:31.55ms
+step:488/1490 train_time:15424ms step_avg:31.61ms
+step:489/1490 train_time:15478ms step_avg:31.65ms
+step:490/1490 train_time:15539ms step_avg:31.71ms
+step:491/1490 train_time:15592ms step_avg:31.76ms
+step:492/1490 train_time:15651ms step_avg:31.81ms
+step:493/1490 train_time:15705ms step_avg:31.86ms
+step:494/1490 train_time:15765ms step_avg:31.91ms
+step:495/1490 train_time:15819ms step_avg:31.96ms
+step:496/1490 train_time:15879ms step_avg:32.01ms
+step:497/1490 train_time:15934ms step_avg:32.06ms
+step:498/1490 train_time:15994ms step_avg:32.12ms
+step:499/1490 train_time:16048ms step_avg:32.16ms
+step:500/1490 train_time:16108ms step_avg:32.22ms
+step:500/1490 val_loss:4.2118 train_time:16179ms step_avg:32.36ms
+step:501/1490 train_time:16198ms step_avg:32.33ms
+step:502/1490 train_time:16223ms step_avg:32.32ms
+step:503/1490 train_time:16281ms step_avg:32.37ms
+step:504/1490 train_time:16344ms step_avg:32.43ms
+step:505/1490 train_time:16398ms step_avg:32.47ms
+step:506/1490 train_time:16459ms step_avg:32.53ms
+step:507/1490 train_time:16514ms step_avg:32.57ms
+step:508/1490 train_time:16573ms step_avg:32.62ms
+step:509/1490 train_time:16627ms step_avg:32.67ms
+step:510/1490 train_time:16686ms step_avg:32.72ms
+step:511/1490 train_time:16739ms step_avg:32.76ms
+step:512/1490 train_time:16798ms step_avg:32.81ms
+step:513/1490 train_time:16850ms step_avg:32.85ms
+step:514/1490 train_time:16909ms step_avg:32.90ms
+step:515/1490 train_time:16963ms step_avg:32.94ms
+step:516/1490 train_time:17023ms step_avg:32.99ms
+step:517/1490 train_time:17076ms step_avg:33.03ms
+step:518/1490 train_time:17135ms step_avg:33.08ms
+step:519/1490 train_time:17190ms step_avg:33.12ms
+step:520/1490 train_time:17251ms step_avg:33.17ms
+step:521/1490 train_time:17306ms step_avg:33.22ms
+step:522/1490 train_time:17367ms step_avg:33.27ms
+step:523/1490 train_time:17421ms step_avg:33.31ms
+step:524/1490 train_time:17481ms step_avg:33.36ms
+step:525/1490 train_time:17536ms step_avg:33.40ms
+step:526/1490 train_time:17595ms step_avg:33.45ms
+step:527/1490 train_time:17650ms step_avg:33.49ms
+step:528/1490 train_time:17710ms step_avg:33.54ms
+step:529/1490 train_time:17764ms step_avg:33.58ms
+step:530/1490 train_time:17823ms step_avg:33.63ms
+step:531/1490 train_time:17876ms step_avg:33.67ms
+step:532/1490 train_time:17935ms step_avg:33.71ms
+step:533/1490 train_time:17989ms step_avg:33.75ms
+step:534/1490 train_time:18048ms step_avg:33.80ms
+step:535/1490 train_time:18102ms step_avg:33.84ms
+step:536/1490 train_time:18162ms step_avg:33.88ms
+step:537/1490 train_time:18216ms step_avg:33.92ms
+step:538/1490 train_time:18277ms step_avg:33.97ms
+step:539/1490 train_time:18332ms step_avg:34.01ms
+step:540/1490 train_time:18391ms step_avg:34.06ms
+step:541/1490 train_time:18446ms step_avg:34.10ms
+step:542/1490 train_time:18506ms step_avg:34.14ms
+step:543/1490 train_time:18560ms step_avg:34.18ms
+step:544/1490 train_time:18621ms step_avg:34.23ms
+step:545/1490 train_time:18674ms step_avg:34.26ms
+step:546/1490 train_time:18733ms step_avg:34.31ms
+step:547/1490 train_time:18786ms step_avg:34.34ms
+step:548/1490 train_time:18845ms step_avg:34.39ms
+step:549/1490 train_time:18899ms step_avg:34.42ms
+step:550/1490 train_time:18958ms step_avg:34.47ms
+step:551/1490 train_time:19012ms step_avg:34.50ms
+step:552/1490 train_time:19071ms step_avg:34.55ms
+step:553/1490 train_time:19126ms step_avg:34.59ms
+step:554/1490 train_time:19186ms step_avg:34.63ms
+step:555/1490 train_time:19240ms step_avg:34.67ms
+step:556/1490 train_time:19300ms step_avg:34.71ms
+step:557/1490 train_time:19355ms step_avg:34.75ms
+step:558/1490 train_time:19415ms step_avg:34.79ms
+step:559/1490 train_time:19469ms step_avg:34.83ms
+step:560/1490 train_time:19529ms step_avg:34.87ms
+step:561/1490 train_time:19582ms step_avg:34.91ms
+step:562/1490 train_time:19643ms step_avg:34.95ms
+step:563/1490 train_time:19696ms step_avg:34.98ms
+step:564/1490 train_time:19756ms step_avg:35.03ms
+step:565/1490 train_time:19809ms step_avg:35.06ms
+step:566/1490 train_time:19868ms step_avg:35.10ms
+step:567/1490 train_time:19921ms step_avg:35.13ms
+step:568/1490 train_time:19981ms step_avg:35.18ms
+step:569/1490 train_time:20035ms step_avg:35.21ms
+step:570/1490 train_time:20093ms step_avg:35.25ms
+step:571/1490 train_time:20148ms step_avg:35.29ms
+step:572/1490 train_time:20208ms step_avg:35.33ms
+step:573/1490 train_time:20263ms step_avg:35.36ms
+step:574/1490 train_time:20324ms step_avg:35.41ms
+step:575/1490 train_time:20378ms step_avg:35.44ms
+step:576/1490 train_time:20439ms step_avg:35.48ms
+step:577/1490 train_time:20493ms step_avg:35.52ms
+step:578/1490 train_time:20553ms step_avg:35.56ms
+step:579/1490 train_time:20607ms step_avg:35.59ms
+step:580/1490 train_time:20666ms step_avg:35.63ms
+step:581/1490 train_time:20719ms step_avg:35.66ms
+step:582/1490 train_time:20779ms step_avg:35.70ms
+step:583/1490 train_time:20833ms step_avg:35.73ms
+step:584/1490 train_time:20892ms step_avg:35.77ms
+step:585/1490 train_time:20946ms step_avg:35.80ms
+step:586/1490 train_time:21005ms step_avg:35.85ms
+step:587/1490 train_time:21059ms step_avg:35.88ms
+step:588/1490 train_time:21120ms step_avg:35.92ms
+step:589/1490 train_time:21174ms step_avg:35.95ms
+step:590/1490 train_time:21234ms step_avg:35.99ms
+step:591/1490 train_time:21288ms step_avg:36.02ms
+step:592/1490 train_time:21348ms step_avg:36.06ms
+step:593/1490 train_time:21402ms step_avg:36.09ms
+step:594/1490 train_time:21462ms step_avg:36.13ms
+step:595/1490 train_time:21517ms step_avg:36.16ms
+step:596/1490 train_time:21578ms step_avg:36.20ms
+step:597/1490 train_time:21632ms step_avg:36.23ms
+step:598/1490 train_time:21691ms step_avg:36.27ms
+step:599/1490 train_time:21745ms step_avg:36.30ms
+step:600/1490 train_time:21804ms step_avg:36.34ms
+step:601/1490 train_time:21858ms step_avg:36.37ms
+step:602/1490 train_time:21917ms step_avg:36.41ms
+step:603/1490 train_time:21971ms step_avg:36.44ms
+step:604/1490 train_time:22030ms step_avg:36.47ms
+step:605/1490 train_time:22085ms step_avg:36.50ms
+step:606/1490 train_time:22144ms step_avg:36.54ms
+step:607/1490 train_time:22198ms step_avg:36.57ms
+step:608/1490 train_time:22259ms step_avg:36.61ms
+step:609/1490 train_time:22313ms step_avg:36.64ms
+step:610/1490 train_time:22372ms step_avg:36.68ms
+step:611/1490 train_time:22427ms step_avg:36.70ms
+step:612/1490 train_time:22486ms step_avg:36.74ms
+step:613/1490 train_time:22540ms step_avg:36.77ms
+step:614/1490 train_time:22599ms step_avg:36.81ms
+step:615/1490 train_time:22654ms step_avg:36.84ms
+step:616/1490 train_time:22714ms step_avg:36.87ms
+step:617/1490 train_time:22769ms step_avg:36.90ms
+step:618/1490 train_time:22828ms step_avg:36.94ms
+step:619/1490 train_time:22882ms step_avg:36.97ms
+step:620/1490 train_time:22942ms step_avg:37.00ms
+step:621/1490 train_time:22996ms step_avg:37.03ms
+step:622/1490 train_time:23056ms step_avg:37.07ms
+step:623/1490 train_time:23109ms step_avg:37.09ms
+step:624/1490 train_time:23168ms step_avg:37.13ms
+step:625/1490 train_time:23222ms step_avg:37.16ms
+step:626/1490 train_time:23282ms step_avg:37.19ms
+step:627/1490 train_time:23336ms step_avg:37.22ms
+step:628/1490 train_time:23396ms step_avg:37.25ms
+step:629/1490 train_time:23449ms step_avg:37.28ms
+step:630/1490 train_time:23509ms step_avg:37.32ms
+step:631/1490 train_time:23564ms step_avg:37.34ms
+step:632/1490 train_time:23624ms step_avg:37.38ms
+step:633/1490 train_time:23678ms step_avg:37.41ms
+step:634/1490 train_time:23738ms step_avg:37.44ms
+step:635/1490 train_time:23792ms step_avg:37.47ms
+step:636/1490 train_time:23850ms step_avg:37.50ms
+step:637/1490 train_time:23905ms step_avg:37.53ms
+step:638/1490 train_time:23965ms step_avg:37.56ms
+step:639/1490 train_time:24018ms step_avg:37.59ms
+step:640/1490 train_time:24077ms step_avg:37.62ms
+step:641/1490 train_time:24132ms step_avg:37.65ms
+step:642/1490 train_time:24192ms step_avg:37.68ms
+step:643/1490 train_time:24246ms step_avg:37.71ms
+step:644/1490 train_time:24306ms step_avg:37.74ms
+step:645/1490 train_time:24361ms step_avg:37.77ms
+step:646/1490 train_time:24421ms step_avg:37.80ms
+step:647/1490 train_time:24475ms step_avg:37.83ms
+step:648/1490 train_time:24535ms step_avg:37.86ms
+step:649/1490 train_time:24588ms step_avg:37.89ms
+step:650/1490 train_time:24648ms step_avg:37.92ms
+step:651/1490 train_time:24702ms step_avg:37.94ms
+step:652/1490 train_time:24763ms step_avg:37.98ms
+step:653/1490 train_time:24817ms step_avg:38.00ms
+step:654/1490 train_time:24877ms step_avg:38.04ms
+step:655/1490 train_time:24931ms step_avg:38.06ms
+step:656/1490 train_time:24989ms step_avg:38.09ms
+step:657/1490 train_time:25043ms step_avg:38.12ms
+step:658/1490 train_time:25103ms step_avg:38.15ms
+step:659/1490 train_time:25157ms step_avg:38.17ms
+step:660/1490 train_time:25217ms step_avg:38.21ms
+step:661/1490 train_time:25272ms step_avg:38.23ms
+step:662/1490 train_time:25331ms step_avg:38.27ms
+step:663/1490 train_time:25385ms step_avg:38.29ms
+step:664/1490 train_time:25445ms step_avg:38.32ms
+step:665/1490 train_time:25499ms step_avg:38.34ms
+step:666/1490 train_time:25558ms step_avg:38.38ms
+step:667/1490 train_time:25613ms step_avg:38.40ms
+step:668/1490 train_time:25671ms step_avg:38.43ms
+step:669/1490 train_time:25726ms step_avg:38.45ms
+step:670/1490 train_time:25785ms step_avg:38.48ms
+step:671/1490 train_time:25839ms step_avg:38.51ms
+step:672/1490 train_time:25899ms step_avg:38.54ms
+step:673/1490 train_time:25954ms step_avg:38.56ms
+step:674/1490 train_time:26013ms step_avg:38.59ms
+step:675/1490 train_time:26067ms step_avg:38.62ms
+step:676/1490 train_time:26127ms step_avg:38.65ms
+step:677/1490 train_time:26181ms step_avg:38.67ms
+step:678/1490 train_time:26241ms step_avg:38.70ms
+step:679/1490 train_time:26296ms step_avg:38.73ms
+step:680/1490 train_time:26355ms step_avg:38.76ms
+step:681/1490 train_time:26408ms step_avg:38.78ms
+step:682/1490 train_time:26468ms step_avg:38.81ms
+step:683/1490 train_time:26522ms step_avg:38.83ms
+step:684/1490 train_time:26582ms step_avg:38.86ms
+step:685/1490 train_time:26636ms step_avg:38.89ms
+step:686/1490 train_time:26696ms step_avg:38.92ms
+step:687/1490 train_time:26752ms step_avg:38.94ms
+step:688/1490 train_time:26811ms step_avg:38.97ms
+step:689/1490 train_time:26866ms step_avg:38.99ms
+step:690/1490 train_time:26925ms step_avg:39.02ms
+step:691/1490 train_time:26979ms step_avg:39.04ms
+step:692/1490 train_time:27039ms step_avg:39.07ms
+step:693/1490 train_time:27095ms step_avg:39.10ms
+step:694/1490 train_time:27154ms step_avg:39.13ms
+step:695/1490 train_time:27208ms step_avg:39.15ms
+step:696/1490 train_time:27267ms step_avg:39.18ms
+step:697/1490 train_time:27321ms step_avg:39.20ms
+step:698/1490 train_time:27381ms step_avg:39.23ms
+step:699/1490 train_time:27435ms step_avg:39.25ms
+step:700/1490 train_time:27494ms step_avg:39.28ms
+step:701/1490 train_time:27548ms step_avg:39.30ms
+step:702/1490 train_time:27608ms step_avg:39.33ms
+step:703/1490 train_time:27662ms step_avg:39.35ms
+step:704/1490 train_time:27723ms step_avg:39.38ms
+step:705/1490 train_time:27777ms step_avg:39.40ms
+step:706/1490 train_time:27837ms step_avg:39.43ms
+step:707/1490 train_time:27890ms step_avg:39.45ms
+step:708/1490 train_time:27950ms step_avg:39.48ms
+step:709/1490 train_time:28005ms step_avg:39.50ms
+step:710/1490 train_time:28064ms step_avg:39.53ms
+step:711/1490 train_time:28119ms step_avg:39.55ms
+step:712/1490 train_time:28179ms step_avg:39.58ms
+step:713/1490 train_time:28233ms step_avg:39.60ms
+step:714/1490 train_time:28292ms step_avg:39.63ms
+step:715/1490 train_time:28347ms step_avg:39.65ms
+step:716/1490 train_time:28406ms step_avg:39.67ms
+step:717/1490 train_time:28460ms step_avg:39.69ms
+step:718/1490 train_time:28521ms step_avg:39.72ms
+step:719/1490 train_time:28575ms step_avg:39.74ms
+step:720/1490 train_time:28634ms step_avg:39.77ms
+step:721/1490 train_time:28689ms step_avg:39.79ms
+step:722/1490 train_time:28748ms step_avg:39.82ms
+step:723/1490 train_time:28801ms step_avg:39.84ms
+step:724/1490 train_time:28861ms step_avg:39.86ms
+step:725/1490 train_time:28916ms step_avg:39.88ms
+step:726/1490 train_time:28975ms step_avg:39.91ms
+step:727/1490 train_time:29029ms step_avg:39.93ms
+step:728/1490 train_time:29089ms step_avg:39.96ms
+step:729/1490 train_time:29144ms step_avg:39.98ms
+step:730/1490 train_time:29203ms step_avg:40.00ms
+step:731/1490 train_time:29258ms step_avg:40.03ms
+step:732/1490 train_time:29319ms step_avg:40.05ms
+step:733/1490 train_time:29373ms step_avg:40.07ms
+step:734/1490 train_time:29433ms step_avg:40.10ms
+step:735/1490 train_time:29486ms step_avg:40.12ms
+step:736/1490 train_time:29546ms step_avg:40.14ms
+step:737/1490 train_time:29600ms step_avg:40.16ms
+step:738/1490 train_time:29660ms step_avg:40.19ms
+step:739/1490 train_time:29713ms step_avg:40.21ms
+step:740/1490 train_time:29773ms step_avg:40.23ms
+step:741/1490 train_time:29827ms step_avg:40.25ms
+step:742/1490 train_time:29887ms step_avg:40.28ms
+step:743/1490 train_time:29940ms step_avg:40.30ms
+step:744/1490 train_time:30001ms step_avg:40.32ms
+step:745/1490 train_time:30056ms step_avg:40.34ms
+step:746/1490 train_time:30115ms step_avg:40.37ms
+step:747/1490 train_time:30169ms step_avg:40.39ms
+step:748/1490 train_time:30230ms step_avg:40.41ms
+step:749/1490 train_time:30284ms step_avg:40.43ms
+step:750/1490 train_time:30343ms step_avg:40.46ms
+step:750/1490 val_loss:3.8067 train_time:30417ms step_avg:40.56ms
+step:751/1490 train_time:30434ms step_avg:40.52ms
+step:752/1490 train_time:30461ms step_avg:40.51ms
+step:753/1490 train_time:30517ms step_avg:40.53ms
+step:754/1490 train_time:30582ms step_avg:40.56ms
+step:755/1490 train_time:30640ms step_avg:40.58ms
+step:756/1490 train_time:30700ms step_avg:40.61ms
+step:757/1490 train_time:30754ms step_avg:40.63ms
+step:758/1490 train_time:30813ms step_avg:40.65ms
+step:759/1490 train_time:30867ms step_avg:40.67ms
+step:760/1490 train_time:30925ms step_avg:40.69ms
+step:761/1490 train_time:30979ms step_avg:40.71ms
+step:762/1490 train_time:31039ms step_avg:40.73ms
+step:763/1490 train_time:31092ms step_avg:40.75ms
+step:764/1490 train_time:31151ms step_avg:40.77ms
+step:765/1490 train_time:31204ms step_avg:40.79ms
+step:766/1490 train_time:31263ms step_avg:40.81ms
+step:767/1490 train_time:31316ms step_avg:40.83ms
+step:768/1490 train_time:31377ms step_avg:40.86ms
+step:769/1490 train_time:31432ms step_avg:40.87ms
+step:770/1490 train_time:31494ms step_avg:40.90ms
+step:771/1490 train_time:31550ms step_avg:40.92ms
+step:772/1490 train_time:31612ms step_avg:40.95ms
+step:773/1490 train_time:31667ms step_avg:40.97ms
+step:774/1490 train_time:31727ms step_avg:40.99ms
+step:775/1490 train_time:31782ms step_avg:41.01ms
+step:776/1490 train_time:31842ms step_avg:41.03ms
+step:777/1490 train_time:31895ms step_avg:41.05ms
+step:778/1490 train_time:31955ms step_avg:41.07ms
+step:779/1490 train_time:32008ms step_avg:41.09ms
+step:780/1490 train_time:32067ms step_avg:41.11ms
+step:781/1490 train_time:32120ms step_avg:41.13ms
+step:782/1490 train_time:32180ms step_avg:41.15ms
+step:783/1490 train_time:32233ms step_avg:41.17ms
+step:784/1490 train_time:32292ms step_avg:41.19ms
+step:785/1490 train_time:32346ms step_avg:41.20ms
+step:786/1490 train_time:32406ms step_avg:41.23ms
+step:787/1490 train_time:32462ms step_avg:41.25ms
+step:788/1490 train_time:32522ms step_avg:41.27ms
+step:789/1490 train_time:32577ms step_avg:41.29ms
+step:790/1490 train_time:32639ms step_avg:41.32ms
+step:791/1490 train_time:32693ms step_avg:41.33ms
+step:792/1490 train_time:32753ms step_avg:41.36ms
+step:793/1490 train_time:32807ms step_avg:41.37ms
+step:794/1490 train_time:32866ms step_avg:41.39ms
+step:795/1490 train_time:32919ms step_avg:41.41ms
+step:796/1490 train_time:32979ms step_avg:41.43ms
+step:797/1490 train_time:33033ms step_avg:41.45ms
+step:798/1490 train_time:33092ms step_avg:41.47ms
+step:799/1490 train_time:33146ms step_avg:41.48ms
+step:800/1490 train_time:33205ms step_avg:41.51ms
+step:801/1490 train_time:33259ms step_avg:41.52ms
+step:802/1490 train_time:33318ms step_avg:41.54ms
+step:803/1490 train_time:33372ms step_avg:41.56ms
+step:804/1490 train_time:33433ms step_avg:41.58ms
+step:805/1490 train_time:33488ms step_avg:41.60ms
+step:806/1490 train_time:33548ms step_avg:41.62ms
+step:807/1490 train_time:33603ms step_avg:41.64ms
+step:808/1490 train_time:33664ms step_avg:41.66ms
+step:809/1490 train_time:33717ms step_avg:41.68ms
+step:810/1490 train_time:33777ms step_avg:41.70ms
+step:811/1490 train_time:33831ms step_avg:41.72ms
+step:812/1490 train_time:33890ms step_avg:41.74ms
+step:813/1490 train_time:33944ms step_avg:41.75ms
+step:814/1490 train_time:34002ms step_avg:41.77ms
+step:815/1490 train_time:34056ms step_avg:41.79ms
+step:816/1490 train_time:34115ms step_avg:41.81ms
+step:817/1490 train_time:34169ms step_avg:41.82ms
+step:818/1490 train_time:34229ms step_avg:41.85ms
+step:819/1490 train_time:34284ms step_avg:41.86ms
+step:820/1490 train_time:34344ms step_avg:41.88ms
+step:821/1490 train_time:34398ms step_avg:41.90ms
+step:822/1490 train_time:34458ms step_avg:41.92ms
+step:823/1490 train_time:34512ms step_avg:41.93ms
+step:824/1490 train_time:34572ms step_avg:41.96ms
+step:825/1490 train_time:34627ms step_avg:41.97ms
+step:826/1490 train_time:34687ms step_avg:41.99ms
+step:827/1490 train_time:34742ms step_avg:42.01ms
+step:828/1490 train_time:34801ms step_avg:42.03ms
+step:829/1490 train_time:34855ms step_avg:42.05ms
+step:830/1490 train_time:34915ms step_avg:42.07ms
+step:831/1490 train_time:34969ms step_avg:42.08ms
+step:832/1490 train_time:35028ms step_avg:42.10ms
+step:833/1490 train_time:35082ms step_avg:42.12ms
+step:834/1490 train_time:35142ms step_avg:42.14ms
+step:835/1490 train_time:35196ms step_avg:42.15ms
+step:836/1490 train_time:35255ms step_avg:42.17ms
+step:837/1490 train_time:35309ms step_avg:42.19ms
+step:838/1490 train_time:35369ms step_avg:42.21ms
+step:839/1490 train_time:35422ms step_avg:42.22ms
+step:840/1490 train_time:35483ms step_avg:42.24ms
+step:841/1490 train_time:35537ms step_avg:42.26ms
+step:842/1490 train_time:35598ms step_avg:42.28ms
+step:843/1490 train_time:35651ms step_avg:42.29ms
+step:844/1490 train_time:35712ms step_avg:42.31ms
+step:845/1490 train_time:35767ms step_avg:42.33ms
+step:846/1490 train_time:35826ms step_avg:42.35ms
+step:847/1490 train_time:35880ms step_avg:42.36ms
+step:848/1490 train_time:35940ms step_avg:42.38ms
+step:849/1490 train_time:35994ms step_avg:42.40ms
+step:850/1490 train_time:36054ms step_avg:42.42ms
+step:851/1490 train_time:36107ms step_avg:42.43ms
+step:852/1490 train_time:36166ms step_avg:42.45ms
+step:853/1490 train_time:36221ms step_avg:42.46ms
+step:854/1490 train_time:36280ms step_avg:42.48ms
+step:855/1490 train_time:36334ms step_avg:42.50ms
+step:856/1490 train_time:36394ms step_avg:42.52ms
+step:857/1490 train_time:36448ms step_avg:42.53ms
+step:858/1490 train_time:36507ms step_avg:42.55ms
+step:859/1490 train_time:36562ms step_avg:42.56ms
+step:860/1490 train_time:36621ms step_avg:42.58ms
+step:861/1490 train_time:36676ms step_avg:42.60ms
+step:862/1490 train_time:36737ms step_avg:42.62ms
+step:863/1490 train_time:36792ms step_avg:42.63ms
+step:864/1490 train_time:36852ms step_avg:42.65ms
+step:865/1490 train_time:36905ms step_avg:42.66ms
+step:866/1490 train_time:36964ms step_avg:42.68ms
+step:867/1490 train_time:37018ms step_avg:42.70ms
+step:868/1490 train_time:37077ms step_avg:42.72ms
+step:869/1490 train_time:37132ms step_avg:42.73ms
+step:870/1490 train_time:37191ms step_avg:42.75ms
+step:871/1490 train_time:37244ms step_avg:42.76ms
+step:872/1490 train_time:37304ms step_avg:42.78ms
+step:873/1490 train_time:37358ms step_avg:42.79ms
+step:874/1490 train_time:37418ms step_avg:42.81ms
+step:875/1490 train_time:37473ms step_avg:42.83ms
+step:876/1490 train_time:37533ms step_avg:42.85ms
+step:877/1490 train_time:37588ms step_avg:42.86ms
+step:878/1490 train_time:37647ms step_avg:42.88ms
+step:879/1490 train_time:37702ms step_avg:42.89ms
+step:880/1490 train_time:37762ms step_avg:42.91ms
+step:881/1490 train_time:37816ms step_avg:42.92ms
+step:882/1490 train_time:37876ms step_avg:42.94ms
+step:883/1490 train_time:37929ms step_avg:42.95ms
+step:884/1490 train_time:37988ms step_avg:42.97ms
+step:885/1490 train_time:38042ms step_avg:42.99ms
+step:886/1490 train_time:38101ms step_avg:43.00ms
+step:887/1490 train_time:38155ms step_avg:43.02ms
+step:888/1490 train_time:38215ms step_avg:43.03ms
+step:889/1490 train_time:38269ms step_avg:43.05ms
+step:890/1490 train_time:38328ms step_avg:43.06ms
+step:891/1490 train_time:38382ms step_avg:43.08ms
+step:892/1490 train_time:38443ms step_avg:43.10ms
+step:893/1490 train_time:38497ms step_avg:43.11ms
+step:894/1490 train_time:38556ms step_avg:43.13ms
+step:895/1490 train_time:38610ms step_avg:43.14ms
+step:896/1490 train_time:38670ms step_avg:43.16ms
+step:897/1490 train_time:38724ms step_avg:43.17ms
+step:898/1490 train_time:38784ms step_avg:43.19ms
+step:899/1490 train_time:38838ms step_avg:43.20ms
+step:900/1490 train_time:38898ms step_avg:43.22ms
+step:901/1490 train_time:38952ms step_avg:43.23ms
+step:902/1490 train_time:39011ms step_avg:43.25ms
+step:903/1490 train_time:39065ms step_avg:43.26ms
+step:904/1490 train_time:39123ms step_avg:43.28ms
+step:905/1490 train_time:39178ms step_avg:43.29ms
+step:906/1490 train_time:39237ms step_avg:43.31ms
+step:907/1490 train_time:39290ms step_avg:43.32ms
+step:908/1490 train_time:39350ms step_avg:43.34ms
+step:909/1490 train_time:39405ms step_avg:43.35ms
+step:910/1490 train_time:39464ms step_avg:43.37ms
+step:911/1490 train_time:39519ms step_avg:43.38ms
+step:912/1490 train_time:39579ms step_avg:43.40ms
+step:913/1490 train_time:39633ms step_avg:43.41ms
+step:914/1490 train_time:39694ms step_avg:43.43ms
+step:915/1490 train_time:39749ms step_avg:43.44ms
+step:916/1490 train_time:39808ms step_avg:43.46ms
+step:917/1490 train_time:39863ms step_avg:43.47ms
+step:918/1490 train_time:39922ms step_avg:43.49ms
+step:919/1490 train_time:39976ms step_avg:43.50ms
+step:920/1490 train_time:40036ms step_avg:43.52ms
+step:921/1490 train_time:40091ms step_avg:43.53ms
+step:922/1490 train_time:40151ms step_avg:43.55ms
+step:923/1490 train_time:40205ms step_avg:43.56ms
+step:924/1490 train_time:40264ms step_avg:43.58ms
+step:925/1490 train_time:40317ms step_avg:43.59ms
+step:926/1490 train_time:40378ms step_avg:43.60ms
+step:927/1490 train_time:40432ms step_avg:43.62ms
+step:928/1490 train_time:40491ms step_avg:43.63ms
+step:929/1490 train_time:40544ms step_avg:43.64ms
+step:930/1490 train_time:40603ms step_avg:43.66ms
+step:931/1490 train_time:40658ms step_avg:43.67ms
+step:932/1490 train_time:40718ms step_avg:43.69ms
+step:933/1490 train_time:40773ms step_avg:43.70ms
+step:934/1490 train_time:40833ms step_avg:43.72ms
+step:935/1490 train_time:40887ms step_avg:43.73ms
+step:936/1490 train_time:40946ms step_avg:43.75ms
+step:937/1490 train_time:41000ms step_avg:43.76ms
+step:938/1490 train_time:41060ms step_avg:43.77ms
+step:939/1490 train_time:41114ms step_avg:43.79ms
+step:940/1490 train_time:41174ms step_avg:43.80ms
+step:941/1490 train_time:41227ms step_avg:43.81ms
+step:942/1490 train_time:41287ms step_avg:43.83ms
+step:943/1490 train_time:41342ms step_avg:43.84ms
+step:944/1490 train_time:41401ms step_avg:43.86ms
+step:945/1490 train_time:41455ms step_avg:43.87ms
+step:946/1490 train_time:41514ms step_avg:43.88ms
+step:947/1490 train_time:41568ms step_avg:43.89ms
+step:948/1490 train_time:41627ms step_avg:43.91ms
+step:949/1490 train_time:41682ms step_avg:43.92ms
+step:950/1490 train_time:41742ms step_avg:43.94ms
+step:951/1490 train_time:41796ms step_avg:43.95ms
+step:952/1490 train_time:41856ms step_avg:43.97ms
+step:953/1490 train_time:41910ms step_avg:43.98ms
+step:954/1490 train_time:41969ms step_avg:43.99ms
+step:955/1490 train_time:42023ms step_avg:44.00ms
+step:956/1490 train_time:42083ms step_avg:44.02ms
+step:957/1490 train_time:42137ms step_avg:44.03ms
+step:958/1490 train_time:42197ms step_avg:44.05ms
+step:959/1490 train_time:42251ms step_avg:44.06ms
+step:960/1490 train_time:42310ms step_avg:44.07ms
+step:961/1490 train_time:42364ms step_avg:44.08ms
+step:962/1490 train_time:42423ms step_avg:44.10ms
+step:963/1490 train_time:42478ms step_avg:44.11ms
+step:964/1490 train_time:42538ms step_avg:44.13ms
+step:965/1490 train_time:42592ms step_avg:44.14ms
+step:966/1490 train_time:42652ms step_avg:44.15ms
+step:967/1490 train_time:42705ms step_avg:44.16ms
+step:968/1490 train_time:42768ms step_avg:44.18ms
+step:969/1490 train_time:42846ms step_avg:44.22ms
+step:970/1490 train_time:42931ms step_avg:44.26ms
+step:971/1490 train_time:43013ms step_avg:44.30ms
+step:972/1490 train_time:43098ms step_avg:44.34ms
+step:973/1490 train_time:43178ms step_avg:44.38ms
+step:974/1490 train_time:43264ms step_avg:44.42ms
+step:975/1490 train_time:43344ms step_avg:44.46ms
+step:976/1490 train_time:43429ms step_avg:44.50ms
+step:977/1490 train_time:43510ms step_avg:44.53ms
+step:978/1490 train_time:43595ms step_avg:44.58ms
+step:979/1490 train_time:43676ms step_avg:44.61ms
+step:980/1490 train_time:43763ms step_avg:44.66ms
+step:981/1490 train_time:43844ms step_avg:44.69ms
+step:982/1490 train_time:43928ms step_avg:44.73ms
+step:983/1490 train_time:44007ms step_avg:44.77ms
+step:984/1490 train_time:44092ms step_avg:44.81ms
+step:985/1490 train_time:44172ms step_avg:44.84ms
+step:986/1490 train_time:44259ms step_avg:44.89ms
+step:987/1490 train_time:44338ms step_avg:44.92ms
+step:988/1490 train_time:44424ms step_avg:44.96ms
+step:989/1490 train_time:44504ms step_avg:45.00ms
+step:990/1490 train_time:44589ms step_avg:45.04ms
+step:991/1490 train_time:44671ms step_avg:45.08ms
+step:992/1490 train_time:44757ms step_avg:45.12ms
+step:993/1490 train_time:44836ms step_avg:45.15ms
+step:994/1490 train_time:44922ms step_avg:45.19ms
+step:995/1490 train_time:45001ms step_avg:45.23ms
+step:996/1490 train_time:45086ms step_avg:45.27ms
+step:997/1490 train_time:45167ms step_avg:45.30ms
+step:998/1490 train_time:45253ms step_avg:45.34ms
+step:999/1490 train_time:45333ms step_avg:45.38ms
+step:1000/1490 train_time:45419ms step_avg:45.42ms
+step:1000/1490 val_loss:3.5171 train_time:45521ms step_avg:45.52ms
+step:1001/1490 train_time:45538ms step_avg:45.49ms
+step:1002/1490 train_time:45589ms step_avg:45.50ms
+step:1003/1490 train_time:45673ms step_avg:45.54ms
+step:1004/1490 train_time:45760ms step_avg:45.58ms
+step:1005/1490 train_time:45842ms step_avg:45.61ms
+step:1006/1490 train_time:45926ms step_avg:45.65ms
+step:1007/1490 train_time:46005ms step_avg:45.69ms
+step:1008/1490 train_time:46089ms step_avg:45.72ms
+step:1009/1490 train_time:46168ms step_avg:45.76ms
+step:1010/1490 train_time:46252ms step_avg:45.79ms
+step:1011/1490 train_time:46331ms step_avg:45.83ms
+step:1012/1490 train_time:46416ms step_avg:45.87ms
+step:1013/1490 train_time:46497ms step_avg:45.90ms
+step:1014/1490 train_time:46584ms step_avg:45.94ms
+step:1015/1490 train_time:46666ms step_avg:45.98ms
+step:1016/1490 train_time:46752ms step_avg:46.02ms
+step:1017/1490 train_time:46833ms step_avg:46.05ms
+step:1018/1490 train_time:46918ms step_avg:46.09ms
+step:1019/1490 train_time:46997ms step_avg:46.12ms
+step:1020/1490 train_time:47081ms step_avg:46.16ms
+step:1021/1490 train_time:47161ms step_avg:46.19ms
+step:1022/1490 train_time:47245ms step_avg:46.23ms
+step:1023/1490 train_time:47325ms step_avg:46.26ms
+step:1024/1490 train_time:47409ms step_avg:46.30ms
+step:1025/1490 train_time:47490ms step_avg:46.33ms
+step:1026/1490 train_time:47578ms step_avg:46.37ms
+step:1027/1490 train_time:47658ms step_avg:46.41ms
+step:1028/1490 train_time:47745ms step_avg:46.44ms
+step:1029/1490 train_time:47826ms step_avg:46.48ms
+step:1030/1490 train_time:47912ms step_avg:46.52ms
+step:1031/1490 train_time:47991ms step_avg:46.55ms
+step:1032/1490 train_time:48076ms step_avg:46.59ms
+step:1033/1490 train_time:48154ms step_avg:46.62ms
+step:1034/1490 train_time:48239ms step_avg:46.65ms
+step:1035/1490 train_time:48320ms step_avg:46.69ms
+step:1036/1490 train_time:48405ms step_avg:46.72ms
+step:1037/1490 train_time:48486ms step_avg:46.76ms
+step:1038/1490 train_time:48572ms step_avg:46.79ms
+step:1039/1490 train_time:48654ms step_avg:46.83ms
+step:1040/1490 train_time:48739ms step_avg:46.86ms
+step:1041/1490 train_time:48821ms step_avg:46.90ms
+step:1042/1490 train_time:48907ms step_avg:46.94ms
+step:1043/1490 train_time:48986ms step_avg:46.97ms
+step:1044/1490 train_time:49071ms step_avg:47.00ms
+step:1045/1490 train_time:49150ms step_avg:47.03ms
+step:1046/1490 train_time:49234ms step_avg:47.07ms
+step:1047/1490 train_time:49314ms step_avg:47.10ms
+step:1048/1490 train_time:49400ms step_avg:47.14ms
+step:1049/1490 train_time:49480ms step_avg:47.17ms
+step:1050/1490 train_time:49567ms step_avg:47.21ms
+step:1051/1490 train_time:49648ms step_avg:47.24ms
+step:1052/1490 train_time:49732ms step_avg:47.27ms
+step:1053/1490 train_time:49814ms step_avg:47.31ms
+step:1054/1490 train_time:49899ms step_avg:47.34ms
+step:1055/1490 train_time:49979ms step_avg:47.37ms
+step:1056/1490 train_time:50064ms step_avg:47.41ms
+step:1057/1490 train_time:50144ms step_avg:47.44ms
+step:1058/1490 train_time:50228ms step_avg:47.47ms
+step:1059/1490 train_time:50307ms step_avg:47.50ms
+step:1060/1490 train_time:50392ms step_avg:47.54ms
+step:1061/1490 train_time:50475ms step_avg:47.57ms
+step:1062/1490 train_time:50561ms step_avg:47.61ms
+step:1063/1490 train_time:50641ms step_avg:47.64ms
+step:1064/1490 train_time:50728ms step_avg:47.68ms
+step:1065/1490 train_time:50807ms step_avg:47.71ms
+step:1066/1490 train_time:50894ms step_avg:47.74ms
+step:1067/1490 train_time:50974ms step_avg:47.77ms
+step:1068/1490 train_time:51059ms step_avg:47.81ms
+step:1069/1490 train_time:51138ms step_avg:47.84ms
+step:1070/1490 train_time:51224ms step_avg:47.87ms
+step:1071/1490 train_time:51303ms step_avg:47.90ms
+step:1072/1490 train_time:51388ms step_avg:47.94ms
+step:1073/1490 train_time:51469ms step_avg:47.97ms
+step:1074/1490 train_time:51555ms step_avg:48.00ms
+step:1075/1490 train_time:51635ms step_avg:48.03ms
+step:1076/1490 train_time:51721ms step_avg:48.07ms
+step:1077/1490 train_time:51802ms step_avg:48.10ms
+step:1078/1490 train_time:51888ms step_avg:48.13ms
+step:1079/1490 train_time:51969ms step_avg:48.16ms
+step:1080/1490 train_time:52053ms step_avg:48.20ms
+step:1081/1490 train_time:52132ms step_avg:48.23ms
+step:1082/1490 train_time:52216ms step_avg:48.26ms
+step:1083/1490 train_time:52296ms step_avg:48.29ms
+step:1084/1490 train_time:52381ms step_avg:48.32ms
+step:1085/1490 train_time:52463ms step_avg:48.35ms
+step:1086/1490 train_time:52550ms step_avg:48.39ms
+step:1087/1490 train_time:52631ms step_avg:48.42ms
+step:1088/1490 train_time:52715ms step_avg:48.45ms
+step:1089/1490 train_time:52795ms step_avg:48.48ms
+step:1090/1490 train_time:52881ms step_avg:48.51ms
+step:1091/1490 train_time:52961ms step_avg:48.54ms
+step:1092/1490 train_time:53047ms step_avg:48.58ms
+step:1093/1490 train_time:53128ms step_avg:48.61ms
+step:1094/1490 train_time:53213ms step_avg:48.64ms
+step:1095/1490 train_time:53293ms step_avg:48.67ms
+step:1096/1490 train_time:53378ms step_avg:48.70ms
+step:1097/1490 train_time:53458ms step_avg:48.73ms
+step:1098/1490 train_time:53544ms step_avg:48.77ms
+step:1099/1490 train_time:53625ms step_avg:48.79ms
+step:1100/1490 train_time:53712ms step_avg:48.83ms
+step:1101/1490 train_time:53792ms step_avg:48.86ms
+step:1102/1490 train_time:53877ms step_avg:48.89ms
+step:1103/1490 train_time:53956ms step_avg:48.92ms
+step:1104/1490 train_time:54042ms step_avg:48.95ms
+step:1105/1490 train_time:54123ms step_avg:48.98ms
+step:1106/1490 train_time:54209ms step_avg:49.01ms
+step:1107/1490 train_time:54289ms step_avg:49.04ms
+step:1108/1490 train_time:54373ms step_avg:49.07ms
+step:1109/1490 train_time:54454ms step_avg:49.10ms
+step:1110/1490 train_time:54539ms step_avg:49.13ms
+step:1111/1490 train_time:54620ms step_avg:49.16ms
+step:1112/1490 train_time:54705ms step_avg:49.20ms
+step:1113/1490 train_time:54787ms step_avg:49.22ms
+step:1114/1490 train_time:54874ms step_avg:49.26ms
+step:1115/1490 train_time:54953ms step_avg:49.29ms
+step:1116/1490 train_time:55037ms step_avg:49.32ms
+step:1117/1490 train_time:55117ms step_avg:49.34ms
+step:1118/1490 train_time:55203ms step_avg:49.38ms
+step:1119/1490 train_time:55282ms step_avg:49.40ms
+step:1120/1490 train_time:55368ms step_avg:49.44ms
+step:1121/1490 train_time:55446ms step_avg:49.46ms
+step:1122/1490 train_time:55532ms step_avg:49.49ms
+step:1123/1490 train_time:55613ms step_avg:49.52ms
+step:1124/1490 train_time:55700ms step_avg:49.55ms
+step:1125/1490 train_time:55781ms step_avg:49.58ms
+step:1126/1490 train_time:55867ms step_avg:49.62ms
+step:1127/1490 train_time:55947ms step_avg:49.64ms
+step:1128/1490 train_time:56033ms step_avg:49.67ms
+step:1129/1490 train_time:56112ms step_avg:49.70ms
+step:1130/1490 train_time:56198ms step_avg:49.73ms
+step:1131/1490 train_time:56278ms step_avg:49.76ms
+step:1132/1490 train_time:56362ms step_avg:49.79ms
+step:1133/1490 train_time:56442ms step_avg:49.82ms
+step:1134/1490 train_time:56529ms step_avg:49.85ms
+step:1135/1490 train_time:56610ms step_avg:49.88ms
+step:1136/1490 train_time:56696ms step_avg:49.91ms
+step:1137/1490 train_time:56777ms step_avg:49.94ms
+step:1138/1490 train_time:56862ms step_avg:49.97ms
+step:1139/1490 train_time:56944ms step_avg:49.99ms
+step:1140/1490 train_time:57028ms step_avg:50.02ms
+step:1141/1490 train_time:57110ms step_avg:50.05ms
+step:1142/1490 train_time:57195ms step_avg:50.08ms
+step:1143/1490 train_time:57274ms step_avg:50.11ms
+step:1144/1490 train_time:57359ms step_avg:50.14ms
+step:1145/1490 train_time:57439ms step_avg:50.17ms
+step:1146/1490 train_time:57525ms step_avg:50.20ms
+step:1147/1490 train_time:57605ms step_avg:50.22ms
+step:1148/1490 train_time:57691ms step_avg:50.25ms
+step:1149/1490 train_time:57772ms step_avg:50.28ms
+step:1150/1490 train_time:57858ms step_avg:50.31ms
+step:1151/1490 train_time:57937ms step_avg:50.34ms
+step:1152/1490 train_time:58022ms step_avg:50.37ms
+step:1153/1490 train_time:58103ms step_avg:50.39ms
+step:1154/1490 train_time:58189ms step_avg:50.42ms
+step:1155/1490 train_time:58268ms step_avg:50.45ms
+step:1156/1490 train_time:58354ms step_avg:50.48ms
+step:1157/1490 train_time:58434ms step_avg:50.50ms
+step:1158/1490 train_time:58519ms step_avg:50.53ms
+step:1159/1490 train_time:58599ms step_avg:50.56ms
+step:1160/1490 train_time:58685ms step_avg:50.59ms
+step:1161/1490 train_time:58765ms step_avg:50.62ms
+step:1162/1490 train_time:58851ms step_avg:50.65ms
+step:1163/1490 train_time:58933ms step_avg:50.67ms
+step:1164/1490 train_time:59017ms step_avg:50.70ms
+step:1165/1490 train_time:59097ms step_avg:50.73ms
+step:1166/1490 train_time:59182ms step_avg:50.76ms
+step:1167/1490 train_time:59263ms step_avg:50.78ms
+step:1168/1490 train_time:59348ms step_avg:50.81ms
+step:1169/1490 train_time:59428ms step_avg:50.84ms
+step:1170/1490 train_time:59514ms step_avg:50.87ms
+step:1171/1490 train_time:59594ms step_avg:50.89ms
+step:1172/1490 train_time:59680ms step_avg:50.92ms
+step:1173/1490 train_time:59760ms step_avg:50.95ms
+step:1174/1490 train_time:59846ms step_avg:50.98ms
+step:1175/1490 train_time:59927ms step_avg:51.00ms
+step:1176/1490 train_time:60014ms step_avg:51.03ms
+step:1177/1490 train_time:60094ms step_avg:51.06ms
+step:1178/1490 train_time:60180ms step_avg:51.09ms
+step:1179/1490 train_time:60260ms step_avg:51.11ms
+step:1180/1490 train_time:60346ms step_avg:51.14ms
+step:1181/1490 train_time:60426ms step_avg:51.17ms
+step:1182/1490 train_time:60511ms step_avg:51.19ms
+step:1183/1490 train_time:60591ms step_avg:51.22ms
+step:1184/1490 train_time:60677ms step_avg:51.25ms
+step:1185/1490 train_time:60756ms step_avg:51.27ms
+step:1186/1490 train_time:60842ms step_avg:51.30ms
+step:1187/1490 train_time:60923ms step_avg:51.33ms
+step:1188/1490 train_time:61009ms step_avg:51.35ms
+step:1189/1490 train_time:61088ms step_avg:51.38ms
+step:1190/1490 train_time:61174ms step_avg:51.41ms
+step:1191/1490 train_time:61254ms step_avg:51.43ms
+step:1192/1490 train_time:61339ms step_avg:51.46ms
+step:1193/1490 train_time:61421ms step_avg:51.48ms
+step:1194/1490 train_time:61506ms step_avg:51.51ms
+step:1195/1490 train_time:61587ms step_avg:51.54ms
+step:1196/1490 train_time:61674ms step_avg:51.57ms
+step:1197/1490 train_time:61754ms step_avg:51.59ms
+step:1198/1490 train_time:61839ms step_avg:51.62ms
+step:1199/1490 train_time:61920ms step_avg:51.64ms
+step:1200/1490 train_time:62006ms step_avg:51.67ms
+step:1201/1490 train_time:62087ms step_avg:51.70ms
+step:1202/1490 train_time:62172ms step_avg:51.72ms
+step:1203/1490 train_time:62253ms step_avg:51.75ms
+step:1204/1490 train_time:62337ms step_avg:51.78ms
+step:1205/1490 train_time:62420ms step_avg:51.80ms
+step:1206/1490 train_time:62505ms step_avg:51.83ms
+step:1207/1490 train_time:62585ms step_avg:51.85ms
+step:1208/1490 train_time:62671ms step_avg:51.88ms
+step:1209/1490 train_time:62750ms step_avg:51.90ms
+step:1210/1490 train_time:62836ms step_avg:51.93ms
+step:1211/1490 train_time:62916ms step_avg:51.95ms
+step:1212/1490 train_time:63000ms step_avg:51.98ms
+step:1213/1490 train_time:63082ms step_avg:52.00ms
+step:1214/1490 train_time:63170ms step_avg:52.03ms
+step:1215/1490 train_time:63251ms step_avg:52.06ms
+step:1216/1490 train_time:63336ms step_avg:52.09ms
+step:1217/1490 train_time:63416ms step_avg:52.11ms
+step:1218/1490 train_time:63501ms step_avg:52.14ms
+step:1219/1490 train_time:63582ms step_avg:52.16ms
+step:1220/1490 train_time:63669ms step_avg:52.19ms
+step:1221/1490 train_time:63749ms step_avg:52.21ms
+step:1222/1490 train_time:63834ms step_avg:52.24ms
+step:1223/1490 train_time:63914ms step_avg:52.26ms
+step:1224/1490 train_time:63999ms step_avg:52.29ms
+step:1225/1490 train_time:64079ms step_avg:52.31ms
+step:1226/1490 train_time:64166ms step_avg:52.34ms
+step:1227/1490 train_time:64246ms step_avg:52.36ms
+step:1228/1490 train_time:64331ms step_avg:52.39ms
+step:1229/1490 train_time:64412ms step_avg:52.41ms
+step:1230/1490 train_time:64497ms step_avg:52.44ms
+step:1231/1490 train_time:64577ms step_avg:52.46ms
+step:1232/1490 train_time:64662ms step_avg:52.49ms
+step:1233/1490 train_time:64743ms step_avg:52.51ms
+step:1234/1490 train_time:64827ms step_avg:52.53ms
+step:1235/1490 train_time:64907ms step_avg:52.56ms
+step:1236/1490 train_time:64993ms step_avg:52.58ms
+step:1237/1490 train_time:65072ms step_avg:52.61ms
+step:1238/1490 train_time:65158ms step_avg:52.63ms
+step:1239/1490 train_time:65239ms step_avg:52.65ms
+step:1240/1490 train_time:65325ms step_avg:52.68ms
+step:1241/1490 train_time:65406ms step_avg:52.70ms
+step:1242/1490 train_time:65491ms step_avg:52.73ms
+step:1243/1490 train_time:65571ms step_avg:52.75ms
+step:1244/1490 train_time:65656ms step_avg:52.78ms
+step:1245/1490 train_time:65735ms step_avg:52.80ms
+step:1246/1490 train_time:65822ms step_avg:52.83ms
+step:1247/1490 train_time:65902ms step_avg:52.85ms
+step:1248/1490 train_time:65989ms step_avg:52.88ms
+step:1249/1490 train_time:66068ms step_avg:52.90ms
+step:1250/1490 train_time:66153ms step_avg:52.92ms
+step:1250/1490 val_loss:3.3713 train_time:66255ms step_avg:53.00ms
+step:1251/1490 train_time:66275ms step_avg:52.98ms
+step:1252/1490 train_time:66321ms step_avg:52.97ms
+step:1253/1490 train_time:66402ms step_avg:52.99ms
+step:1254/1490 train_time:66490ms step_avg:53.02ms
+step:1255/1490 train_time:66571ms step_avg:53.04ms
+step:1256/1490 train_time:66656ms step_avg:53.07ms
+step:1257/1490 train_time:66736ms step_avg:53.09ms
+step:1258/1490 train_time:66820ms step_avg:53.12ms
+step:1259/1490 train_time:66899ms step_avg:53.14ms
+step:1260/1490 train_time:66984ms step_avg:53.16ms
+step:1261/1490 train_time:67064ms step_avg:53.18ms
+step:1262/1490 train_time:67149ms step_avg:53.21ms
+step:1263/1490 train_time:67229ms step_avg:53.23ms
+step:1264/1490 train_time:67319ms step_avg:53.26ms
+step:1265/1490 train_time:67401ms step_avg:53.28ms
+step:1266/1490 train_time:67488ms step_avg:53.31ms
+step:1267/1490 train_time:67570ms step_avg:53.33ms
+step:1268/1490 train_time:67655ms step_avg:53.36ms
+step:1269/1490 train_time:67735ms step_avg:53.38ms
+step:1270/1490 train_time:67821ms step_avg:53.40ms
+step:1271/1490 train_time:67900ms step_avg:53.42ms
+step:1272/1490 train_time:67984ms step_avg:53.45ms
+step:1273/1490 train_time:68063ms step_avg:53.47ms
+step:1274/1490 train_time:68148ms step_avg:53.49ms
+step:1275/1490 train_time:68231ms step_avg:53.51ms
+step:1276/1490 train_time:68319ms step_avg:53.54ms
+step:1277/1490 train_time:68400ms step_avg:53.56ms
+step:1278/1490 train_time:68487ms step_avg:53.59ms
+step:1279/1490 train_time:68568ms step_avg:53.61ms
+step:1280/1490 train_time:68653ms step_avg:53.64ms
+step:1281/1490 train_time:68733ms step_avg:53.66ms
+step:1282/1490 train_time:68819ms step_avg:53.68ms
+step:1283/1490 train_time:68898ms step_avg:53.70ms
+step:1284/1490 train_time:68984ms step_avg:53.73ms
+step:1285/1490 train_time:69063ms step_avg:53.75ms
+step:1286/1490 train_time:69148ms step_avg:53.77ms
+step:1287/1490 train_time:69231ms step_avg:53.79ms
+step:1288/1490 train_time:69319ms step_avg:53.82ms
+step:1289/1490 train_time:69401ms step_avg:53.84ms
+step:1290/1490 train_time:69486ms step_avg:53.87ms
+step:1291/1490 train_time:69568ms step_avg:53.89ms
+step:1292/1490 train_time:69654ms step_avg:53.91ms
+step:1293/1490 train_time:69735ms step_avg:53.93ms
+step:1294/1490 train_time:69821ms step_avg:53.96ms
+step:1295/1490 train_time:69900ms step_avg:53.98ms
+step:1296/1490 train_time:69985ms step_avg:54.00ms
+step:1297/1490 train_time:70065ms step_avg:54.02ms
+step:1298/1490 train_time:70150ms step_avg:54.04ms
+step:1299/1490 train_time:70231ms step_avg:54.07ms
+step:1300/1490 train_time:70318ms step_avg:54.09ms
+step:1301/1490 train_time:70400ms step_avg:54.11ms
+step:1302/1490 train_time:70485ms step_avg:54.14ms
+step:1303/1490 train_time:70567ms step_avg:54.16ms
+step:1304/1490 train_time:70653ms step_avg:54.18ms
+step:1305/1490 train_time:70733ms step_avg:54.20ms
+step:1306/1490 train_time:70820ms step_avg:54.23ms
+step:1307/1490 train_time:70900ms step_avg:54.25ms
+step:1308/1490 train_time:70985ms step_avg:54.27ms
+step:1309/1490 train_time:71064ms step_avg:54.29ms
+step:1310/1490 train_time:71150ms step_avg:54.31ms
+step:1311/1490 train_time:71231ms step_avg:54.33ms
+step:1312/1490 train_time:71317ms step_avg:54.36ms
+step:1313/1490 train_time:71397ms step_avg:54.38ms
+step:1314/1490 train_time:71484ms step_avg:54.40ms
+step:1315/1490 train_time:71564ms step_avg:54.42ms
+step:1316/1490 train_time:71650ms step_avg:54.45ms
+step:1317/1490 train_time:71731ms step_avg:54.47ms
+step:1318/1490 train_time:71816ms step_avg:54.49ms
+step:1319/1490 train_time:71896ms step_avg:54.51ms
+step:1320/1490 train_time:71981ms step_avg:54.53ms
+step:1321/1490 train_time:72060ms step_avg:54.55ms
+step:1322/1490 train_time:72145ms step_avg:54.57ms
+step:1323/1490 train_time:72227ms step_avg:54.59ms
+step:1324/1490 train_time:72313ms step_avg:54.62ms
+step:1325/1490 train_time:72394ms step_avg:54.64ms
+step:1326/1490 train_time:72480ms step_avg:54.66ms
+step:1327/1490 train_time:72559ms step_avg:54.68ms
+step:1328/1490 train_time:72644ms step_avg:54.70ms
+step:1329/1490 train_time:72724ms step_avg:54.72ms
+step:1330/1490 train_time:72809ms step_avg:54.74ms
+step:1331/1490 train_time:72890ms step_avg:54.76ms
+step:1332/1490 train_time:72975ms step_avg:54.79ms
+step:1333/1490 train_time:73056ms step_avg:54.81ms
+step:1334/1490 train_time:73141ms step_avg:54.83ms
+step:1335/1490 train_time:73220ms step_avg:54.85ms
+step:1336/1490 train_time:73307ms step_avg:54.87ms
+step:1337/1490 train_time:73388ms step_avg:54.89ms
+step:1338/1490 train_time:73474ms step_avg:54.91ms
+step:1339/1490 train_time:73553ms step_avg:54.93ms
+step:1340/1490 train_time:73640ms step_avg:54.95ms
+step:1341/1490 train_time:73720ms step_avg:54.97ms
+step:1342/1490 train_time:73806ms step_avg:55.00ms
+step:1343/1490 train_time:73885ms step_avg:55.02ms
+step:1344/1490 train_time:73972ms step_avg:55.04ms
+step:1345/1490 train_time:74052ms step_avg:55.06ms
+step:1346/1490 train_time:74136ms step_avg:55.08ms
+step:1347/1490 train_time:74218ms step_avg:55.10ms
+step:1348/1490 train_time:74303ms step_avg:55.12ms
+step:1349/1490 train_time:74383ms step_avg:55.14ms
+step:1350/1490 train_time:74468ms step_avg:55.16ms
+step:1351/1490 train_time:74549ms step_avg:55.18ms
+step:1352/1490 train_time:74634ms step_avg:55.20ms
+step:1353/1490 train_time:74716ms step_avg:55.22ms
+step:1354/1490 train_time:74801ms step_avg:55.24ms
+step:1355/1490 train_time:74881ms step_avg:55.26ms
+step:1356/1490 train_time:74967ms step_avg:55.29ms
+step:1357/1490 train_time:75047ms step_avg:55.30ms
+step:1358/1490 train_time:75132ms step_avg:55.33ms
+step:1359/1490 train_time:75213ms step_avg:55.34ms
+step:1360/1490 train_time:75299ms step_avg:55.37ms
+step:1361/1490 train_time:75380ms step_avg:55.39ms
+step:1362/1490 train_time:75465ms step_avg:55.41ms
+step:1363/1490 train_time:75546ms step_avg:55.43ms
+step:1364/1490 train_time:75632ms step_avg:55.45ms
+step:1365/1490 train_time:75712ms step_avg:55.47ms
+step:1366/1490 train_time:75799ms step_avg:55.49ms
+step:1367/1490 train_time:75880ms step_avg:55.51ms
+step:1368/1490 train_time:75965ms step_avg:55.53ms
+step:1369/1490 train_time:76046ms step_avg:55.55ms
+step:1370/1490 train_time:76132ms step_avg:55.57ms
+step:1371/1490 train_time:76211ms step_avg:55.59ms
+step:1372/1490 train_time:76297ms step_avg:55.61ms
+step:1373/1490 train_time:76377ms step_avg:55.63ms
+step:1374/1490 train_time:76462ms step_avg:55.65ms
+step:1375/1490 train_time:76542ms step_avg:55.67ms
+step:1376/1490 train_time:76628ms step_avg:55.69ms
+step:1377/1490 train_time:76710ms step_avg:55.71ms
+step:1378/1490 train_time:76795ms step_avg:55.73ms
+step:1379/1490 train_time:76877ms step_avg:55.75ms
+step:1380/1490 train_time:76962ms step_avg:55.77ms
+step:1381/1490 train_time:77041ms step_avg:55.79ms
+step:1382/1490 train_time:77126ms step_avg:55.81ms
+step:1383/1490 train_time:77206ms step_avg:55.82ms
+step:1384/1490 train_time:77292ms step_avg:55.85ms
+step:1385/1490 train_time:77372ms step_avg:55.86ms
+step:1386/1490 train_time:77458ms step_avg:55.89ms
+step:1387/1490 train_time:77538ms step_avg:55.90ms
+step:1388/1490 train_time:77624ms step_avg:55.93ms
+step:1389/1490 train_time:77704ms step_avg:55.94ms
+step:1390/1490 train_time:77790ms step_avg:55.96ms
+step:1391/1490 train_time:77871ms step_avg:55.98ms
+step:1392/1490 train_time:77957ms step_avg:56.00ms
+step:1393/1490 train_time:78039ms step_avg:56.02ms
+step:1394/1490 train_time:78125ms step_avg:56.04ms
+step:1395/1490 train_time:78204ms step_avg:56.06ms
+step:1396/1490 train_time:78291ms step_avg:56.08ms
+step:1397/1490 train_time:78371ms step_avg:56.10ms
+step:1398/1490 train_time:78456ms step_avg:56.12ms
+step:1399/1490 train_time:78537ms step_avg:56.14ms
+step:1400/1490 train_time:78622ms step_avg:56.16ms
+step:1401/1490 train_time:78701ms step_avg:56.17ms
+step:1402/1490 train_time:78787ms step_avg:56.20ms
+step:1403/1490 train_time:78868ms step_avg:56.21ms
+step:1404/1490 train_time:78957ms step_avg:56.24ms
+step:1405/1490 train_time:79037ms step_avg:56.25ms
+step:1406/1490 train_time:79123ms step_avg:56.28ms
+step:1407/1490 train_time:79202ms step_avg:56.29ms
+step:1408/1490 train_time:79288ms step_avg:56.31ms
+step:1409/1490 train_time:79370ms step_avg:56.33ms
+step:1410/1490 train_time:79458ms step_avg:56.35ms
+step:1411/1490 train_time:79539ms step_avg:56.37ms
+step:1412/1490 train_time:79624ms step_avg:56.39ms
+step:1413/1490 train_time:79704ms step_avg:56.41ms
+step:1414/1490 train_time:79789ms step_avg:56.43ms
+step:1415/1490 train_time:79872ms step_avg:56.45ms
+step:1416/1490 train_time:79957ms step_avg:56.47ms
+step:1417/1490 train_time:80038ms step_avg:56.48ms
+step:1418/1490 train_time:80124ms step_avg:56.50ms
+step:1419/1490 train_time:80204ms step_avg:56.52ms
+step:1420/1490 train_time:80290ms step_avg:56.54ms
+step:1421/1490 train_time:80371ms step_avg:56.56ms
+step:1422/1490 train_time:80458ms step_avg:56.58ms
+step:1423/1490 train_time:80538ms step_avg:56.60ms
+step:1424/1490 train_time:80624ms step_avg:56.62ms
+step:1425/1490 train_time:80704ms step_avg:56.63ms
+step:1426/1490 train_time:80790ms step_avg:56.65ms
+step:1427/1490 train_time:80871ms step_avg:56.67ms
+step:1428/1490 train_time:80955ms step_avg:56.69ms
+step:1429/1490 train_time:81035ms step_avg:56.71ms
+step:1430/1490 train_time:81121ms step_avg:56.73ms
+step:1431/1490 train_time:81201ms step_avg:56.74ms
+step:1432/1490 train_time:81287ms step_avg:56.76ms
+step:1433/1490 train_time:81368ms step_avg:56.78ms
+step:1434/1490 train_time:81454ms step_avg:56.80ms
+step:1435/1490 train_time:81532ms step_avg:56.82ms
+step:1436/1490 train_time:81619ms step_avg:56.84ms
+step:1437/1490 train_time:81697ms step_avg:56.85ms
+step:1438/1490 train_time:81783ms step_avg:56.87ms
+step:1439/1490 train_time:81864ms step_avg:56.89ms
+step:1440/1490 train_time:81950ms step_avg:56.91ms
+step:1441/1490 train_time:82031ms step_avg:56.93ms
+step:1442/1490 train_time:82116ms step_avg:56.95ms
+step:1443/1490 train_time:82198ms step_avg:56.96ms
+step:1444/1490 train_time:82284ms step_avg:56.98ms
+step:1445/1490 train_time:82365ms step_avg:57.00ms
+step:1446/1490 train_time:82451ms step_avg:57.02ms
+step:1447/1490 train_time:82532ms step_avg:57.04ms
+step:1448/1490 train_time:82619ms step_avg:57.06ms
+step:1449/1490 train_time:82699ms step_avg:57.07ms
+step:1450/1490 train_time:82783ms step_avg:57.09ms
+step:1451/1490 train_time:82867ms step_avg:57.11ms
+step:1452/1490 train_time:82955ms step_avg:57.13ms
+step:1453/1490 train_time:83037ms step_avg:57.15ms
+step:1454/1490 train_time:83122ms step_avg:57.17ms
+step:1455/1490 train_time:83202ms step_avg:57.18ms
+step:1456/1490 train_time:83287ms step_avg:57.20ms
+step:1457/1490 train_time:83368ms step_avg:57.22ms
+step:1458/1490 train_time:83456ms step_avg:57.24ms
+step:1459/1490 train_time:83535ms step_avg:57.26ms
+step:1460/1490 train_time:83623ms step_avg:57.28ms
+step:1461/1490 train_time:83703ms step_avg:57.29ms
+step:1462/1490 train_time:83788ms step_avg:57.31ms
+step:1463/1490 train_time:83871ms step_avg:57.33ms
+step:1464/1490 train_time:83957ms step_avg:57.35ms
+step:1465/1490 train_time:84039ms step_avg:57.36ms
+step:1466/1490 train_time:84124ms step_avg:57.38ms
+step:1467/1490 train_time:84204ms step_avg:57.40ms
+step:1468/1490 train_time:84291ms step_avg:57.42ms
+step:1469/1490 train_time:84372ms step_avg:57.43ms
+step:1470/1490 train_time:84457ms step_avg:57.45ms
+step:1471/1490 train_time:84538ms step_avg:57.47ms
+step:1472/1490 train_time:84625ms step_avg:57.49ms
+step:1473/1490 train_time:84705ms step_avg:57.51ms
+step:1474/1490 train_time:84791ms step_avg:57.52ms
+step:1475/1490 train_time:84872ms step_avg:57.54ms
+step:1476/1490 train_time:84959ms step_avg:57.56ms
+step:1477/1490 train_time:85040ms step_avg:57.58ms
+step:1478/1490 train_time:85126ms step_avg:57.60ms
+step:1479/1490 train_time:85207ms step_avg:57.61ms
+step:1480/1490 train_time:85293ms step_avg:57.63ms
+step:1481/1490 train_time:85374ms step_avg:57.65ms
+step:1482/1490 train_time:85460ms step_avg:57.67ms
+step:1483/1490 train_time:85541ms step_avg:57.68ms
+step:1484/1490 train_time:85627ms step_avg:57.70ms
+step:1485/1490 train_time:85708ms step_avg:57.72ms
+step:1486/1490 train_time:85794ms step_avg:57.73ms
+step:1487/1490 train_time:85875ms step_avg:57.75ms
+step:1488/1490 train_time:85964ms step_avg:57.77ms
+step:1489/1490 train_time:86044ms step_avg:57.79ms
+step:1490/1490 train_time:86129ms step_avg:57.80ms
+step:1490/1490 val_loss:3.2795 train_time:86234ms step_avg:57.87ms
+peak memory allocated: 31296 MiB reserved: 47202 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/combined/2026-03-22_20-23-10_time-186_secs_06-mbeta2-max-docs_1d2627.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/combined/2026-03-22_20-23-10_time-186_secs_06-mbeta2-max-docs_1d2627.txt
@@ -1,0 +1,4457 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 20:23:25 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            123W /  700W |    1520MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            133W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   41C    P0            124W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1903542      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1903543      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1903544      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1903545      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1903546      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1903547      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1903548      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1903549      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8302 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:72ms step_avg:72.20ms
+step:2/1490 train_time:99ms step_avg:49.55ms
+step:3/1490 train_time:116ms step_avg:38.60ms
+step:4/1490 train_time:143ms step_avg:35.69ms
+step:5/1490 train_time:170ms step_avg:33.92ms
+step:6/1490 train_time:205ms step_avg:34.11ms
+step:7/1490 train_time:232ms step_avg:33.09ms
+step:8/1490 train_time:266ms step_avg:33.31ms
+step:9/1490 train_time:294ms step_avg:32.66ms
+step:10/1490 train_time:329ms step_avg:32.88ms
+step:11/1490 train_time:356ms step_avg:32.40ms
+step:12/1490 train_time:391ms step_avg:32.56ms
+step:13/1490 train_time:419ms step_avg:32.21ms
+step:14/1490 train_time:453ms step_avg:32.37ms
+step:15/1490 train_time:481ms step_avg:32.08ms
+step:16/1490 train_time:515ms step_avg:32.21ms
+step:17/1490 train_time:544ms step_avg:31.98ms
+step:18/1490 train_time:578ms step_avg:32.09ms
+step:19/1490 train_time:606ms step_avg:31.87ms
+step:20/1490 train_time:639ms step_avg:31.97ms
+step:21/1490 train_time:667ms step_avg:31.79ms
+step:22/1490 train_time:702ms step_avg:31.91ms
+step:23/1490 train_time:730ms step_avg:31.75ms
+step:24/1490 train_time:765ms step_avg:31.87ms
+step:25/1490 train_time:793ms step_avg:31.72ms
+step:26/1490 train_time:828ms step_avg:31.84ms
+step:27/1490 train_time:855ms step_avg:31.68ms
+step:28/1490 train_time:890ms step_avg:31.78ms
+step:29/1490 train_time:919ms step_avg:31.67ms
+step:30/1490 train_time:954ms step_avg:31.79ms
+step:31/1490 train_time:984ms step_avg:31.73ms
+step:32/1490 train_time:1019ms step_avg:31.84ms
+step:33/1490 train_time:1048ms step_avg:31.75ms
+step:34/1490 train_time:1083ms step_avg:31.84ms
+step:35/1490 train_time:1111ms step_avg:31.75ms
+step:36/1490 train_time:1146ms step_avg:31.84ms
+step:37/1490 train_time:1174ms step_avg:31.73ms
+step:38/1490 train_time:1209ms step_avg:31.81ms
+step:39/1490 train_time:1237ms step_avg:31.72ms
+step:40/1490 train_time:1272ms step_avg:31.80ms
+step:41/1490 train_time:1300ms step_avg:31.71ms
+step:42/1490 train_time:1335ms step_avg:31.78ms
+step:43/1490 train_time:1363ms step_avg:31.69ms
+step:44/1490 train_time:1397ms step_avg:31.74ms
+step:45/1490 train_time:1425ms step_avg:31.67ms
+step:46/1490 train_time:1459ms step_avg:31.72ms
+step:47/1490 train_time:1487ms step_avg:31.64ms
+step:48/1490 train_time:1521ms step_avg:31.69ms
+step:49/1490 train_time:1549ms step_avg:31.62ms
+step:50/1490 train_time:1584ms step_avg:31.67ms
+step:51/1490 train_time:1612ms step_avg:31.61ms
+step:52/1490 train_time:1646ms step_avg:31.66ms
+step:53/1490 train_time:1674ms step_avg:31.59ms
+step:54/1490 train_time:1709ms step_avg:31.64ms
+step:55/1490 train_time:1737ms step_avg:31.57ms
+step:56/1490 train_time:1771ms step_avg:31.62ms
+step:57/1490 train_time:1799ms step_avg:31.56ms
+step:58/1490 train_time:1833ms step_avg:31.61ms
+step:59/1490 train_time:1862ms step_avg:31.55ms
+step:60/1490 train_time:1896ms step_avg:31.60ms
+step:61/1490 train_time:1924ms step_avg:31.55ms
+step:62/1490 train_time:1959ms step_avg:31.60ms
+step:63/1490 train_time:1988ms step_avg:31.55ms
+step:64/1490 train_time:2023ms step_avg:31.61ms
+step:65/1490 train_time:2052ms step_avg:31.56ms
+step:66/1490 train_time:2086ms step_avg:31.61ms
+step:67/1490 train_time:2114ms step_avg:31.56ms
+step:68/1490 train_time:2150ms step_avg:31.61ms
+step:69/1490 train_time:2178ms step_avg:31.56ms
+step:70/1490 train_time:2213ms step_avg:31.61ms
+step:71/1490 train_time:2241ms step_avg:31.56ms
+step:72/1490 train_time:2276ms step_avg:31.61ms
+step:73/1490 train_time:2304ms step_avg:31.56ms
+step:74/1490 train_time:2338ms step_avg:31.60ms
+step:75/1490 train_time:2367ms step_avg:31.55ms
+step:76/1490 train_time:2401ms step_avg:31.59ms
+step:77/1490 train_time:2429ms step_avg:31.55ms
+step:78/1490 train_time:2464ms step_avg:31.59ms
+step:79/1490 train_time:2492ms step_avg:31.54ms
+step:80/1490 train_time:2526ms step_avg:31.58ms
+step:81/1490 train_time:2554ms step_avg:31.53ms
+step:82/1490 train_time:2589ms step_avg:31.58ms
+step:83/1490 train_time:2617ms step_avg:31.53ms
+step:84/1490 train_time:2652ms step_avg:31.57ms
+step:85/1490 train_time:2680ms step_avg:31.52ms
+step:86/1490 train_time:2714ms step_avg:31.56ms
+step:87/1490 train_time:2742ms step_avg:31.52ms
+step:88/1490 train_time:2776ms step_avg:31.55ms
+step:89/1490 train_time:2805ms step_avg:31.51ms
+step:90/1490 train_time:2839ms step_avg:31.54ms
+step:91/1490 train_time:2867ms step_avg:31.51ms
+step:92/1490 train_time:2901ms step_avg:31.54ms
+step:93/1490 train_time:2930ms step_avg:31.50ms
+step:94/1490 train_time:2965ms step_avg:31.54ms
+step:95/1490 train_time:2993ms step_avg:31.51ms
+step:96/1490 train_time:3028ms step_avg:31.54ms
+step:97/1490 train_time:3056ms step_avg:31.51ms
+step:98/1490 train_time:3091ms step_avg:31.54ms
+step:99/1490 train_time:3119ms step_avg:31.51ms
+step:100/1490 train_time:3154ms step_avg:31.54ms
+step:101/1490 train_time:3182ms step_avg:31.51ms
+step:102/1490 train_time:3216ms step_avg:31.53ms
+step:103/1490 train_time:3245ms step_avg:31.50ms
+step:104/1490 train_time:3279ms step_avg:31.53ms
+step:105/1490 train_time:3307ms step_avg:31.50ms
+step:106/1490 train_time:3342ms step_avg:31.52ms
+step:107/1490 train_time:3370ms step_avg:31.50ms
+step:108/1490 train_time:3405ms step_avg:31.52ms
+step:109/1490 train_time:3433ms step_avg:31.49ms
+step:110/1490 train_time:3468ms step_avg:31.53ms
+step:111/1490 train_time:3496ms step_avg:31.49ms
+step:112/1490 train_time:3530ms step_avg:31.52ms
+step:113/1490 train_time:3559ms step_avg:31.50ms
+step:114/1490 train_time:3593ms step_avg:31.52ms
+step:115/1490 train_time:3622ms step_avg:31.49ms
+step:116/1490 train_time:3656ms step_avg:31.51ms
+step:117/1490 train_time:3684ms step_avg:31.49ms
+step:118/1490 train_time:3718ms step_avg:31.51ms
+step:119/1490 train_time:3746ms step_avg:31.48ms
+step:120/1490 train_time:3780ms step_avg:31.50ms
+step:121/1490 train_time:3808ms step_avg:31.47ms
+step:122/1490 train_time:3843ms step_avg:31.50ms
+step:123/1490 train_time:3871ms step_avg:31.47ms
+step:124/1490 train_time:3906ms step_avg:31.50ms
+step:125/1490 train_time:3934ms step_avg:31.48ms
+step:126/1490 train_time:3969ms step_avg:31.50ms
+step:127/1490 train_time:3997ms step_avg:31.47ms
+step:128/1490 train_time:4032ms step_avg:31.50ms
+step:129/1490 train_time:4060ms step_avg:31.47ms
+step:130/1490 train_time:4094ms step_avg:31.49ms
+step:131/1490 train_time:4123ms step_avg:31.47ms
+step:132/1490 train_time:4157ms step_avg:31.49ms
+step:133/1490 train_time:4185ms step_avg:31.47ms
+step:134/1490 train_time:4220ms step_avg:31.49ms
+step:135/1490 train_time:4248ms step_avg:31.47ms
+step:136/1490 train_time:4283ms step_avg:31.49ms
+step:137/1490 train_time:4311ms step_avg:31.47ms
+step:138/1490 train_time:4346ms step_avg:31.49ms
+step:139/1490 train_time:4374ms step_avg:31.47ms
+step:140/1490 train_time:4409ms step_avg:31.49ms
+step:141/1490 train_time:4437ms step_avg:31.47ms
+step:142/1490 train_time:4472ms step_avg:31.49ms
+step:143/1490 train_time:4500ms step_avg:31.47ms
+step:144/1490 train_time:4534ms step_avg:31.49ms
+step:145/1490 train_time:4563ms step_avg:31.47ms
+step:146/1490 train_time:4597ms step_avg:31.48ms
+step:147/1490 train_time:4626ms step_avg:31.47ms
+step:148/1490 train_time:4660ms step_avg:31.48ms
+step:149/1490 train_time:4688ms step_avg:31.46ms
+step:150/1490 train_time:4722ms step_avg:31.48ms
+step:151/1490 train_time:4750ms step_avg:31.45ms
+step:152/1490 train_time:4784ms step_avg:31.48ms
+step:153/1490 train_time:4812ms step_avg:31.45ms
+step:154/1490 train_time:4847ms step_avg:31.47ms
+step:155/1490 train_time:4875ms step_avg:31.45ms
+step:156/1490 train_time:4911ms step_avg:31.48ms
+step:157/1490 train_time:4938ms step_avg:31.45ms
+step:158/1490 train_time:4973ms step_avg:31.47ms
+step:159/1490 train_time:5001ms step_avg:31.46ms
+step:160/1490 train_time:5036ms step_avg:31.47ms
+step:161/1490 train_time:5064ms step_avg:31.45ms
+step:162/1490 train_time:5098ms step_avg:31.47ms
+step:163/1490 train_time:5127ms step_avg:31.45ms
+step:164/1490 train_time:5161ms step_avg:31.47ms
+step:165/1490 train_time:5189ms step_avg:31.45ms
+step:166/1490 train_time:5225ms step_avg:31.47ms
+step:167/1490 train_time:5252ms step_avg:31.45ms
+step:168/1490 train_time:5287ms step_avg:31.47ms
+step:169/1490 train_time:5315ms step_avg:31.45ms
+step:170/1490 train_time:5350ms step_avg:31.47ms
+step:171/1490 train_time:5378ms step_avg:31.45ms
+step:172/1490 train_time:5413ms step_avg:31.47ms
+step:173/1490 train_time:5442ms step_avg:31.45ms
+step:174/1490 train_time:5476ms step_avg:31.47ms
+step:175/1490 train_time:5504ms step_avg:31.45ms
+step:176/1490 train_time:5538ms step_avg:31.47ms
+step:177/1490 train_time:5567ms step_avg:31.45ms
+step:178/1490 train_time:5601ms step_avg:31.47ms
+step:179/1490 train_time:5630ms step_avg:31.45ms
+step:180/1490 train_time:5664ms step_avg:31.46ms
+step:181/1490 train_time:5691ms step_avg:31.44ms
+step:182/1490 train_time:5726ms step_avg:31.46ms
+step:183/1490 train_time:5754ms step_avg:31.44ms
+step:184/1490 train_time:5788ms step_avg:31.46ms
+step:185/1490 train_time:5816ms step_avg:31.44ms
+step:186/1490 train_time:5850ms step_avg:31.45ms
+step:187/1490 train_time:5879ms step_avg:31.44ms
+step:188/1490 train_time:5913ms step_avg:31.45ms
+step:189/1490 train_time:5942ms step_avg:31.44ms
+step:190/1490 train_time:5976ms step_avg:31.45ms
+step:191/1490 train_time:6004ms step_avg:31.43ms
+step:192/1490 train_time:6038ms step_avg:31.45ms
+step:193/1490 train_time:6066ms step_avg:31.43ms
+step:194/1490 train_time:6100ms step_avg:31.45ms
+step:195/1490 train_time:6129ms step_avg:31.43ms
+step:196/1490 train_time:6164ms step_avg:31.45ms
+step:197/1490 train_time:6192ms step_avg:31.43ms
+step:198/1490 train_time:6227ms step_avg:31.45ms
+step:199/1490 train_time:6254ms step_avg:31.43ms
+step:200/1490 train_time:6289ms step_avg:31.44ms
+step:201/1490 train_time:6317ms step_avg:31.43ms
+step:202/1490 train_time:6352ms step_avg:31.44ms
+step:203/1490 train_time:6380ms step_avg:31.43ms
+step:204/1490 train_time:6414ms step_avg:31.44ms
+step:205/1490 train_time:6442ms step_avg:31.43ms
+step:206/1490 train_time:6477ms step_avg:31.44ms
+step:207/1490 train_time:6505ms step_avg:31.42ms
+step:208/1490 train_time:6539ms step_avg:31.44ms
+step:209/1490 train_time:6567ms step_avg:31.42ms
+step:210/1490 train_time:6602ms step_avg:31.44ms
+step:211/1490 train_time:6630ms step_avg:31.42ms
+step:212/1490 train_time:6665ms step_avg:31.44ms
+step:213/1490 train_time:6693ms step_avg:31.42ms
+step:214/1490 train_time:6728ms step_avg:31.44ms
+step:215/1490 train_time:6756ms step_avg:31.42ms
+step:216/1490 train_time:6790ms step_avg:31.44ms
+step:217/1490 train_time:6818ms step_avg:31.42ms
+step:218/1490 train_time:6853ms step_avg:31.43ms
+step:219/1490 train_time:6881ms step_avg:31.42ms
+step:220/1490 train_time:6915ms step_avg:31.43ms
+step:221/1490 train_time:6943ms step_avg:31.42ms
+step:222/1490 train_time:6977ms step_avg:31.43ms
+step:223/1490 train_time:7006ms step_avg:31.42ms
+step:224/1490 train_time:7040ms step_avg:31.43ms
+step:225/1490 train_time:7068ms step_avg:31.41ms
+step:226/1490 train_time:7102ms step_avg:31.43ms
+step:227/1490 train_time:7131ms step_avg:31.42ms
+step:228/1490 train_time:7166ms step_avg:31.43ms
+step:229/1490 train_time:7194ms step_avg:31.41ms
+step:230/1490 train_time:7228ms step_avg:31.43ms
+step:231/1490 train_time:7257ms step_avg:31.41ms
+step:232/1490 train_time:7291ms step_avg:31.43ms
+step:233/1490 train_time:7319ms step_avg:31.41ms
+step:234/1490 train_time:7353ms step_avg:31.42ms
+step:235/1490 train_time:7382ms step_avg:31.41ms
+step:236/1490 train_time:7416ms step_avg:31.42ms
+step:237/1490 train_time:7444ms step_avg:31.41ms
+step:238/1490 train_time:7479ms step_avg:31.42ms
+step:239/1490 train_time:7507ms step_avg:31.41ms
+step:240/1490 train_time:7541ms step_avg:31.42ms
+step:241/1490 train_time:7570ms step_avg:31.41ms
+step:242/1490 train_time:7605ms step_avg:31.43ms
+step:243/1490 train_time:7633ms step_avg:31.41ms
+step:244/1490 train_time:7668ms step_avg:31.42ms
+step:245/1490 train_time:7696ms step_avg:31.41ms
+step:246/1490 train_time:7731ms step_avg:31.43ms
+step:247/1490 train_time:7759ms step_avg:31.41ms
+step:248/1490 train_time:7793ms step_avg:31.42ms
+step:249/1490 train_time:7822ms step_avg:31.41ms
+step:250/1490 train_time:7856ms step_avg:31.42ms
+step:250/1490 val_loss:4.5001 train_time:7898ms step_avg:31.59ms
+step:251/1490 train_time:7914ms step_avg:31.53ms
+step:252/1490 train_time:7932ms step_avg:31.48ms
+step:253/1490 train_time:7949ms step_avg:31.42ms
+step:254/1490 train_time:7984ms step_avg:31.43ms
+step:255/1490 train_time:8014ms step_avg:31.43ms
+step:256/1490 train_time:8049ms step_avg:31.44ms
+step:257/1490 train_time:8078ms step_avg:31.43ms
+step:258/1490 train_time:8112ms step_avg:31.44ms
+step:259/1490 train_time:8140ms step_avg:31.43ms
+step:260/1490 train_time:8176ms step_avg:31.44ms
+step:261/1490 train_time:8204ms step_avg:31.43ms
+step:262/1490 train_time:8238ms step_avg:31.44ms
+step:263/1490 train_time:8266ms step_avg:31.43ms
+step:264/1490 train_time:8300ms step_avg:31.44ms
+step:265/1490 train_time:8327ms step_avg:31.42ms
+step:266/1490 train_time:8361ms step_avg:31.43ms
+step:267/1490 train_time:8389ms step_avg:31.42ms
+step:268/1490 train_time:8423ms step_avg:31.43ms
+step:269/1490 train_time:8451ms step_avg:31.42ms
+step:270/1490 train_time:8485ms step_avg:31.43ms
+step:271/1490 train_time:8514ms step_avg:31.42ms
+step:272/1490 train_time:8548ms step_avg:31.43ms
+step:273/1490 train_time:8576ms step_avg:31.41ms
+step:274/1490 train_time:8610ms step_avg:31.42ms
+step:275/1490 train_time:8638ms step_avg:31.41ms
+step:276/1490 train_time:8672ms step_avg:31.42ms
+step:277/1490 train_time:8700ms step_avg:31.41ms
+step:278/1490 train_time:8734ms step_avg:31.42ms
+step:279/1490 train_time:8762ms step_avg:31.40ms
+step:280/1490 train_time:8796ms step_avg:31.42ms
+step:281/1490 train_time:8824ms step_avg:31.40ms
+step:282/1490 train_time:8859ms step_avg:31.41ms
+step:283/1490 train_time:8887ms step_avg:31.40ms
+step:284/1490 train_time:8921ms step_avg:31.41ms
+step:285/1490 train_time:8950ms step_avg:31.40ms
+step:286/1490 train_time:8985ms step_avg:31.41ms
+step:287/1490 train_time:9014ms step_avg:31.41ms
+step:288/1490 train_time:9049ms step_avg:31.42ms
+step:289/1490 train_time:9078ms step_avg:31.41ms
+step:290/1490 train_time:9113ms step_avg:31.42ms
+step:291/1490 train_time:9141ms step_avg:31.41ms
+step:292/1490 train_time:9176ms step_avg:31.42ms
+step:293/1490 train_time:9204ms step_avg:31.41ms
+step:294/1490 train_time:9238ms step_avg:31.42ms
+step:295/1490 train_time:9266ms step_avg:31.41ms
+step:296/1490 train_time:9301ms step_avg:31.42ms
+step:297/1490 train_time:9329ms step_avg:31.41ms
+step:298/1490 train_time:9363ms step_avg:31.42ms
+step:299/1490 train_time:9391ms step_avg:31.41ms
+step:300/1490 train_time:9426ms step_avg:31.42ms
+step:301/1490 train_time:9454ms step_avg:31.41ms
+step:302/1490 train_time:9488ms step_avg:31.42ms
+step:303/1490 train_time:9516ms step_avg:31.41ms
+step:304/1490 train_time:9551ms step_avg:31.42ms
+step:305/1490 train_time:9579ms step_avg:31.41ms
+step:306/1490 train_time:9613ms step_avg:31.42ms
+step:307/1490 train_time:9641ms step_avg:31.40ms
+step:308/1490 train_time:9675ms step_avg:31.41ms
+step:309/1490 train_time:9704ms step_avg:31.40ms
+step:310/1490 train_time:9738ms step_avg:31.41ms
+step:311/1490 train_time:9766ms step_avg:31.40ms
+step:312/1490 train_time:9799ms step_avg:31.41ms
+step:313/1490 train_time:9828ms step_avg:31.40ms
+step:314/1490 train_time:9862ms step_avg:31.41ms
+step:315/1490 train_time:9890ms step_avg:31.40ms
+step:316/1490 train_time:9924ms step_avg:31.41ms
+step:317/1490 train_time:9953ms step_avg:31.40ms
+step:318/1490 train_time:9987ms step_avg:31.41ms
+step:319/1490 train_time:10016ms step_avg:31.40ms
+step:320/1490 train_time:10050ms step_avg:31.41ms
+step:321/1490 train_time:10079ms step_avg:31.40ms
+step:322/1490 train_time:10114ms step_avg:31.41ms
+step:323/1490 train_time:10142ms step_avg:31.40ms
+step:324/1490 train_time:10176ms step_avg:31.41ms
+step:325/1490 train_time:10205ms step_avg:31.40ms
+step:326/1490 train_time:10239ms step_avg:31.41ms
+step:327/1490 train_time:10267ms step_avg:31.40ms
+step:328/1490 train_time:10301ms step_avg:31.41ms
+step:329/1490 train_time:10329ms step_avg:31.40ms
+step:330/1490 train_time:10364ms step_avg:31.40ms
+step:331/1490 train_time:10392ms step_avg:31.40ms
+step:332/1490 train_time:10426ms step_avg:31.40ms
+step:333/1490 train_time:10454ms step_avg:31.39ms
+step:334/1490 train_time:10489ms step_avg:31.40ms
+step:335/1490 train_time:10517ms step_avg:31.39ms
+step:336/1490 train_time:10552ms step_avg:31.40ms
+step:337/1490 train_time:10580ms step_avg:31.40ms
+step:338/1490 train_time:10615ms step_avg:31.41ms
+step:339/1490 train_time:10643ms step_avg:31.40ms
+step:340/1490 train_time:10678ms step_avg:31.40ms
+step:341/1490 train_time:10706ms step_avg:31.39ms
+step:342/1490 train_time:10740ms step_avg:31.40ms
+step:343/1490 train_time:10768ms step_avg:31.39ms
+step:344/1490 train_time:10802ms step_avg:31.40ms
+step:345/1490 train_time:10829ms step_avg:31.39ms
+step:346/1490 train_time:10863ms step_avg:31.40ms
+step:347/1490 train_time:10892ms step_avg:31.39ms
+step:348/1490 train_time:10926ms step_avg:31.40ms
+step:349/1490 train_time:10954ms step_avg:31.39ms
+step:350/1490 train_time:10989ms step_avg:31.40ms
+step:351/1490 train_time:11017ms step_avg:31.39ms
+step:352/1490 train_time:11052ms step_avg:31.40ms
+step:353/1490 train_time:11080ms step_avg:31.39ms
+step:354/1490 train_time:11115ms step_avg:31.40ms
+step:355/1490 train_time:11143ms step_avg:31.39ms
+step:356/1490 train_time:11178ms step_avg:31.40ms
+step:357/1490 train_time:11206ms step_avg:31.39ms
+step:358/1490 train_time:11240ms step_avg:31.40ms
+step:359/1490 train_time:11268ms step_avg:31.39ms
+step:360/1490 train_time:11302ms step_avg:31.40ms
+step:361/1490 train_time:11330ms step_avg:31.39ms
+step:362/1490 train_time:11365ms step_avg:31.39ms
+step:363/1490 train_time:11393ms step_avg:31.39ms
+step:364/1490 train_time:11428ms step_avg:31.39ms
+step:365/1490 train_time:11455ms step_avg:31.38ms
+step:366/1490 train_time:11490ms step_avg:31.39ms
+step:367/1490 train_time:11518ms step_avg:31.38ms
+step:368/1490 train_time:11553ms step_avg:31.39ms
+step:369/1490 train_time:11581ms step_avg:31.38ms
+step:370/1490 train_time:11615ms step_avg:31.39ms
+step:371/1490 train_time:11643ms step_avg:31.38ms
+step:372/1490 train_time:11677ms step_avg:31.39ms
+step:373/1490 train_time:11706ms step_avg:31.38ms
+step:374/1490 train_time:11740ms step_avg:31.39ms
+step:375/1490 train_time:11768ms step_avg:31.38ms
+step:376/1490 train_time:11802ms step_avg:31.39ms
+step:377/1490 train_time:11830ms step_avg:31.38ms
+step:378/1490 train_time:11864ms step_avg:31.39ms
+step:379/1490 train_time:11892ms step_avg:31.38ms
+step:380/1490 train_time:11927ms step_avg:31.39ms
+step:381/1490 train_time:11955ms step_avg:31.38ms
+step:382/1490 train_time:11989ms step_avg:31.39ms
+step:383/1490 train_time:12017ms step_avg:31.38ms
+step:384/1490 train_time:12052ms step_avg:31.39ms
+step:385/1490 train_time:12081ms step_avg:31.38ms
+step:386/1490 train_time:12115ms step_avg:31.39ms
+step:387/1490 train_time:12143ms step_avg:31.38ms
+step:388/1490 train_time:12178ms step_avg:31.39ms
+step:389/1490 train_time:12206ms step_avg:31.38ms
+step:390/1490 train_time:12240ms step_avg:31.38ms
+step:391/1490 train_time:12269ms step_avg:31.38ms
+step:392/1490 train_time:12303ms step_avg:31.38ms
+step:393/1490 train_time:12331ms step_avg:31.38ms
+step:394/1490 train_time:12365ms step_avg:31.38ms
+step:395/1490 train_time:12393ms step_avg:31.38ms
+step:396/1490 train_time:12428ms step_avg:31.38ms
+step:397/1490 train_time:12456ms step_avg:31.37ms
+step:398/1490 train_time:12490ms step_avg:31.38ms
+step:399/1490 train_time:12518ms step_avg:31.37ms
+step:400/1490 train_time:12553ms step_avg:31.38ms
+step:401/1490 train_time:12581ms step_avg:31.37ms
+step:402/1490 train_time:12615ms step_avg:31.38ms
+step:403/1490 train_time:12644ms step_avg:31.37ms
+step:404/1490 train_time:12678ms step_avg:31.38ms
+step:405/1490 train_time:12706ms step_avg:31.37ms
+step:406/1490 train_time:12740ms step_avg:31.38ms
+step:407/1490 train_time:12768ms step_avg:31.37ms
+step:408/1490 train_time:12802ms step_avg:31.38ms
+step:409/1490 train_time:12830ms step_avg:31.37ms
+step:410/1490 train_time:12864ms step_avg:31.38ms
+step:411/1490 train_time:12893ms step_avg:31.37ms
+step:412/1490 train_time:12927ms step_avg:31.38ms
+step:413/1490 train_time:12955ms step_avg:31.37ms
+step:414/1490 train_time:12990ms step_avg:31.38ms
+step:415/1490 train_time:13018ms step_avg:31.37ms
+step:416/1490 train_time:13052ms step_avg:31.38ms
+step:417/1490 train_time:13080ms step_avg:31.37ms
+step:418/1490 train_time:13115ms step_avg:31.37ms
+step:419/1490 train_time:13143ms step_avg:31.37ms
+step:420/1490 train_time:13178ms step_avg:31.38ms
+step:421/1490 train_time:13206ms step_avg:31.37ms
+step:422/1490 train_time:13240ms step_avg:31.37ms
+step:423/1490 train_time:13268ms step_avg:31.37ms
+step:424/1490 train_time:13302ms step_avg:31.37ms
+step:425/1490 train_time:13330ms step_avg:31.37ms
+step:426/1490 train_time:13365ms step_avg:31.37ms
+step:427/1490 train_time:13393ms step_avg:31.37ms
+step:428/1490 train_time:13428ms step_avg:31.37ms
+step:429/1490 train_time:13456ms step_avg:31.37ms
+step:430/1490 train_time:13491ms step_avg:31.37ms
+step:431/1490 train_time:13518ms step_avg:31.36ms
+step:432/1490 train_time:13553ms step_avg:31.37ms
+step:433/1490 train_time:13581ms step_avg:31.36ms
+step:434/1490 train_time:13616ms step_avg:31.37ms
+step:435/1490 train_time:13644ms step_avg:31.36ms
+step:436/1490 train_time:13678ms step_avg:31.37ms
+step:437/1490 train_time:13706ms step_avg:31.36ms
+step:438/1490 train_time:13740ms step_avg:31.37ms
+step:439/1490 train_time:13769ms step_avg:31.36ms
+step:440/1490 train_time:13802ms step_avg:31.37ms
+step:441/1490 train_time:13831ms step_avg:31.36ms
+step:442/1490 train_time:13865ms step_avg:31.37ms
+step:443/1490 train_time:13893ms step_avg:31.36ms
+step:444/1490 train_time:13928ms step_avg:31.37ms
+step:445/1490 train_time:13956ms step_avg:31.36ms
+step:446/1490 train_time:13991ms step_avg:31.37ms
+step:447/1490 train_time:14019ms step_avg:31.36ms
+step:448/1490 train_time:14053ms step_avg:31.37ms
+step:449/1490 train_time:14081ms step_avg:31.36ms
+step:450/1490 train_time:14116ms step_avg:31.37ms
+step:451/1490 train_time:14144ms step_avg:31.36ms
+step:452/1490 train_time:14178ms step_avg:31.37ms
+step:453/1490 train_time:14206ms step_avg:31.36ms
+step:454/1490 train_time:14240ms step_avg:31.37ms
+step:455/1490 train_time:14268ms step_avg:31.36ms
+step:456/1490 train_time:14303ms step_avg:31.37ms
+step:457/1490 train_time:14331ms step_avg:31.36ms
+step:458/1490 train_time:14366ms step_avg:31.37ms
+step:459/1490 train_time:14395ms step_avg:31.36ms
+step:460/1490 train_time:14429ms step_avg:31.37ms
+step:461/1490 train_time:14457ms step_avg:31.36ms
+step:462/1490 train_time:14491ms step_avg:31.37ms
+step:463/1490 train_time:14519ms step_avg:31.36ms
+step:464/1490 train_time:14554ms step_avg:31.37ms
+step:465/1490 train_time:14582ms step_avg:31.36ms
+step:466/1490 train_time:14617ms step_avg:31.37ms
+step:467/1490 train_time:14645ms step_avg:31.36ms
+step:468/1490 train_time:14679ms step_avg:31.37ms
+step:469/1490 train_time:14707ms step_avg:31.36ms
+step:470/1490 train_time:14741ms step_avg:31.36ms
+step:471/1490 train_time:14769ms step_avg:31.36ms
+step:472/1490 train_time:14804ms step_avg:31.36ms
+step:473/1490 train_time:14832ms step_avg:31.36ms
+step:474/1490 train_time:14866ms step_avg:31.36ms
+step:475/1490 train_time:14894ms step_avg:31.36ms
+step:476/1490 train_time:14929ms step_avg:31.36ms
+step:477/1490 train_time:14957ms step_avg:31.36ms
+step:478/1490 train_time:14992ms step_avg:31.36ms
+step:479/1490 train_time:15019ms step_avg:31.36ms
+step:480/1490 train_time:15054ms step_avg:31.36ms
+step:481/1490 train_time:15082ms step_avg:31.35ms
+step:482/1490 train_time:15116ms step_avg:31.36ms
+step:483/1490 train_time:15144ms step_avg:31.35ms
+step:484/1490 train_time:15181ms step_avg:31.37ms
+step:485/1490 train_time:15233ms step_avg:31.41ms
+step:486/1490 train_time:15292ms step_avg:31.47ms
+step:487/1490 train_time:15347ms step_avg:31.51ms
+step:488/1490 train_time:15407ms step_avg:31.57ms
+step:489/1490 train_time:15461ms step_avg:31.62ms
+step:490/1490 train_time:15520ms step_avg:31.67ms
+step:491/1490 train_time:15575ms step_avg:31.72ms
+step:492/1490 train_time:15634ms step_avg:31.78ms
+step:493/1490 train_time:15689ms step_avg:31.82ms
+step:494/1490 train_time:15749ms step_avg:31.88ms
+step:495/1490 train_time:15802ms step_avg:31.92ms
+step:496/1490 train_time:15861ms step_avg:31.98ms
+step:497/1490 train_time:15916ms step_avg:32.02ms
+step:498/1490 train_time:15975ms step_avg:32.08ms
+step:499/1490 train_time:16030ms step_avg:32.12ms
+step:500/1490 train_time:16090ms step_avg:32.18ms
+step:500/1490 val_loss:4.2135 train_time:16162ms step_avg:32.32ms
+step:501/1490 train_time:16178ms step_avg:32.29ms
+step:502/1490 train_time:16204ms step_avg:32.28ms
+step:503/1490 train_time:16262ms step_avg:32.33ms
+step:504/1490 train_time:16324ms step_avg:32.39ms
+step:505/1490 train_time:16378ms step_avg:32.43ms
+step:506/1490 train_time:16438ms step_avg:32.49ms
+step:507/1490 train_time:16493ms step_avg:32.53ms
+step:508/1490 train_time:16551ms step_avg:32.58ms
+step:509/1490 train_time:16606ms step_avg:32.62ms
+step:510/1490 train_time:16665ms step_avg:32.68ms
+step:511/1490 train_time:16718ms step_avg:32.72ms
+step:512/1490 train_time:16777ms step_avg:32.77ms
+step:513/1490 train_time:16830ms step_avg:32.81ms
+step:514/1490 train_time:16888ms step_avg:32.86ms
+step:515/1490 train_time:16943ms step_avg:32.90ms
+step:516/1490 train_time:17002ms step_avg:32.95ms
+step:517/1490 train_time:17055ms step_avg:32.99ms
+step:518/1490 train_time:17116ms step_avg:33.04ms
+step:519/1490 train_time:17171ms step_avg:33.09ms
+step:520/1490 train_time:17233ms step_avg:33.14ms
+step:521/1490 train_time:17287ms step_avg:33.18ms
+step:522/1490 train_time:17347ms step_avg:33.23ms
+step:523/1490 train_time:17402ms step_avg:33.27ms
+step:524/1490 train_time:17461ms step_avg:33.32ms
+step:525/1490 train_time:17516ms step_avg:33.36ms
+step:526/1490 train_time:17575ms step_avg:33.41ms
+step:527/1490 train_time:17629ms step_avg:33.45ms
+step:528/1490 train_time:17688ms step_avg:33.50ms
+step:529/1490 train_time:17741ms step_avg:33.54ms
+step:530/1490 train_time:17800ms step_avg:33.58ms
+step:531/1490 train_time:17853ms step_avg:33.62ms
+step:532/1490 train_time:17911ms step_avg:33.67ms
+step:533/1490 train_time:17966ms step_avg:33.71ms
+step:534/1490 train_time:18025ms step_avg:33.75ms
+step:535/1490 train_time:18079ms step_avg:33.79ms
+step:536/1490 train_time:18139ms step_avg:33.84ms
+step:537/1490 train_time:18194ms step_avg:33.88ms
+step:538/1490 train_time:18255ms step_avg:33.93ms
+step:539/1490 train_time:18310ms step_avg:33.97ms
+step:540/1490 train_time:18370ms step_avg:34.02ms
+step:541/1490 train_time:18425ms step_avg:34.06ms
+step:542/1490 train_time:18484ms step_avg:34.10ms
+step:543/1490 train_time:18539ms step_avg:34.14ms
+step:544/1490 train_time:18598ms step_avg:34.19ms
+step:545/1490 train_time:18652ms step_avg:34.22ms
+step:546/1490 train_time:18712ms step_avg:34.27ms
+step:547/1490 train_time:18766ms step_avg:34.31ms
+step:548/1490 train_time:18825ms step_avg:34.35ms
+step:549/1490 train_time:18878ms step_avg:34.39ms
+step:550/1490 train_time:18937ms step_avg:34.43ms
+step:551/1490 train_time:18991ms step_avg:34.47ms
+step:552/1490 train_time:19051ms step_avg:34.51ms
+step:553/1490 train_time:19104ms step_avg:34.55ms
+step:554/1490 train_time:19164ms step_avg:34.59ms
+step:555/1490 train_time:19219ms step_avg:34.63ms
+step:556/1490 train_time:19280ms step_avg:34.68ms
+step:557/1490 train_time:19334ms step_avg:34.71ms
+step:558/1490 train_time:19395ms step_avg:34.76ms
+step:559/1490 train_time:19449ms step_avg:34.79ms
+step:560/1490 train_time:19509ms step_avg:34.84ms
+step:561/1490 train_time:19564ms step_avg:34.87ms
+step:562/1490 train_time:19623ms step_avg:34.92ms
+step:563/1490 train_time:19676ms step_avg:34.95ms
+step:564/1490 train_time:19737ms step_avg:34.99ms
+step:565/1490 train_time:19790ms step_avg:35.03ms
+step:566/1490 train_time:19849ms step_avg:35.07ms
+step:567/1490 train_time:19903ms step_avg:35.10ms
+step:568/1490 train_time:19962ms step_avg:35.14ms
+step:569/1490 train_time:20016ms step_avg:35.18ms
+step:570/1490 train_time:20075ms step_avg:35.22ms
+step:571/1490 train_time:20130ms step_avg:35.25ms
+step:572/1490 train_time:20188ms step_avg:35.29ms
+step:573/1490 train_time:20244ms step_avg:35.33ms
+step:574/1490 train_time:20304ms step_avg:35.37ms
+step:575/1490 train_time:20359ms step_avg:35.41ms
+step:576/1490 train_time:20420ms step_avg:35.45ms
+step:577/1490 train_time:20474ms step_avg:35.48ms
+step:578/1490 train_time:20534ms step_avg:35.53ms
+step:579/1490 train_time:20588ms step_avg:35.56ms
+step:580/1490 train_time:20646ms step_avg:35.60ms
+step:581/1490 train_time:20699ms step_avg:35.63ms
+step:582/1490 train_time:20760ms step_avg:35.67ms
+step:583/1490 train_time:20814ms step_avg:35.70ms
+step:584/1490 train_time:20873ms step_avg:35.74ms
+step:585/1490 train_time:20927ms step_avg:35.77ms
+step:586/1490 train_time:20986ms step_avg:35.81ms
+step:587/1490 train_time:21039ms step_avg:35.84ms
+step:588/1490 train_time:21099ms step_avg:35.88ms
+step:589/1490 train_time:21155ms step_avg:35.92ms
+step:590/1490 train_time:21214ms step_avg:35.96ms
+step:591/1490 train_time:21268ms step_avg:35.99ms
+step:592/1490 train_time:21329ms step_avg:36.03ms
+step:593/1490 train_time:21383ms step_avg:36.06ms
+step:594/1490 train_time:21443ms step_avg:36.10ms
+step:595/1490 train_time:21497ms step_avg:36.13ms
+step:596/1490 train_time:21557ms step_avg:36.17ms
+step:597/1490 train_time:21612ms step_avg:36.20ms
+step:598/1490 train_time:21670ms step_avg:36.24ms
+step:599/1490 train_time:21725ms step_avg:36.27ms
+step:600/1490 train_time:21784ms step_avg:36.31ms
+step:601/1490 train_time:21837ms step_avg:36.33ms
+step:602/1490 train_time:21897ms step_avg:36.37ms
+step:603/1490 train_time:21952ms step_avg:36.40ms
+step:604/1490 train_time:22011ms step_avg:36.44ms
+step:605/1490 train_time:22066ms step_avg:36.47ms
+step:606/1490 train_time:22125ms step_avg:36.51ms
+step:607/1490 train_time:22180ms step_avg:36.54ms
+step:608/1490 train_time:22240ms step_avg:36.58ms
+step:609/1490 train_time:22294ms step_avg:36.61ms
+step:610/1490 train_time:22354ms step_avg:36.65ms
+step:611/1490 train_time:22409ms step_avg:36.68ms
+step:612/1490 train_time:22468ms step_avg:36.71ms
+step:613/1490 train_time:22523ms step_avg:36.74ms
+step:614/1490 train_time:22582ms step_avg:36.78ms
+step:615/1490 train_time:22635ms step_avg:36.81ms
+step:616/1490 train_time:22695ms step_avg:36.84ms
+step:617/1490 train_time:22749ms step_avg:36.87ms
+step:618/1490 train_time:22809ms step_avg:36.91ms
+step:619/1490 train_time:22863ms step_avg:36.94ms
+step:620/1490 train_time:22922ms step_avg:36.97ms
+step:621/1490 train_time:22975ms step_avg:37.00ms
+step:622/1490 train_time:23036ms step_avg:37.03ms
+step:623/1490 train_time:23089ms step_avg:37.06ms
+step:624/1490 train_time:23149ms step_avg:37.10ms
+step:625/1490 train_time:23203ms step_avg:37.12ms
+step:626/1490 train_time:23263ms step_avg:37.16ms
+step:627/1490 train_time:23318ms step_avg:37.19ms
+step:628/1490 train_time:23379ms step_avg:37.23ms
+step:629/1490 train_time:23433ms step_avg:37.26ms
+step:630/1490 train_time:23492ms step_avg:37.29ms
+step:631/1490 train_time:23547ms step_avg:37.32ms
+step:632/1490 train_time:23606ms step_avg:37.35ms
+step:633/1490 train_time:23660ms step_avg:37.38ms
+step:634/1490 train_time:23722ms step_avg:37.42ms
+step:635/1490 train_time:23775ms step_avg:37.44ms
+step:636/1490 train_time:23835ms step_avg:37.48ms
+step:637/1490 train_time:23889ms step_avg:37.50ms
+step:638/1490 train_time:23949ms step_avg:37.54ms
+step:639/1490 train_time:24003ms step_avg:37.56ms
+step:640/1490 train_time:24063ms step_avg:37.60ms
+step:641/1490 train_time:24117ms step_avg:37.62ms
+step:642/1490 train_time:24176ms step_avg:37.66ms
+step:643/1490 train_time:24230ms step_avg:37.68ms
+step:644/1490 train_time:24290ms step_avg:37.72ms
+step:645/1490 train_time:24345ms step_avg:37.74ms
+step:646/1490 train_time:24405ms step_avg:37.78ms
+step:647/1490 train_time:24459ms step_avg:37.80ms
+step:648/1490 train_time:24520ms step_avg:37.84ms
+step:649/1490 train_time:24574ms step_avg:37.86ms
+step:650/1490 train_time:24634ms step_avg:37.90ms
+step:651/1490 train_time:24688ms step_avg:37.92ms
+step:652/1490 train_time:24747ms step_avg:37.96ms
+step:653/1490 train_time:24802ms step_avg:37.98ms
+step:654/1490 train_time:24861ms step_avg:38.01ms
+step:655/1490 train_time:24915ms step_avg:38.04ms
+step:656/1490 train_time:24974ms step_avg:38.07ms
+step:657/1490 train_time:25028ms step_avg:38.09ms
+step:658/1490 train_time:25087ms step_avg:38.13ms
+step:659/1490 train_time:25140ms step_avg:38.15ms
+step:660/1490 train_time:25202ms step_avg:38.18ms
+step:661/1490 train_time:25257ms step_avg:38.21ms
+step:662/1490 train_time:25316ms step_avg:38.24ms
+step:663/1490 train_time:25371ms step_avg:38.27ms
+step:664/1490 train_time:25431ms step_avg:38.30ms
+step:665/1490 train_time:25484ms step_avg:38.32ms
+step:666/1490 train_time:25544ms step_avg:38.35ms
+step:667/1490 train_time:25598ms step_avg:38.38ms
+step:668/1490 train_time:25658ms step_avg:38.41ms
+step:669/1490 train_time:25712ms step_avg:38.43ms
+step:670/1490 train_time:25771ms step_avg:38.46ms
+step:671/1490 train_time:25825ms step_avg:38.49ms
+step:672/1490 train_time:25885ms step_avg:38.52ms
+step:673/1490 train_time:25939ms step_avg:38.54ms
+step:674/1490 train_time:25999ms step_avg:38.57ms
+step:675/1490 train_time:26052ms step_avg:38.60ms
+step:676/1490 train_time:26112ms step_avg:38.63ms
+step:677/1490 train_time:26167ms step_avg:38.65ms
+step:678/1490 train_time:26226ms step_avg:38.68ms
+step:679/1490 train_time:26280ms step_avg:38.70ms
+step:680/1490 train_time:26340ms step_avg:38.74ms
+step:681/1490 train_time:26394ms step_avg:38.76ms
+step:682/1490 train_time:26454ms step_avg:38.79ms
+step:683/1490 train_time:26508ms step_avg:38.81ms
+step:684/1490 train_time:26568ms step_avg:38.84ms
+step:685/1490 train_time:26623ms step_avg:38.87ms
+step:686/1490 train_time:26682ms step_avg:38.89ms
+step:687/1490 train_time:26735ms step_avg:38.92ms
+step:688/1490 train_time:26795ms step_avg:38.95ms
+step:689/1490 train_time:26850ms step_avg:38.97ms
+step:690/1490 train_time:26909ms step_avg:39.00ms
+step:691/1490 train_time:26964ms step_avg:39.02ms
+step:692/1490 train_time:27023ms step_avg:39.05ms
+step:693/1490 train_time:27078ms step_avg:39.07ms
+step:694/1490 train_time:27138ms step_avg:39.10ms
+step:695/1490 train_time:27192ms step_avg:39.13ms
+step:696/1490 train_time:27252ms step_avg:39.15ms
+step:697/1490 train_time:27305ms step_avg:39.18ms
+step:698/1490 train_time:27365ms step_avg:39.20ms
+step:699/1490 train_time:27419ms step_avg:39.23ms
+step:700/1490 train_time:27480ms step_avg:39.26ms
+step:701/1490 train_time:27533ms step_avg:39.28ms
+step:702/1490 train_time:27593ms step_avg:39.31ms
+step:703/1490 train_time:27648ms step_avg:39.33ms
+step:704/1490 train_time:27708ms step_avg:39.36ms
+step:705/1490 train_time:27762ms step_avg:39.38ms
+step:706/1490 train_time:27822ms step_avg:39.41ms
+step:707/1490 train_time:27876ms step_avg:39.43ms
+step:708/1490 train_time:27936ms step_avg:39.46ms
+step:709/1490 train_time:27990ms step_avg:39.48ms
+step:710/1490 train_time:28048ms step_avg:39.50ms
+step:711/1490 train_time:28102ms step_avg:39.53ms
+step:712/1490 train_time:28163ms step_avg:39.55ms
+step:713/1490 train_time:28217ms step_avg:39.57ms
+step:714/1490 train_time:28276ms step_avg:39.60ms
+step:715/1490 train_time:28330ms step_avg:39.62ms
+step:716/1490 train_time:28390ms step_avg:39.65ms
+step:717/1490 train_time:28445ms step_avg:39.67ms
+step:718/1490 train_time:28504ms step_avg:39.70ms
+step:719/1490 train_time:28558ms step_avg:39.72ms
+step:720/1490 train_time:28619ms step_avg:39.75ms
+step:721/1490 train_time:28674ms step_avg:39.77ms
+step:722/1490 train_time:28733ms step_avg:39.80ms
+step:723/1490 train_time:28787ms step_avg:39.82ms
+step:724/1490 train_time:28846ms step_avg:39.84ms
+step:725/1490 train_time:28900ms step_avg:39.86ms
+step:726/1490 train_time:28961ms step_avg:39.89ms
+step:727/1490 train_time:29014ms step_avg:39.91ms
+step:728/1490 train_time:29074ms step_avg:39.94ms
+step:729/1490 train_time:29127ms step_avg:39.95ms
+step:730/1490 train_time:29186ms step_avg:39.98ms
+step:731/1490 train_time:29240ms step_avg:40.00ms
+step:732/1490 train_time:29300ms step_avg:40.03ms
+step:733/1490 train_time:29355ms step_avg:40.05ms
+step:734/1490 train_time:29414ms step_avg:40.07ms
+step:735/1490 train_time:29468ms step_avg:40.09ms
+step:736/1490 train_time:29528ms step_avg:40.12ms
+step:737/1490 train_time:29582ms step_avg:40.14ms
+step:738/1490 train_time:29642ms step_avg:40.17ms
+step:739/1490 train_time:29696ms step_avg:40.18ms
+step:740/1490 train_time:29756ms step_avg:40.21ms
+step:741/1490 train_time:29810ms step_avg:40.23ms
+step:742/1490 train_time:29869ms step_avg:40.25ms
+step:743/1490 train_time:29924ms step_avg:40.27ms
+step:744/1490 train_time:29983ms step_avg:40.30ms
+step:745/1490 train_time:30037ms step_avg:40.32ms
+step:746/1490 train_time:30097ms step_avg:40.34ms
+step:747/1490 train_time:30152ms step_avg:40.36ms
+step:748/1490 train_time:30212ms step_avg:40.39ms
+step:749/1490 train_time:30266ms step_avg:40.41ms
+step:750/1490 train_time:30326ms step_avg:40.44ms
+step:750/1490 val_loss:3.8023 train_time:30399ms step_avg:40.53ms
+step:751/1490 train_time:30415ms step_avg:40.50ms
+step:752/1490 train_time:30441ms step_avg:40.48ms
+step:753/1490 train_time:30501ms step_avg:40.51ms
+step:754/1490 train_time:30563ms step_avg:40.53ms
+step:755/1490 train_time:30618ms step_avg:40.55ms
+step:756/1490 train_time:30678ms step_avg:40.58ms
+step:757/1490 train_time:30731ms step_avg:40.60ms
+step:758/1490 train_time:30790ms step_avg:40.62ms
+step:759/1490 train_time:30844ms step_avg:40.64ms
+step:760/1490 train_time:30903ms step_avg:40.66ms
+step:761/1490 train_time:30957ms step_avg:40.68ms
+step:762/1490 train_time:31016ms step_avg:40.70ms
+step:763/1490 train_time:31070ms step_avg:40.72ms
+step:764/1490 train_time:31128ms step_avg:40.74ms
+step:765/1490 train_time:31182ms step_avg:40.76ms
+step:766/1490 train_time:31241ms step_avg:40.78ms
+step:767/1490 train_time:31295ms step_avg:40.80ms
+step:768/1490 train_time:31355ms step_avg:40.83ms
+step:769/1490 train_time:31410ms step_avg:40.85ms
+step:770/1490 train_time:31472ms step_avg:40.87ms
+step:771/1490 train_time:31527ms step_avg:40.89ms
+step:772/1490 train_time:31587ms step_avg:40.92ms
+step:773/1490 train_time:31643ms step_avg:40.93ms
+step:774/1490 train_time:31703ms step_avg:40.96ms
+step:775/1490 train_time:31757ms step_avg:40.98ms
+step:776/1490 train_time:31815ms step_avg:41.00ms
+step:777/1490 train_time:31869ms step_avg:41.02ms
+step:778/1490 train_time:31928ms step_avg:41.04ms
+step:779/1490 train_time:31982ms step_avg:41.06ms
+step:780/1490 train_time:32041ms step_avg:41.08ms
+step:781/1490 train_time:32095ms step_avg:41.10ms
+step:782/1490 train_time:32155ms step_avg:41.12ms
+step:783/1490 train_time:32208ms step_avg:41.13ms
+step:784/1490 train_time:32268ms step_avg:41.16ms
+step:785/1490 train_time:32322ms step_avg:41.17ms
+step:786/1490 train_time:32383ms step_avg:41.20ms
+step:787/1490 train_time:32437ms step_avg:41.22ms
+step:788/1490 train_time:32497ms step_avg:41.24ms
+step:789/1490 train_time:32552ms step_avg:41.26ms
+step:790/1490 train_time:32613ms step_avg:41.28ms
+step:791/1490 train_time:32667ms step_avg:41.30ms
+step:792/1490 train_time:32726ms step_avg:41.32ms
+step:793/1490 train_time:32781ms step_avg:41.34ms
+step:794/1490 train_time:32841ms step_avg:41.36ms
+step:795/1490 train_time:32895ms step_avg:41.38ms
+step:796/1490 train_time:32954ms step_avg:41.40ms
+step:797/1490 train_time:33008ms step_avg:41.41ms
+step:798/1490 train_time:33066ms step_avg:41.44ms
+step:799/1490 train_time:33120ms step_avg:41.45ms
+step:800/1490 train_time:33179ms step_avg:41.47ms
+step:801/1490 train_time:33233ms step_avg:41.49ms
+step:802/1490 train_time:33292ms step_avg:41.51ms
+step:803/1490 train_time:33347ms step_avg:41.53ms
+step:804/1490 train_time:33406ms step_avg:41.55ms
+step:805/1490 train_time:33461ms step_avg:41.57ms
+step:806/1490 train_time:33521ms step_avg:41.59ms
+step:807/1490 train_time:33576ms step_avg:41.61ms
+step:808/1490 train_time:33636ms step_avg:41.63ms
+step:809/1490 train_time:33690ms step_avg:41.64ms
+step:810/1490 train_time:33750ms step_avg:41.67ms
+step:811/1490 train_time:33805ms step_avg:41.68ms
+step:812/1490 train_time:33864ms step_avg:41.70ms
+step:813/1490 train_time:33919ms step_avg:41.72ms
+step:814/1490 train_time:33978ms step_avg:41.74ms
+step:815/1490 train_time:34031ms step_avg:41.76ms
+step:816/1490 train_time:34090ms step_avg:41.78ms
+step:817/1490 train_time:34145ms step_avg:41.79ms
+step:818/1490 train_time:34204ms step_avg:41.81ms
+step:819/1490 train_time:34258ms step_avg:41.83ms
+step:820/1490 train_time:34318ms step_avg:41.85ms
+step:821/1490 train_time:34371ms step_avg:41.87ms
+step:822/1490 train_time:34431ms step_avg:41.89ms
+step:823/1490 train_time:34487ms step_avg:41.90ms
+step:824/1490 train_time:34546ms step_avg:41.93ms
+step:825/1490 train_time:34600ms step_avg:41.94ms
+step:826/1490 train_time:34660ms step_avg:41.96ms
+step:827/1490 train_time:34714ms step_avg:41.98ms
+step:828/1490 train_time:34774ms step_avg:42.00ms
+step:829/1490 train_time:34828ms step_avg:42.01ms
+step:830/1490 train_time:34888ms step_avg:42.03ms
+step:831/1490 train_time:34942ms step_avg:42.05ms
+step:832/1490 train_time:35002ms step_avg:42.07ms
+step:833/1490 train_time:35055ms step_avg:42.08ms
+step:834/1490 train_time:35114ms step_avg:42.10ms
+step:835/1490 train_time:35168ms step_avg:42.12ms
+step:836/1490 train_time:35227ms step_avg:42.14ms
+step:837/1490 train_time:35282ms step_avg:42.15ms
+step:838/1490 train_time:35341ms step_avg:42.17ms
+step:839/1490 train_time:35395ms step_avg:42.19ms
+step:840/1490 train_time:35456ms step_avg:42.21ms
+step:841/1490 train_time:35509ms step_avg:42.22ms
+step:842/1490 train_time:35569ms step_avg:42.24ms
+step:843/1490 train_time:35623ms step_avg:42.26ms
+step:844/1490 train_time:35684ms step_avg:42.28ms
+step:845/1490 train_time:35738ms step_avg:42.29ms
+step:846/1490 train_time:35798ms step_avg:42.31ms
+step:847/1490 train_time:35853ms step_avg:42.33ms
+step:848/1490 train_time:35912ms step_avg:42.35ms
+step:849/1490 train_time:35965ms step_avg:42.36ms
+step:850/1490 train_time:36025ms step_avg:42.38ms
+step:851/1490 train_time:36078ms step_avg:42.39ms
+step:852/1490 train_time:36138ms step_avg:42.41ms
+step:853/1490 train_time:36191ms step_avg:42.43ms
+step:854/1490 train_time:36252ms step_avg:42.45ms
+step:855/1490 train_time:36305ms step_avg:42.46ms
+step:856/1490 train_time:36365ms step_avg:42.48ms
+step:857/1490 train_time:36420ms step_avg:42.50ms
+step:858/1490 train_time:36480ms step_avg:42.52ms
+step:859/1490 train_time:36534ms step_avg:42.53ms
+step:860/1490 train_time:36593ms step_avg:42.55ms
+step:861/1490 train_time:36647ms step_avg:42.56ms
+step:862/1490 train_time:36707ms step_avg:42.58ms
+step:863/1490 train_time:36761ms step_avg:42.60ms
+step:864/1490 train_time:36821ms step_avg:42.62ms
+step:865/1490 train_time:36875ms step_avg:42.63ms
+step:866/1490 train_time:36934ms step_avg:42.65ms
+step:867/1490 train_time:36989ms step_avg:42.66ms
+step:868/1490 train_time:37048ms step_avg:42.68ms
+step:869/1490 train_time:37101ms step_avg:42.69ms
+step:870/1490 train_time:37161ms step_avg:42.71ms
+step:871/1490 train_time:37215ms step_avg:42.73ms
+step:872/1490 train_time:37274ms step_avg:42.75ms
+step:873/1490 train_time:37329ms step_avg:42.76ms
+step:874/1490 train_time:37388ms step_avg:42.78ms
+step:875/1490 train_time:37442ms step_avg:42.79ms
+step:876/1490 train_time:37502ms step_avg:42.81ms
+step:877/1490 train_time:37556ms step_avg:42.82ms
+step:878/1490 train_time:37616ms step_avg:42.84ms
+step:879/1490 train_time:37670ms step_avg:42.86ms
+step:880/1490 train_time:37729ms step_avg:42.87ms
+step:881/1490 train_time:37784ms step_avg:42.89ms
+step:882/1490 train_time:37845ms step_avg:42.91ms
+step:883/1490 train_time:37899ms step_avg:42.92ms
+step:884/1490 train_time:37958ms step_avg:42.94ms
+step:885/1490 train_time:38011ms step_avg:42.95ms
+step:886/1490 train_time:38072ms step_avg:42.97ms
+step:887/1490 train_time:38125ms step_avg:42.98ms
+step:888/1490 train_time:38185ms step_avg:43.00ms
+step:889/1490 train_time:38240ms step_avg:43.01ms
+step:890/1490 train_time:38299ms step_avg:43.03ms
+step:891/1490 train_time:38354ms step_avg:43.05ms
+step:892/1490 train_time:38413ms step_avg:43.06ms
+step:893/1490 train_time:38468ms step_avg:43.08ms
+step:894/1490 train_time:38527ms step_avg:43.10ms
+step:895/1490 train_time:38582ms step_avg:43.11ms
+step:896/1490 train_time:38643ms step_avg:43.13ms
+step:897/1490 train_time:38697ms step_avg:43.14ms
+step:898/1490 train_time:38757ms step_avg:43.16ms
+step:899/1490 train_time:38810ms step_avg:43.17ms
+step:900/1490 train_time:38870ms step_avg:43.19ms
+step:901/1490 train_time:38924ms step_avg:43.20ms
+step:902/1490 train_time:38983ms step_avg:43.22ms
+step:903/1490 train_time:39038ms step_avg:43.23ms
+step:904/1490 train_time:39097ms step_avg:43.25ms
+step:905/1490 train_time:39151ms step_avg:43.26ms
+step:906/1490 train_time:39211ms step_avg:43.28ms
+step:907/1490 train_time:39264ms step_avg:43.29ms
+step:908/1490 train_time:39324ms step_avg:43.31ms
+step:909/1490 train_time:39379ms step_avg:43.32ms
+step:910/1490 train_time:39439ms step_avg:43.34ms
+step:911/1490 train_time:39493ms step_avg:43.35ms
+step:912/1490 train_time:39553ms step_avg:43.37ms
+step:913/1490 train_time:39606ms step_avg:43.38ms
+step:914/1490 train_time:39666ms step_avg:43.40ms
+step:915/1490 train_time:39720ms step_avg:43.41ms
+step:916/1490 train_time:39780ms step_avg:43.43ms
+step:917/1490 train_time:39835ms step_avg:43.44ms
+step:918/1490 train_time:39894ms step_avg:43.46ms
+step:919/1490 train_time:39948ms step_avg:43.47ms
+step:920/1490 train_time:40008ms step_avg:43.49ms
+step:921/1490 train_time:40062ms step_avg:43.50ms
+step:922/1490 train_time:40121ms step_avg:43.52ms
+step:923/1490 train_time:40176ms step_avg:43.53ms
+step:924/1490 train_time:40235ms step_avg:43.54ms
+step:925/1490 train_time:40289ms step_avg:43.56ms
+step:926/1490 train_time:40349ms step_avg:43.57ms
+step:927/1490 train_time:40404ms step_avg:43.59ms
+step:928/1490 train_time:40463ms step_avg:43.60ms
+step:929/1490 train_time:40518ms step_avg:43.61ms
+step:930/1490 train_time:40577ms step_avg:43.63ms
+step:931/1490 train_time:40630ms step_avg:43.64ms
+step:932/1490 train_time:40691ms step_avg:43.66ms
+step:933/1490 train_time:40745ms step_avg:43.67ms
+step:934/1490 train_time:40805ms step_avg:43.69ms
+step:935/1490 train_time:40859ms step_avg:43.70ms
+step:936/1490 train_time:40919ms step_avg:43.72ms
+step:937/1490 train_time:40974ms step_avg:43.73ms
+step:938/1490 train_time:41033ms step_avg:43.75ms
+step:939/1490 train_time:41087ms step_avg:43.76ms
+step:940/1490 train_time:41147ms step_avg:43.77ms
+step:941/1490 train_time:41201ms step_avg:43.78ms
+step:942/1490 train_time:41260ms step_avg:43.80ms
+step:943/1490 train_time:41313ms step_avg:43.81ms
+step:944/1490 train_time:41374ms step_avg:43.83ms
+step:945/1490 train_time:41428ms step_avg:43.84ms
+step:946/1490 train_time:41487ms step_avg:43.86ms
+step:947/1490 train_time:41542ms step_avg:43.87ms
+step:948/1490 train_time:41602ms step_avg:43.88ms
+step:949/1490 train_time:41655ms step_avg:43.89ms
+step:950/1490 train_time:41714ms step_avg:43.91ms
+step:951/1490 train_time:41769ms step_avg:43.92ms
+step:952/1490 train_time:41828ms step_avg:43.94ms
+step:953/1490 train_time:41883ms step_avg:43.95ms
+step:954/1490 train_time:41943ms step_avg:43.97ms
+step:955/1490 train_time:41998ms step_avg:43.98ms
+step:956/1490 train_time:42057ms step_avg:43.99ms
+step:957/1490 train_time:42112ms step_avg:44.00ms
+step:958/1490 train_time:42171ms step_avg:44.02ms
+step:959/1490 train_time:42225ms step_avg:44.03ms
+step:960/1490 train_time:42285ms step_avg:44.05ms
+step:961/1490 train_time:42338ms step_avg:44.06ms
+step:962/1490 train_time:42397ms step_avg:44.07ms
+step:963/1490 train_time:42452ms step_avg:44.08ms
+step:964/1490 train_time:42513ms step_avg:44.10ms
+step:965/1490 train_time:42567ms step_avg:44.11ms
+step:966/1490 train_time:42627ms step_avg:44.13ms
+step:967/1490 train_time:42681ms step_avg:44.14ms
+step:968/1490 train_time:42744ms step_avg:44.16ms
+step:969/1490 train_time:42821ms step_avg:44.19ms
+step:970/1490 train_time:42907ms step_avg:44.23ms
+step:971/1490 train_time:42986ms step_avg:44.27ms
+step:972/1490 train_time:43073ms step_avg:44.31ms
+step:973/1490 train_time:43152ms step_avg:44.35ms
+step:974/1490 train_time:43237ms step_avg:44.39ms
+step:975/1490 train_time:43318ms step_avg:44.43ms
+step:976/1490 train_time:43406ms step_avg:44.47ms
+step:977/1490 train_time:43487ms step_avg:44.51ms
+step:978/1490 train_time:43574ms step_avg:44.55ms
+step:979/1490 train_time:43652ms step_avg:44.59ms
+step:980/1490 train_time:43738ms step_avg:44.63ms
+step:981/1490 train_time:43819ms step_avg:44.67ms
+step:982/1490 train_time:43905ms step_avg:44.71ms
+step:983/1490 train_time:43987ms step_avg:44.75ms
+step:984/1490 train_time:44072ms step_avg:44.79ms
+step:985/1490 train_time:44150ms step_avg:44.82ms
+step:986/1490 train_time:44236ms step_avg:44.86ms
+step:987/1490 train_time:44318ms step_avg:44.90ms
+step:988/1490 train_time:44403ms step_avg:44.94ms
+step:989/1490 train_time:44485ms step_avg:44.98ms
+step:990/1490 train_time:44570ms step_avg:45.02ms
+step:991/1490 train_time:44650ms step_avg:45.06ms
+step:992/1490 train_time:44735ms step_avg:45.10ms
+step:993/1490 train_time:44815ms step_avg:45.13ms
+step:994/1490 train_time:44901ms step_avg:45.17ms
+step:995/1490 train_time:44982ms step_avg:45.21ms
+step:996/1490 train_time:45068ms step_avg:45.25ms
+step:997/1490 train_time:45149ms step_avg:45.28ms
+step:998/1490 train_time:45233ms step_avg:45.32ms
+step:999/1490 train_time:45312ms step_avg:45.36ms
+step:1000/1490 train_time:45397ms step_avg:45.40ms
+step:1000/1490 val_loss:3.5189 train_time:45501ms step_avg:45.50ms
+step:1001/1490 train_time:45517ms step_avg:45.47ms
+step:1002/1490 train_time:45566ms step_avg:45.48ms
+step:1003/1490 train_time:45651ms step_avg:45.51ms
+step:1004/1490 train_time:45738ms step_avg:45.56ms
+step:1005/1490 train_time:45820ms step_avg:45.59ms
+step:1006/1490 train_time:45904ms step_avg:45.63ms
+step:1007/1490 train_time:45984ms step_avg:45.66ms
+step:1008/1490 train_time:46070ms step_avg:45.70ms
+step:1009/1490 train_time:46148ms step_avg:45.74ms
+step:1010/1490 train_time:46233ms step_avg:45.78ms
+step:1011/1490 train_time:46312ms step_avg:45.81ms
+step:1012/1490 train_time:46396ms step_avg:45.85ms
+step:1013/1490 train_time:46478ms step_avg:45.88ms
+step:1014/1490 train_time:46566ms step_avg:45.92ms
+step:1015/1490 train_time:46648ms step_avg:45.96ms
+step:1016/1490 train_time:46734ms step_avg:46.00ms
+step:1017/1490 train_time:46814ms step_avg:46.03ms
+step:1018/1490 train_time:46900ms step_avg:46.07ms
+step:1019/1490 train_time:46981ms step_avg:46.10ms
+step:1020/1490 train_time:47066ms step_avg:46.14ms
+step:1021/1490 train_time:47144ms step_avg:46.17ms
+step:1022/1490 train_time:47229ms step_avg:46.21ms
+step:1023/1490 train_time:47308ms step_avg:46.24ms
+step:1024/1490 train_time:47393ms step_avg:46.28ms
+step:1025/1490 train_time:47473ms step_avg:46.32ms
+step:1026/1490 train_time:47559ms step_avg:46.35ms
+step:1027/1490 train_time:47642ms step_avg:46.39ms
+step:1028/1490 train_time:47728ms step_avg:46.43ms
+step:1029/1490 train_time:47809ms step_avg:46.46ms
+step:1030/1490 train_time:47894ms step_avg:46.50ms
+step:1031/1490 train_time:47977ms step_avg:46.53ms
+step:1032/1490 train_time:48062ms step_avg:46.57ms
+step:1033/1490 train_time:48141ms step_avg:46.60ms
+step:1034/1490 train_time:48225ms step_avg:46.64ms
+step:1035/1490 train_time:48305ms step_avg:46.67ms
+step:1036/1490 train_time:48391ms step_avg:46.71ms
+step:1037/1490 train_time:48470ms step_avg:46.74ms
+step:1038/1490 train_time:48555ms step_avg:46.78ms
+step:1039/1490 train_time:48638ms step_avg:46.81ms
+step:1040/1490 train_time:48724ms step_avg:46.85ms
+step:1041/1490 train_time:48805ms step_avg:46.88ms
+step:1042/1490 train_time:48891ms step_avg:46.92ms
+step:1043/1490 train_time:48970ms step_avg:46.95ms
+step:1044/1490 train_time:49056ms step_avg:46.99ms
+step:1045/1490 train_time:49135ms step_avg:47.02ms
+step:1046/1490 train_time:49220ms step_avg:47.06ms
+step:1047/1490 train_time:49300ms step_avg:47.09ms
+step:1048/1490 train_time:49387ms step_avg:47.13ms
+step:1049/1490 train_time:49466ms step_avg:47.16ms
+step:1050/1490 train_time:49551ms step_avg:47.19ms
+step:1051/1490 train_time:49633ms step_avg:47.22ms
+step:1052/1490 train_time:49719ms step_avg:47.26ms
+step:1053/1490 train_time:49801ms step_avg:47.29ms
+step:1054/1490 train_time:49887ms step_avg:47.33ms
+step:1055/1490 train_time:49968ms step_avg:47.36ms
+step:1056/1490 train_time:50052ms step_avg:47.40ms
+step:1057/1490 train_time:50132ms step_avg:47.43ms
+step:1058/1490 train_time:50217ms step_avg:47.46ms
+step:1059/1490 train_time:50299ms step_avg:47.50ms
+step:1060/1490 train_time:50385ms step_avg:47.53ms
+step:1061/1490 train_time:50464ms step_avg:47.56ms
+step:1062/1490 train_time:50549ms step_avg:47.60ms
+step:1063/1490 train_time:50629ms step_avg:47.63ms
+step:1064/1490 train_time:50714ms step_avg:47.66ms
+step:1065/1490 train_time:50795ms step_avg:47.69ms
+step:1066/1490 train_time:50880ms step_avg:47.73ms
+step:1067/1490 train_time:50961ms step_avg:47.76ms
+step:1068/1490 train_time:51047ms step_avg:47.80ms
+step:1069/1490 train_time:51126ms step_avg:47.83ms
+step:1070/1490 train_time:51211ms step_avg:47.86ms
+step:1071/1490 train_time:51291ms step_avg:47.89ms
+step:1072/1490 train_time:51377ms step_avg:47.93ms
+step:1073/1490 train_time:51457ms step_avg:47.96ms
+step:1074/1490 train_time:51542ms step_avg:47.99ms
+step:1075/1490 train_time:51622ms step_avg:48.02ms
+step:1076/1490 train_time:51708ms step_avg:48.06ms
+step:1077/1490 train_time:51788ms step_avg:48.09ms
+step:1078/1490 train_time:51873ms step_avg:48.12ms
+step:1079/1490 train_time:51953ms step_avg:48.15ms
+step:1080/1490 train_time:52039ms step_avg:48.18ms
+step:1081/1490 train_time:52119ms step_avg:48.21ms
+step:1082/1490 train_time:52204ms step_avg:48.25ms
+step:1083/1490 train_time:52284ms step_avg:48.28ms
+step:1084/1490 train_time:52369ms step_avg:48.31ms
+step:1085/1490 train_time:52450ms step_avg:48.34ms
+step:1086/1490 train_time:52535ms step_avg:48.37ms
+step:1087/1490 train_time:52616ms step_avg:48.40ms
+step:1088/1490 train_time:52703ms step_avg:48.44ms
+step:1089/1490 train_time:52783ms step_avg:48.47ms
+step:1090/1490 train_time:52868ms step_avg:48.50ms
+step:1091/1490 train_time:52948ms step_avg:48.53ms
+step:1092/1490 train_time:53034ms step_avg:48.57ms
+step:1093/1490 train_time:53114ms step_avg:48.59ms
+step:1094/1490 train_time:53201ms step_avg:48.63ms
+step:1095/1490 train_time:53281ms step_avg:48.66ms
+step:1096/1490 train_time:53366ms step_avg:48.69ms
+step:1097/1490 train_time:53445ms step_avg:48.72ms
+step:1098/1490 train_time:53531ms step_avg:48.75ms
+step:1099/1490 train_time:53611ms step_avg:48.78ms
+step:1100/1490 train_time:53698ms step_avg:48.82ms
+step:1101/1490 train_time:53778ms step_avg:48.84ms
+step:1102/1490 train_time:53863ms step_avg:48.88ms
+step:1103/1490 train_time:53942ms step_avg:48.90ms
+step:1104/1490 train_time:54028ms step_avg:48.94ms
+step:1105/1490 train_time:54108ms step_avg:48.97ms
+step:1106/1490 train_time:54193ms step_avg:49.00ms
+step:1107/1490 train_time:54273ms step_avg:49.03ms
+step:1108/1490 train_time:54360ms step_avg:49.06ms
+step:1109/1490 train_time:54442ms step_avg:49.09ms
+step:1110/1490 train_time:54528ms step_avg:49.12ms
+step:1111/1490 train_time:54609ms step_avg:49.15ms
+step:1112/1490 train_time:54695ms step_avg:49.19ms
+step:1113/1490 train_time:54775ms step_avg:49.21ms
+step:1114/1490 train_time:54860ms step_avg:49.25ms
+step:1115/1490 train_time:54941ms step_avg:49.27ms
+step:1116/1490 train_time:55027ms step_avg:49.31ms
+step:1117/1490 train_time:55109ms step_avg:49.34ms
+step:1118/1490 train_time:55194ms step_avg:49.37ms
+step:1119/1490 train_time:55275ms step_avg:49.40ms
+step:1120/1490 train_time:55362ms step_avg:49.43ms
+step:1121/1490 train_time:55441ms step_avg:49.46ms
+step:1122/1490 train_time:55527ms step_avg:49.49ms
+step:1123/1490 train_time:55609ms step_avg:49.52ms
+step:1124/1490 train_time:55695ms step_avg:49.55ms
+step:1125/1490 train_time:55776ms step_avg:49.58ms
+step:1126/1490 train_time:55861ms step_avg:49.61ms
+step:1127/1490 train_time:55941ms step_avg:49.64ms
+step:1128/1490 train_time:56027ms step_avg:49.67ms
+step:1129/1490 train_time:56108ms step_avg:49.70ms
+step:1130/1490 train_time:56194ms step_avg:49.73ms
+step:1131/1490 train_time:56273ms step_avg:49.76ms
+step:1132/1490 train_time:56359ms step_avg:49.79ms
+step:1133/1490 train_time:56438ms step_avg:49.81ms
+step:1134/1490 train_time:56525ms step_avg:49.85ms
+step:1135/1490 train_time:56605ms step_avg:49.87ms
+step:1136/1490 train_time:56691ms step_avg:49.90ms
+step:1137/1490 train_time:56769ms step_avg:49.93ms
+step:1138/1490 train_time:56854ms step_avg:49.96ms
+step:1139/1490 train_time:56937ms step_avg:49.99ms
+step:1140/1490 train_time:57023ms step_avg:50.02ms
+step:1141/1490 train_time:57103ms step_avg:50.05ms
+step:1142/1490 train_time:57189ms step_avg:50.08ms
+step:1143/1490 train_time:57269ms step_avg:50.10ms
+step:1144/1490 train_time:57353ms step_avg:50.13ms
+step:1145/1490 train_time:57433ms step_avg:50.16ms
+step:1146/1490 train_time:57518ms step_avg:50.19ms
+step:1147/1490 train_time:57598ms step_avg:50.22ms
+step:1148/1490 train_time:57684ms step_avg:50.25ms
+step:1149/1490 train_time:57768ms step_avg:50.28ms
+step:1150/1490 train_time:57851ms step_avg:50.31ms
+step:1151/1490 train_time:57931ms step_avg:50.33ms
+step:1152/1490 train_time:58017ms step_avg:50.36ms
+step:1153/1490 train_time:58099ms step_avg:50.39ms
+step:1154/1490 train_time:58184ms step_avg:50.42ms
+step:1155/1490 train_time:58263ms step_avg:50.44ms
+step:1156/1490 train_time:58348ms step_avg:50.47ms
+step:1157/1490 train_time:58428ms step_avg:50.50ms
+step:1158/1490 train_time:58512ms step_avg:50.53ms
+step:1159/1490 train_time:58593ms step_avg:50.55ms
+step:1160/1490 train_time:58678ms step_avg:50.58ms
+step:1161/1490 train_time:58759ms step_avg:50.61ms
+step:1162/1490 train_time:58844ms step_avg:50.64ms
+step:1163/1490 train_time:58925ms step_avg:50.67ms
+step:1164/1490 train_time:59010ms step_avg:50.70ms
+step:1165/1490 train_time:59090ms step_avg:50.72ms
+step:1166/1490 train_time:59176ms step_avg:50.75ms
+step:1167/1490 train_time:59256ms step_avg:50.78ms
+step:1168/1490 train_time:59342ms step_avg:50.81ms
+step:1169/1490 train_time:59423ms step_avg:50.83ms
+step:1170/1490 train_time:59508ms step_avg:50.86ms
+step:1171/1490 train_time:59588ms step_avg:50.89ms
+step:1172/1490 train_time:59674ms step_avg:50.92ms
+step:1173/1490 train_time:59754ms step_avg:50.94ms
+step:1174/1490 train_time:59839ms step_avg:50.97ms
+step:1175/1490 train_time:59920ms step_avg:51.00ms
+step:1176/1490 train_time:60006ms step_avg:51.03ms
+step:1177/1490 train_time:60087ms step_avg:51.05ms
+step:1178/1490 train_time:60171ms step_avg:51.08ms
+step:1179/1490 train_time:60250ms step_avg:51.10ms
+step:1180/1490 train_time:60337ms step_avg:51.13ms
+step:1181/1490 train_time:60417ms step_avg:51.16ms
+step:1182/1490 train_time:60502ms step_avg:51.19ms
+step:1183/1490 train_time:60582ms step_avg:51.21ms
+step:1184/1490 train_time:60668ms step_avg:51.24ms
+step:1185/1490 train_time:60747ms step_avg:51.26ms
+step:1186/1490 train_time:60834ms step_avg:51.29ms
+step:1187/1490 train_time:60916ms step_avg:51.32ms
+step:1188/1490 train_time:61002ms step_avg:51.35ms
+step:1189/1490 train_time:61082ms step_avg:51.37ms
+step:1190/1490 train_time:61169ms step_avg:51.40ms
+step:1191/1490 train_time:61249ms step_avg:51.43ms
+step:1192/1490 train_time:61335ms step_avg:51.46ms
+step:1193/1490 train_time:61415ms step_avg:51.48ms
+step:1194/1490 train_time:61502ms step_avg:51.51ms
+step:1195/1490 train_time:61582ms step_avg:51.53ms
+step:1196/1490 train_time:61668ms step_avg:51.56ms
+step:1197/1490 train_time:61749ms step_avg:51.59ms
+step:1198/1490 train_time:61835ms step_avg:51.62ms
+step:1199/1490 train_time:61916ms step_avg:51.64ms
+step:1200/1490 train_time:62002ms step_avg:51.67ms
+step:1201/1490 train_time:62083ms step_avg:51.69ms
+step:1202/1490 train_time:62168ms step_avg:51.72ms
+step:1203/1490 train_time:62248ms step_avg:51.74ms
+step:1204/1490 train_time:62333ms step_avg:51.77ms
+step:1205/1490 train_time:62413ms step_avg:51.79ms
+step:1206/1490 train_time:62499ms step_avg:51.82ms
+step:1207/1490 train_time:62579ms step_avg:51.85ms
+step:1208/1490 train_time:62666ms step_avg:51.88ms
+step:1209/1490 train_time:62746ms step_avg:51.90ms
+step:1210/1490 train_time:62832ms step_avg:51.93ms
+step:1211/1490 train_time:62912ms step_avg:51.95ms
+step:1212/1490 train_time:62999ms step_avg:51.98ms
+step:1213/1490 train_time:63080ms step_avg:52.00ms
+step:1214/1490 train_time:63167ms step_avg:52.03ms
+step:1215/1490 train_time:63248ms step_avg:52.06ms
+step:1216/1490 train_time:63333ms step_avg:52.08ms
+step:1217/1490 train_time:63412ms step_avg:52.11ms
+step:1218/1490 train_time:63497ms step_avg:52.13ms
+step:1219/1490 train_time:63578ms step_avg:52.16ms
+step:1220/1490 train_time:63665ms step_avg:52.18ms
+step:1221/1490 train_time:63743ms step_avg:52.21ms
+step:1222/1490 train_time:63829ms step_avg:52.23ms
+step:1223/1490 train_time:63910ms step_avg:52.26ms
+step:1224/1490 train_time:63997ms step_avg:52.28ms
+step:1225/1490 train_time:64077ms step_avg:52.31ms
+step:1226/1490 train_time:64163ms step_avg:52.33ms
+step:1227/1490 train_time:64242ms step_avg:52.36ms
+step:1228/1490 train_time:64327ms step_avg:52.38ms
+step:1229/1490 train_time:64407ms step_avg:52.41ms
+step:1230/1490 train_time:64491ms step_avg:52.43ms
+step:1231/1490 train_time:64571ms step_avg:52.45ms
+step:1232/1490 train_time:64656ms step_avg:52.48ms
+step:1233/1490 train_time:64737ms step_avg:52.50ms
+step:1234/1490 train_time:64823ms step_avg:52.53ms
+step:1235/1490 train_time:64905ms step_avg:52.56ms
+step:1236/1490 train_time:64992ms step_avg:52.58ms
+step:1237/1490 train_time:65073ms step_avg:52.61ms
+step:1238/1490 train_time:65159ms step_avg:52.63ms
+step:1239/1490 train_time:65241ms step_avg:52.66ms
+step:1240/1490 train_time:65326ms step_avg:52.68ms
+step:1241/1490 train_time:65406ms step_avg:52.70ms
+step:1242/1490 train_time:65492ms step_avg:52.73ms
+step:1243/1490 train_time:65570ms step_avg:52.75ms
+step:1244/1490 train_time:65655ms step_avg:52.78ms
+step:1245/1490 train_time:65736ms step_avg:52.80ms
+step:1246/1490 train_time:65823ms step_avg:52.83ms
+step:1247/1490 train_time:65904ms step_avg:52.85ms
+step:1248/1490 train_time:65991ms step_avg:52.88ms
+step:1249/1490 train_time:66071ms step_avg:52.90ms
+step:1250/1490 train_time:66156ms step_avg:52.92ms
+step:1250/1490 val_loss:3.3716 train_time:66258ms step_avg:53.01ms
+step:1251/1490 train_time:66282ms step_avg:52.98ms
+step:1252/1490 train_time:66327ms step_avg:52.98ms
+step:1253/1490 train_time:66411ms step_avg:53.00ms
+step:1254/1490 train_time:66496ms step_avg:53.03ms
+step:1255/1490 train_time:66576ms step_avg:53.05ms
+step:1256/1490 train_time:66661ms step_avg:53.07ms
+step:1257/1490 train_time:66740ms step_avg:53.09ms
+step:1258/1490 train_time:66825ms step_avg:53.12ms
+step:1259/1490 train_time:66904ms step_avg:53.14ms
+step:1260/1490 train_time:66988ms step_avg:53.16ms
+step:1261/1490 train_time:67066ms step_avg:53.19ms
+step:1262/1490 train_time:67152ms step_avg:53.21ms
+step:1263/1490 train_time:67234ms step_avg:53.23ms
+step:1264/1490 train_time:67323ms step_avg:53.26ms
+step:1265/1490 train_time:67407ms step_avg:53.29ms
+step:1266/1490 train_time:67492ms step_avg:53.31ms
+step:1267/1490 train_time:67572ms step_avg:53.33ms
+step:1268/1490 train_time:67657ms step_avg:53.36ms
+step:1269/1490 train_time:67737ms step_avg:53.38ms
+step:1270/1490 train_time:67820ms step_avg:53.40ms
+step:1271/1490 train_time:67901ms step_avg:53.42ms
+step:1272/1490 train_time:67986ms step_avg:53.45ms
+step:1273/1490 train_time:68065ms step_avg:53.47ms
+step:1274/1490 train_time:68150ms step_avg:53.49ms
+step:1275/1490 train_time:68230ms step_avg:53.51ms
+step:1276/1490 train_time:68319ms step_avg:53.54ms
+step:1277/1490 train_time:68399ms step_avg:53.56ms
+step:1278/1490 train_time:68486ms step_avg:53.59ms
+step:1279/1490 train_time:68566ms step_avg:53.61ms
+step:1280/1490 train_time:68651ms step_avg:53.63ms
+step:1281/1490 train_time:68731ms step_avg:53.65ms
+step:1282/1490 train_time:68816ms step_avg:53.68ms
+step:1283/1490 train_time:68897ms step_avg:53.70ms
+step:1284/1490 train_time:68981ms step_avg:53.72ms
+step:1285/1490 train_time:69061ms step_avg:53.74ms
+step:1286/1490 train_time:69148ms step_avg:53.77ms
+step:1287/1490 train_time:69228ms step_avg:53.79ms
+step:1288/1490 train_time:69315ms step_avg:53.82ms
+step:1289/1490 train_time:69394ms step_avg:53.84ms
+step:1290/1490 train_time:69480ms step_avg:53.86ms
+step:1291/1490 train_time:69562ms step_avg:53.88ms
+step:1292/1490 train_time:69647ms step_avg:53.91ms
+step:1293/1490 train_time:69727ms step_avg:53.93ms
+step:1294/1490 train_time:69812ms step_avg:53.95ms
+step:1295/1490 train_time:69893ms step_avg:53.97ms
+step:1296/1490 train_time:69977ms step_avg:53.99ms
+step:1297/1490 train_time:70057ms step_avg:54.01ms
+step:1298/1490 train_time:70144ms step_avg:54.04ms
+step:1299/1490 train_time:70225ms step_avg:54.06ms
+step:1300/1490 train_time:70310ms step_avg:54.08ms
+step:1301/1490 train_time:70391ms step_avg:54.10ms
+step:1302/1490 train_time:70477ms step_avg:54.13ms
+step:1303/1490 train_time:70559ms step_avg:54.15ms
+step:1304/1490 train_time:70646ms step_avg:54.18ms
+step:1305/1490 train_time:70726ms step_avg:54.20ms
+step:1306/1490 train_time:70811ms step_avg:54.22ms
+step:1307/1490 train_time:70890ms step_avg:54.24ms
+step:1308/1490 train_time:70975ms step_avg:54.26ms
+step:1309/1490 train_time:71056ms step_avg:54.28ms
+step:1310/1490 train_time:71141ms step_avg:54.31ms
+step:1311/1490 train_time:71222ms step_avg:54.33ms
+step:1312/1490 train_time:71308ms step_avg:54.35ms
+step:1313/1490 train_time:71387ms step_avg:54.37ms
+step:1314/1490 train_time:71473ms step_avg:54.39ms
+step:1315/1490 train_time:71555ms step_avg:54.41ms
+step:1316/1490 train_time:71642ms step_avg:54.44ms
+step:1317/1490 train_time:71723ms step_avg:54.46ms
+step:1318/1490 train_time:71807ms step_avg:54.48ms
+step:1319/1490 train_time:71886ms step_avg:54.50ms
+step:1320/1490 train_time:71972ms step_avg:54.52ms
+step:1321/1490 train_time:72053ms step_avg:54.54ms
+step:1322/1490 train_time:72139ms step_avg:54.57ms
+step:1323/1490 train_time:72220ms step_avg:54.59ms
+step:1324/1490 train_time:72306ms step_avg:54.61ms
+step:1325/1490 train_time:72386ms step_avg:54.63ms
+step:1326/1490 train_time:72470ms step_avg:54.65ms
+step:1327/1490 train_time:72552ms step_avg:54.67ms
+step:1328/1490 train_time:72639ms step_avg:54.70ms
+step:1329/1490 train_time:72720ms step_avg:54.72ms
+step:1330/1490 train_time:72806ms step_avg:54.74ms
+step:1331/1490 train_time:72885ms step_avg:54.76ms
+step:1332/1490 train_time:72971ms step_avg:54.78ms
+step:1333/1490 train_time:73050ms step_avg:54.80ms
+step:1334/1490 train_time:73137ms step_avg:54.83ms
+step:1335/1490 train_time:73218ms step_avg:54.85ms
+step:1336/1490 train_time:73305ms step_avg:54.87ms
+step:1337/1490 train_time:73385ms step_avg:54.89ms
+step:1338/1490 train_time:73469ms step_avg:54.91ms
+step:1339/1490 train_time:73549ms step_avg:54.93ms
+step:1340/1490 train_time:73634ms step_avg:54.95ms
+step:1341/1490 train_time:73716ms step_avg:54.97ms
+step:1342/1490 train_time:73803ms step_avg:54.99ms
+step:1343/1490 train_time:73883ms step_avg:55.01ms
+step:1344/1490 train_time:73968ms step_avg:55.04ms
+step:1345/1490 train_time:74047ms step_avg:55.05ms
+step:1346/1490 train_time:74133ms step_avg:55.08ms
+step:1347/1490 train_time:74214ms step_avg:55.10ms
+step:1348/1490 train_time:74301ms step_avg:55.12ms
+step:1349/1490 train_time:74381ms step_avg:55.14ms
+step:1350/1490 train_time:74467ms step_avg:55.16ms
+step:1351/1490 train_time:74546ms step_avg:55.18ms
+step:1352/1490 train_time:74631ms step_avg:55.20ms
+step:1353/1490 train_time:74712ms step_avg:55.22ms
+step:1354/1490 train_time:74798ms step_avg:55.24ms
+step:1355/1490 train_time:74878ms step_avg:55.26ms
+step:1356/1490 train_time:74963ms step_avg:55.28ms
+step:1357/1490 train_time:75041ms step_avg:55.30ms
+step:1358/1490 train_time:75127ms step_avg:55.32ms
+step:1359/1490 train_time:75207ms step_avg:55.34ms
+step:1360/1490 train_time:75291ms step_avg:55.36ms
+step:1361/1490 train_time:75371ms step_avg:55.38ms
+step:1362/1490 train_time:75458ms step_avg:55.40ms
+step:1363/1490 train_time:75538ms step_avg:55.42ms
+step:1364/1490 train_time:75622ms step_avg:55.44ms
+step:1365/1490 train_time:75702ms step_avg:55.46ms
+step:1366/1490 train_time:75787ms step_avg:55.48ms
+step:1367/1490 train_time:75868ms step_avg:55.50ms
+step:1368/1490 train_time:75952ms step_avg:55.52ms
+step:1369/1490 train_time:76034ms step_avg:55.54ms
+step:1370/1490 train_time:76120ms step_avg:55.56ms
+step:1371/1490 train_time:76202ms step_avg:55.58ms
+step:1372/1490 train_time:76288ms step_avg:55.60ms
+step:1373/1490 train_time:76367ms step_avg:55.62ms
+step:1374/1490 train_time:76452ms step_avg:55.64ms
+step:1375/1490 train_time:76532ms step_avg:55.66ms
+step:1376/1490 train_time:76619ms step_avg:55.68ms
+step:1377/1490 train_time:76699ms step_avg:55.70ms
+step:1378/1490 train_time:76784ms step_avg:55.72ms
+step:1379/1490 train_time:76863ms step_avg:55.74ms
+step:1380/1490 train_time:76949ms step_avg:55.76ms
+step:1381/1490 train_time:77029ms step_avg:55.78ms
+step:1382/1490 train_time:77114ms step_avg:55.80ms
+step:1383/1490 train_time:77196ms step_avg:55.82ms
+step:1384/1490 train_time:77281ms step_avg:55.84ms
+step:1385/1490 train_time:77362ms step_avg:55.86ms
+step:1386/1490 train_time:77447ms step_avg:55.88ms
+step:1387/1490 train_time:77526ms step_avg:55.89ms
+step:1388/1490 train_time:77612ms step_avg:55.92ms
+step:1389/1490 train_time:77692ms step_avg:55.93ms
+step:1390/1490 train_time:77778ms step_avg:55.96ms
+step:1391/1490 train_time:77858ms step_avg:55.97ms
+step:1392/1490 train_time:77945ms step_avg:55.99ms
+step:1393/1490 train_time:78026ms step_avg:56.01ms
+step:1394/1490 train_time:78111ms step_avg:56.03ms
+step:1395/1490 train_time:78190ms step_avg:56.05ms
+step:1396/1490 train_time:78275ms step_avg:56.07ms
+step:1397/1490 train_time:78356ms step_avg:56.09ms
+step:1398/1490 train_time:78441ms step_avg:56.11ms
+step:1399/1490 train_time:78521ms step_avg:56.13ms
+step:1400/1490 train_time:78606ms step_avg:56.15ms
+step:1401/1490 train_time:78686ms step_avg:56.16ms
+step:1402/1490 train_time:78770ms step_avg:56.18ms
+step:1403/1490 train_time:78852ms step_avg:56.20ms
+step:1404/1490 train_time:78938ms step_avg:56.22ms
+step:1405/1490 train_time:79018ms step_avg:56.24ms
+step:1406/1490 train_time:79103ms step_avg:56.26ms
+step:1407/1490 train_time:79182ms step_avg:56.28ms
+step:1408/1490 train_time:79267ms step_avg:56.30ms
+step:1409/1490 train_time:79348ms step_avg:56.32ms
+step:1410/1490 train_time:79434ms step_avg:56.34ms
+step:1411/1490 train_time:79515ms step_avg:56.35ms
+step:1412/1490 train_time:79600ms step_avg:56.37ms
+step:1413/1490 train_time:79681ms step_avg:56.39ms
+step:1414/1490 train_time:79768ms step_avg:56.41ms
+step:1415/1490 train_time:79847ms step_avg:56.43ms
+step:1416/1490 train_time:79932ms step_avg:56.45ms
+step:1417/1490 train_time:80012ms step_avg:56.47ms
+step:1418/1490 train_time:80099ms step_avg:56.49ms
+step:1419/1490 train_time:80179ms step_avg:56.50ms
+step:1420/1490 train_time:80264ms step_avg:56.52ms
+step:1421/1490 train_time:80344ms step_avg:56.54ms
+step:1422/1490 train_time:80430ms step_avg:56.56ms
+step:1423/1490 train_time:80511ms step_avg:56.58ms
+step:1424/1490 train_time:80596ms step_avg:56.60ms
+step:1425/1490 train_time:80676ms step_avg:56.61ms
+step:1426/1490 train_time:80763ms step_avg:56.64ms
+step:1427/1490 train_time:80843ms step_avg:56.65ms
+step:1428/1490 train_time:80928ms step_avg:56.67ms
+step:1429/1490 train_time:81008ms step_avg:56.69ms
+step:1430/1490 train_time:81093ms step_avg:56.71ms
+step:1431/1490 train_time:81175ms step_avg:56.73ms
+step:1432/1490 train_time:81259ms step_avg:56.75ms
+step:1433/1490 train_time:81339ms step_avg:56.76ms
+step:1434/1490 train_time:81425ms step_avg:56.78ms
+step:1435/1490 train_time:81506ms step_avg:56.80ms
+step:1436/1490 train_time:81591ms step_avg:56.82ms
+step:1437/1490 train_time:81671ms step_avg:56.83ms
+step:1438/1490 train_time:81757ms step_avg:56.85ms
+step:1439/1490 train_time:81838ms step_avg:56.87ms
+step:1440/1490 train_time:81924ms step_avg:56.89ms
+step:1441/1490 train_time:82005ms step_avg:56.91ms
+step:1442/1490 train_time:82089ms step_avg:56.93ms
+step:1443/1490 train_time:82168ms step_avg:56.94ms
+step:1444/1490 train_time:82254ms step_avg:56.96ms
+step:1445/1490 train_time:82336ms step_avg:56.98ms
+step:1446/1490 train_time:82424ms step_avg:57.00ms
+step:1447/1490 train_time:82505ms step_avg:57.02ms
+step:1448/1490 train_time:82589ms step_avg:57.04ms
+step:1449/1490 train_time:82668ms step_avg:57.05ms
+step:1450/1490 train_time:82754ms step_avg:57.07ms
+step:1451/1490 train_time:82839ms step_avg:57.09ms
+step:1452/1490 train_time:82927ms step_avg:57.11ms
+step:1453/1490 train_time:83006ms step_avg:57.13ms
+step:1454/1490 train_time:83091ms step_avg:57.15ms
+step:1455/1490 train_time:83171ms step_avg:57.16ms
+step:1456/1490 train_time:83257ms step_avg:57.18ms
+step:1457/1490 train_time:83338ms step_avg:57.20ms
+step:1458/1490 train_time:83424ms step_avg:57.22ms
+step:1459/1490 train_time:83505ms step_avg:57.23ms
+step:1460/1490 train_time:83591ms step_avg:57.25ms
+step:1461/1490 train_time:83672ms step_avg:57.27ms
+step:1462/1490 train_time:83758ms step_avg:57.29ms
+step:1463/1490 train_time:83839ms step_avg:57.31ms
+step:1464/1490 train_time:83927ms step_avg:57.33ms
+step:1465/1490 train_time:84009ms step_avg:57.34ms
+step:1466/1490 train_time:84093ms step_avg:57.36ms
+step:1467/1490 train_time:84174ms step_avg:57.38ms
+step:1468/1490 train_time:84261ms step_avg:57.40ms
+step:1469/1490 train_time:84340ms step_avg:57.41ms
+step:1470/1490 train_time:84427ms step_avg:57.43ms
+step:1471/1490 train_time:84508ms step_avg:57.45ms
+step:1472/1490 train_time:84592ms step_avg:57.47ms
+step:1473/1490 train_time:84674ms step_avg:57.48ms
+step:1474/1490 train_time:84759ms step_avg:57.50ms
+step:1475/1490 train_time:84840ms step_avg:57.52ms
+step:1476/1490 train_time:84928ms step_avg:57.54ms
+step:1477/1490 train_time:85008ms step_avg:57.55ms
+step:1478/1490 train_time:85092ms step_avg:57.57ms
+step:1479/1490 train_time:85174ms step_avg:57.59ms
+step:1480/1490 train_time:85259ms step_avg:57.61ms
+step:1481/1490 train_time:85341ms step_avg:57.62ms
+step:1482/1490 train_time:85426ms step_avg:57.64ms
+step:1483/1490 train_time:85507ms step_avg:57.66ms
+step:1484/1490 train_time:85592ms step_avg:57.68ms
+step:1485/1490 train_time:85673ms step_avg:57.69ms
+step:1486/1490 train_time:85758ms step_avg:57.71ms
+step:1487/1490 train_time:85839ms step_avg:57.73ms
+step:1488/1490 train_time:85926ms step_avg:57.75ms
+step:1489/1490 train_time:86007ms step_avg:57.76ms
+step:1490/1490 train_time:86092ms step_avg:57.78ms
+step:1490/1490 val_loss:3.2792 train_time:86196ms step_avg:57.85ms
+peak memory allocated: 31296 MiB reserved: 47042 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/combined/2026-03-22_20-26-18_time-186_secs_06-mbeta2-max-docs_615f2a.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/combined/2026-03-22_20-26-18_time-186_secs_06-mbeta2-max-docs_615f2a.txt
@@ -1,0 +1,4457 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 20:26:32 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            122W /  700W |    1520MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            131W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   40C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1918669      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1918670      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1918671      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1918672      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1918673      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1918674      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1918675      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1918676      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8298 train_time:0ms step_avg:0.04ms
+step:1/1490 train_time:88ms step_avg:87.63ms
+step:2/1490 train_time:108ms step_avg:54.01ms
+step:3/1490 train_time:124ms step_avg:41.43ms
+step:4/1490 train_time:156ms step_avg:39.04ms
+step:5/1490 train_time:183ms step_avg:36.58ms
+step:6/1490 train_time:217ms step_avg:36.23ms
+step:7/1490 train_time:245ms step_avg:34.97ms
+step:8/1490 train_time:280ms step_avg:34.94ms
+step:9/1490 train_time:307ms step_avg:34.15ms
+step:10/1490 train_time:342ms step_avg:34.17ms
+step:11/1490 train_time:370ms step_avg:33.63ms
+step:12/1490 train_time:404ms step_avg:33.67ms
+step:13/1490 train_time:432ms step_avg:33.24ms
+step:14/1490 train_time:466ms step_avg:33.29ms
+step:15/1490 train_time:494ms step_avg:32.95ms
+step:16/1490 train_time:528ms step_avg:33.01ms
+step:17/1490 train_time:556ms step_avg:32.73ms
+step:18/1490 train_time:591ms step_avg:32.84ms
+step:19/1490 train_time:619ms step_avg:32.57ms
+step:20/1490 train_time:653ms step_avg:32.65ms
+step:21/1490 train_time:681ms step_avg:32.43ms
+step:22/1490 train_time:715ms step_avg:32.51ms
+step:23/1490 train_time:743ms step_avg:32.32ms
+step:24/1490 train_time:778ms step_avg:32.40ms
+step:25/1490 train_time:806ms step_avg:32.22ms
+step:26/1490 train_time:840ms step_avg:32.30ms
+step:27/1490 train_time:868ms step_avg:32.15ms
+step:28/1490 train_time:902ms step_avg:32.22ms
+step:29/1490 train_time:930ms step_avg:32.08ms
+step:30/1490 train_time:964ms step_avg:32.14ms
+step:31/1490 train_time:994ms step_avg:32.05ms
+step:32/1490 train_time:1030ms step_avg:32.18ms
+step:33/1490 train_time:1060ms step_avg:32.11ms
+step:34/1490 train_time:1095ms step_avg:32.21ms
+step:35/1490 train_time:1124ms step_avg:32.11ms
+step:36/1490 train_time:1159ms step_avg:32.19ms
+step:37/1490 train_time:1188ms step_avg:32.10ms
+step:38/1490 train_time:1222ms step_avg:32.16ms
+step:39/1490 train_time:1250ms step_avg:32.06ms
+step:40/1490 train_time:1285ms step_avg:32.12ms
+step:41/1490 train_time:1313ms step_avg:32.03ms
+step:42/1490 train_time:1347ms step_avg:32.08ms
+step:43/1490 train_time:1376ms step_avg:31.99ms
+step:44/1490 train_time:1410ms step_avg:32.05ms
+step:45/1490 train_time:1439ms step_avg:31.97ms
+step:46/1490 train_time:1473ms step_avg:32.03ms
+step:47/1490 train_time:1501ms step_avg:31.93ms
+step:48/1490 train_time:1535ms step_avg:31.98ms
+step:49/1490 train_time:1563ms step_avg:31.90ms
+step:50/1490 train_time:1597ms step_avg:31.95ms
+step:51/1490 train_time:1625ms step_avg:31.87ms
+step:52/1490 train_time:1660ms step_avg:31.92ms
+step:53/1490 train_time:1688ms step_avg:31.85ms
+step:54/1490 train_time:1722ms step_avg:31.89ms
+step:55/1490 train_time:1750ms step_avg:31.83ms
+step:56/1490 train_time:1785ms step_avg:31.87ms
+step:57/1490 train_time:1813ms step_avg:31.80ms
+step:58/1490 train_time:1847ms step_avg:31.84ms
+step:59/1490 train_time:1875ms step_avg:31.78ms
+step:60/1490 train_time:1909ms step_avg:31.82ms
+step:61/1490 train_time:1938ms step_avg:31.76ms
+step:62/1490 train_time:1973ms step_avg:31.82ms
+step:63/1490 train_time:2001ms step_avg:31.76ms
+step:64/1490 train_time:2036ms step_avg:31.81ms
+step:65/1490 train_time:2064ms step_avg:31.76ms
+step:66/1490 train_time:2099ms step_avg:31.81ms
+step:67/1490 train_time:2129ms step_avg:31.77ms
+step:68/1490 train_time:2163ms step_avg:31.81ms
+step:69/1490 train_time:2191ms step_avg:31.76ms
+step:70/1490 train_time:2226ms step_avg:31.80ms
+step:71/1490 train_time:2254ms step_avg:31.75ms
+step:72/1490 train_time:2288ms step_avg:31.78ms
+step:73/1490 train_time:2317ms step_avg:31.73ms
+step:74/1490 train_time:2352ms step_avg:31.78ms
+step:75/1490 train_time:2380ms step_avg:31.73ms
+step:76/1490 train_time:2414ms step_avg:31.77ms
+step:77/1490 train_time:2442ms step_avg:31.72ms
+step:78/1490 train_time:2478ms step_avg:31.76ms
+step:79/1490 train_time:2505ms step_avg:31.72ms
+step:80/1490 train_time:2540ms step_avg:31.75ms
+step:81/1490 train_time:2568ms step_avg:31.70ms
+step:82/1490 train_time:2602ms step_avg:31.74ms
+step:83/1490 train_time:2630ms step_avg:31.69ms
+step:84/1490 train_time:2664ms step_avg:31.72ms
+step:85/1490 train_time:2692ms step_avg:31.67ms
+step:86/1490 train_time:2726ms step_avg:31.70ms
+step:87/1490 train_time:2754ms step_avg:31.66ms
+step:88/1490 train_time:2789ms step_avg:31.69ms
+step:89/1490 train_time:2817ms step_avg:31.65ms
+step:90/1490 train_time:2852ms step_avg:31.69ms
+step:91/1490 train_time:2880ms step_avg:31.65ms
+step:92/1490 train_time:2914ms step_avg:31.68ms
+step:93/1490 train_time:2942ms step_avg:31.64ms
+step:94/1490 train_time:2978ms step_avg:31.68ms
+step:95/1490 train_time:3005ms step_avg:31.64ms
+step:96/1490 train_time:3040ms step_avg:31.67ms
+step:97/1490 train_time:3069ms step_avg:31.63ms
+step:98/1490 train_time:3103ms step_avg:31.66ms
+step:99/1490 train_time:3131ms step_avg:31.63ms
+step:100/1490 train_time:3166ms step_avg:31.66ms
+step:101/1490 train_time:3194ms step_avg:31.62ms
+step:102/1490 train_time:3228ms step_avg:31.65ms
+step:103/1490 train_time:3257ms step_avg:31.62ms
+step:104/1490 train_time:3292ms step_avg:31.65ms
+step:105/1490 train_time:3320ms step_avg:31.62ms
+step:106/1490 train_time:3355ms step_avg:31.65ms
+step:107/1490 train_time:3383ms step_avg:31.61ms
+step:108/1490 train_time:3418ms step_avg:31.64ms
+step:109/1490 train_time:3446ms step_avg:31.62ms
+step:110/1490 train_time:3482ms step_avg:31.65ms
+step:111/1490 train_time:3509ms step_avg:31.61ms
+step:112/1490 train_time:3543ms step_avg:31.64ms
+step:113/1490 train_time:3571ms step_avg:31.60ms
+step:114/1490 train_time:3605ms step_avg:31.63ms
+step:115/1490 train_time:3633ms step_avg:31.59ms
+step:116/1490 train_time:3667ms step_avg:31.61ms
+step:117/1490 train_time:3696ms step_avg:31.59ms
+step:118/1490 train_time:3730ms step_avg:31.61ms
+step:119/1490 train_time:3758ms step_avg:31.58ms
+step:120/1490 train_time:3793ms step_avg:31.61ms
+step:121/1490 train_time:3821ms step_avg:31.58ms
+step:122/1490 train_time:3856ms step_avg:31.61ms
+step:123/1490 train_time:3884ms step_avg:31.58ms
+step:124/1490 train_time:3918ms step_avg:31.60ms
+step:125/1490 train_time:3946ms step_avg:31.57ms
+step:126/1490 train_time:3981ms step_avg:31.60ms
+step:127/1490 train_time:4009ms step_avg:31.57ms
+step:128/1490 train_time:4044ms step_avg:31.59ms
+step:129/1490 train_time:4072ms step_avg:31.56ms
+step:130/1490 train_time:4106ms step_avg:31.58ms
+step:131/1490 train_time:4134ms step_avg:31.56ms
+step:132/1490 train_time:4168ms step_avg:31.58ms
+step:133/1490 train_time:4196ms step_avg:31.55ms
+step:134/1490 train_time:4231ms step_avg:31.58ms
+step:135/1490 train_time:4259ms step_avg:31.55ms
+step:136/1490 train_time:4294ms step_avg:31.57ms
+step:137/1490 train_time:4323ms step_avg:31.55ms
+step:138/1490 train_time:4358ms step_avg:31.58ms
+step:139/1490 train_time:4386ms step_avg:31.55ms
+step:140/1490 train_time:4420ms step_avg:31.57ms
+step:141/1490 train_time:4449ms step_avg:31.55ms
+step:142/1490 train_time:4483ms step_avg:31.57ms
+step:143/1490 train_time:4511ms step_avg:31.54ms
+step:144/1490 train_time:4545ms step_avg:31.56ms
+step:145/1490 train_time:4573ms step_avg:31.54ms
+step:146/1490 train_time:4607ms step_avg:31.55ms
+step:147/1490 train_time:4635ms step_avg:31.53ms
+step:148/1490 train_time:4669ms step_avg:31.55ms
+step:149/1490 train_time:4698ms step_avg:31.53ms
+step:150/1490 train_time:4732ms step_avg:31.55ms
+step:151/1490 train_time:4760ms step_avg:31.52ms
+step:152/1490 train_time:4795ms step_avg:31.55ms
+step:153/1490 train_time:4823ms step_avg:31.52ms
+step:154/1490 train_time:4858ms step_avg:31.55ms
+step:155/1490 train_time:4886ms step_avg:31.52ms
+step:156/1490 train_time:4921ms step_avg:31.54ms
+step:157/1490 train_time:4949ms step_avg:31.52ms
+step:158/1490 train_time:4984ms step_avg:31.54ms
+step:159/1490 train_time:5012ms step_avg:31.52ms
+step:160/1490 train_time:5045ms step_avg:31.53ms
+step:161/1490 train_time:5074ms step_avg:31.51ms
+step:162/1490 train_time:5108ms step_avg:31.53ms
+step:163/1490 train_time:5136ms step_avg:31.51ms
+step:164/1490 train_time:5171ms step_avg:31.53ms
+step:165/1490 train_time:5199ms step_avg:31.51ms
+step:166/1490 train_time:5235ms step_avg:31.54ms
+step:167/1490 train_time:5262ms step_avg:31.51ms
+step:168/1490 train_time:5297ms step_avg:31.53ms
+step:169/1490 train_time:5325ms step_avg:31.51ms
+step:170/1490 train_time:5360ms step_avg:31.53ms
+step:171/1490 train_time:5388ms step_avg:31.51ms
+step:172/1490 train_time:5423ms step_avg:31.53ms
+step:173/1490 train_time:5451ms step_avg:31.51ms
+step:174/1490 train_time:5485ms step_avg:31.52ms
+step:175/1490 train_time:5513ms step_avg:31.51ms
+step:176/1490 train_time:5548ms step_avg:31.52ms
+step:177/1490 train_time:5576ms step_avg:31.50ms
+step:178/1490 train_time:5611ms step_avg:31.52ms
+step:179/1490 train_time:5639ms step_avg:31.50ms
+step:180/1490 train_time:5673ms step_avg:31.52ms
+step:181/1490 train_time:5701ms step_avg:31.50ms
+step:182/1490 train_time:5736ms step_avg:31.52ms
+step:183/1490 train_time:5764ms step_avg:31.50ms
+step:184/1490 train_time:5799ms step_avg:31.52ms
+step:185/1490 train_time:5828ms step_avg:31.50ms
+step:186/1490 train_time:5862ms step_avg:31.52ms
+step:187/1490 train_time:5890ms step_avg:31.50ms
+step:188/1490 train_time:5925ms step_avg:31.51ms
+step:189/1490 train_time:5952ms step_avg:31.49ms
+step:190/1490 train_time:5987ms step_avg:31.51ms
+step:191/1490 train_time:6014ms step_avg:31.49ms
+step:192/1490 train_time:6049ms step_avg:31.50ms
+step:193/1490 train_time:6077ms step_avg:31.49ms
+step:194/1490 train_time:6112ms step_avg:31.50ms
+step:195/1490 train_time:6140ms step_avg:31.49ms
+step:196/1490 train_time:6175ms step_avg:31.50ms
+step:197/1490 train_time:6203ms step_avg:31.48ms
+step:198/1490 train_time:6237ms step_avg:31.50ms
+step:199/1490 train_time:6266ms step_avg:31.49ms
+step:200/1490 train_time:6301ms step_avg:31.50ms
+step:201/1490 train_time:6329ms step_avg:31.49ms
+step:202/1490 train_time:6364ms step_avg:31.50ms
+step:203/1490 train_time:6391ms step_avg:31.48ms
+step:204/1490 train_time:6425ms step_avg:31.50ms
+step:205/1490 train_time:6453ms step_avg:31.48ms
+step:206/1490 train_time:6488ms step_avg:31.49ms
+step:207/1490 train_time:6516ms step_avg:31.48ms
+step:208/1490 train_time:6550ms step_avg:31.49ms
+step:209/1490 train_time:6578ms step_avg:31.48ms
+step:210/1490 train_time:6613ms step_avg:31.49ms
+step:211/1490 train_time:6641ms step_avg:31.47ms
+step:212/1490 train_time:6676ms step_avg:31.49ms
+step:213/1490 train_time:6704ms step_avg:31.47ms
+step:214/1490 train_time:6739ms step_avg:31.49ms
+step:215/1490 train_time:6767ms step_avg:31.47ms
+step:216/1490 train_time:6801ms step_avg:31.49ms
+step:217/1490 train_time:6829ms step_avg:31.47ms
+step:218/1490 train_time:6863ms step_avg:31.48ms
+step:219/1490 train_time:6891ms step_avg:31.47ms
+step:220/1490 train_time:6925ms step_avg:31.48ms
+step:221/1490 train_time:6953ms step_avg:31.46ms
+step:222/1490 train_time:6988ms step_avg:31.48ms
+step:223/1490 train_time:7016ms step_avg:31.46ms
+step:224/1490 train_time:7051ms step_avg:31.48ms
+step:225/1490 train_time:7079ms step_avg:31.46ms
+step:226/1490 train_time:7114ms step_avg:31.48ms
+step:227/1490 train_time:7142ms step_avg:31.46ms
+step:228/1490 train_time:7177ms step_avg:31.48ms
+step:229/1490 train_time:7205ms step_avg:31.46ms
+step:230/1490 train_time:7239ms step_avg:31.47ms
+step:231/1490 train_time:7267ms step_avg:31.46ms
+step:232/1490 train_time:7302ms step_avg:31.47ms
+step:233/1490 train_time:7330ms step_avg:31.46ms
+step:234/1490 train_time:7364ms step_avg:31.47ms
+step:235/1490 train_time:7392ms step_avg:31.45ms
+step:236/1490 train_time:7426ms step_avg:31.47ms
+step:237/1490 train_time:7454ms step_avg:31.45ms
+step:238/1490 train_time:7489ms step_avg:31.47ms
+step:239/1490 train_time:7518ms step_avg:31.45ms
+step:240/1490 train_time:7552ms step_avg:31.47ms
+step:241/1490 train_time:7580ms step_avg:31.45ms
+step:242/1490 train_time:7615ms step_avg:31.47ms
+step:243/1490 train_time:7643ms step_avg:31.45ms
+step:244/1490 train_time:7678ms step_avg:31.47ms
+step:245/1490 train_time:7706ms step_avg:31.45ms
+step:246/1490 train_time:7740ms step_avg:31.46ms
+step:247/1490 train_time:7769ms step_avg:31.45ms
+step:248/1490 train_time:7803ms step_avg:31.46ms
+step:249/1490 train_time:7831ms step_avg:31.45ms
+step:250/1490 train_time:7865ms step_avg:31.46ms
+step:250/1490 val_loss:4.4984 train_time:7907ms step_avg:31.63ms
+step:251/1490 train_time:7923ms step_avg:31.57ms
+step:252/1490 train_time:7941ms step_avg:31.51ms
+step:253/1490 train_time:7958ms step_avg:31.46ms
+step:254/1490 train_time:7993ms step_avg:31.47ms
+step:255/1490 train_time:8023ms step_avg:31.46ms
+step:256/1490 train_time:8058ms step_avg:31.48ms
+step:257/1490 train_time:8088ms step_avg:31.47ms
+step:258/1490 train_time:8124ms step_avg:31.49ms
+step:259/1490 train_time:8153ms step_avg:31.48ms
+step:260/1490 train_time:8187ms step_avg:31.49ms
+step:261/1490 train_time:8216ms step_avg:31.48ms
+step:262/1490 train_time:8250ms step_avg:31.49ms
+step:263/1490 train_time:8278ms step_avg:31.47ms
+step:264/1490 train_time:8312ms step_avg:31.48ms
+step:265/1490 train_time:8340ms step_avg:31.47ms
+step:266/1490 train_time:8374ms step_avg:31.48ms
+step:267/1490 train_time:8402ms step_avg:31.47ms
+step:268/1490 train_time:8435ms step_avg:31.48ms
+step:269/1490 train_time:8463ms step_avg:31.46ms
+step:270/1490 train_time:8497ms step_avg:31.47ms
+step:271/1490 train_time:8525ms step_avg:31.46ms
+step:272/1490 train_time:8559ms step_avg:31.47ms
+step:273/1490 train_time:8587ms step_avg:31.45ms
+step:274/1490 train_time:8621ms step_avg:31.46ms
+step:275/1490 train_time:8649ms step_avg:31.45ms
+step:276/1490 train_time:8683ms step_avg:31.46ms
+step:277/1490 train_time:8711ms step_avg:31.45ms
+step:278/1490 train_time:8746ms step_avg:31.46ms
+step:279/1490 train_time:8773ms step_avg:31.45ms
+step:280/1490 train_time:8808ms step_avg:31.46ms
+step:281/1490 train_time:8836ms step_avg:31.44ms
+step:282/1490 train_time:8870ms step_avg:31.45ms
+step:283/1490 train_time:8898ms step_avg:31.44ms
+step:284/1490 train_time:8933ms step_avg:31.46ms
+step:285/1490 train_time:8962ms step_avg:31.45ms
+step:286/1490 train_time:8997ms step_avg:31.46ms
+step:287/1490 train_time:9026ms step_avg:31.45ms
+step:288/1490 train_time:9061ms step_avg:31.46ms
+step:289/1490 train_time:9089ms step_avg:31.45ms
+step:290/1490 train_time:9125ms step_avg:31.46ms
+step:291/1490 train_time:9152ms step_avg:31.45ms
+step:292/1490 train_time:9188ms step_avg:31.46ms
+step:293/1490 train_time:9216ms step_avg:31.45ms
+step:294/1490 train_time:9250ms step_avg:31.46ms
+step:295/1490 train_time:9279ms step_avg:31.45ms
+step:296/1490 train_time:9313ms step_avg:31.46ms
+step:297/1490 train_time:9341ms step_avg:31.45ms
+step:298/1490 train_time:9375ms step_avg:31.46ms
+step:299/1490 train_time:9403ms step_avg:31.45ms
+step:300/1490 train_time:9437ms step_avg:31.46ms
+step:301/1490 train_time:9465ms step_avg:31.45ms
+step:302/1490 train_time:9499ms step_avg:31.45ms
+step:303/1490 train_time:9527ms step_avg:31.44ms
+step:304/1490 train_time:9561ms step_avg:31.45ms
+step:305/1490 train_time:9589ms step_avg:31.44ms
+step:306/1490 train_time:9624ms step_avg:31.45ms
+step:307/1490 train_time:9652ms step_avg:31.44ms
+step:308/1490 train_time:9686ms step_avg:31.45ms
+step:309/1490 train_time:9714ms step_avg:31.44ms
+step:310/1490 train_time:9749ms step_avg:31.45ms
+step:311/1490 train_time:9777ms step_avg:31.44ms
+step:312/1490 train_time:9812ms step_avg:31.45ms
+step:313/1490 train_time:9839ms step_avg:31.44ms
+step:314/1490 train_time:9874ms step_avg:31.45ms
+step:315/1490 train_time:9902ms step_avg:31.43ms
+step:316/1490 train_time:9936ms step_avg:31.44ms
+step:317/1490 train_time:9964ms step_avg:31.43ms
+step:318/1490 train_time:9998ms step_avg:31.44ms
+step:319/1490 train_time:10027ms step_avg:31.43ms
+step:320/1490 train_time:10062ms step_avg:31.44ms
+step:321/1490 train_time:10091ms step_avg:31.43ms
+step:322/1490 train_time:10126ms step_avg:31.45ms
+step:323/1490 train_time:10154ms step_avg:31.44ms
+step:324/1490 train_time:10189ms step_avg:31.45ms
+step:325/1490 train_time:10217ms step_avg:31.44ms
+step:326/1490 train_time:10252ms step_avg:31.45ms
+step:327/1490 train_time:10280ms step_avg:31.44ms
+step:328/1490 train_time:10314ms step_avg:31.44ms
+step:329/1490 train_time:10342ms step_avg:31.43ms
+step:330/1490 train_time:10376ms step_avg:31.44ms
+step:331/1490 train_time:10404ms step_avg:31.43ms
+step:332/1490 train_time:10438ms step_avg:31.44ms
+step:333/1490 train_time:10466ms step_avg:31.43ms
+step:334/1490 train_time:10501ms step_avg:31.44ms
+step:335/1490 train_time:10529ms step_avg:31.43ms
+step:336/1490 train_time:10563ms step_avg:31.44ms
+step:337/1490 train_time:10591ms step_avg:31.43ms
+step:338/1490 train_time:10625ms step_avg:31.44ms
+step:339/1490 train_time:10654ms step_avg:31.43ms
+step:340/1490 train_time:10688ms step_avg:31.44ms
+step:341/1490 train_time:10716ms step_avg:31.43ms
+step:342/1490 train_time:10751ms step_avg:31.44ms
+step:343/1490 train_time:10779ms step_avg:31.42ms
+step:344/1490 train_time:10813ms step_avg:31.43ms
+step:345/1490 train_time:10841ms step_avg:31.42ms
+step:346/1490 train_time:10875ms step_avg:31.43ms
+step:347/1490 train_time:10903ms step_avg:31.42ms
+step:348/1490 train_time:10938ms step_avg:31.43ms
+step:349/1490 train_time:10966ms step_avg:31.42ms
+step:350/1490 train_time:11001ms step_avg:31.43ms
+step:351/1490 train_time:11029ms step_avg:31.42ms
+step:352/1490 train_time:11065ms step_avg:31.43ms
+step:353/1490 train_time:11092ms step_avg:31.42ms
+step:354/1490 train_time:11127ms step_avg:31.43ms
+step:355/1490 train_time:11156ms step_avg:31.43ms
+step:356/1490 train_time:11191ms step_avg:31.43ms
+step:357/1490 train_time:11219ms step_avg:31.43ms
+step:358/1490 train_time:11253ms step_avg:31.43ms
+step:359/1490 train_time:11281ms step_avg:31.42ms
+step:360/1490 train_time:11315ms step_avg:31.43ms
+step:361/1490 train_time:11344ms step_avg:31.42ms
+step:362/1490 train_time:11378ms step_avg:31.43ms
+step:363/1490 train_time:11406ms step_avg:31.42ms
+step:364/1490 train_time:11441ms step_avg:31.43ms
+step:365/1490 train_time:11469ms step_avg:31.42ms
+step:366/1490 train_time:11503ms step_avg:31.43ms
+step:367/1490 train_time:11531ms step_avg:31.42ms
+step:368/1490 train_time:11566ms step_avg:31.43ms
+step:369/1490 train_time:11594ms step_avg:31.42ms
+step:370/1490 train_time:11628ms step_avg:31.43ms
+step:371/1490 train_time:11656ms step_avg:31.42ms
+step:372/1490 train_time:11691ms step_avg:31.43ms
+step:373/1490 train_time:11719ms step_avg:31.42ms
+step:374/1490 train_time:11753ms step_avg:31.43ms
+step:375/1490 train_time:11781ms step_avg:31.42ms
+step:376/1490 train_time:11815ms step_avg:31.42ms
+step:377/1490 train_time:11843ms step_avg:31.42ms
+step:378/1490 train_time:11878ms step_avg:31.42ms
+step:379/1490 train_time:11906ms step_avg:31.41ms
+step:380/1490 train_time:11941ms step_avg:31.42ms
+step:381/1490 train_time:11969ms step_avg:31.42ms
+step:382/1490 train_time:12004ms step_avg:31.42ms
+step:383/1490 train_time:12032ms step_avg:31.42ms
+step:384/1490 train_time:12067ms step_avg:31.42ms
+step:385/1490 train_time:12096ms step_avg:31.42ms
+step:386/1490 train_time:12130ms step_avg:31.42ms
+step:387/1490 train_time:12158ms step_avg:31.42ms
+step:388/1490 train_time:12192ms step_avg:31.42ms
+step:389/1490 train_time:12221ms step_avg:31.42ms
+step:390/1490 train_time:12255ms step_avg:31.42ms
+step:391/1490 train_time:12283ms step_avg:31.41ms
+step:392/1490 train_time:12317ms step_avg:31.42ms
+step:393/1490 train_time:12344ms step_avg:31.41ms
+step:394/1490 train_time:12379ms step_avg:31.42ms
+step:395/1490 train_time:12407ms step_avg:31.41ms
+step:396/1490 train_time:12442ms step_avg:31.42ms
+step:397/1490 train_time:12470ms step_avg:31.41ms
+step:398/1490 train_time:12505ms step_avg:31.42ms
+step:399/1490 train_time:12532ms step_avg:31.41ms
+step:400/1490 train_time:12567ms step_avg:31.42ms
+step:401/1490 train_time:12595ms step_avg:31.41ms
+step:402/1490 train_time:12630ms step_avg:31.42ms
+step:403/1490 train_time:12658ms step_avg:31.41ms
+step:404/1490 train_time:12692ms step_avg:31.42ms
+step:405/1490 train_time:12720ms step_avg:31.41ms
+step:406/1490 train_time:12755ms step_avg:31.42ms
+step:407/1490 train_time:12783ms step_avg:31.41ms
+step:408/1490 train_time:12816ms step_avg:31.41ms
+step:409/1490 train_time:12845ms step_avg:31.41ms
+step:410/1490 train_time:12879ms step_avg:31.41ms
+step:411/1490 train_time:12907ms step_avg:31.40ms
+step:412/1490 train_time:12942ms step_avg:31.41ms
+step:413/1490 train_time:12970ms step_avg:31.40ms
+step:414/1490 train_time:13004ms step_avg:31.41ms
+step:415/1490 train_time:13033ms step_avg:31.40ms
+step:416/1490 train_time:13067ms step_avg:31.41ms
+step:417/1490 train_time:13095ms step_avg:31.40ms
+step:418/1490 train_time:13130ms step_avg:31.41ms
+step:419/1490 train_time:13158ms step_avg:31.40ms
+step:420/1490 train_time:13192ms step_avg:31.41ms
+step:421/1490 train_time:13220ms step_avg:31.40ms
+step:422/1490 train_time:13254ms step_avg:31.41ms
+step:423/1490 train_time:13283ms step_avg:31.40ms
+step:424/1490 train_time:13317ms step_avg:31.41ms
+step:425/1490 train_time:13345ms step_avg:31.40ms
+step:426/1490 train_time:13379ms step_avg:31.41ms
+step:427/1490 train_time:13408ms step_avg:31.40ms
+step:428/1490 train_time:13442ms step_avg:31.41ms
+step:429/1490 train_time:13470ms step_avg:31.40ms
+step:430/1490 train_time:13505ms step_avg:31.41ms
+step:431/1490 train_time:13532ms step_avg:31.40ms
+step:432/1490 train_time:13567ms step_avg:31.40ms
+step:433/1490 train_time:13595ms step_avg:31.40ms
+step:434/1490 train_time:13630ms step_avg:31.41ms
+step:435/1490 train_time:13658ms step_avg:31.40ms
+step:436/1490 train_time:13692ms step_avg:31.40ms
+step:437/1490 train_time:13720ms step_avg:31.40ms
+step:438/1490 train_time:13754ms step_avg:31.40ms
+step:439/1490 train_time:13782ms step_avg:31.39ms
+step:440/1490 train_time:13816ms step_avg:31.40ms
+step:441/1490 train_time:13845ms step_avg:31.39ms
+step:442/1490 train_time:13879ms step_avg:31.40ms
+step:443/1490 train_time:13907ms step_avg:31.39ms
+step:444/1490 train_time:13942ms step_avg:31.40ms
+step:445/1490 train_time:13970ms step_avg:31.39ms
+step:446/1490 train_time:14005ms step_avg:31.40ms
+step:447/1490 train_time:14033ms step_avg:31.39ms
+step:448/1490 train_time:14068ms step_avg:31.40ms
+step:449/1490 train_time:14096ms step_avg:31.39ms
+step:450/1490 train_time:14130ms step_avg:31.40ms
+step:451/1490 train_time:14159ms step_avg:31.39ms
+step:452/1490 train_time:14193ms step_avg:31.40ms
+step:453/1490 train_time:14221ms step_avg:31.39ms
+step:454/1490 train_time:14256ms step_avg:31.40ms
+step:455/1490 train_time:14283ms step_avg:31.39ms
+step:456/1490 train_time:14317ms step_avg:31.40ms
+step:457/1490 train_time:14347ms step_avg:31.39ms
+step:458/1490 train_time:14381ms step_avg:31.40ms
+step:459/1490 train_time:14409ms step_avg:31.39ms
+step:460/1490 train_time:14444ms step_avg:31.40ms
+step:461/1490 train_time:14472ms step_avg:31.39ms
+step:462/1490 train_time:14506ms step_avg:31.40ms
+step:463/1490 train_time:14534ms step_avg:31.39ms
+step:464/1490 train_time:14568ms step_avg:31.40ms
+step:465/1490 train_time:14597ms step_avg:31.39ms
+step:466/1490 train_time:14632ms step_avg:31.40ms
+step:467/1490 train_time:14660ms step_avg:31.39ms
+step:468/1490 train_time:14694ms step_avg:31.40ms
+step:469/1490 train_time:14722ms step_avg:31.39ms
+step:470/1490 train_time:14756ms step_avg:31.40ms
+step:471/1490 train_time:14784ms step_avg:31.39ms
+step:472/1490 train_time:14818ms step_avg:31.39ms
+step:473/1490 train_time:14847ms step_avg:31.39ms
+step:474/1490 train_time:14881ms step_avg:31.39ms
+step:475/1490 train_time:14909ms step_avg:31.39ms
+step:476/1490 train_time:14944ms step_avg:31.40ms
+step:477/1490 train_time:14971ms step_avg:31.39ms
+step:478/1490 train_time:15006ms step_avg:31.39ms
+step:479/1490 train_time:15034ms step_avg:31.39ms
+step:480/1490 train_time:15068ms step_avg:31.39ms
+step:481/1490 train_time:15096ms step_avg:31.39ms
+step:482/1490 train_time:15131ms step_avg:31.39ms
+step:483/1490 train_time:15159ms step_avg:31.38ms
+step:484/1490 train_time:15196ms step_avg:31.40ms
+step:485/1490 train_time:15247ms step_avg:31.44ms
+step:486/1490 train_time:15307ms step_avg:31.50ms
+step:487/1490 train_time:15360ms step_avg:31.54ms
+step:488/1490 train_time:15419ms step_avg:31.60ms
+step:489/1490 train_time:15473ms step_avg:31.64ms
+step:490/1490 train_time:15533ms step_avg:31.70ms
+step:491/1490 train_time:15587ms step_avg:31.75ms
+step:492/1490 train_time:15646ms step_avg:31.80ms
+step:493/1490 train_time:15701ms step_avg:31.85ms
+step:494/1490 train_time:15760ms step_avg:31.90ms
+step:495/1490 train_time:15814ms step_avg:31.95ms
+step:496/1490 train_time:15874ms step_avg:32.00ms
+step:497/1490 train_time:15927ms step_avg:32.05ms
+step:498/1490 train_time:15986ms step_avg:32.10ms
+step:499/1490 train_time:16041ms step_avg:32.15ms
+step:500/1490 train_time:16101ms step_avg:32.20ms
+step:500/1490 val_loss:4.2252 train_time:16172ms step_avg:32.34ms
+step:501/1490 train_time:16188ms step_avg:32.31ms
+step:502/1490 train_time:16214ms step_avg:32.30ms
+step:503/1490 train_time:16271ms step_avg:32.35ms
+step:504/1490 train_time:16333ms step_avg:32.41ms
+step:505/1490 train_time:16391ms step_avg:32.46ms
+step:506/1490 train_time:16450ms step_avg:32.51ms
+step:507/1490 train_time:16505ms step_avg:32.55ms
+step:508/1490 train_time:16563ms step_avg:32.61ms
+step:509/1490 train_time:16618ms step_avg:32.65ms
+step:510/1490 train_time:16677ms step_avg:32.70ms
+step:511/1490 train_time:16730ms step_avg:32.74ms
+step:512/1490 train_time:16790ms step_avg:32.79ms
+step:513/1490 train_time:16843ms step_avg:32.83ms
+step:514/1490 train_time:16902ms step_avg:32.88ms
+step:515/1490 train_time:16955ms step_avg:32.92ms
+step:516/1490 train_time:17014ms step_avg:32.97ms
+step:517/1490 train_time:17067ms step_avg:33.01ms
+step:518/1490 train_time:17126ms step_avg:33.06ms
+step:519/1490 train_time:17182ms step_avg:33.11ms
+step:520/1490 train_time:17243ms step_avg:33.16ms
+step:521/1490 train_time:17299ms step_avg:33.20ms
+step:522/1490 train_time:17359ms step_avg:33.26ms
+step:523/1490 train_time:17415ms step_avg:33.30ms
+step:524/1490 train_time:17475ms step_avg:33.35ms
+step:525/1490 train_time:17530ms step_avg:33.39ms
+step:526/1490 train_time:17591ms step_avg:33.44ms
+step:527/1490 train_time:17645ms step_avg:33.48ms
+step:528/1490 train_time:17704ms step_avg:33.53ms
+step:529/1490 train_time:17757ms step_avg:33.57ms
+step:530/1490 train_time:17816ms step_avg:33.62ms
+step:531/1490 train_time:17870ms step_avg:33.65ms
+step:532/1490 train_time:17929ms step_avg:33.70ms
+step:533/1490 train_time:17982ms step_avg:33.74ms
+step:534/1490 train_time:18041ms step_avg:33.79ms
+step:535/1490 train_time:18095ms step_avg:33.82ms
+step:536/1490 train_time:18155ms step_avg:33.87ms
+step:537/1490 train_time:18209ms step_avg:33.91ms
+step:538/1490 train_time:18270ms step_avg:33.96ms
+step:539/1490 train_time:18325ms step_avg:34.00ms
+step:540/1490 train_time:18386ms step_avg:34.05ms
+step:541/1490 train_time:18441ms step_avg:34.09ms
+step:542/1490 train_time:18501ms step_avg:34.13ms
+step:543/1490 train_time:18555ms step_avg:34.17ms
+step:544/1490 train_time:18614ms step_avg:34.22ms
+step:545/1490 train_time:18667ms step_avg:34.25ms
+step:546/1490 train_time:18728ms step_avg:34.30ms
+step:547/1490 train_time:18781ms step_avg:34.33ms
+step:548/1490 train_time:18840ms step_avg:34.38ms
+step:549/1490 train_time:18893ms step_avg:34.41ms
+step:550/1490 train_time:18952ms step_avg:34.46ms
+step:551/1490 train_time:19006ms step_avg:34.49ms
+step:552/1490 train_time:19065ms step_avg:34.54ms
+step:553/1490 train_time:19120ms step_avg:34.58ms
+step:554/1490 train_time:19181ms step_avg:34.62ms
+step:555/1490 train_time:19235ms step_avg:34.66ms
+step:556/1490 train_time:19295ms step_avg:34.70ms
+step:557/1490 train_time:19349ms step_avg:34.74ms
+step:558/1490 train_time:19410ms step_avg:34.78ms
+step:559/1490 train_time:19465ms step_avg:34.82ms
+step:560/1490 train_time:19524ms step_avg:34.87ms
+step:561/1490 train_time:19579ms step_avg:34.90ms
+step:562/1490 train_time:19638ms step_avg:34.94ms
+step:563/1490 train_time:19693ms step_avg:34.98ms
+step:564/1490 train_time:19751ms step_avg:35.02ms
+step:565/1490 train_time:19805ms step_avg:35.05ms
+step:566/1490 train_time:19864ms step_avg:35.09ms
+step:567/1490 train_time:19918ms step_avg:35.13ms
+step:568/1490 train_time:19978ms step_avg:35.17ms
+step:569/1490 train_time:20032ms step_avg:35.20ms
+step:570/1490 train_time:20091ms step_avg:35.25ms
+step:571/1490 train_time:20144ms step_avg:35.28ms
+step:572/1490 train_time:20204ms step_avg:35.32ms
+step:573/1490 train_time:20258ms step_avg:35.35ms
+step:574/1490 train_time:20320ms step_avg:35.40ms
+step:575/1490 train_time:20374ms step_avg:35.43ms
+step:576/1490 train_time:20434ms step_avg:35.48ms
+step:577/1490 train_time:20487ms step_avg:35.51ms
+step:578/1490 train_time:20547ms step_avg:35.55ms
+step:579/1490 train_time:20601ms step_avg:35.58ms
+step:580/1490 train_time:20660ms step_avg:35.62ms
+step:581/1490 train_time:20714ms step_avg:35.65ms
+step:582/1490 train_time:20773ms step_avg:35.69ms
+step:583/1490 train_time:20827ms step_avg:35.72ms
+step:584/1490 train_time:20886ms step_avg:35.76ms
+step:585/1490 train_time:20940ms step_avg:35.79ms
+step:586/1490 train_time:21000ms step_avg:35.84ms
+step:587/1490 train_time:21053ms step_avg:35.87ms
+step:588/1490 train_time:21112ms step_avg:35.91ms
+step:589/1490 train_time:21167ms step_avg:35.94ms
+step:590/1490 train_time:21227ms step_avg:35.98ms
+step:591/1490 train_time:21281ms step_avg:36.01ms
+step:592/1490 train_time:21341ms step_avg:36.05ms
+step:593/1490 train_time:21395ms step_avg:36.08ms
+step:594/1490 train_time:21456ms step_avg:36.12ms
+step:595/1490 train_time:21510ms step_avg:36.15ms
+step:596/1490 train_time:21570ms step_avg:36.19ms
+step:597/1490 train_time:21624ms step_avg:36.22ms
+step:598/1490 train_time:21684ms step_avg:36.26ms
+step:599/1490 train_time:21737ms step_avg:36.29ms
+step:600/1490 train_time:21797ms step_avg:36.33ms
+step:601/1490 train_time:21850ms step_avg:36.36ms
+step:602/1490 train_time:21910ms step_avg:36.39ms
+step:603/1490 train_time:21964ms step_avg:36.42ms
+step:604/1490 train_time:22023ms step_avg:36.46ms
+step:605/1490 train_time:22077ms step_avg:36.49ms
+step:606/1490 train_time:22136ms step_avg:36.53ms
+step:607/1490 train_time:22190ms step_avg:36.56ms
+step:608/1490 train_time:22250ms step_avg:36.59ms
+step:609/1490 train_time:22305ms step_avg:36.63ms
+step:610/1490 train_time:22365ms step_avg:36.66ms
+step:611/1490 train_time:22418ms step_avg:36.69ms
+step:612/1490 train_time:22478ms step_avg:36.73ms
+step:613/1490 train_time:22533ms step_avg:36.76ms
+step:614/1490 train_time:22592ms step_avg:36.80ms
+step:615/1490 train_time:22646ms step_avg:36.82ms
+step:616/1490 train_time:22706ms step_avg:36.86ms
+step:617/1490 train_time:22759ms step_avg:36.89ms
+step:618/1490 train_time:22819ms step_avg:36.92ms
+step:619/1490 train_time:22873ms step_avg:36.95ms
+step:620/1490 train_time:22932ms step_avg:36.99ms
+step:621/1490 train_time:22986ms step_avg:37.01ms
+step:622/1490 train_time:23045ms step_avg:37.05ms
+step:623/1490 train_time:23099ms step_avg:37.08ms
+step:624/1490 train_time:23158ms step_avg:37.11ms
+step:625/1490 train_time:23213ms step_avg:37.14ms
+step:626/1490 train_time:23272ms step_avg:37.18ms
+step:627/1490 train_time:23327ms step_avg:37.20ms
+step:628/1490 train_time:23387ms step_avg:37.24ms
+step:629/1490 train_time:23441ms step_avg:37.27ms
+step:630/1490 train_time:23501ms step_avg:37.30ms
+step:631/1490 train_time:23555ms step_avg:37.33ms
+step:632/1490 train_time:23614ms step_avg:37.36ms
+step:633/1490 train_time:23668ms step_avg:37.39ms
+step:634/1490 train_time:23728ms step_avg:37.43ms
+step:635/1490 train_time:23782ms step_avg:37.45ms
+step:636/1490 train_time:23842ms step_avg:37.49ms
+step:637/1490 train_time:23896ms step_avg:37.51ms
+step:638/1490 train_time:23955ms step_avg:37.55ms
+step:639/1490 train_time:24009ms step_avg:37.57ms
+step:640/1490 train_time:24068ms step_avg:37.61ms
+step:641/1490 train_time:24123ms step_avg:37.63ms
+step:642/1490 train_time:24183ms step_avg:37.67ms
+step:643/1490 train_time:24237ms step_avg:37.69ms
+step:644/1490 train_time:24296ms step_avg:37.73ms
+step:645/1490 train_time:24350ms step_avg:37.75ms
+step:646/1490 train_time:24410ms step_avg:37.79ms
+step:647/1490 train_time:24464ms step_avg:37.81ms
+step:648/1490 train_time:24524ms step_avg:37.85ms
+step:649/1490 train_time:24578ms step_avg:37.87ms
+step:650/1490 train_time:24637ms step_avg:37.90ms
+step:651/1490 train_time:24692ms step_avg:37.93ms
+step:652/1490 train_time:24751ms step_avg:37.96ms
+step:653/1490 train_time:24805ms step_avg:37.99ms
+step:654/1490 train_time:24864ms step_avg:38.02ms
+step:655/1490 train_time:24918ms step_avg:38.04ms
+step:656/1490 train_time:24977ms step_avg:38.07ms
+step:657/1490 train_time:25030ms step_avg:38.10ms
+step:658/1490 train_time:25090ms step_avg:38.13ms
+step:659/1490 train_time:25144ms step_avg:38.15ms
+step:660/1490 train_time:25203ms step_avg:38.19ms
+step:661/1490 train_time:25257ms step_avg:38.21ms
+step:662/1490 train_time:25316ms step_avg:38.24ms
+step:663/1490 train_time:25370ms step_avg:38.27ms
+step:664/1490 train_time:25429ms step_avg:38.30ms
+step:665/1490 train_time:25484ms step_avg:38.32ms
+step:666/1490 train_time:25543ms step_avg:38.35ms
+step:667/1490 train_time:25597ms step_avg:38.38ms
+step:668/1490 train_time:25657ms step_avg:38.41ms
+step:669/1490 train_time:25711ms step_avg:38.43ms
+step:670/1490 train_time:25769ms step_avg:38.46ms
+step:671/1490 train_time:25824ms step_avg:38.49ms
+step:672/1490 train_time:25883ms step_avg:38.52ms
+step:673/1490 train_time:25937ms step_avg:38.54ms
+step:674/1490 train_time:25996ms step_avg:38.57ms
+step:675/1490 train_time:26049ms step_avg:38.59ms
+step:676/1490 train_time:26109ms step_avg:38.62ms
+step:677/1490 train_time:26163ms step_avg:38.65ms
+step:678/1490 train_time:26223ms step_avg:38.68ms
+step:679/1490 train_time:26277ms step_avg:38.70ms
+step:680/1490 train_time:26338ms step_avg:38.73ms
+step:681/1490 train_time:26391ms step_avg:38.75ms
+step:682/1490 train_time:26450ms step_avg:38.78ms
+step:683/1490 train_time:26504ms step_avg:38.81ms
+step:684/1490 train_time:26564ms step_avg:38.84ms
+step:685/1490 train_time:26618ms step_avg:38.86ms
+step:686/1490 train_time:26678ms step_avg:38.89ms
+step:687/1490 train_time:26732ms step_avg:38.91ms
+step:688/1490 train_time:26792ms step_avg:38.94ms
+step:689/1490 train_time:26845ms step_avg:38.96ms
+step:690/1490 train_time:26905ms step_avg:38.99ms
+step:691/1490 train_time:26959ms step_avg:39.01ms
+step:692/1490 train_time:27019ms step_avg:39.04ms
+step:693/1490 train_time:27073ms step_avg:39.07ms
+step:694/1490 train_time:27132ms step_avg:39.10ms
+step:695/1490 train_time:27187ms step_avg:39.12ms
+step:696/1490 train_time:27246ms step_avg:39.15ms
+step:697/1490 train_time:27299ms step_avg:39.17ms
+step:698/1490 train_time:27359ms step_avg:39.20ms
+step:699/1490 train_time:27413ms step_avg:39.22ms
+step:700/1490 train_time:27473ms step_avg:39.25ms
+step:701/1490 train_time:27527ms step_avg:39.27ms
+step:702/1490 train_time:27587ms step_avg:39.30ms
+step:703/1490 train_time:27641ms step_avg:39.32ms
+step:704/1490 train_time:27701ms step_avg:39.35ms
+step:705/1490 train_time:27755ms step_avg:39.37ms
+step:706/1490 train_time:27814ms step_avg:39.40ms
+step:707/1490 train_time:27866ms step_avg:39.41ms
+step:708/1490 train_time:27926ms step_avg:39.44ms
+step:709/1490 train_time:27980ms step_avg:39.46ms
+step:710/1490 train_time:28040ms step_avg:39.49ms
+step:711/1490 train_time:28094ms step_avg:39.51ms
+step:712/1490 train_time:28153ms step_avg:39.54ms
+step:713/1490 train_time:28207ms step_avg:39.56ms
+step:714/1490 train_time:28266ms step_avg:39.59ms
+step:715/1490 train_time:28320ms step_avg:39.61ms
+step:716/1490 train_time:28381ms step_avg:39.64ms
+step:717/1490 train_time:28435ms step_avg:39.66ms
+step:718/1490 train_time:28494ms step_avg:39.68ms
+step:719/1490 train_time:28548ms step_avg:39.70ms
+step:720/1490 train_time:28608ms step_avg:39.73ms
+step:721/1490 train_time:28661ms step_avg:39.75ms
+step:722/1490 train_time:28722ms step_avg:39.78ms
+step:723/1490 train_time:28775ms step_avg:39.80ms
+step:724/1490 train_time:28835ms step_avg:39.83ms
+step:725/1490 train_time:28889ms step_avg:39.85ms
+step:726/1490 train_time:28948ms step_avg:39.87ms
+step:727/1490 train_time:29003ms step_avg:39.89ms
+step:728/1490 train_time:29061ms step_avg:39.92ms
+step:729/1490 train_time:29115ms step_avg:39.94ms
+step:730/1490 train_time:29175ms step_avg:39.97ms
+step:731/1490 train_time:29228ms step_avg:39.98ms
+step:732/1490 train_time:29289ms step_avg:40.01ms
+step:733/1490 train_time:29343ms step_avg:40.03ms
+step:734/1490 train_time:29402ms step_avg:40.06ms
+step:735/1490 train_time:29456ms step_avg:40.08ms
+step:736/1490 train_time:29516ms step_avg:40.10ms
+step:737/1490 train_time:29570ms step_avg:40.12ms
+step:738/1490 train_time:29630ms step_avg:40.15ms
+step:739/1490 train_time:29684ms step_avg:40.17ms
+step:740/1490 train_time:29743ms step_avg:40.19ms
+step:741/1490 train_time:29798ms step_avg:40.21ms
+step:742/1490 train_time:29858ms step_avg:40.24ms
+step:743/1490 train_time:29911ms step_avg:40.26ms
+step:744/1490 train_time:29972ms step_avg:40.28ms
+step:745/1490 train_time:30026ms step_avg:40.30ms
+step:746/1490 train_time:30085ms step_avg:40.33ms
+step:747/1490 train_time:30139ms step_avg:40.35ms
+step:748/1490 train_time:30199ms step_avg:40.37ms
+step:749/1490 train_time:30253ms step_avg:40.39ms
+step:750/1490 train_time:30312ms step_avg:40.42ms
+step:750/1490 val_loss:3.8095 train_time:30384ms step_avg:40.51ms
+step:751/1490 train_time:30401ms step_avg:40.48ms
+step:752/1490 train_time:30427ms step_avg:40.46ms
+step:753/1490 train_time:30487ms step_avg:40.49ms
+step:754/1490 train_time:30548ms step_avg:40.51ms
+step:755/1490 train_time:30604ms step_avg:40.53ms
+step:756/1490 train_time:30664ms step_avg:40.56ms
+step:757/1490 train_time:30717ms step_avg:40.58ms
+step:758/1490 train_time:30775ms step_avg:40.60ms
+step:759/1490 train_time:30828ms step_avg:40.62ms
+step:760/1490 train_time:30888ms step_avg:40.64ms
+step:761/1490 train_time:30941ms step_avg:40.66ms
+step:762/1490 train_time:31001ms step_avg:40.68ms
+step:763/1490 train_time:31053ms step_avg:40.70ms
+step:764/1490 train_time:31113ms step_avg:40.72ms
+step:765/1490 train_time:31166ms step_avg:40.74ms
+step:766/1490 train_time:31226ms step_avg:40.76ms
+step:767/1490 train_time:31280ms step_avg:40.78ms
+step:768/1490 train_time:31339ms step_avg:40.81ms
+step:769/1490 train_time:31395ms step_avg:40.83ms
+step:770/1490 train_time:31456ms step_avg:40.85ms
+step:771/1490 train_time:31512ms step_avg:40.87ms
+step:772/1490 train_time:31573ms step_avg:40.90ms
+step:773/1490 train_time:31629ms step_avg:40.92ms
+step:774/1490 train_time:31689ms step_avg:40.94ms
+step:775/1490 train_time:31743ms step_avg:40.96ms
+step:776/1490 train_time:31802ms step_avg:40.98ms
+step:777/1490 train_time:31855ms step_avg:41.00ms
+step:778/1490 train_time:31915ms step_avg:41.02ms
+step:779/1490 train_time:31968ms step_avg:41.04ms
+step:780/1490 train_time:32027ms step_avg:41.06ms
+step:781/1490 train_time:32080ms step_avg:41.08ms
+step:782/1490 train_time:32139ms step_avg:41.10ms
+step:783/1490 train_time:32192ms step_avg:41.11ms
+step:784/1490 train_time:32251ms step_avg:41.14ms
+step:785/1490 train_time:32305ms step_avg:41.15ms
+step:786/1490 train_time:32366ms step_avg:41.18ms
+step:787/1490 train_time:32422ms step_avg:41.20ms
+step:788/1490 train_time:32482ms step_avg:41.22ms
+step:789/1490 train_time:32537ms step_avg:41.24ms
+step:790/1490 train_time:32599ms step_avg:41.26ms
+step:791/1490 train_time:32653ms step_avg:41.28ms
+step:792/1490 train_time:32713ms step_avg:41.30ms
+step:793/1490 train_time:32766ms step_avg:41.32ms
+step:794/1490 train_time:32827ms step_avg:41.34ms
+step:795/1490 train_time:32881ms step_avg:41.36ms
+step:796/1490 train_time:32941ms step_avg:41.38ms
+step:797/1490 train_time:32994ms step_avg:41.40ms
+step:798/1490 train_time:33053ms step_avg:41.42ms
+step:799/1490 train_time:33106ms step_avg:41.43ms
+step:800/1490 train_time:33165ms step_avg:41.46ms
+step:801/1490 train_time:33219ms step_avg:41.47ms
+step:802/1490 train_time:33279ms step_avg:41.50ms
+step:803/1490 train_time:33334ms step_avg:41.51ms
+step:804/1490 train_time:33395ms step_avg:41.54ms
+step:805/1490 train_time:33450ms step_avg:41.55ms
+step:806/1490 train_time:33510ms step_avg:41.58ms
+step:807/1490 train_time:33564ms step_avg:41.59ms
+step:808/1490 train_time:33625ms step_avg:41.61ms
+step:809/1490 train_time:33679ms step_avg:41.63ms
+step:810/1490 train_time:33738ms step_avg:41.65ms
+step:811/1490 train_time:33792ms step_avg:41.67ms
+step:812/1490 train_time:33851ms step_avg:41.69ms
+step:813/1490 train_time:33905ms step_avg:41.70ms
+step:814/1490 train_time:33965ms step_avg:41.73ms
+step:815/1490 train_time:34019ms step_avg:41.74ms
+step:816/1490 train_time:34077ms step_avg:41.76ms
+step:817/1490 train_time:34131ms step_avg:41.78ms
+step:818/1490 train_time:34191ms step_avg:41.80ms
+step:819/1490 train_time:34245ms step_avg:41.81ms
+step:820/1490 train_time:34305ms step_avg:41.84ms
+step:821/1490 train_time:34360ms step_avg:41.85ms
+step:822/1490 train_time:34419ms step_avg:41.87ms
+step:823/1490 train_time:34473ms step_avg:41.89ms
+step:824/1490 train_time:34534ms step_avg:41.91ms
+step:825/1490 train_time:34589ms step_avg:41.93ms
+step:826/1490 train_time:34649ms step_avg:41.95ms
+step:827/1490 train_time:34703ms step_avg:41.96ms
+step:828/1490 train_time:34763ms step_avg:41.98ms
+step:829/1490 train_time:34817ms step_avg:42.00ms
+step:830/1490 train_time:34876ms step_avg:42.02ms
+step:831/1490 train_time:34930ms step_avg:42.03ms
+step:832/1490 train_time:34990ms step_avg:42.05ms
+step:833/1490 train_time:35043ms step_avg:42.07ms
+step:834/1490 train_time:35102ms step_avg:42.09ms
+step:835/1490 train_time:35156ms step_avg:42.10ms
+step:836/1490 train_time:35215ms step_avg:42.12ms
+step:837/1490 train_time:35269ms step_avg:42.14ms
+step:838/1490 train_time:35329ms step_avg:42.16ms
+step:839/1490 train_time:35384ms step_avg:42.17ms
+step:840/1490 train_time:35445ms step_avg:42.20ms
+step:841/1490 train_time:35499ms step_avg:42.21ms
+step:842/1490 train_time:35559ms step_avg:42.23ms
+step:843/1490 train_time:35614ms step_avg:42.25ms
+step:844/1490 train_time:35673ms step_avg:42.27ms
+step:845/1490 train_time:35727ms step_avg:42.28ms
+step:846/1490 train_time:35787ms step_avg:42.30ms
+step:847/1490 train_time:35842ms step_avg:42.32ms
+step:848/1490 train_time:35901ms step_avg:42.34ms
+step:849/1490 train_time:35955ms step_avg:42.35ms
+step:850/1490 train_time:36015ms step_avg:42.37ms
+step:851/1490 train_time:36068ms step_avg:42.38ms
+step:852/1490 train_time:36127ms step_avg:42.40ms
+step:853/1490 train_time:36181ms step_avg:42.42ms
+step:854/1490 train_time:36241ms step_avg:42.44ms
+step:855/1490 train_time:36295ms step_avg:42.45ms
+step:856/1490 train_time:36354ms step_avg:42.47ms
+step:857/1490 train_time:36408ms step_avg:42.48ms
+step:858/1490 train_time:36469ms step_avg:42.50ms
+step:859/1490 train_time:36524ms step_avg:42.52ms
+step:860/1490 train_time:36584ms step_avg:42.54ms
+step:861/1490 train_time:36638ms step_avg:42.55ms
+step:862/1490 train_time:36698ms step_avg:42.57ms
+step:863/1490 train_time:36752ms step_avg:42.59ms
+step:864/1490 train_time:36811ms step_avg:42.61ms
+step:865/1490 train_time:36865ms step_avg:42.62ms
+step:866/1490 train_time:36925ms step_avg:42.64ms
+step:867/1490 train_time:36979ms step_avg:42.65ms
+step:868/1490 train_time:37038ms step_avg:42.67ms
+step:869/1490 train_time:37092ms step_avg:42.68ms
+step:870/1490 train_time:37151ms step_avg:42.70ms
+step:871/1490 train_time:37205ms step_avg:42.72ms
+step:872/1490 train_time:37265ms step_avg:42.74ms
+step:873/1490 train_time:37319ms step_avg:42.75ms
+step:874/1490 train_time:37378ms step_avg:42.77ms
+step:875/1490 train_time:37432ms step_avg:42.78ms
+step:876/1490 train_time:37493ms step_avg:42.80ms
+step:877/1490 train_time:37547ms step_avg:42.81ms
+step:878/1490 train_time:37608ms step_avg:42.83ms
+step:879/1490 train_time:37662ms step_avg:42.85ms
+step:880/1490 train_time:37722ms step_avg:42.87ms
+step:881/1490 train_time:37776ms step_avg:42.88ms
+step:882/1490 train_time:37835ms step_avg:42.90ms
+step:883/1490 train_time:37889ms step_avg:42.91ms
+step:884/1490 train_time:37948ms step_avg:42.93ms
+step:885/1490 train_time:38002ms step_avg:42.94ms
+step:886/1490 train_time:38061ms step_avg:42.96ms
+step:887/1490 train_time:38115ms step_avg:42.97ms
+step:888/1490 train_time:38174ms step_avg:42.99ms
+step:889/1490 train_time:38229ms step_avg:43.00ms
+step:890/1490 train_time:38289ms step_avg:43.02ms
+step:891/1490 train_time:38343ms step_avg:43.03ms
+step:892/1490 train_time:38404ms step_avg:43.05ms
+step:893/1490 train_time:38457ms step_avg:43.07ms
+step:894/1490 train_time:38516ms step_avg:43.08ms
+step:895/1490 train_time:38571ms step_avg:43.10ms
+step:896/1490 train_time:38631ms step_avg:43.12ms
+step:897/1490 train_time:38685ms step_avg:43.13ms
+step:898/1490 train_time:38746ms step_avg:43.15ms
+step:899/1490 train_time:38801ms step_avg:43.16ms
+step:900/1490 train_time:38860ms step_avg:43.18ms
+step:901/1490 train_time:38914ms step_avg:43.19ms
+step:902/1490 train_time:38973ms step_avg:43.21ms
+step:903/1490 train_time:39028ms step_avg:43.22ms
+step:904/1490 train_time:39088ms step_avg:43.24ms
+step:905/1490 train_time:39141ms step_avg:43.25ms
+step:906/1490 train_time:39200ms step_avg:43.27ms
+step:907/1490 train_time:39254ms step_avg:43.28ms
+step:908/1490 train_time:39314ms step_avg:43.30ms
+step:909/1490 train_time:39368ms step_avg:43.31ms
+step:910/1490 train_time:39429ms step_avg:43.33ms
+step:911/1490 train_time:39482ms step_avg:43.34ms
+step:912/1490 train_time:39542ms step_avg:43.36ms
+step:913/1490 train_time:39596ms step_avg:43.37ms
+step:914/1490 train_time:39655ms step_avg:43.39ms
+step:915/1490 train_time:39710ms step_avg:43.40ms
+step:916/1490 train_time:39770ms step_avg:43.42ms
+step:917/1490 train_time:39825ms step_avg:43.43ms
+step:918/1490 train_time:39885ms step_avg:43.45ms
+step:919/1490 train_time:39939ms step_avg:43.46ms
+step:920/1490 train_time:39999ms step_avg:43.48ms
+step:921/1490 train_time:40053ms step_avg:43.49ms
+step:922/1490 train_time:40111ms step_avg:43.50ms
+step:923/1490 train_time:40166ms step_avg:43.52ms
+step:924/1490 train_time:40226ms step_avg:43.53ms
+step:925/1490 train_time:40279ms step_avg:43.55ms
+step:926/1490 train_time:40339ms step_avg:43.56ms
+step:927/1490 train_time:40394ms step_avg:43.57ms
+step:928/1490 train_time:40454ms step_avg:43.59ms
+step:929/1490 train_time:40507ms step_avg:43.60ms
+step:930/1490 train_time:40568ms step_avg:43.62ms
+step:931/1490 train_time:40622ms step_avg:43.63ms
+step:932/1490 train_time:40682ms step_avg:43.65ms
+step:933/1490 train_time:40736ms step_avg:43.66ms
+step:934/1490 train_time:40796ms step_avg:43.68ms
+step:935/1490 train_time:40850ms step_avg:43.69ms
+step:936/1490 train_time:40909ms step_avg:43.71ms
+step:937/1490 train_time:40964ms step_avg:43.72ms
+step:938/1490 train_time:41024ms step_avg:43.74ms
+step:939/1490 train_time:41078ms step_avg:43.75ms
+step:940/1490 train_time:41138ms step_avg:43.76ms
+step:941/1490 train_time:41192ms step_avg:43.77ms
+step:942/1490 train_time:41251ms step_avg:43.79ms
+step:943/1490 train_time:41305ms step_avg:43.80ms
+step:944/1490 train_time:41365ms step_avg:43.82ms
+step:945/1490 train_time:41419ms step_avg:43.83ms
+step:946/1490 train_time:41478ms step_avg:43.85ms
+step:947/1490 train_time:41533ms step_avg:43.86ms
+step:948/1490 train_time:41592ms step_avg:43.87ms
+step:949/1490 train_time:41646ms step_avg:43.88ms
+step:950/1490 train_time:41706ms step_avg:43.90ms
+step:951/1490 train_time:41760ms step_avg:43.91ms
+step:952/1490 train_time:41819ms step_avg:43.93ms
+step:953/1490 train_time:41873ms step_avg:43.94ms
+step:954/1490 train_time:41934ms step_avg:43.96ms
+step:955/1490 train_time:41988ms step_avg:43.97ms
+step:956/1490 train_time:42048ms step_avg:43.98ms
+step:957/1490 train_time:42102ms step_avg:43.99ms
+step:958/1490 train_time:42161ms step_avg:44.01ms
+step:959/1490 train_time:42216ms step_avg:44.02ms
+step:960/1490 train_time:42275ms step_avg:44.04ms
+step:961/1490 train_time:42331ms step_avg:44.05ms
+step:962/1490 train_time:42390ms step_avg:44.06ms
+step:963/1490 train_time:42444ms step_avg:44.07ms
+step:964/1490 train_time:42504ms step_avg:44.09ms
+step:965/1490 train_time:42559ms step_avg:44.10ms
+step:966/1490 train_time:42618ms step_avg:44.12ms
+step:967/1490 train_time:42672ms step_avg:44.13ms
+step:968/1490 train_time:42735ms step_avg:44.15ms
+step:969/1490 train_time:42813ms step_avg:44.18ms
+step:970/1490 train_time:42898ms step_avg:44.22ms
+step:971/1490 train_time:42980ms step_avg:44.26ms
+step:972/1490 train_time:43065ms step_avg:44.31ms
+step:973/1490 train_time:43146ms step_avg:44.34ms
+step:974/1490 train_time:43231ms step_avg:44.39ms
+step:975/1490 train_time:43310ms step_avg:44.42ms
+step:976/1490 train_time:43395ms step_avg:44.46ms
+step:977/1490 train_time:43475ms step_avg:44.50ms
+step:978/1490 train_time:43561ms step_avg:44.54ms
+step:979/1490 train_time:43642ms step_avg:44.58ms
+step:980/1490 train_time:43728ms step_avg:44.62ms
+step:981/1490 train_time:43808ms step_avg:44.66ms
+step:982/1490 train_time:43893ms step_avg:44.70ms
+step:983/1490 train_time:43973ms step_avg:44.73ms
+step:984/1490 train_time:44058ms step_avg:44.77ms
+step:985/1490 train_time:44138ms step_avg:44.81ms
+step:986/1490 train_time:44223ms step_avg:44.85ms
+step:987/1490 train_time:44304ms step_avg:44.89ms
+step:988/1490 train_time:44389ms step_avg:44.93ms
+step:989/1490 train_time:44469ms step_avg:44.96ms
+step:990/1490 train_time:44555ms step_avg:45.00ms
+step:991/1490 train_time:44635ms step_avg:45.04ms
+step:992/1490 train_time:44721ms step_avg:45.08ms
+step:993/1490 train_time:44802ms step_avg:45.12ms
+step:994/1490 train_time:44886ms step_avg:45.16ms
+step:995/1490 train_time:44968ms step_avg:45.19ms
+step:996/1490 train_time:45054ms step_avg:45.23ms
+step:997/1490 train_time:45134ms step_avg:45.27ms
+step:998/1490 train_time:45219ms step_avg:45.31ms
+step:999/1490 train_time:45300ms step_avg:45.35ms
+step:1000/1490 train_time:45385ms step_avg:45.39ms
+step:1000/1490 val_loss:3.5174 train_time:45486ms step_avg:45.49ms
+step:1001/1490 train_time:45505ms step_avg:45.46ms
+step:1002/1490 train_time:45553ms step_avg:45.46ms
+step:1003/1490 train_time:45635ms step_avg:45.50ms
+step:1004/1490 train_time:45725ms step_avg:45.54ms
+step:1005/1490 train_time:45806ms step_avg:45.58ms
+step:1006/1490 train_time:45889ms step_avg:45.62ms
+step:1007/1490 train_time:45969ms step_avg:45.65ms
+step:1008/1490 train_time:46053ms step_avg:45.69ms
+step:1009/1490 train_time:46133ms step_avg:45.72ms
+step:1010/1490 train_time:46217ms step_avg:45.76ms
+step:1011/1490 train_time:46297ms step_avg:45.79ms
+step:1012/1490 train_time:46380ms step_avg:45.83ms
+step:1013/1490 train_time:46461ms step_avg:45.87ms
+step:1014/1490 train_time:46549ms step_avg:45.91ms
+step:1015/1490 train_time:46633ms step_avg:45.94ms
+step:1016/1490 train_time:46720ms step_avg:45.98ms
+step:1017/1490 train_time:46799ms step_avg:46.02ms
+step:1018/1490 train_time:46885ms step_avg:46.06ms
+step:1019/1490 train_time:46966ms step_avg:46.09ms
+step:1020/1490 train_time:47052ms step_avg:46.13ms
+step:1021/1490 train_time:47131ms step_avg:46.16ms
+step:1022/1490 train_time:47216ms step_avg:46.20ms
+step:1023/1490 train_time:47295ms step_avg:46.23ms
+step:1024/1490 train_time:47380ms step_avg:46.27ms
+step:1025/1490 train_time:47460ms step_avg:46.30ms
+step:1026/1490 train_time:47547ms step_avg:46.34ms
+step:1027/1490 train_time:47630ms step_avg:46.38ms
+step:1028/1490 train_time:47717ms step_avg:46.42ms
+step:1029/1490 train_time:47796ms step_avg:46.45ms
+step:1030/1490 train_time:47880ms step_avg:46.49ms
+step:1031/1490 train_time:47962ms step_avg:46.52ms
+step:1032/1490 train_time:48047ms step_avg:46.56ms
+step:1033/1490 train_time:48127ms step_avg:46.59ms
+step:1034/1490 train_time:48215ms step_avg:46.63ms
+step:1035/1490 train_time:48294ms step_avg:46.66ms
+step:1036/1490 train_time:48378ms step_avg:46.70ms
+step:1037/1490 train_time:48458ms step_avg:46.73ms
+step:1038/1490 train_time:48543ms step_avg:46.77ms
+step:1039/1490 train_time:48624ms step_avg:46.80ms
+step:1040/1490 train_time:48711ms step_avg:46.84ms
+step:1041/1490 train_time:48792ms step_avg:46.87ms
+step:1042/1490 train_time:48879ms step_avg:46.91ms
+step:1043/1490 train_time:48958ms step_avg:46.94ms
+step:1044/1490 train_time:49042ms step_avg:46.98ms
+step:1045/1490 train_time:49122ms step_avg:47.01ms
+step:1046/1490 train_time:49206ms step_avg:47.04ms
+step:1047/1490 train_time:49287ms step_avg:47.07ms
+step:1048/1490 train_time:49372ms step_avg:47.11ms
+step:1049/1490 train_time:49452ms step_avg:47.14ms
+step:1050/1490 train_time:49538ms step_avg:47.18ms
+step:1051/1490 train_time:49620ms step_avg:47.21ms
+step:1052/1490 train_time:49706ms step_avg:47.25ms
+step:1053/1490 train_time:49787ms step_avg:47.28ms
+step:1054/1490 train_time:49873ms step_avg:47.32ms
+step:1055/1490 train_time:49952ms step_avg:47.35ms
+step:1056/1490 train_time:50038ms step_avg:47.38ms
+step:1057/1490 train_time:50118ms step_avg:47.42ms
+step:1058/1490 train_time:50202ms step_avg:47.45ms
+step:1059/1490 train_time:50282ms step_avg:47.48ms
+step:1060/1490 train_time:50367ms step_avg:47.52ms
+step:1061/1490 train_time:50448ms step_avg:47.55ms
+step:1062/1490 train_time:50535ms step_avg:47.58ms
+step:1063/1490 train_time:50617ms step_avg:47.62ms
+step:1064/1490 train_time:50703ms step_avg:47.65ms
+step:1065/1490 train_time:50783ms step_avg:47.68ms
+step:1066/1490 train_time:50868ms step_avg:47.72ms
+step:1067/1490 train_time:50948ms step_avg:47.75ms
+step:1068/1490 train_time:51034ms step_avg:47.78ms
+step:1069/1490 train_time:51115ms step_avg:47.82ms
+step:1070/1490 train_time:51199ms step_avg:47.85ms
+step:1071/1490 train_time:51279ms step_avg:47.88ms
+step:1072/1490 train_time:51364ms step_avg:47.91ms
+step:1073/1490 train_time:51443ms step_avg:47.94ms
+step:1074/1490 train_time:51529ms step_avg:47.98ms
+step:1075/1490 train_time:51610ms step_avg:48.01ms
+step:1076/1490 train_time:51696ms step_avg:48.05ms
+step:1077/1490 train_time:51776ms step_avg:48.07ms
+step:1078/1490 train_time:51860ms step_avg:48.11ms
+step:1079/1490 train_time:51940ms step_avg:48.14ms
+step:1080/1490 train_time:52026ms step_avg:48.17ms
+step:1081/1490 train_time:52107ms step_avg:48.20ms
+step:1082/1490 train_time:52191ms step_avg:48.24ms
+step:1083/1490 train_time:52271ms step_avg:48.27ms
+step:1084/1490 train_time:52358ms step_avg:48.30ms
+step:1085/1490 train_time:52438ms step_avg:48.33ms
+step:1086/1490 train_time:52523ms step_avg:48.36ms
+step:1087/1490 train_time:52603ms step_avg:48.39ms
+step:1088/1490 train_time:52688ms step_avg:48.43ms
+step:1089/1490 train_time:52770ms step_avg:48.46ms
+step:1090/1490 train_time:52856ms step_avg:48.49ms
+step:1091/1490 train_time:52937ms step_avg:48.52ms
+step:1092/1490 train_time:53021ms step_avg:48.55ms
+step:1093/1490 train_time:53101ms step_avg:48.58ms
+step:1094/1490 train_time:53186ms step_avg:48.62ms
+step:1095/1490 train_time:53268ms step_avg:48.65ms
+step:1096/1490 train_time:53355ms step_avg:48.68ms
+step:1097/1490 train_time:53436ms step_avg:48.71ms
+step:1098/1490 train_time:53520ms step_avg:48.74ms
+step:1099/1490 train_time:53600ms step_avg:48.77ms
+step:1100/1490 train_time:53686ms step_avg:48.81ms
+step:1101/1490 train_time:53767ms step_avg:48.83ms
+step:1102/1490 train_time:53853ms step_avg:48.87ms
+step:1103/1490 train_time:53934ms step_avg:48.90ms
+step:1104/1490 train_time:54020ms step_avg:48.93ms
+step:1105/1490 train_time:54099ms step_avg:48.96ms
+step:1106/1490 train_time:54183ms step_avg:48.99ms
+step:1107/1490 train_time:54264ms step_avg:49.02ms
+step:1108/1490 train_time:54350ms step_avg:49.05ms
+step:1109/1490 train_time:54431ms step_avg:49.08ms
+step:1110/1490 train_time:54516ms step_avg:49.11ms
+step:1111/1490 train_time:54595ms step_avg:49.14ms
+step:1112/1490 train_time:54680ms step_avg:49.17ms
+step:1113/1490 train_time:54760ms step_avg:49.20ms
+step:1114/1490 train_time:54846ms step_avg:49.23ms
+step:1115/1490 train_time:54927ms step_avg:49.26ms
+step:1116/1490 train_time:55014ms step_avg:49.30ms
+step:1117/1490 train_time:55094ms step_avg:49.32ms
+step:1118/1490 train_time:55180ms step_avg:49.36ms
+step:1119/1490 train_time:55260ms step_avg:49.38ms
+step:1120/1490 train_time:55345ms step_avg:49.42ms
+step:1121/1490 train_time:55426ms step_avg:49.44ms
+step:1122/1490 train_time:55511ms step_avg:49.48ms
+step:1123/1490 train_time:55592ms step_avg:49.50ms
+step:1124/1490 train_time:55677ms step_avg:49.53ms
+step:1125/1490 train_time:55757ms step_avg:49.56ms
+step:1126/1490 train_time:55842ms step_avg:49.59ms
+step:1127/1490 train_time:55920ms step_avg:49.62ms
+step:1128/1490 train_time:56006ms step_avg:49.65ms
+step:1129/1490 train_time:56088ms step_avg:49.68ms
+step:1130/1490 train_time:56175ms step_avg:49.71ms
+step:1131/1490 train_time:56254ms step_avg:49.74ms
+step:1132/1490 train_time:56339ms step_avg:49.77ms
+step:1133/1490 train_time:56419ms step_avg:49.80ms
+step:1134/1490 train_time:56505ms step_avg:49.83ms
+step:1135/1490 train_time:56585ms step_avg:49.85ms
+step:1136/1490 train_time:56671ms step_avg:49.89ms
+step:1137/1490 train_time:56751ms step_avg:49.91ms
+step:1138/1490 train_time:56838ms step_avg:49.95ms
+step:1139/1490 train_time:56919ms step_avg:49.97ms
+step:1140/1490 train_time:57003ms step_avg:50.00ms
+step:1141/1490 train_time:57085ms step_avg:50.03ms
+step:1142/1490 train_time:57170ms step_avg:50.06ms
+step:1143/1490 train_time:57251ms step_avg:50.09ms
+step:1144/1490 train_time:57336ms step_avg:50.12ms
+step:1145/1490 train_time:57417ms step_avg:50.15ms
+step:1146/1490 train_time:57502ms step_avg:50.18ms
+step:1147/1490 train_time:57581ms step_avg:50.20ms
+step:1148/1490 train_time:57667ms step_avg:50.23ms
+step:1149/1490 train_time:57749ms step_avg:50.26ms
+step:1150/1490 train_time:57838ms step_avg:50.29ms
+step:1151/1490 train_time:57916ms step_avg:50.32ms
+step:1152/1490 train_time:58000ms step_avg:50.35ms
+step:1153/1490 train_time:58080ms step_avg:50.37ms
+step:1154/1490 train_time:58167ms step_avg:50.40ms
+step:1155/1490 train_time:58247ms step_avg:50.43ms
+step:1156/1490 train_time:58333ms step_avg:50.46ms
+step:1157/1490 train_time:58413ms step_avg:50.49ms
+step:1158/1490 train_time:58499ms step_avg:50.52ms
+step:1159/1490 train_time:58579ms step_avg:50.54ms
+step:1160/1490 train_time:58663ms step_avg:50.57ms
+step:1161/1490 train_time:58744ms step_avg:50.60ms
+step:1162/1490 train_time:58831ms step_avg:50.63ms
+step:1163/1490 train_time:58912ms step_avg:50.66ms
+step:1164/1490 train_time:58996ms step_avg:50.68ms
+step:1165/1490 train_time:59077ms step_avg:50.71ms
+step:1166/1490 train_time:59161ms step_avg:50.74ms
+step:1167/1490 train_time:59241ms step_avg:50.76ms
+step:1168/1490 train_time:59328ms step_avg:50.79ms
+step:1169/1490 train_time:59409ms step_avg:50.82ms
+step:1170/1490 train_time:59495ms step_avg:50.85ms
+step:1171/1490 train_time:59574ms step_avg:50.87ms
+step:1172/1490 train_time:59660ms step_avg:50.90ms
+step:1173/1490 train_time:59741ms step_avg:50.93ms
+step:1174/1490 train_time:59826ms step_avg:50.96ms
+step:1175/1490 train_time:59907ms step_avg:50.98ms
+step:1176/1490 train_time:59994ms step_avg:51.01ms
+step:1177/1490 train_time:60073ms step_avg:51.04ms
+step:1178/1490 train_time:60159ms step_avg:51.07ms
+step:1179/1490 train_time:60239ms step_avg:51.09ms
+step:1180/1490 train_time:60325ms step_avg:51.12ms
+step:1181/1490 train_time:60405ms step_avg:51.15ms
+step:1182/1490 train_time:60491ms step_avg:51.18ms
+step:1183/1490 train_time:60570ms step_avg:51.20ms
+step:1184/1490 train_time:60656ms step_avg:51.23ms
+step:1185/1490 train_time:60735ms step_avg:51.25ms
+step:1186/1490 train_time:60823ms step_avg:51.28ms
+step:1187/1490 train_time:60901ms step_avg:51.31ms
+step:1188/1490 train_time:60986ms step_avg:51.34ms
+step:1189/1490 train_time:61067ms step_avg:51.36ms
+step:1190/1490 train_time:61152ms step_avg:51.39ms
+step:1191/1490 train_time:61232ms step_avg:51.41ms
+step:1192/1490 train_time:61318ms step_avg:51.44ms
+step:1193/1490 train_time:61398ms step_avg:51.47ms
+step:1194/1490 train_time:61483ms step_avg:51.49ms
+step:1195/1490 train_time:61564ms step_avg:51.52ms
+step:1196/1490 train_time:61649ms step_avg:51.55ms
+step:1197/1490 train_time:61730ms step_avg:51.57ms
+step:1198/1490 train_time:61818ms step_avg:51.60ms
+step:1199/1490 train_time:61897ms step_avg:51.62ms
+step:1200/1490 train_time:61982ms step_avg:51.65ms
+step:1201/1490 train_time:62061ms step_avg:51.67ms
+step:1202/1490 train_time:62147ms step_avg:51.70ms
+step:1203/1490 train_time:62227ms step_avg:51.73ms
+step:1204/1490 train_time:62313ms step_avg:51.75ms
+step:1205/1490 train_time:62392ms step_avg:51.78ms
+step:1206/1490 train_time:62478ms step_avg:51.81ms
+step:1207/1490 train_time:62557ms step_avg:51.83ms
+step:1208/1490 train_time:62642ms step_avg:51.86ms
+step:1209/1490 train_time:62722ms step_avg:51.88ms
+step:1210/1490 train_time:62808ms step_avg:51.91ms
+step:1211/1490 train_time:62890ms step_avg:51.93ms
+step:1212/1490 train_time:62973ms step_avg:51.96ms
+step:1213/1490 train_time:63053ms step_avg:51.98ms
+step:1214/1490 train_time:63139ms step_avg:52.01ms
+step:1215/1490 train_time:63219ms step_avg:52.03ms
+step:1216/1490 train_time:63304ms step_avg:52.06ms
+step:1217/1490 train_time:63384ms step_avg:52.08ms
+step:1218/1490 train_time:63470ms step_avg:52.11ms
+step:1219/1490 train_time:63552ms step_avg:52.13ms
+step:1220/1490 train_time:63638ms step_avg:52.16ms
+step:1221/1490 train_time:63719ms step_avg:52.19ms
+step:1222/1490 train_time:63804ms step_avg:52.21ms
+step:1223/1490 train_time:63884ms step_avg:52.24ms
+step:1224/1490 train_time:63969ms step_avg:52.26ms
+step:1225/1490 train_time:64050ms step_avg:52.29ms
+step:1226/1490 train_time:64135ms step_avg:52.31ms
+step:1227/1490 train_time:64216ms step_avg:52.34ms
+step:1228/1490 train_time:64300ms step_avg:52.36ms
+step:1229/1490 train_time:64379ms step_avg:52.38ms
+step:1230/1490 train_time:64465ms step_avg:52.41ms
+step:1231/1490 train_time:64546ms step_avg:52.43ms
+step:1232/1490 train_time:64632ms step_avg:52.46ms
+step:1233/1490 train_time:64713ms step_avg:52.48ms
+step:1234/1490 train_time:64800ms step_avg:52.51ms
+step:1235/1490 train_time:64879ms step_avg:52.53ms
+step:1236/1490 train_time:64964ms step_avg:52.56ms
+step:1237/1490 train_time:65043ms step_avg:52.58ms
+step:1238/1490 train_time:65130ms step_avg:52.61ms
+step:1239/1490 train_time:65210ms step_avg:52.63ms
+step:1240/1490 train_time:65295ms step_avg:52.66ms
+step:1241/1490 train_time:65375ms step_avg:52.68ms
+step:1242/1490 train_time:65460ms step_avg:52.71ms
+step:1243/1490 train_time:65540ms step_avg:52.73ms
+step:1244/1490 train_time:65627ms step_avg:52.75ms
+step:1245/1490 train_time:65708ms step_avg:52.78ms
+step:1246/1490 train_time:65794ms step_avg:52.80ms
+step:1247/1490 train_time:65874ms step_avg:52.83ms
+step:1248/1490 train_time:65961ms step_avg:52.85ms
+step:1249/1490 train_time:66040ms step_avg:52.87ms
+step:1250/1490 train_time:66125ms step_avg:52.90ms
+step:1250/1490 val_loss:3.3726 train_time:66228ms step_avg:52.98ms
+step:1251/1490 train_time:66244ms step_avg:52.95ms
+step:1252/1490 train_time:66292ms step_avg:52.95ms
+step:1253/1490 train_time:66380ms step_avg:52.98ms
+step:1254/1490 train_time:66472ms step_avg:53.01ms
+step:1255/1490 train_time:66552ms step_avg:53.03ms
+step:1256/1490 train_time:66639ms step_avg:53.06ms
+step:1257/1490 train_time:66721ms step_avg:53.08ms
+step:1258/1490 train_time:66804ms step_avg:53.10ms
+step:1259/1490 train_time:66882ms step_avg:53.12ms
+step:1260/1490 train_time:66966ms step_avg:53.15ms
+step:1261/1490 train_time:67044ms step_avg:53.17ms
+step:1262/1490 train_time:67128ms step_avg:53.19ms
+step:1263/1490 train_time:67209ms step_avg:53.21ms
+step:1264/1490 train_time:67299ms step_avg:53.24ms
+step:1265/1490 train_time:67384ms step_avg:53.27ms
+step:1266/1490 train_time:67471ms step_avg:53.30ms
+step:1267/1490 train_time:67552ms step_avg:53.32ms
+step:1268/1490 train_time:67639ms step_avg:53.34ms
+step:1269/1490 train_time:67720ms step_avg:53.36ms
+step:1270/1490 train_time:67804ms step_avg:53.39ms
+step:1271/1490 train_time:67884ms step_avg:53.41ms
+step:1272/1490 train_time:67968ms step_avg:53.43ms
+step:1273/1490 train_time:68047ms step_avg:53.45ms
+step:1274/1490 train_time:68132ms step_avg:53.48ms
+step:1275/1490 train_time:68213ms step_avg:53.50ms
+step:1276/1490 train_time:68302ms step_avg:53.53ms
+step:1277/1490 train_time:68384ms step_avg:53.55ms
+step:1278/1490 train_time:68470ms step_avg:53.58ms
+step:1279/1490 train_time:68552ms step_avg:53.60ms
+step:1280/1490 train_time:68639ms step_avg:53.62ms
+step:1281/1490 train_time:68718ms step_avg:53.64ms
+step:1282/1490 train_time:68803ms step_avg:53.67ms
+step:1283/1490 train_time:68882ms step_avg:53.69ms
+step:1284/1490 train_time:68966ms step_avg:53.71ms
+step:1285/1490 train_time:69045ms step_avg:53.73ms
+step:1286/1490 train_time:69130ms step_avg:53.76ms
+step:1287/1490 train_time:69211ms step_avg:53.78ms
+step:1288/1490 train_time:69298ms step_avg:53.80ms
+step:1289/1490 train_time:69380ms step_avg:53.82ms
+step:1290/1490 train_time:69465ms step_avg:53.85ms
+step:1291/1490 train_time:69545ms step_avg:53.87ms
+step:1292/1490 train_time:69632ms step_avg:53.89ms
+step:1293/1490 train_time:69715ms step_avg:53.92ms
+step:1294/1490 train_time:69800ms step_avg:53.94ms
+step:1295/1490 train_time:69880ms step_avg:53.96ms
+step:1296/1490 train_time:69965ms step_avg:53.99ms
+step:1297/1490 train_time:70043ms step_avg:54.00ms
+step:1298/1490 train_time:70129ms step_avg:54.03ms
+step:1299/1490 train_time:70208ms step_avg:54.05ms
+step:1300/1490 train_time:70295ms step_avg:54.07ms
+step:1301/1490 train_time:70377ms step_avg:54.09ms
+step:1302/1490 train_time:70463ms step_avg:54.12ms
+step:1303/1490 train_time:70544ms step_avg:54.14ms
+step:1304/1490 train_time:70630ms step_avg:54.16ms
+step:1305/1490 train_time:70709ms step_avg:54.18ms
+step:1306/1490 train_time:70795ms step_avg:54.21ms
+step:1307/1490 train_time:70876ms step_avg:54.23ms
+step:1308/1490 train_time:70961ms step_avg:54.25ms
+step:1309/1490 train_time:71041ms step_avg:54.27ms
+step:1310/1490 train_time:71125ms step_avg:54.29ms
+step:1311/1490 train_time:71204ms step_avg:54.31ms
+step:1312/1490 train_time:71290ms step_avg:54.34ms
+step:1313/1490 train_time:71373ms step_avg:54.36ms
+step:1314/1490 train_time:71459ms step_avg:54.38ms
+step:1315/1490 train_time:71540ms step_avg:54.40ms
+step:1316/1490 train_time:71627ms step_avg:54.43ms
+step:1317/1490 train_time:71705ms step_avg:54.45ms
+step:1318/1490 train_time:71791ms step_avg:54.47ms
+step:1319/1490 train_time:71873ms step_avg:54.49ms
+step:1320/1490 train_time:71958ms step_avg:54.51ms
+step:1321/1490 train_time:72037ms step_avg:54.53ms
+step:1322/1490 train_time:72123ms step_avg:54.56ms
+step:1323/1490 train_time:72202ms step_avg:54.57ms
+step:1324/1490 train_time:72287ms step_avg:54.60ms
+step:1325/1490 train_time:72368ms step_avg:54.62ms
+step:1326/1490 train_time:72454ms step_avg:54.64ms
+step:1327/1490 train_time:72535ms step_avg:54.66ms
+step:1328/1490 train_time:72623ms step_avg:54.69ms
+step:1329/1490 train_time:72702ms step_avg:54.70ms
+step:1330/1490 train_time:72786ms step_avg:54.73ms
+step:1331/1490 train_time:72867ms step_avg:54.75ms
+step:1332/1490 train_time:72952ms step_avg:54.77ms
+step:1333/1490 train_time:73033ms step_avg:54.79ms
+step:1334/1490 train_time:73121ms step_avg:54.81ms
+step:1335/1490 train_time:73201ms step_avg:54.83ms
+step:1336/1490 train_time:73287ms step_avg:54.86ms
+step:1337/1490 train_time:73365ms step_avg:54.87ms
+step:1338/1490 train_time:73451ms step_avg:54.90ms
+step:1339/1490 train_time:73532ms step_avg:54.92ms
+step:1340/1490 train_time:73619ms step_avg:54.94ms
+step:1341/1490 train_time:73699ms step_avg:54.96ms
+step:1342/1490 train_time:73784ms step_avg:54.98ms
+step:1343/1490 train_time:73862ms step_avg:55.00ms
+step:1344/1490 train_time:73947ms step_avg:55.02ms
+step:1345/1490 train_time:74028ms step_avg:55.04ms
+step:1346/1490 train_time:74113ms step_avg:55.06ms
+step:1347/1490 train_time:74194ms step_avg:55.08ms
+step:1348/1490 train_time:74279ms step_avg:55.10ms
+step:1349/1490 train_time:74359ms step_avg:55.12ms
+step:1350/1490 train_time:74446ms step_avg:55.15ms
+step:1351/1490 train_time:74526ms step_avg:55.16ms
+step:1352/1490 train_time:74612ms step_avg:55.19ms
+step:1353/1490 train_time:74692ms step_avg:55.20ms
+step:1354/1490 train_time:74778ms step_avg:55.23ms
+step:1355/1490 train_time:74857ms step_avg:55.24ms
+step:1356/1490 train_time:74942ms step_avg:55.27ms
+step:1357/1490 train_time:75022ms step_avg:55.29ms
+step:1358/1490 train_time:75107ms step_avg:55.31ms
+step:1359/1490 train_time:75187ms step_avg:55.32ms
+step:1360/1490 train_time:75273ms step_avg:55.35ms
+step:1361/1490 train_time:75354ms step_avg:55.37ms
+step:1362/1490 train_time:75441ms step_avg:55.39ms
+step:1363/1490 train_time:75522ms step_avg:55.41ms
+step:1364/1490 train_time:75607ms step_avg:55.43ms
+step:1365/1490 train_time:75687ms step_avg:55.45ms
+step:1366/1490 train_time:75773ms step_avg:55.47ms
+step:1367/1490 train_time:75852ms step_avg:55.49ms
+step:1368/1490 train_time:75938ms step_avg:55.51ms
+step:1369/1490 train_time:76019ms step_avg:55.53ms
+step:1370/1490 train_time:76105ms step_avg:55.55ms
+step:1371/1490 train_time:76184ms step_avg:55.57ms
+step:1372/1490 train_time:76270ms step_avg:55.59ms
+step:1373/1490 train_time:76350ms step_avg:55.61ms
+step:1374/1490 train_time:76436ms step_avg:55.63ms
+step:1375/1490 train_time:76518ms step_avg:55.65ms
+step:1376/1490 train_time:76604ms step_avg:55.67ms
+step:1377/1490 train_time:76683ms step_avg:55.69ms
+step:1378/1490 train_time:76768ms step_avg:55.71ms
+step:1379/1490 train_time:76848ms step_avg:55.73ms
+step:1380/1490 train_time:76935ms step_avg:55.75ms
+step:1381/1490 train_time:77015ms step_avg:55.77ms
+step:1382/1490 train_time:77100ms step_avg:55.79ms
+step:1383/1490 train_time:77179ms step_avg:55.81ms
+step:1384/1490 train_time:77265ms step_avg:55.83ms
+step:1385/1490 train_time:77345ms step_avg:55.84ms
+step:1386/1490 train_time:77432ms step_avg:55.87ms
+step:1387/1490 train_time:77514ms step_avg:55.89ms
+step:1388/1490 train_time:77599ms step_avg:55.91ms
+step:1389/1490 train_time:77680ms step_avg:55.93ms
+step:1390/1490 train_time:77764ms step_avg:55.95ms
+step:1391/1490 train_time:77844ms step_avg:55.96ms
+step:1392/1490 train_time:77930ms step_avg:55.98ms
+step:1393/1490 train_time:78011ms step_avg:56.00ms
+step:1394/1490 train_time:78096ms step_avg:56.02ms
+step:1395/1490 train_time:78175ms step_avg:56.04ms
+step:1396/1490 train_time:78261ms step_avg:56.06ms
+step:1397/1490 train_time:78342ms step_avg:56.08ms
+step:1398/1490 train_time:78427ms step_avg:56.10ms
+step:1399/1490 train_time:78506ms step_avg:56.12ms
+step:1400/1490 train_time:78594ms step_avg:56.14ms
+step:1401/1490 train_time:78676ms step_avg:56.16ms
+step:1402/1490 train_time:78763ms step_avg:56.18ms
+step:1403/1490 train_time:78842ms step_avg:56.20ms
+step:1404/1490 train_time:78927ms step_avg:56.22ms
+step:1405/1490 train_time:79007ms step_avg:56.23ms
+step:1406/1490 train_time:79094ms step_avg:56.25ms
+step:1407/1490 train_time:79174ms step_avg:56.27ms
+step:1408/1490 train_time:79260ms step_avg:56.29ms
+step:1409/1490 train_time:79339ms step_avg:56.31ms
+step:1410/1490 train_time:79426ms step_avg:56.33ms
+step:1411/1490 train_time:79505ms step_avg:56.35ms
+step:1412/1490 train_time:79592ms step_avg:56.37ms
+step:1413/1490 train_time:79675ms step_avg:56.39ms
+step:1414/1490 train_time:79761ms step_avg:56.41ms
+step:1415/1490 train_time:79842ms step_avg:56.43ms
+step:1416/1490 train_time:79927ms step_avg:56.45ms
+step:1417/1490 train_time:80006ms step_avg:56.46ms
+step:1418/1490 train_time:80091ms step_avg:56.48ms
+step:1419/1490 train_time:80172ms step_avg:56.50ms
+step:1420/1490 train_time:80259ms step_avg:56.52ms
+step:1421/1490 train_time:80340ms step_avg:56.54ms
+step:1422/1490 train_time:80426ms step_avg:56.56ms
+step:1423/1490 train_time:80505ms step_avg:56.57ms
+step:1424/1490 train_time:80591ms step_avg:56.59ms
+step:1425/1490 train_time:80671ms step_avg:56.61ms
+step:1426/1490 train_time:80758ms step_avg:56.63ms
+step:1427/1490 train_time:80838ms step_avg:56.65ms
+step:1428/1490 train_time:80925ms step_avg:56.67ms
+step:1429/1490 train_time:81004ms step_avg:56.69ms
+step:1430/1490 train_time:81089ms step_avg:56.71ms
+step:1431/1490 train_time:81170ms step_avg:56.72ms
+step:1432/1490 train_time:81256ms step_avg:56.74ms
+step:1433/1490 train_time:81335ms step_avg:56.76ms
+step:1434/1490 train_time:81422ms step_avg:56.78ms
+step:1435/1490 train_time:81500ms step_avg:56.79ms
+step:1436/1490 train_time:81586ms step_avg:56.81ms
+step:1437/1490 train_time:81667ms step_avg:56.83ms
+step:1438/1490 train_time:81753ms step_avg:56.85ms
+step:1439/1490 train_time:81835ms step_avg:56.87ms
+step:1440/1490 train_time:81921ms step_avg:56.89ms
+step:1441/1490 train_time:82000ms step_avg:56.90ms
+step:1442/1490 train_time:82085ms step_avg:56.92ms
+step:1443/1490 train_time:82164ms step_avg:56.94ms
+step:1444/1490 train_time:82252ms step_avg:56.96ms
+step:1445/1490 train_time:82333ms step_avg:56.98ms
+step:1446/1490 train_time:82420ms step_avg:57.00ms
+step:1447/1490 train_time:82501ms step_avg:57.02ms
+step:1448/1490 train_time:82585ms step_avg:57.03ms
+step:1449/1490 train_time:82666ms step_avg:57.05ms
+step:1450/1490 train_time:82752ms step_avg:57.07ms
+step:1451/1490 train_time:82839ms step_avg:57.09ms
+step:1452/1490 train_time:82927ms step_avg:57.11ms
+step:1453/1490 train_time:83006ms step_avg:57.13ms
+step:1454/1490 train_time:83092ms step_avg:57.15ms
+step:1455/1490 train_time:83171ms step_avg:57.16ms
+step:1456/1490 train_time:83257ms step_avg:57.18ms
+step:1457/1490 train_time:83337ms step_avg:57.20ms
+step:1458/1490 train_time:83425ms step_avg:57.22ms
+step:1459/1490 train_time:83504ms step_avg:57.23ms
+step:1460/1490 train_time:83591ms step_avg:57.25ms
+step:1461/1490 train_time:83671ms step_avg:57.27ms
+step:1462/1490 train_time:83758ms step_avg:57.29ms
+step:1463/1490 train_time:83841ms step_avg:57.31ms
+step:1464/1490 train_time:83926ms step_avg:57.33ms
+step:1465/1490 train_time:84006ms step_avg:57.34ms
+step:1466/1490 train_time:84092ms step_avg:57.36ms
+step:1467/1490 train_time:84174ms step_avg:57.38ms
+step:1468/1490 train_time:84260ms step_avg:57.40ms
+step:1469/1490 train_time:84342ms step_avg:57.41ms
+step:1470/1490 train_time:84428ms step_avg:57.43ms
+step:1471/1490 train_time:84507ms step_avg:57.45ms
+step:1472/1490 train_time:84592ms step_avg:57.47ms
+step:1473/1490 train_time:84675ms step_avg:57.48ms
+step:1474/1490 train_time:84761ms step_avg:57.50ms
+step:1475/1490 train_time:84841ms step_avg:57.52ms
+step:1476/1490 train_time:84926ms step_avg:57.54ms
+step:1477/1490 train_time:85006ms step_avg:57.55ms
+step:1478/1490 train_time:85092ms step_avg:57.57ms
+step:1479/1490 train_time:85173ms step_avg:57.59ms
+step:1480/1490 train_time:85260ms step_avg:57.61ms
+step:1481/1490 train_time:85341ms step_avg:57.62ms
+step:1482/1490 train_time:85427ms step_avg:57.64ms
+step:1483/1490 train_time:85507ms step_avg:57.66ms
+step:1484/1490 train_time:85592ms step_avg:57.68ms
+step:1485/1490 train_time:85673ms step_avg:57.69ms
+step:1486/1490 train_time:85760ms step_avg:57.71ms
+step:1487/1490 train_time:85841ms step_avg:57.73ms
+step:1488/1490 train_time:85927ms step_avg:57.75ms
+step:1489/1490 train_time:86007ms step_avg:57.76ms
+step:1490/1490 train_time:86093ms step_avg:57.78ms
+step:1490/1490 val_loss:3.2794 train_time:86200ms step_avg:57.85ms
+peak memory allocated: 31296 MiB reserved: 47042 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/combined/2026-03-22_20-29-26_time-185_secs_06-mbeta2-max-docs_9a92dd.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/combined/2026-03-22_20-29-26_time-185_secs_06-mbeta2-max-docs_9a92dd.txt
@@ -1,0 +1,4457 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 20:29:41 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            132W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   41C    P0            124W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1933573      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1933574      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1933575      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1933576      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1933577      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1933578      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1933579      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1933580      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8289 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:73ms step_avg:72.70ms
+step:2/1490 train_time:98ms step_avg:49.22ms
+step:3/1490 train_time:115ms step_avg:38.32ms
+step:4/1490 train_time:146ms step_avg:36.62ms
+step:5/1490 train_time:173ms step_avg:34.66ms
+step:6/1490 train_time:208ms step_avg:34.71ms
+step:7/1490 train_time:235ms step_avg:33.63ms
+step:8/1490 train_time:270ms step_avg:33.71ms
+step:9/1490 train_time:297ms step_avg:33.04ms
+step:10/1490 train_time:332ms step_avg:33.20ms
+step:11/1490 train_time:360ms step_avg:32.72ms
+step:12/1490 train_time:394ms step_avg:32.87ms
+step:13/1490 train_time:422ms step_avg:32.48ms
+step:14/1490 train_time:457ms step_avg:32.62ms
+step:15/1490 train_time:485ms step_avg:32.33ms
+step:16/1490 train_time:519ms step_avg:32.45ms
+step:17/1490 train_time:547ms step_avg:32.20ms
+step:18/1490 train_time:581ms step_avg:32.30ms
+step:19/1490 train_time:610ms step_avg:32.09ms
+step:20/1490 train_time:644ms step_avg:32.18ms
+step:21/1490 train_time:672ms step_avg:32.00ms
+step:22/1490 train_time:706ms step_avg:32.10ms
+step:23/1490 train_time:734ms step_avg:31.92ms
+step:24/1490 train_time:768ms step_avg:32.00ms
+step:25/1490 train_time:796ms step_avg:31.86ms
+step:26/1490 train_time:831ms step_avg:31.98ms
+step:27/1490 train_time:859ms step_avg:31.83ms
+step:28/1490 train_time:894ms step_avg:31.92ms
+step:29/1490 train_time:922ms step_avg:31.78ms
+step:30/1490 train_time:956ms step_avg:31.88ms
+step:31/1490 train_time:986ms step_avg:31.79ms
+step:32/1490 train_time:1021ms step_avg:31.91ms
+step:33/1490 train_time:1050ms step_avg:31.83ms
+step:34/1490 train_time:1085ms step_avg:31.90ms
+step:35/1490 train_time:1114ms step_avg:31.83ms
+step:36/1490 train_time:1149ms step_avg:31.91ms
+step:37/1490 train_time:1177ms step_avg:31.82ms
+step:38/1490 train_time:1213ms step_avg:31.92ms
+step:39/1490 train_time:1241ms step_avg:31.81ms
+step:40/1490 train_time:1275ms step_avg:31.88ms
+step:41/1490 train_time:1303ms step_avg:31.79ms
+step:42/1490 train_time:1338ms step_avg:31.86ms
+step:43/1490 train_time:1366ms step_avg:31.78ms
+step:44/1490 train_time:1401ms step_avg:31.84ms
+step:45/1490 train_time:1429ms step_avg:31.76ms
+step:46/1490 train_time:1463ms step_avg:31.81ms
+step:47/1490 train_time:1492ms step_avg:31.74ms
+step:48/1490 train_time:1526ms step_avg:31.78ms
+step:49/1490 train_time:1554ms step_avg:31.72ms
+step:50/1490 train_time:1588ms step_avg:31.76ms
+step:51/1490 train_time:1616ms step_avg:31.69ms
+step:52/1490 train_time:1651ms step_avg:31.75ms
+step:53/1490 train_time:1679ms step_avg:31.68ms
+step:54/1490 train_time:1714ms step_avg:31.73ms
+step:55/1490 train_time:1741ms step_avg:31.66ms
+step:56/1490 train_time:1776ms step_avg:31.71ms
+step:57/1490 train_time:1804ms step_avg:31.65ms
+step:58/1490 train_time:1838ms step_avg:31.69ms
+step:59/1490 train_time:1866ms step_avg:31.63ms
+step:60/1490 train_time:1901ms step_avg:31.68ms
+step:61/1490 train_time:1929ms step_avg:31.63ms
+step:62/1490 train_time:1964ms step_avg:31.67ms
+step:63/1490 train_time:1993ms step_avg:31.63ms
+step:64/1490 train_time:2026ms step_avg:31.66ms
+step:65/1490 train_time:2055ms step_avg:31.62ms
+step:66/1490 train_time:2090ms step_avg:31.67ms
+step:67/1490 train_time:2118ms step_avg:31.62ms
+step:68/1490 train_time:2153ms step_avg:31.67ms
+step:69/1490 train_time:2182ms step_avg:31.62ms
+step:70/1490 train_time:2217ms step_avg:31.68ms
+step:71/1490 train_time:2246ms step_avg:31.63ms
+step:72/1490 train_time:2280ms step_avg:31.67ms
+step:73/1490 train_time:2309ms step_avg:31.63ms
+step:74/1490 train_time:2343ms step_avg:31.67ms
+step:75/1490 train_time:2372ms step_avg:31.63ms
+step:76/1490 train_time:2406ms step_avg:31.66ms
+step:77/1490 train_time:2435ms step_avg:31.63ms
+step:78/1490 train_time:2470ms step_avg:31.66ms
+step:79/1490 train_time:2498ms step_avg:31.62ms
+step:80/1490 train_time:2533ms step_avg:31.66ms
+step:81/1490 train_time:2561ms step_avg:31.62ms
+step:82/1490 train_time:2595ms step_avg:31.65ms
+step:83/1490 train_time:2623ms step_avg:31.60ms
+step:84/1490 train_time:2658ms step_avg:31.64ms
+step:85/1490 train_time:2686ms step_avg:31.60ms
+step:86/1490 train_time:2720ms step_avg:31.63ms
+step:87/1490 train_time:2748ms step_avg:31.59ms
+step:88/1490 train_time:2782ms step_avg:31.62ms
+step:89/1490 train_time:2811ms step_avg:31.58ms
+step:90/1490 train_time:2844ms step_avg:31.61ms
+step:91/1490 train_time:2873ms step_avg:31.57ms
+step:92/1490 train_time:2907ms step_avg:31.60ms
+step:93/1490 train_time:2936ms step_avg:31.57ms
+step:94/1490 train_time:2970ms step_avg:31.60ms
+step:95/1490 train_time:2999ms step_avg:31.57ms
+step:96/1490 train_time:3033ms step_avg:31.60ms
+step:97/1490 train_time:3062ms step_avg:31.56ms
+step:98/1490 train_time:3096ms step_avg:31.60ms
+step:99/1490 train_time:3124ms step_avg:31.56ms
+step:100/1490 train_time:3159ms step_avg:31.59ms
+step:101/1490 train_time:3187ms step_avg:31.55ms
+step:102/1490 train_time:3221ms step_avg:31.58ms
+step:103/1490 train_time:3250ms step_avg:31.56ms
+step:104/1490 train_time:3284ms step_avg:31.58ms
+step:105/1490 train_time:3313ms step_avg:31.55ms
+step:106/1490 train_time:3347ms step_avg:31.58ms
+step:107/1490 train_time:3376ms step_avg:31.55ms
+step:108/1490 train_time:3410ms step_avg:31.57ms
+step:109/1490 train_time:3438ms step_avg:31.55ms
+step:110/1490 train_time:3473ms step_avg:31.57ms
+step:111/1490 train_time:3501ms step_avg:31.54ms
+step:112/1490 train_time:3536ms step_avg:31.57ms
+step:113/1490 train_time:3564ms step_avg:31.54ms
+step:114/1490 train_time:3599ms step_avg:31.57ms
+step:115/1490 train_time:3627ms step_avg:31.54ms
+step:116/1490 train_time:3662ms step_avg:31.57ms
+step:117/1490 train_time:3690ms step_avg:31.54ms
+step:118/1490 train_time:3724ms step_avg:31.56ms
+step:119/1490 train_time:3753ms step_avg:31.53ms
+step:120/1490 train_time:3786ms step_avg:31.55ms
+step:121/1490 train_time:3815ms step_avg:31.53ms
+step:122/1490 train_time:3849ms step_avg:31.55ms
+step:123/1490 train_time:3878ms step_avg:31.53ms
+step:124/1490 train_time:3912ms step_avg:31.55ms
+step:125/1490 train_time:3940ms step_avg:31.52ms
+step:126/1490 train_time:3975ms step_avg:31.54ms
+step:127/1490 train_time:4003ms step_avg:31.52ms
+step:128/1490 train_time:4038ms step_avg:31.54ms
+step:129/1490 train_time:4066ms step_avg:31.52ms
+step:130/1490 train_time:4101ms step_avg:31.55ms
+step:131/1490 train_time:4129ms step_avg:31.52ms
+step:132/1490 train_time:4164ms step_avg:31.54ms
+step:133/1490 train_time:4192ms step_avg:31.52ms
+step:134/1490 train_time:4226ms step_avg:31.54ms
+step:135/1490 train_time:4255ms step_avg:31.52ms
+step:136/1490 train_time:4289ms step_avg:31.54ms
+step:137/1490 train_time:4317ms step_avg:31.51ms
+step:138/1490 train_time:4352ms step_avg:31.54ms
+step:139/1490 train_time:4381ms step_avg:31.52ms
+step:140/1490 train_time:4415ms step_avg:31.54ms
+step:141/1490 train_time:4443ms step_avg:31.51ms
+step:142/1490 train_time:4478ms step_avg:31.53ms
+step:143/1490 train_time:4506ms step_avg:31.51ms
+step:144/1490 train_time:4541ms step_avg:31.53ms
+step:145/1490 train_time:4569ms step_avg:31.51ms
+step:146/1490 train_time:4604ms step_avg:31.53ms
+step:147/1490 train_time:4632ms step_avg:31.51ms
+step:148/1490 train_time:4667ms step_avg:31.53ms
+step:149/1490 train_time:4695ms step_avg:31.51ms
+step:150/1490 train_time:4729ms step_avg:31.53ms
+step:151/1490 train_time:4758ms step_avg:31.51ms
+step:152/1490 train_time:4792ms step_avg:31.53ms
+step:153/1490 train_time:4820ms step_avg:31.50ms
+step:154/1490 train_time:4855ms step_avg:31.52ms
+step:155/1490 train_time:4883ms step_avg:31.50ms
+step:156/1490 train_time:4918ms step_avg:31.52ms
+step:157/1490 train_time:4946ms step_avg:31.50ms
+step:158/1490 train_time:4980ms step_avg:31.52ms
+step:159/1490 train_time:5009ms step_avg:31.50ms
+step:160/1490 train_time:5043ms step_avg:31.52ms
+step:161/1490 train_time:5072ms step_avg:31.50ms
+step:162/1490 train_time:5106ms step_avg:31.52ms
+step:163/1490 train_time:5134ms step_avg:31.50ms
+step:164/1490 train_time:5168ms step_avg:31.51ms
+step:165/1490 train_time:5196ms step_avg:31.49ms
+step:166/1490 train_time:5231ms step_avg:31.51ms
+step:167/1490 train_time:5260ms step_avg:31.49ms
+step:168/1490 train_time:5294ms step_avg:31.51ms
+step:169/1490 train_time:5323ms step_avg:31.50ms
+step:170/1490 train_time:5357ms step_avg:31.51ms
+step:171/1490 train_time:5385ms step_avg:31.49ms
+step:172/1490 train_time:5420ms step_avg:31.51ms
+step:173/1490 train_time:5448ms step_avg:31.49ms
+step:174/1490 train_time:5482ms step_avg:31.51ms
+step:175/1490 train_time:5510ms step_avg:31.49ms
+step:176/1490 train_time:5544ms step_avg:31.50ms
+step:177/1490 train_time:5573ms step_avg:31.48ms
+step:178/1490 train_time:5607ms step_avg:31.50ms
+step:179/1490 train_time:5635ms step_avg:31.48ms
+step:180/1490 train_time:5670ms step_avg:31.50ms
+step:181/1490 train_time:5698ms step_avg:31.48ms
+step:182/1490 train_time:5733ms step_avg:31.50ms
+step:183/1490 train_time:5761ms step_avg:31.48ms
+step:184/1490 train_time:5796ms step_avg:31.50ms
+step:185/1490 train_time:5824ms step_avg:31.48ms
+step:186/1490 train_time:5859ms step_avg:31.50ms
+step:187/1490 train_time:5887ms step_avg:31.48ms
+step:188/1490 train_time:5922ms step_avg:31.50ms
+step:189/1490 train_time:5950ms step_avg:31.48ms
+step:190/1490 train_time:5984ms step_avg:31.49ms
+step:191/1490 train_time:6013ms step_avg:31.48ms
+step:192/1490 train_time:6046ms step_avg:31.49ms
+step:193/1490 train_time:6075ms step_avg:31.48ms
+step:194/1490 train_time:6109ms step_avg:31.49ms
+step:195/1490 train_time:6138ms step_avg:31.47ms
+step:196/1490 train_time:6172ms step_avg:31.49ms
+step:197/1490 train_time:6200ms step_avg:31.47ms
+step:198/1490 train_time:6235ms step_avg:31.49ms
+step:199/1490 train_time:6263ms step_avg:31.47ms
+step:200/1490 train_time:6298ms step_avg:31.49ms
+step:201/1490 train_time:6327ms step_avg:31.48ms
+step:202/1490 train_time:6361ms step_avg:31.49ms
+step:203/1490 train_time:6389ms step_avg:31.47ms
+step:204/1490 train_time:6424ms step_avg:31.49ms
+step:205/1490 train_time:6452ms step_avg:31.47ms
+step:206/1490 train_time:6486ms step_avg:31.48ms
+step:207/1490 train_time:6514ms step_avg:31.47ms
+step:208/1490 train_time:6548ms step_avg:31.48ms
+step:209/1490 train_time:6576ms step_avg:31.47ms
+step:210/1490 train_time:6611ms step_avg:31.48ms
+step:211/1490 train_time:6639ms step_avg:31.46ms
+step:212/1490 train_time:6674ms step_avg:31.48ms
+step:213/1490 train_time:6702ms step_avg:31.46ms
+step:214/1490 train_time:6736ms step_avg:31.48ms
+step:215/1490 train_time:6765ms step_avg:31.46ms
+step:216/1490 train_time:6799ms step_avg:31.48ms
+step:217/1490 train_time:6827ms step_avg:31.46ms
+step:218/1490 train_time:6862ms step_avg:31.48ms
+step:219/1490 train_time:6890ms step_avg:31.46ms
+step:220/1490 train_time:6924ms step_avg:31.47ms
+step:221/1490 train_time:6952ms step_avg:31.46ms
+step:222/1490 train_time:6986ms step_avg:31.47ms
+step:223/1490 train_time:7015ms step_avg:31.46ms
+step:224/1490 train_time:7049ms step_avg:31.47ms
+step:225/1490 train_time:7077ms step_avg:31.45ms
+step:226/1490 train_time:7112ms step_avg:31.47ms
+step:227/1490 train_time:7140ms step_avg:31.45ms
+step:228/1490 train_time:7175ms step_avg:31.47ms
+step:229/1490 train_time:7203ms step_avg:31.45ms
+step:230/1490 train_time:7238ms step_avg:31.47ms
+step:231/1490 train_time:7266ms step_avg:31.46ms
+step:232/1490 train_time:7301ms step_avg:31.47ms
+step:233/1490 train_time:7329ms step_avg:31.46ms
+step:234/1490 train_time:7364ms step_avg:31.47ms
+step:235/1490 train_time:7393ms step_avg:31.46ms
+step:236/1490 train_time:7427ms step_avg:31.47ms
+step:237/1490 train_time:7455ms step_avg:31.46ms
+step:238/1490 train_time:7489ms step_avg:31.47ms
+step:239/1490 train_time:7517ms step_avg:31.45ms
+step:240/1490 train_time:7552ms step_avg:31.46ms
+step:241/1490 train_time:7580ms step_avg:31.45ms
+step:242/1490 train_time:7614ms step_avg:31.46ms
+step:243/1490 train_time:7642ms step_avg:31.45ms
+step:244/1490 train_time:7676ms step_avg:31.46ms
+step:245/1490 train_time:7705ms step_avg:31.45ms
+step:246/1490 train_time:7739ms step_avg:31.46ms
+step:247/1490 train_time:7768ms step_avg:31.45ms
+step:248/1490 train_time:7802ms step_avg:31.46ms
+step:249/1490 train_time:7830ms step_avg:31.45ms
+step:250/1490 train_time:7865ms step_avg:31.46ms
+step:250/1490 val_loss:4.5036 train_time:7908ms step_avg:31.63ms
+step:251/1490 train_time:7923ms step_avg:31.57ms
+step:252/1490 train_time:7940ms step_avg:31.51ms
+step:253/1490 train_time:7958ms step_avg:31.46ms
+step:254/1490 train_time:7993ms step_avg:31.47ms
+step:255/1490 train_time:8022ms step_avg:31.46ms
+step:256/1490 train_time:8059ms step_avg:31.48ms
+step:257/1490 train_time:8090ms step_avg:31.48ms
+step:258/1490 train_time:8124ms step_avg:31.49ms
+step:259/1490 train_time:8152ms step_avg:31.48ms
+step:260/1490 train_time:8186ms step_avg:31.49ms
+step:261/1490 train_time:8215ms step_avg:31.48ms
+step:262/1490 train_time:8249ms step_avg:31.49ms
+step:263/1490 train_time:8277ms step_avg:31.47ms
+step:264/1490 train_time:8312ms step_avg:31.48ms
+step:265/1490 train_time:8340ms step_avg:31.47ms
+step:266/1490 train_time:8374ms step_avg:31.48ms
+step:267/1490 train_time:8402ms step_avg:31.47ms
+step:268/1490 train_time:8436ms step_avg:31.48ms
+step:269/1490 train_time:8464ms step_avg:31.46ms
+step:270/1490 train_time:8498ms step_avg:31.47ms
+step:271/1490 train_time:8526ms step_avg:31.46ms
+step:272/1490 train_time:8560ms step_avg:31.47ms
+step:273/1490 train_time:8588ms step_avg:31.46ms
+step:274/1490 train_time:8622ms step_avg:31.47ms
+step:275/1490 train_time:8650ms step_avg:31.46ms
+step:276/1490 train_time:8684ms step_avg:31.46ms
+step:277/1490 train_time:8712ms step_avg:31.45ms
+step:278/1490 train_time:8747ms step_avg:31.46ms
+step:279/1490 train_time:8775ms step_avg:31.45ms
+step:280/1490 train_time:8809ms step_avg:31.46ms
+step:281/1490 train_time:8837ms step_avg:31.45ms
+step:282/1490 train_time:8872ms step_avg:31.46ms
+step:283/1490 train_time:8900ms step_avg:31.45ms
+step:284/1490 train_time:8936ms step_avg:31.47ms
+step:285/1490 train_time:8965ms step_avg:31.46ms
+step:286/1490 train_time:8999ms step_avg:31.47ms
+step:287/1490 train_time:9028ms step_avg:31.46ms
+step:288/1490 train_time:9063ms step_avg:31.47ms
+step:289/1490 train_time:9091ms step_avg:31.46ms
+step:290/1490 train_time:9125ms step_avg:31.47ms
+step:291/1490 train_time:9154ms step_avg:31.46ms
+step:292/1490 train_time:9188ms step_avg:31.47ms
+step:293/1490 train_time:9217ms step_avg:31.46ms
+step:294/1490 train_time:9252ms step_avg:31.47ms
+step:295/1490 train_time:9280ms step_avg:31.46ms
+step:296/1490 train_time:9315ms step_avg:31.47ms
+step:297/1490 train_time:9343ms step_avg:31.46ms
+step:298/1490 train_time:9377ms step_avg:31.47ms
+step:299/1490 train_time:9406ms step_avg:31.46ms
+step:300/1490 train_time:9440ms step_avg:31.47ms
+step:301/1490 train_time:9468ms step_avg:31.46ms
+step:302/1490 train_time:9502ms step_avg:31.46ms
+step:303/1490 train_time:9530ms step_avg:31.45ms
+step:304/1490 train_time:9565ms step_avg:31.46ms
+step:305/1490 train_time:9593ms step_avg:31.45ms
+step:306/1490 train_time:9627ms step_avg:31.46ms
+step:307/1490 train_time:9655ms step_avg:31.45ms
+step:308/1490 train_time:9689ms step_avg:31.46ms
+step:309/1490 train_time:9717ms step_avg:31.45ms
+step:310/1490 train_time:9751ms step_avg:31.46ms
+step:311/1490 train_time:9779ms step_avg:31.44ms
+step:312/1490 train_time:9814ms step_avg:31.45ms
+step:313/1490 train_time:9842ms step_avg:31.44ms
+step:314/1490 train_time:9877ms step_avg:31.46ms
+step:315/1490 train_time:9906ms step_avg:31.45ms
+step:316/1490 train_time:9940ms step_avg:31.46ms
+step:317/1490 train_time:9969ms step_avg:31.45ms
+step:318/1490 train_time:10003ms step_avg:31.46ms
+step:319/1490 train_time:10032ms step_avg:31.45ms
+step:320/1490 train_time:10066ms step_avg:31.46ms
+step:321/1490 train_time:10095ms step_avg:31.45ms
+step:322/1490 train_time:10129ms step_avg:31.46ms
+step:323/1490 train_time:10157ms step_avg:31.45ms
+step:324/1490 train_time:10192ms step_avg:31.46ms
+step:325/1490 train_time:10220ms step_avg:31.45ms
+step:326/1490 train_time:10255ms step_avg:31.46ms
+step:327/1490 train_time:10283ms step_avg:31.45ms
+step:328/1490 train_time:10317ms step_avg:31.46ms
+step:329/1490 train_time:10346ms step_avg:31.45ms
+step:330/1490 train_time:10380ms step_avg:31.45ms
+step:331/1490 train_time:10408ms step_avg:31.44ms
+step:332/1490 train_time:10442ms step_avg:31.45ms
+step:333/1490 train_time:10470ms step_avg:31.44ms
+step:334/1490 train_time:10504ms step_avg:31.45ms
+step:335/1490 train_time:10533ms step_avg:31.44ms
+step:336/1490 train_time:10567ms step_avg:31.45ms
+step:337/1490 train_time:10595ms step_avg:31.44ms
+step:338/1490 train_time:10630ms step_avg:31.45ms
+step:339/1490 train_time:10658ms step_avg:31.44ms
+step:340/1490 train_time:10692ms step_avg:31.45ms
+step:341/1490 train_time:10720ms step_avg:31.44ms
+step:342/1490 train_time:10755ms step_avg:31.45ms
+step:343/1490 train_time:10783ms step_avg:31.44ms
+step:344/1490 train_time:10817ms step_avg:31.44ms
+step:345/1490 train_time:10845ms step_avg:31.44ms
+step:346/1490 train_time:10879ms step_avg:31.44ms
+step:347/1490 train_time:10908ms step_avg:31.43ms
+step:348/1490 train_time:10942ms step_avg:31.44ms
+step:349/1490 train_time:10971ms step_avg:31.43ms
+step:350/1490 train_time:11004ms step_avg:31.44ms
+step:351/1490 train_time:11033ms step_avg:31.43ms
+step:352/1490 train_time:11068ms step_avg:31.44ms
+step:353/1490 train_time:11096ms step_avg:31.43ms
+step:354/1490 train_time:11131ms step_avg:31.44ms
+step:355/1490 train_time:11159ms step_avg:31.44ms
+step:356/1490 train_time:11195ms step_avg:31.45ms
+step:357/1490 train_time:11223ms step_avg:31.44ms
+step:358/1490 train_time:11258ms step_avg:31.45ms
+step:359/1490 train_time:11286ms step_avg:31.44ms
+step:360/1490 train_time:11320ms step_avg:31.44ms
+step:361/1490 train_time:11348ms step_avg:31.44ms
+step:362/1490 train_time:11382ms step_avg:31.44ms
+step:363/1490 train_time:11411ms step_avg:31.43ms
+step:364/1490 train_time:11444ms step_avg:31.44ms
+step:365/1490 train_time:11473ms step_avg:31.43ms
+step:366/1490 train_time:11507ms step_avg:31.44ms
+step:367/1490 train_time:11535ms step_avg:31.43ms
+step:368/1490 train_time:11570ms step_avg:31.44ms
+step:369/1490 train_time:11598ms step_avg:31.43ms
+step:370/1490 train_time:11633ms step_avg:31.44ms
+step:371/1490 train_time:11661ms step_avg:31.43ms
+step:372/1490 train_time:11695ms step_avg:31.44ms
+step:373/1490 train_time:11724ms step_avg:31.43ms
+step:374/1490 train_time:11758ms step_avg:31.44ms
+step:375/1490 train_time:11786ms step_avg:31.43ms
+step:376/1490 train_time:11820ms step_avg:31.44ms
+step:377/1490 train_time:11848ms step_avg:31.43ms
+step:378/1490 train_time:11882ms step_avg:31.43ms
+step:379/1490 train_time:11911ms step_avg:31.43ms
+step:380/1490 train_time:11945ms step_avg:31.43ms
+step:381/1490 train_time:11973ms step_avg:31.43ms
+step:382/1490 train_time:12007ms step_avg:31.43ms
+step:383/1490 train_time:12036ms step_avg:31.43ms
+step:384/1490 train_time:12071ms step_avg:31.43ms
+step:385/1490 train_time:12099ms step_avg:31.43ms
+step:386/1490 train_time:12134ms step_avg:31.44ms
+step:387/1490 train_time:12162ms step_avg:31.43ms
+step:388/1490 train_time:12197ms step_avg:31.44ms
+step:389/1490 train_time:12226ms step_avg:31.43ms
+step:390/1490 train_time:12260ms step_avg:31.44ms
+step:391/1490 train_time:12288ms step_avg:31.43ms
+step:392/1490 train_time:12322ms step_avg:31.43ms
+step:393/1490 train_time:12351ms step_avg:31.43ms
+step:394/1490 train_time:12385ms step_avg:31.43ms
+step:395/1490 train_time:12414ms step_avg:31.43ms
+step:396/1490 train_time:12448ms step_avg:31.43ms
+step:397/1490 train_time:12476ms step_avg:31.43ms
+step:398/1490 train_time:12510ms step_avg:31.43ms
+step:399/1490 train_time:12539ms step_avg:31.43ms
+step:400/1490 train_time:12573ms step_avg:31.43ms
+step:401/1490 train_time:12601ms step_avg:31.42ms
+step:402/1490 train_time:12636ms step_avg:31.43ms
+step:403/1490 train_time:12664ms step_avg:31.43ms
+step:404/1490 train_time:12699ms step_avg:31.43ms
+step:405/1490 train_time:12727ms step_avg:31.43ms
+step:406/1490 train_time:12761ms step_avg:31.43ms
+step:407/1490 train_time:12790ms step_avg:31.42ms
+step:408/1490 train_time:12823ms step_avg:31.43ms
+step:409/1490 train_time:12852ms step_avg:31.42ms
+step:410/1490 train_time:12886ms step_avg:31.43ms
+step:411/1490 train_time:12915ms step_avg:31.42ms
+step:412/1490 train_time:12949ms step_avg:31.43ms
+step:413/1490 train_time:12977ms step_avg:31.42ms
+step:414/1490 train_time:13012ms step_avg:31.43ms
+step:415/1490 train_time:13040ms step_avg:31.42ms
+step:416/1490 train_time:13075ms step_avg:31.43ms
+step:417/1490 train_time:13103ms step_avg:31.42ms
+step:418/1490 train_time:13138ms step_avg:31.43ms
+step:419/1490 train_time:13167ms step_avg:31.42ms
+step:420/1490 train_time:13201ms step_avg:31.43ms
+step:421/1490 train_time:13229ms step_avg:31.42ms
+step:422/1490 train_time:13263ms step_avg:31.43ms
+step:423/1490 train_time:13291ms step_avg:31.42ms
+step:424/1490 train_time:13325ms step_avg:31.43ms
+step:425/1490 train_time:13354ms step_avg:31.42ms
+step:426/1490 train_time:13387ms step_avg:31.43ms
+step:427/1490 train_time:13416ms step_avg:31.42ms
+step:428/1490 train_time:13450ms step_avg:31.43ms
+step:429/1490 train_time:13478ms step_avg:31.42ms
+step:430/1490 train_time:13513ms step_avg:31.43ms
+step:431/1490 train_time:13541ms step_avg:31.42ms
+step:432/1490 train_time:13577ms step_avg:31.43ms
+step:433/1490 train_time:13606ms step_avg:31.42ms
+step:434/1490 train_time:13640ms step_avg:31.43ms
+step:435/1490 train_time:13668ms step_avg:31.42ms
+step:436/1490 train_time:13702ms step_avg:31.43ms
+step:437/1490 train_time:13731ms step_avg:31.42ms
+step:438/1490 train_time:13765ms step_avg:31.43ms
+step:439/1490 train_time:13793ms step_avg:31.42ms
+step:440/1490 train_time:13827ms step_avg:31.43ms
+step:441/1490 train_time:13856ms step_avg:31.42ms
+step:442/1490 train_time:13890ms step_avg:31.43ms
+step:443/1490 train_time:13918ms step_avg:31.42ms
+step:444/1490 train_time:13953ms step_avg:31.43ms
+step:445/1490 train_time:13981ms step_avg:31.42ms
+step:446/1490 train_time:14016ms step_avg:31.43ms
+step:447/1490 train_time:14044ms step_avg:31.42ms
+step:448/1490 train_time:14079ms step_avg:31.43ms
+step:449/1490 train_time:14107ms step_avg:31.42ms
+step:450/1490 train_time:14141ms step_avg:31.42ms
+step:451/1490 train_time:14169ms step_avg:31.42ms
+step:452/1490 train_time:14204ms step_avg:31.42ms
+step:453/1490 train_time:14232ms step_avg:31.42ms
+step:454/1490 train_time:14266ms step_avg:31.42ms
+step:455/1490 train_time:14294ms step_avg:31.42ms
+step:456/1490 train_time:14328ms step_avg:31.42ms
+step:457/1490 train_time:14356ms step_avg:31.41ms
+step:458/1490 train_time:14390ms step_avg:31.42ms
+step:459/1490 train_time:14419ms step_avg:31.41ms
+step:460/1490 train_time:14453ms step_avg:31.42ms
+step:461/1490 train_time:14481ms step_avg:31.41ms
+step:462/1490 train_time:14516ms step_avg:31.42ms
+step:463/1490 train_time:14544ms step_avg:31.41ms
+step:464/1490 train_time:14579ms step_avg:31.42ms
+step:465/1490 train_time:14607ms step_avg:31.41ms
+step:466/1490 train_time:14641ms step_avg:31.42ms
+step:467/1490 train_time:14669ms step_avg:31.41ms
+step:468/1490 train_time:14703ms step_avg:31.42ms
+step:469/1490 train_time:14731ms step_avg:31.41ms
+step:470/1490 train_time:14765ms step_avg:31.42ms
+step:471/1490 train_time:14794ms step_avg:31.41ms
+step:472/1490 train_time:14828ms step_avg:31.42ms
+step:473/1490 train_time:14856ms step_avg:31.41ms
+step:474/1490 train_time:14891ms step_avg:31.42ms
+step:475/1490 train_time:14919ms step_avg:31.41ms
+step:476/1490 train_time:14953ms step_avg:31.41ms
+step:477/1490 train_time:14982ms step_avg:31.41ms
+step:478/1490 train_time:15016ms step_avg:31.41ms
+step:479/1490 train_time:15044ms step_avg:31.41ms
+step:480/1490 train_time:15079ms step_avg:31.41ms
+step:481/1490 train_time:15107ms step_avg:31.41ms
+step:482/1490 train_time:15141ms step_avg:31.41ms
+step:483/1490 train_time:15169ms step_avg:31.41ms
+step:484/1490 train_time:15206ms step_avg:31.42ms
+step:485/1490 train_time:15258ms step_avg:31.46ms
+step:486/1490 train_time:15317ms step_avg:31.52ms
+step:487/1490 train_time:15371ms step_avg:31.56ms
+step:488/1490 train_time:15432ms step_avg:31.62ms
+step:489/1490 train_time:15486ms step_avg:31.67ms
+step:490/1490 train_time:15546ms step_avg:31.73ms
+step:491/1490 train_time:15601ms step_avg:31.77ms
+step:492/1490 train_time:15661ms step_avg:31.83ms
+step:493/1490 train_time:15715ms step_avg:31.88ms
+step:494/1490 train_time:15775ms step_avg:31.93ms
+step:495/1490 train_time:15829ms step_avg:31.98ms
+step:496/1490 train_time:15889ms step_avg:32.03ms
+step:497/1490 train_time:15943ms step_avg:32.08ms
+step:498/1490 train_time:16003ms step_avg:32.14ms
+step:499/1490 train_time:16059ms step_avg:32.18ms
+step:500/1490 train_time:16119ms step_avg:32.24ms
+step:500/1490 val_loss:4.2309 train_time:16190ms step_avg:32.38ms
+step:501/1490 train_time:16206ms step_avg:32.35ms
+step:502/1490 train_time:16233ms step_avg:32.34ms
+step:503/1490 train_time:16290ms step_avg:32.39ms
+step:504/1490 train_time:16351ms step_avg:32.44ms
+step:505/1490 train_time:16406ms step_avg:32.49ms
+step:506/1490 train_time:16466ms step_avg:32.54ms
+step:507/1490 train_time:16520ms step_avg:32.58ms
+step:508/1490 train_time:16578ms step_avg:32.63ms
+step:509/1490 train_time:16632ms step_avg:32.68ms
+step:510/1490 train_time:16691ms step_avg:32.73ms
+step:511/1490 train_time:16745ms step_avg:32.77ms
+step:512/1490 train_time:16805ms step_avg:32.82ms
+step:513/1490 train_time:16858ms step_avg:32.86ms
+step:514/1490 train_time:16916ms step_avg:32.91ms
+step:515/1490 train_time:16970ms step_avg:32.95ms
+step:516/1490 train_time:17029ms step_avg:33.00ms
+step:517/1490 train_time:17083ms step_avg:33.04ms
+step:518/1490 train_time:17145ms step_avg:33.10ms
+step:519/1490 train_time:17200ms step_avg:33.14ms
+step:520/1490 train_time:17261ms step_avg:33.19ms
+step:521/1490 train_time:17315ms step_avg:33.23ms
+step:522/1490 train_time:17376ms step_avg:33.29ms
+step:523/1490 train_time:17432ms step_avg:33.33ms
+step:524/1490 train_time:17492ms step_avg:33.38ms
+step:525/1490 train_time:17546ms step_avg:33.42ms
+step:526/1490 train_time:17605ms step_avg:33.47ms
+step:527/1490 train_time:17659ms step_avg:33.51ms
+step:528/1490 train_time:17717ms step_avg:33.56ms
+step:529/1490 train_time:17772ms step_avg:33.59ms
+step:530/1490 train_time:17830ms step_avg:33.64ms
+step:531/1490 train_time:17884ms step_avg:33.68ms
+step:532/1490 train_time:17943ms step_avg:33.73ms
+step:533/1490 train_time:17997ms step_avg:33.76ms
+step:534/1490 train_time:18057ms step_avg:33.81ms
+step:535/1490 train_time:18110ms step_avg:33.85ms
+step:536/1490 train_time:18170ms step_avg:33.90ms
+step:537/1490 train_time:18226ms step_avg:33.94ms
+step:538/1490 train_time:18286ms step_avg:33.99ms
+step:539/1490 train_time:18341ms step_avg:34.03ms
+step:540/1490 train_time:18401ms step_avg:34.08ms
+step:541/1490 train_time:18456ms step_avg:34.11ms
+step:542/1490 train_time:18515ms step_avg:34.16ms
+step:543/1490 train_time:18569ms step_avg:34.20ms
+step:544/1490 train_time:18629ms step_avg:34.24ms
+step:545/1490 train_time:18682ms step_avg:34.28ms
+step:546/1490 train_time:18742ms step_avg:34.33ms
+step:547/1490 train_time:18796ms step_avg:34.36ms
+step:548/1490 train_time:18855ms step_avg:34.41ms
+step:549/1490 train_time:18908ms step_avg:34.44ms
+step:550/1490 train_time:18967ms step_avg:34.49ms
+step:551/1490 train_time:19021ms step_avg:34.52ms
+step:552/1490 train_time:19081ms step_avg:34.57ms
+step:553/1490 train_time:19136ms step_avg:34.60ms
+step:554/1490 train_time:19195ms step_avg:34.65ms
+step:555/1490 train_time:19250ms step_avg:34.68ms
+step:556/1490 train_time:19310ms step_avg:34.73ms
+step:557/1490 train_time:19364ms step_avg:34.77ms
+step:558/1490 train_time:19424ms step_avg:34.81ms
+step:559/1490 train_time:19479ms step_avg:34.85ms
+step:560/1490 train_time:19538ms step_avg:34.89ms
+step:561/1490 train_time:19592ms step_avg:34.92ms
+step:562/1490 train_time:19652ms step_avg:34.97ms
+step:563/1490 train_time:19706ms step_avg:35.00ms
+step:564/1490 train_time:19765ms step_avg:35.04ms
+step:565/1490 train_time:19819ms step_avg:35.08ms
+step:566/1490 train_time:19878ms step_avg:35.12ms
+step:567/1490 train_time:19931ms step_avg:35.15ms
+step:568/1490 train_time:19992ms step_avg:35.20ms
+step:569/1490 train_time:20046ms step_avg:35.23ms
+step:570/1490 train_time:20105ms step_avg:35.27ms
+step:571/1490 train_time:20159ms step_avg:35.31ms
+step:572/1490 train_time:20220ms step_avg:35.35ms
+step:573/1490 train_time:20274ms step_avg:35.38ms
+step:574/1490 train_time:20333ms step_avg:35.42ms
+step:575/1490 train_time:20388ms step_avg:35.46ms
+step:576/1490 train_time:20448ms step_avg:35.50ms
+step:577/1490 train_time:20502ms step_avg:35.53ms
+step:578/1490 train_time:20563ms step_avg:35.58ms
+step:579/1490 train_time:20617ms step_avg:35.61ms
+step:580/1490 train_time:20676ms step_avg:35.65ms
+step:581/1490 train_time:20730ms step_avg:35.68ms
+step:582/1490 train_time:20789ms step_avg:35.72ms
+step:583/1490 train_time:20843ms step_avg:35.75ms
+step:584/1490 train_time:20902ms step_avg:35.79ms
+step:585/1490 train_time:20956ms step_avg:35.82ms
+step:586/1490 train_time:21015ms step_avg:35.86ms
+step:587/1490 train_time:21069ms step_avg:35.89ms
+step:588/1490 train_time:21128ms step_avg:35.93ms
+step:589/1490 train_time:21183ms step_avg:35.96ms
+step:590/1490 train_time:21243ms step_avg:36.00ms
+step:591/1490 train_time:21297ms step_avg:36.04ms
+step:592/1490 train_time:21357ms step_avg:36.08ms
+step:593/1490 train_time:21411ms step_avg:36.11ms
+step:594/1490 train_time:21471ms step_avg:36.15ms
+step:595/1490 train_time:21525ms step_avg:36.18ms
+step:596/1490 train_time:21586ms step_avg:36.22ms
+step:597/1490 train_time:21640ms step_avg:36.25ms
+step:598/1490 train_time:21699ms step_avg:36.29ms
+step:599/1490 train_time:21753ms step_avg:36.32ms
+step:600/1490 train_time:21812ms step_avg:36.35ms
+step:601/1490 train_time:21867ms step_avg:36.38ms
+step:602/1490 train_time:21926ms step_avg:36.42ms
+step:603/1490 train_time:21980ms step_avg:36.45ms
+step:604/1490 train_time:22039ms step_avg:36.49ms
+step:605/1490 train_time:22093ms step_avg:36.52ms
+step:606/1490 train_time:22152ms step_avg:36.55ms
+step:607/1490 train_time:22207ms step_avg:36.59ms
+step:608/1490 train_time:22268ms step_avg:36.62ms
+step:609/1490 train_time:22322ms step_avg:36.65ms
+step:610/1490 train_time:22382ms step_avg:36.69ms
+step:611/1490 train_time:22436ms step_avg:36.72ms
+step:612/1490 train_time:22495ms step_avg:36.76ms
+step:613/1490 train_time:22550ms step_avg:36.79ms
+step:614/1490 train_time:22609ms step_avg:36.82ms
+step:615/1490 train_time:22663ms step_avg:36.85ms
+step:616/1490 train_time:22723ms step_avg:36.89ms
+step:617/1490 train_time:22778ms step_avg:36.92ms
+step:618/1490 train_time:22836ms step_avg:36.95ms
+step:619/1490 train_time:22890ms step_avg:36.98ms
+step:620/1490 train_time:22950ms step_avg:37.02ms
+step:621/1490 train_time:23004ms step_avg:37.04ms
+step:622/1490 train_time:23064ms step_avg:37.08ms
+step:623/1490 train_time:23118ms step_avg:37.11ms
+step:624/1490 train_time:23178ms step_avg:37.14ms
+step:625/1490 train_time:23232ms step_avg:37.17ms
+step:626/1490 train_time:23291ms step_avg:37.21ms
+step:627/1490 train_time:23346ms step_avg:37.23ms
+step:628/1490 train_time:23406ms step_avg:37.27ms
+step:629/1490 train_time:23459ms step_avg:37.30ms
+step:630/1490 train_time:23519ms step_avg:37.33ms
+step:631/1490 train_time:23574ms step_avg:37.36ms
+step:632/1490 train_time:23633ms step_avg:37.39ms
+step:633/1490 train_time:23688ms step_avg:37.42ms
+step:634/1490 train_time:23748ms step_avg:37.46ms
+step:635/1490 train_time:23802ms step_avg:37.48ms
+step:636/1490 train_time:23862ms step_avg:37.52ms
+step:637/1490 train_time:23916ms step_avg:37.54ms
+step:638/1490 train_time:23974ms step_avg:37.58ms
+step:639/1490 train_time:24028ms step_avg:37.60ms
+step:640/1490 train_time:24088ms step_avg:37.64ms
+step:641/1490 train_time:24142ms step_avg:37.66ms
+step:642/1490 train_time:24202ms step_avg:37.70ms
+step:643/1490 train_time:24257ms step_avg:37.72ms
+step:644/1490 train_time:24316ms step_avg:37.76ms
+step:645/1490 train_time:24370ms step_avg:37.78ms
+step:646/1490 train_time:24429ms step_avg:37.82ms
+step:647/1490 train_time:24485ms step_avg:37.84ms
+step:648/1490 train_time:24546ms step_avg:37.88ms
+step:649/1490 train_time:24600ms step_avg:37.90ms
+step:650/1490 train_time:24659ms step_avg:37.94ms
+step:651/1490 train_time:24713ms step_avg:37.96ms
+step:652/1490 train_time:24773ms step_avg:38.00ms
+step:653/1490 train_time:24827ms step_avg:38.02ms
+step:654/1490 train_time:24887ms step_avg:38.05ms
+step:655/1490 train_time:24941ms step_avg:38.08ms
+step:656/1490 train_time:25000ms step_avg:38.11ms
+step:657/1490 train_time:25054ms step_avg:38.13ms
+step:658/1490 train_time:25113ms step_avg:38.17ms
+step:659/1490 train_time:25168ms step_avg:38.19ms
+step:660/1490 train_time:25227ms step_avg:38.22ms
+step:661/1490 train_time:25282ms step_avg:38.25ms
+step:662/1490 train_time:25342ms step_avg:38.28ms
+step:663/1490 train_time:25396ms step_avg:38.31ms
+step:664/1490 train_time:25455ms step_avg:38.34ms
+step:665/1490 train_time:25510ms step_avg:38.36ms
+step:666/1490 train_time:25568ms step_avg:38.39ms
+step:667/1490 train_time:25623ms step_avg:38.42ms
+step:668/1490 train_time:25683ms step_avg:38.45ms
+step:669/1490 train_time:25737ms step_avg:38.47ms
+step:670/1490 train_time:25796ms step_avg:38.50ms
+step:671/1490 train_time:25851ms step_avg:38.53ms
+step:672/1490 train_time:25910ms step_avg:38.56ms
+step:673/1490 train_time:25963ms step_avg:38.58ms
+step:674/1490 train_time:26024ms step_avg:38.61ms
+step:675/1490 train_time:26078ms step_avg:38.63ms
+step:676/1490 train_time:26136ms step_avg:38.66ms
+step:677/1490 train_time:26191ms step_avg:38.69ms
+step:678/1490 train_time:26250ms step_avg:38.72ms
+step:679/1490 train_time:26305ms step_avg:38.74ms
+step:680/1490 train_time:26365ms step_avg:38.77ms
+step:681/1490 train_time:26419ms step_avg:38.80ms
+step:682/1490 train_time:26479ms step_avg:38.82ms
+step:683/1490 train_time:26533ms step_avg:38.85ms
+step:684/1490 train_time:26594ms step_avg:38.88ms
+step:685/1490 train_time:26649ms step_avg:38.90ms
+step:686/1490 train_time:26708ms step_avg:38.93ms
+step:687/1490 train_time:26761ms step_avg:38.95ms
+step:688/1490 train_time:26821ms step_avg:38.98ms
+step:689/1490 train_time:26875ms step_avg:39.01ms
+step:690/1490 train_time:26934ms step_avg:39.03ms
+step:691/1490 train_time:26989ms step_avg:39.06ms
+step:692/1490 train_time:27049ms step_avg:39.09ms
+step:693/1490 train_time:27102ms step_avg:39.11ms
+step:694/1490 train_time:27162ms step_avg:39.14ms
+step:695/1490 train_time:27218ms step_avg:39.16ms
+step:696/1490 train_time:27277ms step_avg:39.19ms
+step:697/1490 train_time:27330ms step_avg:39.21ms
+step:698/1490 train_time:27390ms step_avg:39.24ms
+step:699/1490 train_time:27444ms step_avg:39.26ms
+step:700/1490 train_time:27504ms step_avg:39.29ms
+step:701/1490 train_time:27558ms step_avg:39.31ms
+step:702/1490 train_time:27618ms step_avg:39.34ms
+step:703/1490 train_time:27673ms step_avg:39.36ms
+step:704/1490 train_time:27733ms step_avg:39.39ms
+step:705/1490 train_time:27788ms step_avg:39.42ms
+step:706/1490 train_time:27848ms step_avg:39.44ms
+step:707/1490 train_time:27901ms step_avg:39.46ms
+step:708/1490 train_time:27961ms step_avg:39.49ms
+step:709/1490 train_time:28014ms step_avg:39.51ms
+step:710/1490 train_time:28073ms step_avg:39.54ms
+step:711/1490 train_time:28127ms step_avg:39.56ms
+step:712/1490 train_time:28187ms step_avg:39.59ms
+step:713/1490 train_time:28241ms step_avg:39.61ms
+step:714/1490 train_time:28301ms step_avg:39.64ms
+step:715/1490 train_time:28355ms step_avg:39.66ms
+step:716/1490 train_time:28415ms step_avg:39.69ms
+step:717/1490 train_time:28469ms step_avg:39.71ms
+step:718/1490 train_time:28528ms step_avg:39.73ms
+step:719/1490 train_time:28583ms step_avg:39.75ms
+step:720/1490 train_time:28644ms step_avg:39.78ms
+step:721/1490 train_time:28698ms step_avg:39.80ms
+step:722/1490 train_time:28758ms step_avg:39.83ms
+step:723/1490 train_time:28812ms step_avg:39.85ms
+step:724/1490 train_time:28872ms step_avg:39.88ms
+step:725/1490 train_time:28926ms step_avg:39.90ms
+step:726/1490 train_time:28985ms step_avg:39.92ms
+step:727/1490 train_time:29039ms step_avg:39.94ms
+step:728/1490 train_time:29098ms step_avg:39.97ms
+step:729/1490 train_time:29152ms step_avg:39.99ms
+step:730/1490 train_time:29211ms step_avg:40.02ms
+step:731/1490 train_time:29266ms step_avg:40.04ms
+step:732/1490 train_time:29326ms step_avg:40.06ms
+step:733/1490 train_time:29380ms step_avg:40.08ms
+step:734/1490 train_time:29440ms step_avg:40.11ms
+step:735/1490 train_time:29494ms step_avg:40.13ms
+step:736/1490 train_time:29554ms step_avg:40.15ms
+step:737/1490 train_time:29608ms step_avg:40.17ms
+step:738/1490 train_time:29667ms step_avg:40.20ms
+step:739/1490 train_time:29721ms step_avg:40.22ms
+step:740/1490 train_time:29782ms step_avg:40.25ms
+step:741/1490 train_time:29835ms step_avg:40.26ms
+step:742/1490 train_time:29894ms step_avg:40.29ms
+step:743/1490 train_time:29950ms step_avg:40.31ms
+step:744/1490 train_time:30009ms step_avg:40.33ms
+step:745/1490 train_time:30062ms step_avg:40.35ms
+step:746/1490 train_time:30122ms step_avg:40.38ms
+step:747/1490 train_time:30175ms step_avg:40.40ms
+step:748/1490 train_time:30234ms step_avg:40.42ms
+step:749/1490 train_time:30289ms step_avg:40.44ms
+step:750/1490 train_time:30349ms step_avg:40.47ms
+step:750/1490 val_loss:3.8069 train_time:30422ms step_avg:40.56ms
+step:751/1490 train_time:30438ms step_avg:40.53ms
+step:752/1490 train_time:30465ms step_avg:40.51ms
+step:753/1490 train_time:30522ms step_avg:40.53ms
+step:754/1490 train_time:30585ms step_avg:40.56ms
+step:755/1490 train_time:30639ms step_avg:40.58ms
+step:756/1490 train_time:30700ms step_avg:40.61ms
+step:757/1490 train_time:30754ms step_avg:40.63ms
+step:758/1490 train_time:30813ms step_avg:40.65ms
+step:759/1490 train_time:30868ms step_avg:40.67ms
+step:760/1490 train_time:30927ms step_avg:40.69ms
+step:761/1490 train_time:30980ms step_avg:40.71ms
+step:762/1490 train_time:31039ms step_avg:40.73ms
+step:763/1490 train_time:31091ms step_avg:40.75ms
+step:764/1490 train_time:31150ms step_avg:40.77ms
+step:765/1490 train_time:31204ms step_avg:40.79ms
+step:766/1490 train_time:31263ms step_avg:40.81ms
+step:767/1490 train_time:31317ms step_avg:40.83ms
+step:768/1490 train_time:31377ms step_avg:40.86ms
+step:769/1490 train_time:31432ms step_avg:40.87ms
+step:770/1490 train_time:31495ms step_avg:40.90ms
+step:771/1490 train_time:31550ms step_avg:40.92ms
+step:772/1490 train_time:31611ms step_avg:40.95ms
+step:773/1490 train_time:31666ms step_avg:40.96ms
+step:774/1490 train_time:31725ms step_avg:40.99ms
+step:775/1490 train_time:31780ms step_avg:41.01ms
+step:776/1490 train_time:31839ms step_avg:41.03ms
+step:777/1490 train_time:31893ms step_avg:41.05ms
+step:778/1490 train_time:31953ms step_avg:41.07ms
+step:779/1490 train_time:32006ms step_avg:41.09ms
+step:780/1490 train_time:32065ms step_avg:41.11ms
+step:781/1490 train_time:32119ms step_avg:41.13ms
+step:782/1490 train_time:32179ms step_avg:41.15ms
+step:783/1490 train_time:32232ms step_avg:41.16ms
+step:784/1490 train_time:32291ms step_avg:41.19ms
+step:785/1490 train_time:32345ms step_avg:41.20ms
+step:786/1490 train_time:32405ms step_avg:41.23ms
+step:787/1490 train_time:32459ms step_avg:41.24ms
+step:788/1490 train_time:32519ms step_avg:41.27ms
+step:789/1490 train_time:32575ms step_avg:41.29ms
+step:790/1490 train_time:32636ms step_avg:41.31ms
+step:791/1490 train_time:32690ms step_avg:41.33ms
+step:792/1490 train_time:32750ms step_avg:41.35ms
+step:793/1490 train_time:32804ms step_avg:41.37ms
+step:794/1490 train_time:32863ms step_avg:41.39ms
+step:795/1490 train_time:32917ms step_avg:41.41ms
+step:796/1490 train_time:32977ms step_avg:41.43ms
+step:797/1490 train_time:33030ms step_avg:41.44ms
+step:798/1490 train_time:33089ms step_avg:41.46ms
+step:799/1490 train_time:33142ms step_avg:41.48ms
+step:800/1490 train_time:33202ms step_avg:41.50ms
+step:801/1490 train_time:33256ms step_avg:41.52ms
+step:802/1490 train_time:33316ms step_avg:41.54ms
+step:803/1490 train_time:33369ms step_avg:41.56ms
+step:804/1490 train_time:33429ms step_avg:41.58ms
+step:805/1490 train_time:33484ms step_avg:41.59ms
+step:806/1490 train_time:33543ms step_avg:41.62ms
+step:807/1490 train_time:33599ms step_avg:41.63ms
+step:808/1490 train_time:33658ms step_avg:41.66ms
+step:809/1490 train_time:33713ms step_avg:41.67ms
+step:810/1490 train_time:33773ms step_avg:41.70ms
+step:811/1490 train_time:33827ms step_avg:41.71ms
+step:812/1490 train_time:33887ms step_avg:41.73ms
+step:813/1490 train_time:33940ms step_avg:41.75ms
+step:814/1490 train_time:33999ms step_avg:41.77ms
+step:815/1490 train_time:34052ms step_avg:41.78ms
+step:816/1490 train_time:34112ms step_avg:41.80ms
+step:817/1490 train_time:34165ms step_avg:41.82ms
+step:818/1490 train_time:34224ms step_avg:41.84ms
+step:819/1490 train_time:34279ms step_avg:41.85ms
+step:820/1490 train_time:34339ms step_avg:41.88ms
+step:821/1490 train_time:34393ms step_avg:41.89ms
+step:822/1490 train_time:34454ms step_avg:41.91ms
+step:823/1490 train_time:34509ms step_avg:41.93ms
+step:824/1490 train_time:34568ms step_avg:41.95ms
+step:825/1490 train_time:34623ms step_avg:41.97ms
+step:826/1490 train_time:34684ms step_avg:41.99ms
+step:827/1490 train_time:34738ms step_avg:42.00ms
+step:828/1490 train_time:34798ms step_avg:42.03ms
+step:829/1490 train_time:34852ms step_avg:42.04ms
+step:830/1490 train_time:34912ms step_avg:42.06ms
+step:831/1490 train_time:34966ms step_avg:42.08ms
+step:832/1490 train_time:35025ms step_avg:42.10ms
+step:833/1490 train_time:35078ms step_avg:42.11ms
+step:834/1490 train_time:35137ms step_avg:42.13ms
+step:835/1490 train_time:35191ms step_avg:42.14ms
+step:836/1490 train_time:35251ms step_avg:42.17ms
+step:837/1490 train_time:35306ms step_avg:42.18ms
+step:838/1490 train_time:35365ms step_avg:42.20ms
+step:839/1490 train_time:35419ms step_avg:42.22ms
+step:840/1490 train_time:35480ms step_avg:42.24ms
+step:841/1490 train_time:35534ms step_avg:42.25ms
+step:842/1490 train_time:35594ms step_avg:42.27ms
+step:843/1490 train_time:35648ms step_avg:42.29ms
+step:844/1490 train_time:35707ms step_avg:42.31ms
+step:845/1490 train_time:35762ms step_avg:42.32ms
+step:846/1490 train_time:35821ms step_avg:42.34ms
+step:847/1490 train_time:35876ms step_avg:42.36ms
+step:848/1490 train_time:35936ms step_avg:42.38ms
+step:849/1490 train_time:35989ms step_avg:42.39ms
+step:850/1490 train_time:36048ms step_avg:42.41ms
+step:851/1490 train_time:36103ms step_avg:42.42ms
+step:852/1490 train_time:36162ms step_avg:42.44ms
+step:853/1490 train_time:36217ms step_avg:42.46ms
+step:854/1490 train_time:36277ms step_avg:42.48ms
+step:855/1490 train_time:36331ms step_avg:42.49ms
+step:856/1490 train_time:36390ms step_avg:42.51ms
+step:857/1490 train_time:36443ms step_avg:42.52ms
+step:858/1490 train_time:36503ms step_avg:42.54ms
+step:859/1490 train_time:36558ms step_avg:42.56ms
+step:860/1490 train_time:36617ms step_avg:42.58ms
+step:861/1490 train_time:36671ms step_avg:42.59ms
+step:862/1490 train_time:36732ms step_avg:42.61ms
+step:863/1490 train_time:36785ms step_avg:42.62ms
+step:864/1490 train_time:36844ms step_avg:42.64ms
+step:865/1490 train_time:36899ms step_avg:42.66ms
+step:866/1490 train_time:36959ms step_avg:42.68ms
+step:867/1490 train_time:37012ms step_avg:42.69ms
+step:868/1490 train_time:37072ms step_avg:42.71ms
+step:869/1490 train_time:37125ms step_avg:42.72ms
+step:870/1490 train_time:37184ms step_avg:42.74ms
+step:871/1490 train_time:37239ms step_avg:42.75ms
+step:872/1490 train_time:37298ms step_avg:42.77ms
+step:873/1490 train_time:37352ms step_avg:42.79ms
+step:874/1490 train_time:37412ms step_avg:42.81ms
+step:875/1490 train_time:37467ms step_avg:42.82ms
+step:876/1490 train_time:37525ms step_avg:42.84ms
+step:877/1490 train_time:37580ms step_avg:42.85ms
+step:878/1490 train_time:37639ms step_avg:42.87ms
+step:879/1490 train_time:37693ms step_avg:42.88ms
+step:880/1490 train_time:37754ms step_avg:42.90ms
+step:881/1490 train_time:37808ms step_avg:42.92ms
+step:882/1490 train_time:37868ms step_avg:42.93ms
+step:883/1490 train_time:37922ms step_avg:42.95ms
+step:884/1490 train_time:37982ms step_avg:42.97ms
+step:885/1490 train_time:38036ms step_avg:42.98ms
+step:886/1490 train_time:38096ms step_avg:43.00ms
+step:887/1490 train_time:38149ms step_avg:43.01ms
+step:888/1490 train_time:38209ms step_avg:43.03ms
+step:889/1490 train_time:38263ms step_avg:43.04ms
+step:890/1490 train_time:38322ms step_avg:43.06ms
+step:891/1490 train_time:38376ms step_avg:43.07ms
+step:892/1490 train_time:38436ms step_avg:43.09ms
+step:893/1490 train_time:38490ms step_avg:43.10ms
+step:894/1490 train_time:38549ms step_avg:43.12ms
+step:895/1490 train_time:38603ms step_avg:43.13ms
+step:896/1490 train_time:38662ms step_avg:43.15ms
+step:897/1490 train_time:38717ms step_avg:43.16ms
+step:898/1490 train_time:38777ms step_avg:43.18ms
+step:899/1490 train_time:38831ms step_avg:43.19ms
+step:900/1490 train_time:38891ms step_avg:43.21ms
+step:901/1490 train_time:38945ms step_avg:43.22ms
+step:902/1490 train_time:39004ms step_avg:43.24ms
+step:903/1490 train_time:39058ms step_avg:43.25ms
+step:904/1490 train_time:39118ms step_avg:43.27ms
+step:905/1490 train_time:39171ms step_avg:43.28ms
+step:906/1490 train_time:39231ms step_avg:43.30ms
+step:907/1490 train_time:39285ms step_avg:43.31ms
+step:908/1490 train_time:39344ms step_avg:43.33ms
+step:909/1490 train_time:39399ms step_avg:43.34ms
+step:910/1490 train_time:39457ms step_avg:43.36ms
+step:911/1490 train_time:39512ms step_avg:43.37ms
+step:912/1490 train_time:39572ms step_avg:43.39ms
+step:913/1490 train_time:39627ms step_avg:43.40ms
+step:914/1490 train_time:39687ms step_avg:43.42ms
+step:915/1490 train_time:39741ms step_avg:43.43ms
+step:916/1490 train_time:39801ms step_avg:43.45ms
+step:917/1490 train_time:39855ms step_avg:43.46ms
+step:918/1490 train_time:39915ms step_avg:43.48ms
+step:919/1490 train_time:39969ms step_avg:43.49ms
+step:920/1490 train_time:40029ms step_avg:43.51ms
+step:921/1490 train_time:40082ms step_avg:43.52ms
+step:922/1490 train_time:40142ms step_avg:43.54ms
+step:923/1490 train_time:40196ms step_avg:43.55ms
+step:924/1490 train_time:40256ms step_avg:43.57ms
+step:925/1490 train_time:40310ms step_avg:43.58ms
+step:926/1490 train_time:40369ms step_avg:43.60ms
+step:927/1490 train_time:40423ms step_avg:43.61ms
+step:928/1490 train_time:40484ms step_avg:43.63ms
+step:929/1490 train_time:40539ms step_avg:43.64ms
+step:930/1490 train_time:40598ms step_avg:43.65ms
+step:931/1490 train_time:40652ms step_avg:43.67ms
+step:932/1490 train_time:40712ms step_avg:43.68ms
+step:933/1490 train_time:40766ms step_avg:43.69ms
+step:934/1490 train_time:40825ms step_avg:43.71ms
+step:935/1490 train_time:40879ms step_avg:43.72ms
+step:936/1490 train_time:40939ms step_avg:43.74ms
+step:937/1490 train_time:40994ms step_avg:43.75ms
+step:938/1490 train_time:41054ms step_avg:43.77ms
+step:939/1490 train_time:41107ms step_avg:43.78ms
+step:940/1490 train_time:41167ms step_avg:43.79ms
+step:941/1490 train_time:41221ms step_avg:43.81ms
+step:942/1490 train_time:41281ms step_avg:43.82ms
+step:943/1490 train_time:41335ms step_avg:43.83ms
+step:944/1490 train_time:41394ms step_avg:43.85ms
+step:945/1490 train_time:41449ms step_avg:43.86ms
+step:946/1490 train_time:41508ms step_avg:43.88ms
+step:947/1490 train_time:41562ms step_avg:43.89ms
+step:948/1490 train_time:41622ms step_avg:43.91ms
+step:949/1490 train_time:41677ms step_avg:43.92ms
+step:950/1490 train_time:41736ms step_avg:43.93ms
+step:951/1490 train_time:41790ms step_avg:43.94ms
+step:952/1490 train_time:41849ms step_avg:43.96ms
+step:953/1490 train_time:41903ms step_avg:43.97ms
+step:954/1490 train_time:41963ms step_avg:43.99ms
+step:955/1490 train_time:42018ms step_avg:44.00ms
+step:956/1490 train_time:42078ms step_avg:44.01ms
+step:957/1490 train_time:42132ms step_avg:44.02ms
+step:958/1490 train_time:42191ms step_avg:44.04ms
+step:959/1490 train_time:42246ms step_avg:44.05ms
+step:960/1490 train_time:42305ms step_avg:44.07ms
+step:961/1490 train_time:42359ms step_avg:44.08ms
+step:962/1490 train_time:42418ms step_avg:44.09ms
+step:963/1490 train_time:42472ms step_avg:44.10ms
+step:964/1490 train_time:42532ms step_avg:44.12ms
+step:965/1490 train_time:42587ms step_avg:44.13ms
+step:966/1490 train_time:42647ms step_avg:44.15ms
+step:967/1490 train_time:42701ms step_avg:44.16ms
+step:968/1490 train_time:42764ms step_avg:44.18ms
+step:969/1490 train_time:42842ms step_avg:44.21ms
+step:970/1490 train_time:42928ms step_avg:44.26ms
+step:971/1490 train_time:43009ms step_avg:44.29ms
+step:972/1490 train_time:43094ms step_avg:44.34ms
+step:973/1490 train_time:43175ms step_avg:44.37ms
+step:974/1490 train_time:43261ms step_avg:44.42ms
+step:975/1490 train_time:43342ms step_avg:44.45ms
+step:976/1490 train_time:43427ms step_avg:44.49ms
+step:977/1490 train_time:43508ms step_avg:44.53ms
+step:978/1490 train_time:43594ms step_avg:44.57ms
+step:979/1490 train_time:43674ms step_avg:44.61ms
+step:980/1490 train_time:43763ms step_avg:44.66ms
+step:981/1490 train_time:43842ms step_avg:44.69ms
+step:982/1490 train_time:43928ms step_avg:44.73ms
+step:983/1490 train_time:44009ms step_avg:44.77ms
+step:984/1490 train_time:44095ms step_avg:44.81ms
+step:985/1490 train_time:44175ms step_avg:44.85ms
+step:986/1490 train_time:44262ms step_avg:44.89ms
+step:987/1490 train_time:44343ms step_avg:44.93ms
+step:988/1490 train_time:44428ms step_avg:44.97ms
+step:989/1490 train_time:44508ms step_avg:45.00ms
+step:990/1490 train_time:44594ms step_avg:45.04ms
+step:991/1490 train_time:44674ms step_avg:45.08ms
+step:992/1490 train_time:44761ms step_avg:45.12ms
+step:993/1490 train_time:44841ms step_avg:45.16ms
+step:994/1490 train_time:44925ms step_avg:45.20ms
+step:995/1490 train_time:45005ms step_avg:45.23ms
+step:996/1490 train_time:45090ms step_avg:45.27ms
+step:997/1490 train_time:45171ms step_avg:45.31ms
+step:998/1490 train_time:45256ms step_avg:45.35ms
+step:999/1490 train_time:45337ms step_avg:45.38ms
+step:1000/1490 train_time:45423ms step_avg:45.42ms
+step:1000/1490 val_loss:3.5121 train_time:45525ms step_avg:45.53ms
+step:1001/1490 train_time:45541ms step_avg:45.50ms
+step:1002/1490 train_time:45593ms step_avg:45.50ms
+step:1003/1490 train_time:45676ms step_avg:45.54ms
+step:1004/1490 train_time:45764ms step_avg:45.58ms
+step:1005/1490 train_time:45845ms step_avg:45.62ms
+step:1006/1490 train_time:45930ms step_avg:45.66ms
+step:1007/1490 train_time:46010ms step_avg:45.69ms
+step:1008/1490 train_time:46094ms step_avg:45.73ms
+step:1009/1490 train_time:46173ms step_avg:45.76ms
+step:1010/1490 train_time:46257ms step_avg:45.80ms
+step:1011/1490 train_time:46337ms step_avg:45.83ms
+step:1012/1490 train_time:46421ms step_avg:45.87ms
+step:1013/1490 train_time:46501ms step_avg:45.90ms
+step:1014/1490 train_time:46588ms step_avg:45.94ms
+step:1015/1490 train_time:46672ms step_avg:45.98ms
+step:1016/1490 train_time:46760ms step_avg:46.02ms
+step:1017/1490 train_time:46841ms step_avg:46.06ms
+step:1018/1490 train_time:46927ms step_avg:46.10ms
+step:1019/1490 train_time:47008ms step_avg:46.13ms
+step:1020/1490 train_time:47092ms step_avg:46.17ms
+step:1021/1490 train_time:47172ms step_avg:46.20ms
+step:1022/1490 train_time:47257ms step_avg:46.24ms
+step:1023/1490 train_time:47336ms step_avg:46.27ms
+step:1024/1490 train_time:47421ms step_avg:46.31ms
+step:1025/1490 train_time:47500ms step_avg:46.34ms
+step:1026/1490 train_time:47586ms step_avg:46.38ms
+step:1027/1490 train_time:47669ms step_avg:46.42ms
+step:1028/1490 train_time:47756ms step_avg:46.46ms
+step:1029/1490 train_time:47837ms step_avg:46.49ms
+step:1030/1490 train_time:47924ms step_avg:46.53ms
+step:1031/1490 train_time:48003ms step_avg:46.56ms
+step:1032/1490 train_time:48088ms step_avg:46.60ms
+step:1033/1490 train_time:48168ms step_avg:46.63ms
+step:1034/1490 train_time:48254ms step_avg:46.67ms
+step:1035/1490 train_time:48333ms step_avg:46.70ms
+step:1036/1490 train_time:48419ms step_avg:46.74ms
+step:1037/1490 train_time:48498ms step_avg:46.77ms
+step:1038/1490 train_time:48584ms step_avg:46.81ms
+step:1039/1490 train_time:48666ms step_avg:46.84ms
+step:1040/1490 train_time:48753ms step_avg:46.88ms
+step:1041/1490 train_time:48836ms step_avg:46.91ms
+step:1042/1490 train_time:48923ms step_avg:46.95ms
+step:1043/1490 train_time:49001ms step_avg:46.98ms
+step:1044/1490 train_time:49087ms step_avg:47.02ms
+step:1045/1490 train_time:49167ms step_avg:47.05ms
+step:1046/1490 train_time:49252ms step_avg:47.09ms
+step:1047/1490 train_time:49333ms step_avg:47.12ms
+step:1048/1490 train_time:49420ms step_avg:47.16ms
+step:1049/1490 train_time:49500ms step_avg:47.19ms
+step:1050/1490 train_time:49585ms step_avg:47.22ms
+step:1051/1490 train_time:49665ms step_avg:47.26ms
+step:1052/1490 train_time:49752ms step_avg:47.29ms
+step:1053/1490 train_time:49833ms step_avg:47.32ms
+step:1054/1490 train_time:49920ms step_avg:47.36ms
+step:1055/1490 train_time:50000ms step_avg:47.39ms
+step:1056/1490 train_time:50084ms step_avg:47.43ms
+step:1057/1490 train_time:50165ms step_avg:47.46ms
+step:1058/1490 train_time:50250ms step_avg:47.50ms
+step:1059/1490 train_time:50331ms step_avg:47.53ms
+step:1060/1490 train_time:50416ms step_avg:47.56ms
+step:1061/1490 train_time:50496ms step_avg:47.59ms
+step:1062/1490 train_time:50581ms step_avg:47.63ms
+step:1063/1490 train_time:50662ms step_avg:47.66ms
+step:1064/1490 train_time:50748ms step_avg:47.70ms
+step:1065/1490 train_time:50829ms step_avg:47.73ms
+step:1066/1490 train_time:50914ms step_avg:47.76ms
+step:1067/1490 train_time:50993ms step_avg:47.79ms
+step:1068/1490 train_time:51079ms step_avg:47.83ms
+step:1069/1490 train_time:51159ms step_avg:47.86ms
+step:1070/1490 train_time:51245ms step_avg:47.89ms
+step:1071/1490 train_time:51325ms step_avg:47.92ms
+step:1072/1490 train_time:51411ms step_avg:47.96ms
+step:1073/1490 train_time:51492ms step_avg:47.99ms
+step:1074/1490 train_time:51577ms step_avg:48.02ms
+step:1075/1490 train_time:51657ms step_avg:48.05ms
+step:1076/1490 train_time:51742ms step_avg:48.09ms
+step:1077/1490 train_time:51822ms step_avg:48.12ms
+step:1078/1490 train_time:51908ms step_avg:48.15ms
+step:1079/1490 train_time:51989ms step_avg:48.18ms
+step:1080/1490 train_time:52075ms step_avg:48.22ms
+step:1081/1490 train_time:52155ms step_avg:48.25ms
+step:1082/1490 train_time:52240ms step_avg:48.28ms
+step:1083/1490 train_time:52320ms step_avg:48.31ms
+step:1084/1490 train_time:52406ms step_avg:48.35ms
+step:1085/1490 train_time:52487ms step_avg:48.38ms
+step:1086/1490 train_time:52573ms step_avg:48.41ms
+step:1087/1490 train_time:52654ms step_avg:48.44ms
+step:1088/1490 train_time:52740ms step_avg:48.47ms
+step:1089/1490 train_time:52819ms step_avg:48.50ms
+step:1090/1490 train_time:52905ms step_avg:48.54ms
+step:1091/1490 train_time:52985ms step_avg:48.57ms
+step:1092/1490 train_time:53072ms step_avg:48.60ms
+step:1093/1490 train_time:53152ms step_avg:48.63ms
+step:1094/1490 train_time:53238ms step_avg:48.66ms
+step:1095/1490 train_time:53319ms step_avg:48.69ms
+step:1096/1490 train_time:53403ms step_avg:48.73ms
+step:1097/1490 train_time:53482ms step_avg:48.75ms
+step:1098/1490 train_time:53568ms step_avg:48.79ms
+step:1099/1490 train_time:53649ms step_avg:48.82ms
+step:1100/1490 train_time:53734ms step_avg:48.85ms
+step:1101/1490 train_time:53816ms step_avg:48.88ms
+step:1102/1490 train_time:53902ms step_avg:48.91ms
+step:1103/1490 train_time:53982ms step_avg:48.94ms
+step:1104/1490 train_time:54068ms step_avg:48.97ms
+step:1105/1490 train_time:54149ms step_avg:49.00ms
+step:1106/1490 train_time:54234ms step_avg:49.04ms
+step:1107/1490 train_time:54315ms step_avg:49.07ms
+step:1108/1490 train_time:54401ms step_avg:49.10ms
+step:1109/1490 train_time:54481ms step_avg:49.13ms
+step:1110/1490 train_time:54566ms step_avg:49.16ms
+step:1111/1490 train_time:54647ms step_avg:49.19ms
+step:1112/1490 train_time:54733ms step_avg:49.22ms
+step:1113/1490 train_time:54814ms step_avg:49.25ms
+step:1114/1490 train_time:54900ms step_avg:49.28ms
+step:1115/1490 train_time:54979ms step_avg:49.31ms
+step:1116/1490 train_time:55065ms step_avg:49.34ms
+step:1117/1490 train_time:55145ms step_avg:49.37ms
+step:1118/1490 train_time:55230ms step_avg:49.40ms
+step:1119/1490 train_time:55311ms step_avg:49.43ms
+step:1120/1490 train_time:55397ms step_avg:49.46ms
+step:1121/1490 train_time:55479ms step_avg:49.49ms
+step:1122/1490 train_time:55564ms step_avg:49.52ms
+step:1123/1490 train_time:55644ms step_avg:49.55ms
+step:1124/1490 train_time:55729ms step_avg:49.58ms
+step:1125/1490 train_time:55809ms step_avg:49.61ms
+step:1126/1490 train_time:55895ms step_avg:49.64ms
+step:1127/1490 train_time:55973ms step_avg:49.67ms
+step:1128/1490 train_time:56059ms step_avg:49.70ms
+step:1129/1490 train_time:56139ms step_avg:49.72ms
+step:1130/1490 train_time:56224ms step_avg:49.76ms
+step:1131/1490 train_time:56304ms step_avg:49.78ms
+step:1132/1490 train_time:56390ms step_avg:49.81ms
+step:1133/1490 train_time:56470ms step_avg:49.84ms
+step:1134/1490 train_time:56556ms step_avg:49.87ms
+step:1135/1490 train_time:56637ms step_avg:49.90ms
+step:1136/1490 train_time:56723ms step_avg:49.93ms
+step:1137/1490 train_time:56803ms step_avg:49.96ms
+step:1138/1490 train_time:56888ms step_avg:49.99ms
+step:1139/1490 train_time:56969ms step_avg:50.02ms
+step:1140/1490 train_time:57056ms step_avg:50.05ms
+step:1141/1490 train_time:57137ms step_avg:50.08ms
+step:1142/1490 train_time:57223ms step_avg:50.11ms
+step:1143/1490 train_time:57303ms step_avg:50.13ms
+step:1144/1490 train_time:57387ms step_avg:50.16ms
+step:1145/1490 train_time:57468ms step_avg:50.19ms
+step:1146/1490 train_time:57554ms step_avg:50.22ms
+step:1147/1490 train_time:57635ms step_avg:50.25ms
+step:1148/1490 train_time:57721ms step_avg:50.28ms
+step:1149/1490 train_time:57801ms step_avg:50.31ms
+step:1150/1490 train_time:57886ms step_avg:50.34ms
+step:1151/1490 train_time:57967ms step_avg:50.36ms
+step:1152/1490 train_time:58053ms step_avg:50.39ms
+step:1153/1490 train_time:58134ms step_avg:50.42ms
+step:1154/1490 train_time:58220ms step_avg:50.45ms
+step:1155/1490 train_time:58300ms step_avg:50.48ms
+step:1156/1490 train_time:58385ms step_avg:50.51ms
+step:1157/1490 train_time:58466ms step_avg:50.53ms
+step:1158/1490 train_time:58553ms step_avg:50.56ms
+step:1159/1490 train_time:58633ms step_avg:50.59ms
+step:1160/1490 train_time:58720ms step_avg:50.62ms
+step:1161/1490 train_time:58799ms step_avg:50.65ms
+step:1162/1490 train_time:58884ms step_avg:50.67ms
+step:1163/1490 train_time:58963ms step_avg:50.70ms
+step:1164/1490 train_time:59048ms step_avg:50.73ms
+step:1165/1490 train_time:59130ms step_avg:50.76ms
+step:1166/1490 train_time:59217ms step_avg:50.79ms
+step:1167/1490 train_time:59296ms step_avg:50.81ms
+step:1168/1490 train_time:59381ms step_avg:50.84ms
+step:1169/1490 train_time:59461ms step_avg:50.86ms
+step:1170/1490 train_time:59546ms step_avg:50.89ms
+step:1171/1490 train_time:59627ms step_avg:50.92ms
+step:1172/1490 train_time:59712ms step_avg:50.95ms
+step:1173/1490 train_time:59792ms step_avg:50.97ms
+step:1174/1490 train_time:59877ms step_avg:51.00ms
+step:1175/1490 train_time:59958ms step_avg:51.03ms
+step:1176/1490 train_time:60042ms step_avg:51.06ms
+step:1177/1490 train_time:60122ms step_avg:51.08ms
+step:1178/1490 train_time:60209ms step_avg:51.11ms
+step:1179/1490 train_time:60290ms step_avg:51.14ms
+step:1180/1490 train_time:60378ms step_avg:51.17ms
+step:1181/1490 train_time:60457ms step_avg:51.19ms
+step:1182/1490 train_time:60542ms step_avg:51.22ms
+step:1183/1490 train_time:60621ms step_avg:51.24ms
+step:1184/1490 train_time:60707ms step_avg:51.27ms
+step:1185/1490 train_time:60788ms step_avg:51.30ms
+step:1186/1490 train_time:60874ms step_avg:51.33ms
+step:1187/1490 train_time:60955ms step_avg:51.35ms
+step:1188/1490 train_time:61042ms step_avg:51.38ms
+step:1189/1490 train_time:61121ms step_avg:51.41ms
+step:1190/1490 train_time:61207ms step_avg:51.43ms
+step:1191/1490 train_time:61288ms step_avg:51.46ms
+step:1192/1490 train_time:61375ms step_avg:51.49ms
+step:1193/1490 train_time:61454ms step_avg:51.51ms
+step:1194/1490 train_time:61540ms step_avg:51.54ms
+step:1195/1490 train_time:61620ms step_avg:51.57ms
+step:1196/1490 train_time:61706ms step_avg:51.59ms
+step:1197/1490 train_time:61786ms step_avg:51.62ms
+step:1198/1490 train_time:61873ms step_avg:51.65ms
+step:1199/1490 train_time:61953ms step_avg:51.67ms
+step:1200/1490 train_time:62039ms step_avg:51.70ms
+step:1201/1490 train_time:62120ms step_avg:51.72ms
+step:1202/1490 train_time:62204ms step_avg:51.75ms
+step:1203/1490 train_time:62284ms step_avg:51.77ms
+step:1204/1490 train_time:62370ms step_avg:51.80ms
+step:1205/1490 train_time:62451ms step_avg:51.83ms
+step:1206/1490 train_time:62536ms step_avg:51.85ms
+step:1207/1490 train_time:62616ms step_avg:51.88ms
+step:1208/1490 train_time:62700ms step_avg:51.90ms
+step:1209/1490 train_time:62780ms step_avg:51.93ms
+step:1210/1490 train_time:62868ms step_avg:51.96ms
+step:1211/1490 train_time:62949ms step_avg:51.98ms
+step:1212/1490 train_time:63035ms step_avg:52.01ms
+step:1213/1490 train_time:63115ms step_avg:52.03ms
+step:1214/1490 train_time:63200ms step_avg:52.06ms
+step:1215/1490 train_time:63279ms step_avg:52.08ms
+step:1216/1490 train_time:63365ms step_avg:52.11ms
+step:1217/1490 train_time:63445ms step_avg:52.13ms
+step:1218/1490 train_time:63531ms step_avg:52.16ms
+step:1219/1490 train_time:63612ms step_avg:52.18ms
+step:1220/1490 train_time:63697ms step_avg:52.21ms
+step:1221/1490 train_time:63776ms step_avg:52.23ms
+step:1222/1490 train_time:63862ms step_avg:52.26ms
+step:1223/1490 train_time:63942ms step_avg:52.28ms
+step:1224/1490 train_time:64029ms step_avg:52.31ms
+step:1225/1490 train_time:64112ms step_avg:52.34ms
+step:1226/1490 train_time:64196ms step_avg:52.36ms
+step:1227/1490 train_time:64275ms step_avg:52.38ms
+step:1228/1490 train_time:64362ms step_avg:52.41ms
+step:1229/1490 train_time:64441ms step_avg:52.43ms
+step:1230/1490 train_time:64527ms step_avg:52.46ms
+step:1231/1490 train_time:64608ms step_avg:52.48ms
+step:1232/1490 train_time:64694ms step_avg:52.51ms
+step:1233/1490 train_time:64774ms step_avg:52.53ms
+step:1234/1490 train_time:64859ms step_avg:52.56ms
+step:1235/1490 train_time:64939ms step_avg:52.58ms
+step:1236/1490 train_time:65024ms step_avg:52.61ms
+step:1237/1490 train_time:65104ms step_avg:52.63ms
+step:1238/1490 train_time:65191ms step_avg:52.66ms
+step:1239/1490 train_time:65273ms step_avg:52.68ms
+step:1240/1490 train_time:65360ms step_avg:52.71ms
+step:1241/1490 train_time:65439ms step_avg:52.73ms
+step:1242/1490 train_time:65524ms step_avg:52.76ms
+step:1243/1490 train_time:65603ms step_avg:52.78ms
+step:1244/1490 train_time:65689ms step_avg:52.80ms
+step:1245/1490 train_time:65770ms step_avg:52.83ms
+step:1246/1490 train_time:65856ms step_avg:52.85ms
+step:1247/1490 train_time:65936ms step_avg:52.88ms
+step:1248/1490 train_time:66022ms step_avg:52.90ms
+step:1249/1490 train_time:66102ms step_avg:52.92ms
+step:1250/1490 train_time:66188ms step_avg:52.95ms
+step:1250/1490 val_loss:3.3696 train_time:66291ms step_avg:53.03ms
+step:1251/1490 train_time:66307ms step_avg:53.00ms
+step:1252/1490 train_time:66358ms step_avg:53.00ms
+step:1253/1490 train_time:66441ms step_avg:53.03ms
+step:1254/1490 train_time:66531ms step_avg:53.06ms
+step:1255/1490 train_time:66610ms step_avg:53.08ms
+step:1256/1490 train_time:66694ms step_avg:53.10ms
+step:1257/1490 train_time:66773ms step_avg:53.12ms
+step:1258/1490 train_time:66857ms step_avg:53.15ms
+step:1259/1490 train_time:66937ms step_avg:53.17ms
+step:1260/1490 train_time:67020ms step_avg:53.19ms
+step:1261/1490 train_time:67099ms step_avg:53.21ms
+step:1262/1490 train_time:67186ms step_avg:53.24ms
+step:1263/1490 train_time:67266ms step_avg:53.26ms
+step:1264/1490 train_time:67353ms step_avg:53.29ms
+step:1265/1490 train_time:67436ms step_avg:53.31ms
+step:1266/1490 train_time:67524ms step_avg:53.34ms
+step:1267/1490 train_time:67604ms step_avg:53.36ms
+step:1268/1490 train_time:67690ms step_avg:53.38ms
+step:1269/1490 train_time:67769ms step_avg:53.40ms
+step:1270/1490 train_time:67852ms step_avg:53.43ms
+step:1271/1490 train_time:67931ms step_avg:53.45ms
+step:1272/1490 train_time:68015ms step_avg:53.47ms
+step:1273/1490 train_time:68095ms step_avg:53.49ms
+step:1274/1490 train_time:68180ms step_avg:53.52ms
+step:1275/1490 train_time:68261ms step_avg:53.54ms
+step:1276/1490 train_time:68349ms step_avg:53.57ms
+step:1277/1490 train_time:68432ms step_avg:53.59ms
+step:1278/1490 train_time:68517ms step_avg:53.61ms
+step:1279/1490 train_time:68599ms step_avg:53.63ms
+step:1280/1490 train_time:68685ms step_avg:53.66ms
+step:1281/1490 train_time:68764ms step_avg:53.68ms
+step:1282/1490 train_time:68850ms step_avg:53.71ms
+step:1283/1490 train_time:68932ms step_avg:53.73ms
+step:1284/1490 train_time:69015ms step_avg:53.75ms
+step:1285/1490 train_time:69094ms step_avg:53.77ms
+step:1286/1490 train_time:69180ms step_avg:53.79ms
+step:1287/1490 train_time:69262ms step_avg:53.82ms
+step:1288/1490 train_time:69348ms step_avg:53.84ms
+step:1289/1490 train_time:69429ms step_avg:53.86ms
+step:1290/1490 train_time:69514ms step_avg:53.89ms
+step:1291/1490 train_time:69595ms step_avg:53.91ms
+step:1292/1490 train_time:69681ms step_avg:53.93ms
+step:1293/1490 train_time:69762ms step_avg:53.95ms
+step:1294/1490 train_time:69847ms step_avg:53.98ms
+step:1295/1490 train_time:69927ms step_avg:54.00ms
+step:1296/1490 train_time:70012ms step_avg:54.02ms
+step:1297/1490 train_time:70092ms step_avg:54.04ms
+step:1298/1490 train_time:70176ms step_avg:54.07ms
+step:1299/1490 train_time:70256ms step_avg:54.08ms
+step:1300/1490 train_time:70343ms step_avg:54.11ms
+step:1301/1490 train_time:70425ms step_avg:54.13ms
+step:1302/1490 train_time:70511ms step_avg:54.16ms
+step:1303/1490 train_time:70591ms step_avg:54.18ms
+step:1304/1490 train_time:70676ms step_avg:54.20ms
+step:1305/1490 train_time:70757ms step_avg:54.22ms
+step:1306/1490 train_time:70842ms step_avg:54.24ms
+step:1307/1490 train_time:70923ms step_avg:54.26ms
+step:1308/1490 train_time:71007ms step_avg:54.29ms
+step:1309/1490 train_time:71086ms step_avg:54.31ms
+step:1310/1490 train_time:71170ms step_avg:54.33ms
+step:1311/1490 train_time:71250ms step_avg:54.35ms
+step:1312/1490 train_time:71337ms step_avg:54.37ms
+step:1313/1490 train_time:71417ms step_avg:54.39ms
+step:1314/1490 train_time:71504ms step_avg:54.42ms
+step:1315/1490 train_time:71584ms step_avg:54.44ms
+step:1316/1490 train_time:71671ms step_avg:54.46ms
+step:1317/1490 train_time:71753ms step_avg:54.48ms
+step:1318/1490 train_time:71838ms step_avg:54.51ms
+step:1319/1490 train_time:71919ms step_avg:54.53ms
+step:1320/1490 train_time:72004ms step_avg:54.55ms
+step:1321/1490 train_time:72083ms step_avg:54.57ms
+step:1322/1490 train_time:72169ms step_avg:54.59ms
+step:1323/1490 train_time:72249ms step_avg:54.61ms
+step:1324/1490 train_time:72335ms step_avg:54.63ms
+step:1325/1490 train_time:72413ms step_avg:54.65ms
+step:1326/1490 train_time:72499ms step_avg:54.67ms
+step:1327/1490 train_time:72581ms step_avg:54.70ms
+step:1328/1490 train_time:72667ms step_avg:54.72ms
+step:1329/1490 train_time:72747ms step_avg:54.74ms
+step:1330/1490 train_time:72833ms step_avg:54.76ms
+step:1331/1490 train_time:72912ms step_avg:54.78ms
+step:1332/1490 train_time:72997ms step_avg:54.80ms
+step:1333/1490 train_time:73078ms step_avg:54.82ms
+step:1334/1490 train_time:73163ms step_avg:54.84ms
+step:1335/1490 train_time:73243ms step_avg:54.86ms
+step:1336/1490 train_time:73331ms step_avg:54.89ms
+step:1337/1490 train_time:73411ms step_avg:54.91ms
+step:1338/1490 train_time:73496ms step_avg:54.93ms
+step:1339/1490 train_time:73579ms step_avg:54.95ms
+step:1340/1490 train_time:73665ms step_avg:54.97ms
+step:1341/1490 train_time:73747ms step_avg:54.99ms
+step:1342/1490 train_time:73833ms step_avg:55.02ms
+step:1343/1490 train_time:73912ms step_avg:55.03ms
+step:1344/1490 train_time:73998ms step_avg:55.06ms
+step:1345/1490 train_time:74078ms step_avg:55.08ms
+step:1346/1490 train_time:74164ms step_avg:55.10ms
+step:1347/1490 train_time:74244ms step_avg:55.12ms
+step:1348/1490 train_time:74331ms step_avg:55.14ms
+step:1349/1490 train_time:74411ms step_avg:55.16ms
+step:1350/1490 train_time:74497ms step_avg:55.18ms
+step:1351/1490 train_time:74578ms step_avg:55.20ms
+step:1352/1490 train_time:74664ms step_avg:55.22ms
+step:1353/1490 train_time:74743ms step_avg:55.24ms
+step:1354/1490 train_time:74830ms step_avg:55.27ms
+step:1355/1490 train_time:74909ms step_avg:55.28ms
+step:1356/1490 train_time:74993ms step_avg:55.30ms
+step:1357/1490 train_time:75073ms step_avg:55.32ms
+step:1358/1490 train_time:75158ms step_avg:55.34ms
+step:1359/1490 train_time:75239ms step_avg:55.36ms
+step:1360/1490 train_time:75324ms step_avg:55.39ms
+step:1361/1490 train_time:75404ms step_avg:55.40ms
+step:1362/1490 train_time:75489ms step_avg:55.43ms
+step:1363/1490 train_time:75570ms step_avg:55.44ms
+step:1364/1490 train_time:75657ms step_avg:55.47ms
+step:1365/1490 train_time:75738ms step_avg:55.49ms
+step:1366/1490 train_time:75825ms step_avg:55.51ms
+step:1367/1490 train_time:75907ms step_avg:55.53ms
+step:1368/1490 train_time:75990ms step_avg:55.55ms
+step:1369/1490 train_time:76069ms step_avg:55.57ms
+step:1370/1490 train_time:76155ms step_avg:55.59ms
+step:1371/1490 train_time:76236ms step_avg:55.61ms
+step:1372/1490 train_time:76321ms step_avg:55.63ms
+step:1373/1490 train_time:76402ms step_avg:55.65ms
+step:1374/1490 train_time:76487ms step_avg:55.67ms
+step:1375/1490 train_time:76568ms step_avg:55.69ms
+step:1376/1490 train_time:76653ms step_avg:55.71ms
+step:1377/1490 train_time:76733ms step_avg:55.72ms
+step:1378/1490 train_time:76820ms step_avg:55.75ms
+step:1379/1490 train_time:76905ms step_avg:55.77ms
+step:1380/1490 train_time:76989ms step_avg:55.79ms
+step:1381/1490 train_time:77069ms step_avg:55.81ms
+step:1382/1490 train_time:77155ms step_avg:55.83ms
+step:1383/1490 train_time:77236ms step_avg:55.85ms
+step:1384/1490 train_time:77321ms step_avg:55.87ms
+step:1385/1490 train_time:77401ms step_avg:55.88ms
+step:1386/1490 train_time:77486ms step_avg:55.91ms
+step:1387/1490 train_time:77566ms step_avg:55.92ms
+step:1388/1490 train_time:77652ms step_avg:55.95ms
+step:1389/1490 train_time:77733ms step_avg:55.96ms
+step:1390/1490 train_time:77818ms step_avg:55.98ms
+step:1391/1490 train_time:77899ms step_avg:56.00ms
+step:1392/1490 train_time:77985ms step_avg:56.02ms
+step:1393/1490 train_time:78067ms step_avg:56.04ms
+step:1394/1490 train_time:78153ms step_avg:56.06ms
+step:1395/1490 train_time:78233ms step_avg:56.08ms
+step:1396/1490 train_time:78318ms step_avg:56.10ms
+step:1397/1490 train_time:78398ms step_avg:56.12ms
+step:1398/1490 train_time:78483ms step_avg:56.14ms
+step:1399/1490 train_time:78564ms step_avg:56.16ms
+step:1400/1490 train_time:78650ms step_avg:56.18ms
+step:1401/1490 train_time:78730ms step_avg:56.20ms
+step:1402/1490 train_time:78816ms step_avg:56.22ms
+step:1403/1490 train_time:78896ms step_avg:56.23ms
+step:1404/1490 train_time:78984ms step_avg:56.26ms
+step:1405/1490 train_time:79064ms step_avg:56.27ms
+step:1406/1490 train_time:79151ms step_avg:56.29ms
+step:1407/1490 train_time:79232ms step_avg:56.31ms
+step:1408/1490 train_time:79316ms step_avg:56.33ms
+step:1409/1490 train_time:79396ms step_avg:56.35ms
+step:1410/1490 train_time:79483ms step_avg:56.37ms
+step:1411/1490 train_time:79564ms step_avg:56.39ms
+step:1412/1490 train_time:79650ms step_avg:56.41ms
+step:1413/1490 train_time:79732ms step_avg:56.43ms
+step:1414/1490 train_time:79816ms step_avg:56.45ms
+step:1415/1490 train_time:79897ms step_avg:56.46ms
+step:1416/1490 train_time:79984ms step_avg:56.49ms
+step:1417/1490 train_time:80064ms step_avg:56.50ms
+step:1418/1490 train_time:80150ms step_avg:56.52ms
+step:1419/1490 train_time:80231ms step_avg:56.54ms
+step:1420/1490 train_time:80315ms step_avg:56.56ms
+step:1421/1490 train_time:80394ms step_avg:56.58ms
+step:1422/1490 train_time:80480ms step_avg:56.60ms
+step:1423/1490 train_time:80562ms step_avg:56.61ms
+step:1424/1490 train_time:80648ms step_avg:56.63ms
+step:1425/1490 train_time:80728ms step_avg:56.65ms
+step:1426/1490 train_time:80813ms step_avg:56.67ms
+step:1427/1490 train_time:80893ms step_avg:56.69ms
+step:1428/1490 train_time:80980ms step_avg:56.71ms
+step:1429/1490 train_time:81062ms step_avg:56.73ms
+step:1430/1490 train_time:81148ms step_avg:56.75ms
+step:1431/1490 train_time:81229ms step_avg:56.76ms
+step:1432/1490 train_time:81315ms step_avg:56.78ms
+step:1433/1490 train_time:81393ms step_avg:56.80ms
+step:1434/1490 train_time:81479ms step_avg:56.82ms
+step:1435/1490 train_time:81559ms step_avg:56.84ms
+step:1436/1490 train_time:81645ms step_avg:56.86ms
+step:1437/1490 train_time:81725ms step_avg:56.87ms
+step:1438/1490 train_time:81809ms step_avg:56.89ms
+step:1439/1490 train_time:81889ms step_avg:56.91ms
+step:1440/1490 train_time:81975ms step_avg:56.93ms
+step:1441/1490 train_time:82056ms step_avg:56.94ms
+step:1442/1490 train_time:82142ms step_avg:56.96ms
+step:1443/1490 train_time:82223ms step_avg:56.98ms
+step:1444/1490 train_time:82309ms step_avg:57.00ms
+step:1445/1490 train_time:82388ms step_avg:57.02ms
+step:1446/1490 train_time:82473ms step_avg:57.04ms
+step:1447/1490 train_time:82554ms step_avg:57.05ms
+step:1448/1490 train_time:82640ms step_avg:57.07ms
+step:1449/1490 train_time:82720ms step_avg:57.09ms
+step:1450/1490 train_time:82805ms step_avg:57.11ms
+step:1451/1490 train_time:82889ms step_avg:57.13ms
+step:1452/1490 train_time:82976ms step_avg:57.15ms
+step:1453/1490 train_time:83056ms step_avg:57.16ms
+step:1454/1490 train_time:83144ms step_avg:57.18ms
+step:1455/1490 train_time:83224ms step_avg:57.20ms
+step:1456/1490 train_time:83309ms step_avg:57.22ms
+step:1457/1490 train_time:83390ms step_avg:57.23ms
+step:1458/1490 train_time:83475ms step_avg:57.25ms
+step:1459/1490 train_time:83554ms step_avg:57.27ms
+step:1460/1490 train_time:83640ms step_avg:57.29ms
+step:1461/1490 train_time:83721ms step_avg:57.30ms
+step:1462/1490 train_time:83807ms step_avg:57.32ms
+step:1463/1490 train_time:83888ms step_avg:57.34ms
+step:1464/1490 train_time:83975ms step_avg:57.36ms
+step:1465/1490 train_time:84056ms step_avg:57.38ms
+step:1466/1490 train_time:84142ms step_avg:57.40ms
+step:1467/1490 train_time:84222ms step_avg:57.41ms
+step:1468/1490 train_time:84309ms step_avg:57.43ms
+step:1469/1490 train_time:84388ms step_avg:57.45ms
+step:1470/1490 train_time:84474ms step_avg:57.47ms
+step:1471/1490 train_time:84553ms step_avg:57.48ms
+step:1472/1490 train_time:84639ms step_avg:57.50ms
+step:1473/1490 train_time:84720ms step_avg:57.52ms
+step:1474/1490 train_time:84806ms step_avg:57.53ms
+step:1475/1490 train_time:84888ms step_avg:57.55ms
+step:1476/1490 train_time:84973ms step_avg:57.57ms
+step:1477/1490 train_time:85053ms step_avg:57.58ms
+step:1478/1490 train_time:85138ms step_avg:57.60ms
+step:1479/1490 train_time:85220ms step_avg:57.62ms
+step:1480/1490 train_time:85305ms step_avg:57.64ms
+step:1481/1490 train_time:85387ms step_avg:57.65ms
+step:1482/1490 train_time:85472ms step_avg:57.67ms
+step:1483/1490 train_time:85552ms step_avg:57.69ms
+step:1484/1490 train_time:85638ms step_avg:57.71ms
+step:1485/1490 train_time:85719ms step_avg:57.72ms
+step:1486/1490 train_time:85805ms step_avg:57.74ms
+step:1487/1490 train_time:85886ms step_avg:57.76ms
+step:1488/1490 train_time:85974ms step_avg:57.78ms
+step:1489/1490 train_time:86054ms step_avg:57.79ms
+step:1490/1490 train_time:86140ms step_avg:57.81ms
+step:1490/1490 val_loss:3.2766 train_time:86244ms step_avg:57.88ms
+peak memory allocated: 31296 MiB reserved: 47042 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/max_num_docs/2026-03-22_18-13-43_time-275_secs_00-cu-seqlens_d75fa0.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/max_num_docs/2026-03-22_18-13-43_time-275_secs_00-cu-seqlens_d75fa0.txt
@@ -1,0 +1,4457 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 18:13:58 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   40C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   34C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   32C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   38C    P0            130W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   39C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   33C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   38C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   30C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1345126      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1345127      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1345128      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1345129      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1345130      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1345131      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1345132      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1345133      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8294 train_time:0ms step_avg:0.04ms
+step:1/1490 train_time:84ms step_avg:84.20ms
+step:2/1490 train_time:109ms step_avg:54.52ms
+step:3/1490 train_time:125ms step_avg:41.80ms
+step:4/1490 train_time:150ms step_avg:37.52ms
+step:5/1490 train_time:177ms step_avg:35.42ms
+step:6/1490 train_time:212ms step_avg:35.29ms
+step:7/1490 train_time:239ms step_avg:34.12ms
+step:8/1490 train_time:273ms step_avg:34.17ms
+step:9/1490 train_time:301ms step_avg:33.49ms
+step:10/1490 train_time:336ms step_avg:33.59ms
+step:11/1490 train_time:364ms step_avg:33.06ms
+step:12/1490 train_time:398ms step_avg:33.15ms
+step:13/1490 train_time:426ms step_avg:32.77ms
+step:14/1490 train_time:460ms step_avg:32.87ms
+step:15/1490 train_time:488ms step_avg:32.55ms
+step:16/1490 train_time:523ms step_avg:32.66ms
+step:17/1490 train_time:551ms step_avg:32.38ms
+step:18/1490 train_time:585ms step_avg:32.48ms
+step:19/1490 train_time:613ms step_avg:32.25ms
+step:20/1490 train_time:647ms step_avg:32.34ms
+step:21/1490 train_time:675ms step_avg:32.15ms
+step:22/1490 train_time:710ms step_avg:32.26ms
+step:23/1490 train_time:737ms step_avg:32.06ms
+step:24/1490 train_time:772ms step_avg:32.15ms
+step:25/1490 train_time:800ms step_avg:32.00ms
+step:26/1490 train_time:834ms step_avg:32.08ms
+step:27/1490 train_time:862ms step_avg:31.93ms
+step:28/1490 train_time:896ms step_avg:32.01ms
+step:29/1490 train_time:924ms step_avg:31.87ms
+step:30/1490 train_time:958ms step_avg:31.94ms
+step:31/1490 train_time:987ms step_avg:31.84ms
+step:32/1490 train_time:1022ms step_avg:31.95ms
+step:33/1490 train_time:1051ms step_avg:31.85ms
+step:34/1490 train_time:1086ms step_avg:31.95ms
+step:35/1490 train_time:1115ms step_avg:31.85ms
+step:36/1490 train_time:1150ms step_avg:31.95ms
+step:37/1490 train_time:1179ms step_avg:31.86ms
+step:38/1490 train_time:1213ms step_avg:31.93ms
+step:39/1490 train_time:1242ms step_avg:31.84ms
+step:40/1490 train_time:1276ms step_avg:31.91ms
+step:41/1490 train_time:1305ms step_avg:31.83ms
+step:42/1490 train_time:1339ms step_avg:31.89ms
+step:43/1490 train_time:1368ms step_avg:31.80ms
+step:44/1490 train_time:1402ms step_avg:31.86ms
+step:45/1490 train_time:1430ms step_avg:31.77ms
+step:46/1490 train_time:1464ms step_avg:31.83ms
+step:47/1490 train_time:1492ms step_avg:31.75ms
+step:48/1490 train_time:1527ms step_avg:31.81ms
+step:49/1490 train_time:1555ms step_avg:31.73ms
+step:50/1490 train_time:1589ms step_avg:31.78ms
+step:51/1490 train_time:1617ms step_avg:31.72ms
+step:52/1490 train_time:1652ms step_avg:31.77ms
+step:53/1490 train_time:1680ms step_avg:31.70ms
+step:54/1490 train_time:1714ms step_avg:31.74ms
+step:55/1490 train_time:1742ms step_avg:31.68ms
+step:56/1490 train_time:1776ms step_avg:31.72ms
+step:57/1490 train_time:1805ms step_avg:31.66ms
+step:58/1490 train_time:1839ms step_avg:31.70ms
+step:59/1490 train_time:1867ms step_avg:31.64ms
+step:60/1490 train_time:1901ms step_avg:31.68ms
+step:61/1490 train_time:1929ms step_avg:31.62ms
+step:62/1490 train_time:1964ms step_avg:31.67ms
+step:63/1490 train_time:1992ms step_avg:31.62ms
+step:64/1490 train_time:2027ms step_avg:31.67ms
+step:65/1490 train_time:2055ms step_avg:31.61ms
+step:66/1490 train_time:2090ms step_avg:31.66ms
+step:67/1490 train_time:2118ms step_avg:31.61ms
+step:68/1490 train_time:2152ms step_avg:31.65ms
+step:69/1490 train_time:2181ms step_avg:31.61ms
+step:70/1490 train_time:2215ms step_avg:31.65ms
+step:71/1490 train_time:2244ms step_avg:31.60ms
+step:72/1490 train_time:2278ms step_avg:31.64ms
+step:73/1490 train_time:2307ms step_avg:31.60ms
+step:74/1490 train_time:2341ms step_avg:31.64ms
+step:75/1490 train_time:2370ms step_avg:31.59ms
+step:76/1490 train_time:2404ms step_avg:31.64ms
+step:77/1490 train_time:2432ms step_avg:31.59ms
+step:78/1490 train_time:2467ms step_avg:31.62ms
+step:79/1490 train_time:2495ms step_avg:31.58ms
+step:80/1490 train_time:2529ms step_avg:31.61ms
+step:81/1490 train_time:2557ms step_avg:31.56ms
+step:82/1490 train_time:2591ms step_avg:31.60ms
+step:83/1490 train_time:2620ms step_avg:31.56ms
+step:84/1490 train_time:2654ms step_avg:31.59ms
+step:85/1490 train_time:2682ms step_avg:31.56ms
+step:86/1490 train_time:2717ms step_avg:31.59ms
+step:87/1490 train_time:2745ms step_avg:31.56ms
+step:88/1490 train_time:2779ms step_avg:31.58ms
+step:89/1490 train_time:2807ms step_avg:31.54ms
+step:90/1490 train_time:2841ms step_avg:31.57ms
+step:91/1490 train_time:2870ms step_avg:31.54ms
+step:92/1490 train_time:2904ms step_avg:31.57ms
+step:93/1490 train_time:2933ms step_avg:31.54ms
+step:94/1490 train_time:2967ms step_avg:31.57ms
+step:95/1490 train_time:2995ms step_avg:31.53ms
+step:96/1490 train_time:3030ms step_avg:31.56ms
+step:97/1490 train_time:3059ms step_avg:31.54ms
+step:98/1490 train_time:3093ms step_avg:31.57ms
+step:99/1490 train_time:3122ms step_avg:31.54ms
+step:100/1490 train_time:3156ms step_avg:31.56ms
+step:101/1490 train_time:3185ms step_avg:31.53ms
+step:102/1490 train_time:3219ms step_avg:31.56ms
+step:103/1490 train_time:3248ms step_avg:31.53ms
+step:104/1490 train_time:3283ms step_avg:31.56ms
+step:105/1490 train_time:3311ms step_avg:31.53ms
+step:106/1490 train_time:3346ms step_avg:31.56ms
+step:107/1490 train_time:3374ms step_avg:31.53ms
+step:108/1490 train_time:3409ms step_avg:31.56ms
+step:109/1490 train_time:3437ms step_avg:31.53ms
+step:110/1490 train_time:3471ms step_avg:31.56ms
+step:111/1490 train_time:3500ms step_avg:31.53ms
+step:112/1490 train_time:3534ms step_avg:31.55ms
+step:113/1490 train_time:3562ms step_avg:31.52ms
+step:114/1490 train_time:3596ms step_avg:31.55ms
+step:115/1490 train_time:3624ms step_avg:31.52ms
+step:116/1490 train_time:3659ms step_avg:31.54ms
+step:117/1490 train_time:3687ms step_avg:31.51ms
+step:118/1490 train_time:3722ms step_avg:31.54ms
+step:119/1490 train_time:3750ms step_avg:31.51ms
+step:120/1490 train_time:3784ms step_avg:31.53ms
+step:121/1490 train_time:3812ms step_avg:31.50ms
+step:122/1490 train_time:3846ms step_avg:31.52ms
+step:123/1490 train_time:3874ms step_avg:31.50ms
+step:124/1490 train_time:3909ms step_avg:31.52ms
+step:125/1490 train_time:3936ms step_avg:31.49ms
+step:126/1490 train_time:3971ms step_avg:31.52ms
+step:127/1490 train_time:3999ms step_avg:31.49ms
+step:128/1490 train_time:4034ms step_avg:31.52ms
+step:129/1490 train_time:4062ms step_avg:31.49ms
+step:130/1490 train_time:4097ms step_avg:31.51ms
+step:131/1490 train_time:4125ms step_avg:31.49ms
+step:132/1490 train_time:4159ms step_avg:31.51ms
+step:133/1490 train_time:4187ms step_avg:31.48ms
+step:134/1490 train_time:4222ms step_avg:31.51ms
+step:135/1490 train_time:4250ms step_avg:31.48ms
+step:136/1490 train_time:4285ms step_avg:31.51ms
+step:137/1490 train_time:4313ms step_avg:31.48ms
+step:138/1490 train_time:4348ms step_avg:31.50ms
+step:139/1490 train_time:4376ms step_avg:31.48ms
+step:140/1490 train_time:4411ms step_avg:31.51ms
+step:141/1490 train_time:4439ms step_avg:31.48ms
+step:142/1490 train_time:4474ms step_avg:31.50ms
+step:143/1490 train_time:4502ms step_avg:31.48ms
+step:144/1490 train_time:4536ms step_avg:31.50ms
+step:145/1490 train_time:4565ms step_avg:31.48ms
+step:146/1490 train_time:4599ms step_avg:31.50ms
+step:147/1490 train_time:4627ms step_avg:31.47ms
+step:148/1490 train_time:4661ms step_avg:31.49ms
+step:149/1490 train_time:4689ms step_avg:31.47ms
+step:150/1490 train_time:4723ms step_avg:31.49ms
+step:151/1490 train_time:4751ms step_avg:31.47ms
+step:152/1490 train_time:4786ms step_avg:31.49ms
+step:153/1490 train_time:4814ms step_avg:31.46ms
+step:154/1490 train_time:4848ms step_avg:31.48ms
+step:155/1490 train_time:4877ms step_avg:31.46ms
+step:156/1490 train_time:4911ms step_avg:31.48ms
+step:157/1490 train_time:4939ms step_avg:31.46ms
+step:158/1490 train_time:4974ms step_avg:31.48ms
+step:159/1490 train_time:5002ms step_avg:31.46ms
+step:160/1490 train_time:5036ms step_avg:31.48ms
+step:161/1490 train_time:5065ms step_avg:31.46ms
+step:162/1490 train_time:5099ms step_avg:31.47ms
+step:163/1490 train_time:5127ms step_avg:31.46ms
+step:164/1490 train_time:5161ms step_avg:31.47ms
+step:165/1490 train_time:5190ms step_avg:31.45ms
+step:166/1490 train_time:5224ms step_avg:31.47ms
+step:167/1490 train_time:5252ms step_avg:31.45ms
+step:168/1490 train_time:5287ms step_avg:31.47ms
+step:169/1490 train_time:5315ms step_avg:31.45ms
+step:170/1490 train_time:5349ms step_avg:31.47ms
+step:171/1490 train_time:5378ms step_avg:31.45ms
+step:172/1490 train_time:5413ms step_avg:31.47ms
+step:173/1490 train_time:5441ms step_avg:31.45ms
+step:174/1490 train_time:5475ms step_avg:31.47ms
+step:175/1490 train_time:5504ms step_avg:31.45ms
+step:176/1490 train_time:5538ms step_avg:31.47ms
+step:177/1490 train_time:5566ms step_avg:31.45ms
+step:178/1490 train_time:5600ms step_avg:31.46ms
+step:179/1490 train_time:5629ms step_avg:31.44ms
+step:180/1490 train_time:5663ms step_avg:31.46ms
+step:181/1490 train_time:5691ms step_avg:31.44ms
+step:182/1490 train_time:5725ms step_avg:31.46ms
+step:183/1490 train_time:5753ms step_avg:31.44ms
+step:184/1490 train_time:5788ms step_avg:31.46ms
+step:185/1490 train_time:5816ms step_avg:31.44ms
+step:186/1490 train_time:5850ms step_avg:31.45ms
+step:187/1490 train_time:5878ms step_avg:31.44ms
+step:188/1490 train_time:5913ms step_avg:31.45ms
+step:189/1490 train_time:5941ms step_avg:31.43ms
+step:190/1490 train_time:5975ms step_avg:31.45ms
+step:191/1490 train_time:6004ms step_avg:31.43ms
+step:192/1490 train_time:6038ms step_avg:31.45ms
+step:193/1490 train_time:6066ms step_avg:31.43ms
+step:194/1490 train_time:6100ms step_avg:31.44ms
+step:195/1490 train_time:6128ms step_avg:31.43ms
+step:196/1490 train_time:6162ms step_avg:31.44ms
+step:197/1490 train_time:6190ms step_avg:31.42ms
+step:198/1490 train_time:6225ms step_avg:31.44ms
+step:199/1490 train_time:6254ms step_avg:31.43ms
+step:200/1490 train_time:6288ms step_avg:31.44ms
+step:201/1490 train_time:6316ms step_avg:31.42ms
+step:202/1490 train_time:6351ms step_avg:31.44ms
+step:203/1490 train_time:6380ms step_avg:31.43ms
+step:204/1490 train_time:6415ms step_avg:31.44ms
+step:205/1490 train_time:6443ms step_avg:31.43ms
+step:206/1490 train_time:6477ms step_avg:31.44ms
+step:207/1490 train_time:6506ms step_avg:31.43ms
+step:208/1490 train_time:6540ms step_avg:31.44ms
+step:209/1490 train_time:6568ms step_avg:31.43ms
+step:210/1490 train_time:6603ms step_avg:31.44ms
+step:211/1490 train_time:6631ms step_avg:31.43ms
+step:212/1490 train_time:6665ms step_avg:31.44ms
+step:213/1490 train_time:6693ms step_avg:31.42ms
+step:214/1490 train_time:6728ms step_avg:31.44ms
+step:215/1490 train_time:6756ms step_avg:31.42ms
+step:216/1490 train_time:6790ms step_avg:31.44ms
+step:217/1490 train_time:6818ms step_avg:31.42ms
+step:218/1490 train_time:6853ms step_avg:31.43ms
+step:219/1490 train_time:6881ms step_avg:31.42ms
+step:220/1490 train_time:6916ms step_avg:31.43ms
+step:221/1490 train_time:6944ms step_avg:31.42ms
+step:222/1490 train_time:6978ms step_avg:31.43ms
+step:223/1490 train_time:7006ms step_avg:31.42ms
+step:224/1490 train_time:7040ms step_avg:31.43ms
+step:225/1490 train_time:7069ms step_avg:31.42ms
+step:226/1490 train_time:7103ms step_avg:31.43ms
+step:227/1490 train_time:7131ms step_avg:31.41ms
+step:228/1490 train_time:7166ms step_avg:31.43ms
+step:229/1490 train_time:7194ms step_avg:31.41ms
+step:230/1490 train_time:7229ms step_avg:31.43ms
+step:231/1490 train_time:7257ms step_avg:31.41ms
+step:232/1490 train_time:7291ms step_avg:31.43ms
+step:233/1490 train_time:7319ms step_avg:31.41ms
+step:234/1490 train_time:7354ms step_avg:31.43ms
+step:235/1490 train_time:7382ms step_avg:31.41ms
+step:236/1490 train_time:7417ms step_avg:31.43ms
+step:237/1490 train_time:7445ms step_avg:31.41ms
+step:238/1490 train_time:7479ms step_avg:31.43ms
+step:239/1490 train_time:7508ms step_avg:31.41ms
+step:240/1490 train_time:7542ms step_avg:31.42ms
+step:241/1490 train_time:7570ms step_avg:31.41ms
+step:242/1490 train_time:7605ms step_avg:31.42ms
+step:243/1490 train_time:7633ms step_avg:31.41ms
+step:244/1490 train_time:7668ms step_avg:31.42ms
+step:245/1490 train_time:7696ms step_avg:31.41ms
+step:246/1490 train_time:7730ms step_avg:31.42ms
+step:247/1490 train_time:7759ms step_avg:31.41ms
+step:248/1490 train_time:7793ms step_avg:31.42ms
+step:249/1490 train_time:7821ms step_avg:31.41ms
+step:250/1490 train_time:7855ms step_avg:31.42ms
+step:250/1490 val_loss:4.4973 train_time:7898ms step_avg:31.59ms
+step:251/1490 train_time:7917ms step_avg:31.54ms
+step:252/1490 train_time:7936ms step_avg:31.49ms
+step:253/1490 train_time:7950ms step_avg:31.42ms
+step:254/1490 train_time:7986ms step_avg:31.44ms
+step:255/1490 train_time:8017ms step_avg:31.44ms
+step:256/1490 train_time:8052ms step_avg:31.45ms
+step:257/1490 train_time:8081ms step_avg:31.44ms
+step:258/1490 train_time:8116ms step_avg:31.46ms
+step:259/1490 train_time:8144ms step_avg:31.44ms
+step:260/1490 train_time:8179ms step_avg:31.46ms
+step:261/1490 train_time:8208ms step_avg:31.45ms
+step:262/1490 train_time:8242ms step_avg:31.46ms
+step:263/1490 train_time:8270ms step_avg:31.44ms
+step:264/1490 train_time:8304ms step_avg:31.46ms
+step:265/1490 train_time:8333ms step_avg:31.44ms
+step:266/1490 train_time:8367ms step_avg:31.46ms
+step:267/1490 train_time:8395ms step_avg:31.44ms
+step:268/1490 train_time:8429ms step_avg:31.45ms
+step:269/1490 train_time:8457ms step_avg:31.44ms
+step:270/1490 train_time:8490ms step_avg:31.45ms
+step:271/1490 train_time:8519ms step_avg:31.43ms
+step:272/1490 train_time:8553ms step_avg:31.44ms
+step:273/1490 train_time:8581ms step_avg:31.43ms
+step:274/1490 train_time:8615ms step_avg:31.44ms
+step:275/1490 train_time:8643ms step_avg:31.43ms
+step:276/1490 train_time:8677ms step_avg:31.44ms
+step:277/1490 train_time:8705ms step_avg:31.43ms
+step:278/1490 train_time:8739ms step_avg:31.44ms
+step:279/1490 train_time:8767ms step_avg:31.42ms
+step:280/1490 train_time:8801ms step_avg:31.43ms
+step:281/1490 train_time:8830ms step_avg:31.42ms
+step:282/1490 train_time:8864ms step_avg:31.43ms
+step:283/1490 train_time:8893ms step_avg:31.42ms
+step:284/1490 train_time:8927ms step_avg:31.43ms
+step:285/1490 train_time:8956ms step_avg:31.42ms
+step:286/1490 train_time:8990ms step_avg:31.43ms
+step:287/1490 train_time:9019ms step_avg:31.42ms
+step:288/1490 train_time:9054ms step_avg:31.44ms
+step:289/1490 train_time:9082ms step_avg:31.43ms
+step:290/1490 train_time:9117ms step_avg:31.44ms
+step:291/1490 train_time:9145ms step_avg:31.43ms
+step:292/1490 train_time:9179ms step_avg:31.44ms
+step:293/1490 train_time:9208ms step_avg:31.43ms
+step:294/1490 train_time:9243ms step_avg:31.44ms
+step:295/1490 train_time:9271ms step_avg:31.43ms
+step:296/1490 train_time:9306ms step_avg:31.44ms
+step:297/1490 train_time:9334ms step_avg:31.43ms
+step:298/1490 train_time:9369ms step_avg:31.44ms
+step:299/1490 train_time:9397ms step_avg:31.43ms
+step:300/1490 train_time:9431ms step_avg:31.44ms
+step:301/1490 train_time:9459ms step_avg:31.42ms
+step:302/1490 train_time:9493ms step_avg:31.43ms
+step:303/1490 train_time:9521ms step_avg:31.42ms
+step:304/1490 train_time:9555ms step_avg:31.43ms
+step:305/1490 train_time:9583ms step_avg:31.42ms
+step:306/1490 train_time:9617ms step_avg:31.43ms
+step:307/1490 train_time:9645ms step_avg:31.42ms
+step:308/1490 train_time:9679ms step_avg:31.43ms
+step:309/1490 train_time:9707ms step_avg:31.41ms
+step:310/1490 train_time:9741ms step_avg:31.42ms
+step:311/1490 train_time:9769ms step_avg:31.41ms
+step:312/1490 train_time:9804ms step_avg:31.42ms
+step:313/1490 train_time:9832ms step_avg:31.41ms
+step:314/1490 train_time:9867ms step_avg:31.42ms
+step:315/1490 train_time:9895ms step_avg:31.41ms
+step:316/1490 train_time:9929ms step_avg:31.42ms
+step:317/1490 train_time:9957ms step_avg:31.41ms
+step:318/1490 train_time:9992ms step_avg:31.42ms
+step:319/1490 train_time:10020ms step_avg:31.41ms
+step:320/1490 train_time:10055ms step_avg:31.42ms
+step:321/1490 train_time:10083ms step_avg:31.41ms
+step:322/1490 train_time:10117ms step_avg:31.42ms
+step:323/1490 train_time:10146ms step_avg:31.41ms
+step:324/1490 train_time:10181ms step_avg:31.42ms
+step:325/1490 train_time:10209ms step_avg:31.41ms
+step:326/1490 train_time:10245ms step_avg:31.43ms
+step:327/1490 train_time:10273ms step_avg:31.41ms
+step:328/1490 train_time:10307ms step_avg:31.42ms
+step:329/1490 train_time:10335ms step_avg:31.41ms
+step:330/1490 train_time:10370ms step_avg:31.42ms
+step:331/1490 train_time:10398ms step_avg:31.41ms
+step:332/1490 train_time:10432ms step_avg:31.42ms
+step:333/1490 train_time:10460ms step_avg:31.41ms
+step:334/1490 train_time:10495ms step_avg:31.42ms
+step:335/1490 train_time:10523ms step_avg:31.41ms
+step:336/1490 train_time:10557ms step_avg:31.42ms
+step:337/1490 train_time:10585ms step_avg:31.41ms
+step:338/1490 train_time:10619ms step_avg:31.42ms
+step:339/1490 train_time:10647ms step_avg:31.41ms
+step:340/1490 train_time:10681ms step_avg:31.42ms
+step:341/1490 train_time:10710ms step_avg:31.41ms
+step:342/1490 train_time:10744ms step_avg:31.41ms
+step:343/1490 train_time:10772ms step_avg:31.41ms
+step:344/1490 train_time:10806ms step_avg:31.41ms
+step:345/1490 train_time:10835ms step_avg:31.40ms
+step:346/1490 train_time:10869ms step_avg:31.41ms
+step:347/1490 train_time:10897ms step_avg:31.40ms
+step:348/1490 train_time:10931ms step_avg:31.41ms
+step:349/1490 train_time:10959ms step_avg:31.40ms
+step:350/1490 train_time:10993ms step_avg:31.41ms
+step:351/1490 train_time:11021ms step_avg:31.40ms
+step:352/1490 train_time:11056ms step_avg:31.41ms
+step:353/1490 train_time:11084ms step_avg:31.40ms
+step:354/1490 train_time:11119ms step_avg:31.41ms
+step:355/1490 train_time:11147ms step_avg:31.40ms
+step:356/1490 train_time:11182ms step_avg:31.41ms
+step:357/1490 train_time:11210ms step_avg:31.40ms
+step:358/1490 train_time:11245ms step_avg:31.41ms
+step:359/1490 train_time:11273ms step_avg:31.40ms
+step:360/1490 train_time:11307ms step_avg:31.41ms
+step:361/1490 train_time:11336ms step_avg:31.40ms
+step:362/1490 train_time:11370ms step_avg:31.41ms
+step:363/1490 train_time:11398ms step_avg:31.40ms
+step:364/1490 train_time:11432ms step_avg:31.41ms
+step:365/1490 train_time:11460ms step_avg:31.40ms
+step:366/1490 train_time:11494ms step_avg:31.41ms
+step:367/1490 train_time:11523ms step_avg:31.40ms
+step:368/1490 train_time:11557ms step_avg:31.41ms
+step:369/1490 train_time:11585ms step_avg:31.40ms
+step:370/1490 train_time:11620ms step_avg:31.40ms
+step:371/1490 train_time:11648ms step_avg:31.40ms
+step:372/1490 train_time:11683ms step_avg:31.40ms
+step:373/1490 train_time:11711ms step_avg:31.40ms
+step:374/1490 train_time:11746ms step_avg:31.41ms
+step:375/1490 train_time:11774ms step_avg:31.40ms
+step:376/1490 train_time:11808ms step_avg:31.41ms
+step:377/1490 train_time:11837ms step_avg:31.40ms
+step:378/1490 train_time:11871ms step_avg:31.40ms
+step:379/1490 train_time:11899ms step_avg:31.40ms
+step:380/1490 train_time:11933ms step_avg:31.40ms
+step:381/1490 train_time:11961ms step_avg:31.39ms
+step:382/1490 train_time:11996ms step_avg:31.40ms
+step:383/1490 train_time:12024ms step_avg:31.39ms
+step:384/1490 train_time:12058ms step_avg:31.40ms
+step:385/1490 train_time:12087ms step_avg:31.39ms
+step:386/1490 train_time:12122ms step_avg:31.40ms
+step:387/1490 train_time:12150ms step_avg:31.40ms
+step:388/1490 train_time:12184ms step_avg:31.40ms
+step:389/1490 train_time:12213ms step_avg:31.40ms
+step:390/1490 train_time:12247ms step_avg:31.40ms
+step:391/1490 train_time:12276ms step_avg:31.40ms
+step:392/1490 train_time:12310ms step_avg:31.40ms
+step:393/1490 train_time:12338ms step_avg:31.40ms
+step:394/1490 train_time:12373ms step_avg:31.40ms
+step:395/1490 train_time:12401ms step_avg:31.40ms
+step:396/1490 train_time:12435ms step_avg:31.40ms
+step:397/1490 train_time:12464ms step_avg:31.39ms
+step:398/1490 train_time:12498ms step_avg:31.40ms
+step:399/1490 train_time:12526ms step_avg:31.39ms
+step:400/1490 train_time:12561ms step_avg:31.40ms
+step:401/1490 train_time:12589ms step_avg:31.39ms
+step:402/1490 train_time:12623ms step_avg:31.40ms
+step:403/1490 train_time:12652ms step_avg:31.39ms
+step:404/1490 train_time:12686ms step_avg:31.40ms
+step:405/1490 train_time:12714ms step_avg:31.39ms
+step:406/1490 train_time:12749ms step_avg:31.40ms
+step:407/1490 train_time:12777ms step_avg:31.39ms
+step:408/1490 train_time:12811ms step_avg:31.40ms
+step:409/1490 train_time:12839ms step_avg:31.39ms
+step:410/1490 train_time:12873ms step_avg:31.40ms
+step:411/1490 train_time:12902ms step_avg:31.39ms
+step:412/1490 train_time:12937ms step_avg:31.40ms
+step:413/1490 train_time:12965ms step_avg:31.39ms
+step:414/1490 train_time:12999ms step_avg:31.40ms
+step:415/1490 train_time:13027ms step_avg:31.39ms
+step:416/1490 train_time:13062ms step_avg:31.40ms
+step:417/1490 train_time:13090ms step_avg:31.39ms
+step:418/1490 train_time:13124ms step_avg:31.40ms
+step:419/1490 train_time:13153ms step_avg:31.39ms
+step:420/1490 train_time:13187ms step_avg:31.40ms
+step:421/1490 train_time:13216ms step_avg:31.39ms
+step:422/1490 train_time:13250ms step_avg:31.40ms
+step:423/1490 train_time:13279ms step_avg:31.39ms
+step:424/1490 train_time:13313ms step_avg:31.40ms
+step:425/1490 train_time:13341ms step_avg:31.39ms
+step:426/1490 train_time:13376ms step_avg:31.40ms
+step:427/1490 train_time:13404ms step_avg:31.39ms
+step:428/1490 train_time:13439ms step_avg:31.40ms
+step:429/1490 train_time:13466ms step_avg:31.39ms
+step:430/1490 train_time:13501ms step_avg:31.40ms
+step:431/1490 train_time:13529ms step_avg:31.39ms
+step:432/1490 train_time:13564ms step_avg:31.40ms
+step:433/1490 train_time:13592ms step_avg:31.39ms
+step:434/1490 train_time:13626ms step_avg:31.40ms
+step:435/1490 train_time:13655ms step_avg:31.39ms
+step:436/1490 train_time:13689ms step_avg:31.40ms
+step:437/1490 train_time:13717ms step_avg:31.39ms
+step:438/1490 train_time:13751ms step_avg:31.39ms
+step:439/1490 train_time:13779ms step_avg:31.39ms
+step:440/1490 train_time:13814ms step_avg:31.39ms
+step:441/1490 train_time:13842ms step_avg:31.39ms
+step:442/1490 train_time:13877ms step_avg:31.39ms
+step:443/1490 train_time:13905ms step_avg:31.39ms
+step:444/1490 train_time:13939ms step_avg:31.39ms
+step:445/1490 train_time:13967ms step_avg:31.39ms
+step:446/1490 train_time:14001ms step_avg:31.39ms
+step:447/1490 train_time:14030ms step_avg:31.39ms
+step:448/1490 train_time:14064ms step_avg:31.39ms
+step:449/1490 train_time:14093ms step_avg:31.39ms
+step:450/1490 train_time:14127ms step_avg:31.39ms
+step:451/1490 train_time:14155ms step_avg:31.39ms
+step:452/1490 train_time:14190ms step_avg:31.39ms
+step:453/1490 train_time:14218ms step_avg:31.39ms
+step:454/1490 train_time:14252ms step_avg:31.39ms
+step:455/1490 train_time:14280ms step_avg:31.39ms
+step:456/1490 train_time:14315ms step_avg:31.39ms
+step:457/1490 train_time:14343ms step_avg:31.38ms
+step:458/1490 train_time:14378ms step_avg:31.39ms
+step:459/1490 train_time:14406ms step_avg:31.38ms
+step:460/1490 train_time:14440ms step_avg:31.39ms
+step:461/1490 train_time:14468ms step_avg:31.38ms
+step:462/1490 train_time:14503ms step_avg:31.39ms
+step:463/1490 train_time:14531ms step_avg:31.39ms
+step:464/1490 train_time:14566ms step_avg:31.39ms
+step:465/1490 train_time:14594ms step_avg:31.39ms
+step:466/1490 train_time:14628ms step_avg:31.39ms
+step:467/1490 train_time:14657ms step_avg:31.38ms
+step:468/1490 train_time:14691ms step_avg:31.39ms
+step:469/1490 train_time:14719ms step_avg:31.38ms
+step:470/1490 train_time:14753ms step_avg:31.39ms
+step:471/1490 train_time:14781ms step_avg:31.38ms
+step:472/1490 train_time:14816ms step_avg:31.39ms
+step:473/1490 train_time:14844ms step_avg:31.38ms
+step:474/1490 train_time:14879ms step_avg:31.39ms
+step:475/1490 train_time:14907ms step_avg:31.38ms
+step:476/1490 train_time:14941ms step_avg:31.39ms
+step:477/1490 train_time:14970ms step_avg:31.38ms
+step:478/1490 train_time:15004ms step_avg:31.39ms
+step:479/1490 train_time:15033ms step_avg:31.38ms
+step:480/1490 train_time:15067ms step_avg:31.39ms
+step:481/1490 train_time:15095ms step_avg:31.38ms
+step:482/1490 train_time:15130ms step_avg:31.39ms
+step:483/1490 train_time:15158ms step_avg:31.38ms
+step:484/1490 train_time:15195ms step_avg:31.39ms
+step:485/1490 train_time:15247ms step_avg:31.44ms
+step:486/1490 train_time:15305ms step_avg:31.49ms
+step:487/1490 train_time:15360ms step_avg:31.54ms
+step:488/1490 train_time:15420ms step_avg:31.60ms
+step:489/1490 train_time:15474ms step_avg:31.64ms
+step:490/1490 train_time:15533ms step_avg:31.70ms
+step:491/1490 train_time:15587ms step_avg:31.75ms
+step:492/1490 train_time:15647ms step_avg:31.80ms
+step:493/1490 train_time:15701ms step_avg:31.85ms
+step:494/1490 train_time:15760ms step_avg:31.90ms
+step:495/1490 train_time:15814ms step_avg:31.95ms
+step:496/1490 train_time:15873ms step_avg:32.00ms
+step:497/1490 train_time:15927ms step_avg:32.05ms
+step:498/1490 train_time:15987ms step_avg:32.10ms
+step:499/1490 train_time:16041ms step_avg:32.15ms
+step:500/1490 train_time:16101ms step_avg:32.20ms
+step:500/1490 val_loss:4.2357 train_time:16173ms step_avg:32.35ms
+step:501/1490 train_time:16190ms step_avg:32.32ms
+step:502/1490 train_time:16217ms step_avg:32.30ms
+step:503/1490 train_time:16276ms step_avg:32.36ms
+step:504/1490 train_time:16339ms step_avg:32.42ms
+step:505/1490 train_time:16394ms step_avg:32.46ms
+step:506/1490 train_time:16454ms step_avg:32.52ms
+step:507/1490 train_time:16508ms step_avg:32.56ms
+step:508/1490 train_time:16567ms step_avg:32.61ms
+step:509/1490 train_time:16621ms step_avg:32.65ms
+step:510/1490 train_time:16679ms step_avg:32.70ms
+step:511/1490 train_time:16733ms step_avg:32.75ms
+step:512/1490 train_time:16792ms step_avg:32.80ms
+step:513/1490 train_time:16845ms step_avg:32.84ms
+step:514/1490 train_time:16904ms step_avg:32.89ms
+step:515/1490 train_time:16957ms step_avg:32.93ms
+step:516/1490 train_time:17016ms step_avg:32.98ms
+step:517/1490 train_time:17069ms step_avg:33.02ms
+step:518/1490 train_time:17129ms step_avg:33.07ms
+step:519/1490 train_time:17184ms step_avg:33.11ms
+step:520/1490 train_time:17246ms step_avg:33.16ms
+step:521/1490 train_time:17301ms step_avg:33.21ms
+step:522/1490 train_time:17361ms step_avg:33.26ms
+step:523/1490 train_time:17417ms step_avg:33.30ms
+step:524/1490 train_time:17478ms step_avg:33.35ms
+step:525/1490 train_time:17533ms step_avg:33.40ms
+step:526/1490 train_time:17592ms step_avg:33.45ms
+step:527/1490 train_time:17646ms step_avg:33.48ms
+step:528/1490 train_time:17705ms step_avg:33.53ms
+step:529/1490 train_time:17759ms step_avg:33.57ms
+step:530/1490 train_time:17818ms step_avg:33.62ms
+step:531/1490 train_time:17871ms step_avg:33.66ms
+step:532/1490 train_time:17930ms step_avg:33.70ms
+step:533/1490 train_time:17982ms step_avg:33.74ms
+step:534/1490 train_time:18041ms step_avg:33.78ms
+step:535/1490 train_time:18095ms step_avg:33.82ms
+step:536/1490 train_time:18156ms step_avg:33.87ms
+step:537/1490 train_time:18210ms step_avg:33.91ms
+step:538/1490 train_time:18271ms step_avg:33.96ms
+step:539/1490 train_time:18326ms step_avg:34.00ms
+step:540/1490 train_time:18386ms step_avg:34.05ms
+step:541/1490 train_time:18441ms step_avg:34.09ms
+step:542/1490 train_time:18500ms step_avg:34.13ms
+step:543/1490 train_time:18553ms step_avg:34.17ms
+step:544/1490 train_time:18613ms step_avg:34.22ms
+step:545/1490 train_time:18668ms step_avg:34.25ms
+step:546/1490 train_time:18727ms step_avg:34.30ms
+step:547/1490 train_time:18781ms step_avg:34.34ms
+step:548/1490 train_time:18840ms step_avg:34.38ms
+step:549/1490 train_time:18895ms step_avg:34.42ms
+step:550/1490 train_time:18954ms step_avg:34.46ms
+step:551/1490 train_time:19008ms step_avg:34.50ms
+step:552/1490 train_time:19067ms step_avg:34.54ms
+step:553/1490 train_time:19120ms step_avg:34.58ms
+step:554/1490 train_time:19180ms step_avg:34.62ms
+step:555/1490 train_time:19235ms step_avg:34.66ms
+step:556/1490 train_time:19295ms step_avg:34.70ms
+step:557/1490 train_time:19351ms step_avg:34.74ms
+step:558/1490 train_time:19411ms step_avg:34.79ms
+step:559/1490 train_time:19465ms step_avg:34.82ms
+step:560/1490 train_time:19523ms step_avg:34.86ms
+step:561/1490 train_time:19577ms step_avg:34.90ms
+step:562/1490 train_time:19638ms step_avg:34.94ms
+step:563/1490 train_time:19692ms step_avg:34.98ms
+step:564/1490 train_time:19751ms step_avg:35.02ms
+step:565/1490 train_time:19805ms step_avg:35.05ms
+step:566/1490 train_time:19864ms step_avg:35.10ms
+step:567/1490 train_time:19918ms step_avg:35.13ms
+step:568/1490 train_time:19977ms step_avg:35.17ms
+step:569/1490 train_time:20031ms step_avg:35.20ms
+step:570/1490 train_time:20090ms step_avg:35.25ms
+step:571/1490 train_time:20144ms step_avg:35.28ms
+step:572/1490 train_time:20205ms step_avg:35.32ms
+step:573/1490 train_time:20259ms step_avg:35.36ms
+step:574/1490 train_time:20318ms step_avg:35.40ms
+step:575/1490 train_time:20373ms step_avg:35.43ms
+step:576/1490 train_time:20434ms step_avg:35.48ms
+step:577/1490 train_time:20488ms step_avg:35.51ms
+step:578/1490 train_time:20548ms step_avg:35.55ms
+step:579/1490 train_time:20602ms step_avg:35.58ms
+step:580/1490 train_time:20661ms step_avg:35.62ms
+step:581/1490 train_time:20715ms step_avg:35.65ms
+step:582/1490 train_time:20775ms step_avg:35.70ms
+step:583/1490 train_time:20829ms step_avg:35.73ms
+step:584/1490 train_time:20888ms step_avg:35.77ms
+step:585/1490 train_time:20941ms step_avg:35.80ms
+step:586/1490 train_time:21001ms step_avg:35.84ms
+step:587/1490 train_time:21054ms step_avg:35.87ms
+step:588/1490 train_time:21116ms step_avg:35.91ms
+step:589/1490 train_time:21170ms step_avg:35.94ms
+step:590/1490 train_time:21231ms step_avg:35.98ms
+step:591/1490 train_time:21285ms step_avg:36.02ms
+step:592/1490 train_time:21344ms step_avg:36.05ms
+step:593/1490 train_time:21399ms step_avg:36.09ms
+step:594/1490 train_time:21459ms step_avg:36.13ms
+step:595/1490 train_time:21512ms step_avg:36.16ms
+step:596/1490 train_time:21573ms step_avg:36.20ms
+step:597/1490 train_time:21627ms step_avg:36.23ms
+step:598/1490 train_time:21686ms step_avg:36.26ms
+step:599/1490 train_time:21741ms step_avg:36.30ms
+step:600/1490 train_time:21801ms step_avg:36.33ms
+step:601/1490 train_time:21855ms step_avg:36.36ms
+step:602/1490 train_time:21915ms step_avg:36.40ms
+step:603/1490 train_time:21968ms step_avg:36.43ms
+step:604/1490 train_time:22028ms step_avg:36.47ms
+step:605/1490 train_time:22082ms step_avg:36.50ms
+step:606/1490 train_time:22142ms step_avg:36.54ms
+step:607/1490 train_time:22197ms step_avg:36.57ms
+step:608/1490 train_time:22257ms step_avg:36.61ms
+step:609/1490 train_time:22312ms step_avg:36.64ms
+step:610/1490 train_time:22372ms step_avg:36.67ms
+step:611/1490 train_time:22426ms step_avg:36.70ms
+step:612/1490 train_time:22485ms step_avg:36.74ms
+step:613/1490 train_time:22539ms step_avg:36.77ms
+step:614/1490 train_time:22600ms step_avg:36.81ms
+step:615/1490 train_time:22653ms step_avg:36.83ms
+step:616/1490 train_time:22713ms step_avg:36.87ms
+step:617/1490 train_time:22768ms step_avg:36.90ms
+step:618/1490 train_time:22827ms step_avg:36.94ms
+step:619/1490 train_time:22881ms step_avg:36.96ms
+step:620/1490 train_time:22940ms step_avg:37.00ms
+step:621/1490 train_time:22995ms step_avg:37.03ms
+step:622/1490 train_time:23055ms step_avg:37.07ms
+step:623/1490 train_time:23110ms step_avg:37.09ms
+step:624/1490 train_time:23169ms step_avg:37.13ms
+step:625/1490 train_time:23223ms step_avg:37.16ms
+step:626/1490 train_time:23283ms step_avg:37.19ms
+step:627/1490 train_time:23337ms step_avg:37.22ms
+step:628/1490 train_time:23398ms step_avg:37.26ms
+step:629/1490 train_time:23451ms step_avg:37.28ms
+step:630/1490 train_time:23511ms step_avg:37.32ms
+step:631/1490 train_time:23565ms step_avg:37.35ms
+step:632/1490 train_time:23625ms step_avg:37.38ms
+step:633/1490 train_time:23679ms step_avg:37.41ms
+step:634/1490 train_time:23739ms step_avg:37.44ms
+step:635/1490 train_time:23794ms step_avg:37.47ms
+step:636/1490 train_time:23853ms step_avg:37.50ms
+step:637/1490 train_time:23906ms step_avg:37.53ms
+step:638/1490 train_time:23966ms step_avg:37.56ms
+step:639/1490 train_time:24020ms step_avg:37.59ms
+step:640/1490 train_time:24080ms step_avg:37.63ms
+step:641/1490 train_time:24135ms step_avg:37.65ms
+step:642/1490 train_time:24195ms step_avg:37.69ms
+step:643/1490 train_time:24249ms step_avg:37.71ms
+step:644/1490 train_time:24309ms step_avg:37.75ms
+step:645/1490 train_time:24363ms step_avg:37.77ms
+step:646/1490 train_time:24422ms step_avg:37.81ms
+step:647/1490 train_time:24477ms step_avg:37.83ms
+step:648/1490 train_time:24538ms step_avg:37.87ms
+step:649/1490 train_time:24593ms step_avg:37.89ms
+step:650/1490 train_time:24652ms step_avg:37.93ms
+step:651/1490 train_time:24706ms step_avg:37.95ms
+step:652/1490 train_time:24766ms step_avg:37.99ms
+step:653/1490 train_time:24820ms step_avg:38.01ms
+step:654/1490 train_time:24879ms step_avg:38.04ms
+step:655/1490 train_time:24933ms step_avg:38.07ms
+step:656/1490 train_time:24992ms step_avg:38.10ms
+step:657/1490 train_time:25046ms step_avg:38.12ms
+step:658/1490 train_time:25106ms step_avg:38.16ms
+step:659/1490 train_time:25160ms step_avg:38.18ms
+step:660/1490 train_time:25220ms step_avg:38.21ms
+step:661/1490 train_time:25274ms step_avg:38.24ms
+step:662/1490 train_time:25334ms step_avg:38.27ms
+step:663/1490 train_time:25387ms step_avg:38.29ms
+step:664/1490 train_time:25447ms step_avg:38.32ms
+step:665/1490 train_time:25502ms step_avg:38.35ms
+step:666/1490 train_time:25560ms step_avg:38.38ms
+step:667/1490 train_time:25614ms step_avg:38.40ms
+step:668/1490 train_time:25674ms step_avg:38.43ms
+step:669/1490 train_time:25729ms step_avg:38.46ms
+step:670/1490 train_time:25788ms step_avg:38.49ms
+step:671/1490 train_time:25842ms step_avg:38.51ms
+step:672/1490 train_time:25901ms step_avg:38.54ms
+step:673/1490 train_time:25956ms step_avg:38.57ms
+step:674/1490 train_time:26015ms step_avg:38.60ms
+step:675/1490 train_time:26070ms step_avg:38.62ms
+step:676/1490 train_time:26130ms step_avg:38.65ms
+step:677/1490 train_time:26183ms step_avg:38.67ms
+step:678/1490 train_time:26242ms step_avg:38.70ms
+step:679/1490 train_time:26296ms step_avg:38.73ms
+step:680/1490 train_time:26356ms step_avg:38.76ms
+step:681/1490 train_time:26411ms step_avg:38.78ms
+step:682/1490 train_time:26470ms step_avg:38.81ms
+step:683/1490 train_time:26524ms step_avg:38.83ms
+step:684/1490 train_time:26583ms step_avg:38.86ms
+step:685/1490 train_time:26638ms step_avg:38.89ms
+step:686/1490 train_time:26698ms step_avg:38.92ms
+step:687/1490 train_time:26752ms step_avg:38.94ms
+step:688/1490 train_time:26813ms step_avg:38.97ms
+step:689/1490 train_time:26866ms step_avg:38.99ms
+step:690/1490 train_time:26925ms step_avg:39.02ms
+step:691/1490 train_time:26980ms step_avg:39.04ms
+step:692/1490 train_time:27038ms step_avg:39.07ms
+step:693/1490 train_time:27092ms step_avg:39.09ms
+step:694/1490 train_time:27152ms step_avg:39.12ms
+step:695/1490 train_time:27206ms step_avg:39.14ms
+step:696/1490 train_time:27264ms step_avg:39.17ms
+step:697/1490 train_time:27318ms step_avg:39.19ms
+step:698/1490 train_time:27378ms step_avg:39.22ms
+step:699/1490 train_time:27434ms step_avg:39.25ms
+step:700/1490 train_time:27494ms step_avg:39.28ms
+step:701/1490 train_time:27547ms step_avg:39.30ms
+step:702/1490 train_time:27606ms step_avg:39.33ms
+step:703/1490 train_time:27661ms step_avg:39.35ms
+step:704/1490 train_time:27720ms step_avg:39.38ms
+step:705/1490 train_time:27775ms step_avg:39.40ms
+step:706/1490 train_time:27834ms step_avg:39.43ms
+step:707/1490 train_time:27888ms step_avg:39.45ms
+step:708/1490 train_time:27947ms step_avg:39.47ms
+step:709/1490 train_time:28001ms step_avg:39.49ms
+step:710/1490 train_time:28060ms step_avg:39.52ms
+step:711/1490 train_time:28115ms step_avg:39.54ms
+step:712/1490 train_time:28174ms step_avg:39.57ms
+step:713/1490 train_time:28229ms step_avg:39.59ms
+step:714/1490 train_time:28288ms step_avg:39.62ms
+step:715/1490 train_time:28342ms step_avg:39.64ms
+step:716/1490 train_time:28402ms step_avg:39.67ms
+step:717/1490 train_time:28456ms step_avg:39.69ms
+step:718/1490 train_time:28516ms step_avg:39.72ms
+step:719/1490 train_time:28570ms step_avg:39.74ms
+step:720/1490 train_time:28631ms step_avg:39.77ms
+step:721/1490 train_time:28684ms step_avg:39.78ms
+step:722/1490 train_time:28745ms step_avg:39.81ms
+step:723/1490 train_time:28800ms step_avg:39.83ms
+step:724/1490 train_time:28859ms step_avg:39.86ms
+step:725/1490 train_time:28912ms step_avg:39.88ms
+step:726/1490 train_time:28972ms step_avg:39.91ms
+step:727/1490 train_time:29027ms step_avg:39.93ms
+step:728/1490 train_time:29086ms step_avg:39.95ms
+step:729/1490 train_time:29140ms step_avg:39.97ms
+step:730/1490 train_time:29199ms step_avg:40.00ms
+step:731/1490 train_time:29253ms step_avg:40.02ms
+step:732/1490 train_time:29313ms step_avg:40.04ms
+step:733/1490 train_time:29367ms step_avg:40.06ms
+step:734/1490 train_time:29426ms step_avg:40.09ms
+step:735/1490 train_time:29480ms step_avg:40.11ms
+step:736/1490 train_time:29540ms step_avg:40.14ms
+step:737/1490 train_time:29596ms step_avg:40.16ms
+step:738/1490 train_time:29655ms step_avg:40.18ms
+step:739/1490 train_time:29709ms step_avg:40.20ms
+step:740/1490 train_time:29769ms step_avg:40.23ms
+step:741/1490 train_time:29823ms step_avg:40.25ms
+step:742/1490 train_time:29882ms step_avg:40.27ms
+step:743/1490 train_time:29936ms step_avg:40.29ms
+step:744/1490 train_time:29997ms step_avg:40.32ms
+step:745/1490 train_time:30050ms step_avg:40.34ms
+step:746/1490 train_time:30110ms step_avg:40.36ms
+step:747/1490 train_time:30164ms step_avg:40.38ms
+step:748/1490 train_time:30224ms step_avg:40.41ms
+step:749/1490 train_time:30278ms step_avg:40.42ms
+step:750/1490 train_time:30337ms step_avg:40.45ms
+step:750/1490 val_loss:3.8110 train_time:30410ms step_avg:40.55ms
+step:751/1490 train_time:30427ms step_avg:40.51ms
+step:752/1490 train_time:30453ms step_avg:40.50ms
+step:753/1490 train_time:30511ms step_avg:40.52ms
+step:754/1490 train_time:30575ms step_avg:40.55ms
+step:755/1490 train_time:30630ms step_avg:40.57ms
+step:756/1490 train_time:30690ms step_avg:40.59ms
+step:757/1490 train_time:30743ms step_avg:40.61ms
+step:758/1490 train_time:30803ms step_avg:40.64ms
+step:759/1490 train_time:30856ms step_avg:40.65ms
+step:760/1490 train_time:30917ms step_avg:40.68ms
+step:761/1490 train_time:30970ms step_avg:40.70ms
+step:762/1490 train_time:31028ms step_avg:40.72ms
+step:763/1490 train_time:31081ms step_avg:40.74ms
+step:764/1490 train_time:31140ms step_avg:40.76ms
+step:765/1490 train_time:31194ms step_avg:40.78ms
+step:766/1490 train_time:31253ms step_avg:40.80ms
+step:767/1490 train_time:31306ms step_avg:40.82ms
+step:768/1490 train_time:31366ms step_avg:40.84ms
+step:769/1490 train_time:31422ms step_avg:40.86ms
+step:770/1490 train_time:31483ms step_avg:40.89ms
+step:771/1490 train_time:31538ms step_avg:40.91ms
+step:772/1490 train_time:31600ms step_avg:40.93ms
+step:773/1490 train_time:31655ms step_avg:40.95ms
+step:774/1490 train_time:31714ms step_avg:40.97ms
+step:775/1490 train_time:31768ms step_avg:40.99ms
+step:776/1490 train_time:31827ms step_avg:41.01ms
+step:777/1490 train_time:31881ms step_avg:41.03ms
+step:778/1490 train_time:31940ms step_avg:41.05ms
+step:779/1490 train_time:31994ms step_avg:41.07ms
+step:780/1490 train_time:32052ms step_avg:41.09ms
+step:781/1490 train_time:32105ms step_avg:41.11ms
+step:782/1490 train_time:32164ms step_avg:41.13ms
+step:783/1490 train_time:32217ms step_avg:41.15ms
+step:784/1490 train_time:32277ms step_avg:41.17ms
+step:785/1490 train_time:32332ms step_avg:41.19ms
+step:786/1490 train_time:32392ms step_avg:41.21ms
+step:787/1490 train_time:32448ms step_avg:41.23ms
+step:788/1490 train_time:32508ms step_avg:41.25ms
+step:789/1490 train_time:32563ms step_avg:41.27ms
+step:790/1490 train_time:32623ms step_avg:41.30ms
+step:791/1490 train_time:32678ms step_avg:41.31ms
+step:792/1490 train_time:32738ms step_avg:41.34ms
+step:793/1490 train_time:32792ms step_avg:41.35ms
+step:794/1490 train_time:32852ms step_avg:41.38ms
+step:795/1490 train_time:32906ms step_avg:41.39ms
+step:796/1490 train_time:32965ms step_avg:41.41ms
+step:797/1490 train_time:33020ms step_avg:41.43ms
+step:798/1490 train_time:33079ms step_avg:41.45ms
+step:799/1490 train_time:33132ms step_avg:41.47ms
+step:800/1490 train_time:33191ms step_avg:41.49ms
+step:801/1490 train_time:33245ms step_avg:41.50ms
+step:802/1490 train_time:33304ms step_avg:41.53ms
+step:803/1490 train_time:33358ms step_avg:41.54ms
+step:804/1490 train_time:33419ms step_avg:41.57ms
+step:805/1490 train_time:33473ms step_avg:41.58ms
+step:806/1490 train_time:33535ms step_avg:41.61ms
+step:807/1490 train_time:33590ms step_avg:41.62ms
+step:808/1490 train_time:33650ms step_avg:41.65ms
+step:809/1490 train_time:33704ms step_avg:41.66ms
+step:810/1490 train_time:33763ms step_avg:41.68ms
+step:811/1490 train_time:33819ms step_avg:41.70ms
+step:812/1490 train_time:33878ms step_avg:41.72ms
+step:813/1490 train_time:33931ms step_avg:41.74ms
+step:814/1490 train_time:33990ms step_avg:41.76ms
+step:815/1490 train_time:34044ms step_avg:41.77ms
+step:816/1490 train_time:34103ms step_avg:41.79ms
+step:817/1490 train_time:34157ms step_avg:41.81ms
+step:818/1490 train_time:34217ms step_avg:41.83ms
+step:819/1490 train_time:34270ms step_avg:41.84ms
+step:820/1490 train_time:34330ms step_avg:41.87ms
+step:821/1490 train_time:34383ms step_avg:41.88ms
+step:822/1490 train_time:34443ms step_avg:41.90ms
+step:823/1490 train_time:34497ms step_avg:41.92ms
+step:824/1490 train_time:34559ms step_avg:41.94ms
+step:825/1490 train_time:34614ms step_avg:41.96ms
+step:826/1490 train_time:34674ms step_avg:41.98ms
+step:827/1490 train_time:34728ms step_avg:41.99ms
+step:828/1490 train_time:34787ms step_avg:42.01ms
+step:829/1490 train_time:34842ms step_avg:42.03ms
+step:830/1490 train_time:34900ms step_avg:42.05ms
+step:831/1490 train_time:34954ms step_avg:42.06ms
+step:832/1490 train_time:35014ms step_avg:42.08ms
+step:833/1490 train_time:35068ms step_avg:42.10ms
+step:834/1490 train_time:35127ms step_avg:42.12ms
+step:835/1490 train_time:35181ms step_avg:42.13ms
+step:836/1490 train_time:35240ms step_avg:42.15ms
+step:837/1490 train_time:35294ms step_avg:42.17ms
+step:838/1490 train_time:35354ms step_avg:42.19ms
+step:839/1490 train_time:35408ms step_avg:42.20ms
+step:840/1490 train_time:35466ms step_avg:42.22ms
+step:841/1490 train_time:35522ms step_avg:42.24ms
+step:842/1490 train_time:35582ms step_avg:42.26ms
+step:843/1490 train_time:35636ms step_avg:42.27ms
+step:844/1490 train_time:35696ms step_avg:42.29ms
+step:845/1490 train_time:35751ms step_avg:42.31ms
+step:846/1490 train_time:35810ms step_avg:42.33ms
+step:847/1490 train_time:35863ms step_avg:42.34ms
+step:848/1490 train_time:35923ms step_avg:42.36ms
+step:849/1490 train_time:35976ms step_avg:42.38ms
+step:850/1490 train_time:36037ms step_avg:42.40ms
+step:851/1490 train_time:36091ms step_avg:42.41ms
+step:852/1490 train_time:36152ms step_avg:42.43ms
+step:853/1490 train_time:36206ms step_avg:42.45ms
+step:854/1490 train_time:36266ms step_avg:42.47ms
+step:855/1490 train_time:36320ms step_avg:42.48ms
+step:856/1490 train_time:36379ms step_avg:42.50ms
+step:857/1490 train_time:36434ms step_avg:42.51ms
+step:858/1490 train_time:36495ms step_avg:42.54ms
+step:859/1490 train_time:36550ms step_avg:42.55ms
+step:860/1490 train_time:36610ms step_avg:42.57ms
+step:861/1490 train_time:36663ms step_avg:42.58ms
+step:862/1490 train_time:36723ms step_avg:42.60ms
+step:863/1490 train_time:36777ms step_avg:42.61ms
+step:864/1490 train_time:36837ms step_avg:42.64ms
+step:865/1490 train_time:36891ms step_avg:42.65ms
+step:866/1490 train_time:36952ms step_avg:42.67ms
+step:867/1490 train_time:37006ms step_avg:42.68ms
+step:868/1490 train_time:37064ms step_avg:42.70ms
+step:869/1490 train_time:37119ms step_avg:42.72ms
+step:870/1490 train_time:37178ms step_avg:42.73ms
+step:871/1490 train_time:37232ms step_avg:42.75ms
+step:872/1490 train_time:37292ms step_avg:42.77ms
+step:873/1490 train_time:37345ms step_avg:42.78ms
+step:874/1490 train_time:37405ms step_avg:42.80ms
+step:875/1490 train_time:37459ms step_avg:42.81ms
+step:876/1490 train_time:37520ms step_avg:42.83ms
+step:877/1490 train_time:37573ms step_avg:42.84ms
+step:878/1490 train_time:37634ms step_avg:42.86ms
+step:879/1490 train_time:37689ms step_avg:42.88ms
+step:880/1490 train_time:37748ms step_avg:42.90ms
+step:881/1490 train_time:37803ms step_avg:42.91ms
+step:882/1490 train_time:37862ms step_avg:42.93ms
+step:883/1490 train_time:37917ms step_avg:42.94ms
+step:884/1490 train_time:37976ms step_avg:42.96ms
+step:885/1490 train_time:38030ms step_avg:42.97ms
+step:886/1490 train_time:38090ms step_avg:42.99ms
+step:887/1490 train_time:38144ms step_avg:43.00ms
+step:888/1490 train_time:38203ms step_avg:43.02ms
+step:889/1490 train_time:38257ms step_avg:43.03ms
+step:890/1490 train_time:38317ms step_avg:43.05ms
+step:891/1490 train_time:38372ms step_avg:43.07ms
+step:892/1490 train_time:38432ms step_avg:43.09ms
+step:893/1490 train_time:38487ms step_avg:43.10ms
+step:894/1490 train_time:38545ms step_avg:43.12ms
+step:895/1490 train_time:38600ms step_avg:43.13ms
+step:896/1490 train_time:38660ms step_avg:43.15ms
+step:897/1490 train_time:38714ms step_avg:43.16ms
+step:898/1490 train_time:38775ms step_avg:43.18ms
+step:899/1490 train_time:38829ms step_avg:43.19ms
+step:900/1490 train_time:38888ms step_avg:43.21ms
+step:901/1490 train_time:38942ms step_avg:43.22ms
+step:902/1490 train_time:39001ms step_avg:43.24ms
+step:903/1490 train_time:39056ms step_avg:43.25ms
+step:904/1490 train_time:39117ms step_avg:43.27ms
+step:905/1490 train_time:39170ms step_avg:43.28ms
+step:906/1490 train_time:39229ms step_avg:43.30ms
+step:907/1490 train_time:39283ms step_avg:43.31ms
+step:908/1490 train_time:39342ms step_avg:43.33ms
+step:909/1490 train_time:39397ms step_avg:43.34ms
+step:910/1490 train_time:39456ms step_avg:43.36ms
+step:911/1490 train_time:39510ms step_avg:43.37ms
+step:912/1490 train_time:39569ms step_avg:43.39ms
+step:913/1490 train_time:39624ms step_avg:43.40ms
+step:914/1490 train_time:39683ms step_avg:43.42ms
+step:915/1490 train_time:39738ms step_avg:43.43ms
+step:916/1490 train_time:39798ms step_avg:43.45ms
+step:917/1490 train_time:39853ms step_avg:43.46ms
+step:918/1490 train_time:39913ms step_avg:43.48ms
+step:919/1490 train_time:39967ms step_avg:43.49ms
+step:920/1490 train_time:40026ms step_avg:43.51ms
+step:921/1490 train_time:40080ms step_avg:43.52ms
+step:922/1490 train_time:40140ms step_avg:43.54ms
+step:923/1490 train_time:40194ms step_avg:43.55ms
+step:924/1490 train_time:40254ms step_avg:43.56ms
+step:925/1490 train_time:40307ms step_avg:43.58ms
+step:926/1490 train_time:40366ms step_avg:43.59ms
+step:927/1490 train_time:40421ms step_avg:43.60ms
+step:928/1490 train_time:40480ms step_avg:43.62ms
+step:929/1490 train_time:40534ms step_avg:43.63ms
+step:930/1490 train_time:40595ms step_avg:43.65ms
+step:931/1490 train_time:40649ms step_avg:43.66ms
+step:932/1490 train_time:40710ms step_avg:43.68ms
+step:933/1490 train_time:40763ms step_avg:43.69ms
+step:934/1490 train_time:40823ms step_avg:43.71ms
+step:935/1490 train_time:40877ms step_avg:43.72ms
+step:936/1490 train_time:40936ms step_avg:43.74ms
+step:937/1490 train_time:40990ms step_avg:43.75ms
+step:938/1490 train_time:41049ms step_avg:43.76ms
+step:939/1490 train_time:41103ms step_avg:43.77ms
+step:940/1490 train_time:41163ms step_avg:43.79ms
+step:941/1490 train_time:41218ms step_avg:43.80ms
+step:942/1490 train_time:41278ms step_avg:43.82ms
+step:943/1490 train_time:41331ms step_avg:43.83ms
+step:944/1490 train_time:41391ms step_avg:43.85ms
+step:945/1490 train_time:41445ms step_avg:43.86ms
+step:946/1490 train_time:41505ms step_avg:43.87ms
+step:947/1490 train_time:41558ms step_avg:43.88ms
+step:948/1490 train_time:41619ms step_avg:43.90ms
+step:949/1490 train_time:41672ms step_avg:43.91ms
+step:950/1490 train_time:41733ms step_avg:43.93ms
+step:951/1490 train_time:41788ms step_avg:43.94ms
+step:952/1490 train_time:41847ms step_avg:43.96ms
+step:953/1490 train_time:41901ms step_avg:43.97ms
+step:954/1490 train_time:41960ms step_avg:43.98ms
+step:955/1490 train_time:42014ms step_avg:43.99ms
+step:956/1490 train_time:42073ms step_avg:44.01ms
+step:957/1490 train_time:42128ms step_avg:44.02ms
+step:958/1490 train_time:42187ms step_avg:44.04ms
+step:959/1490 train_time:42240ms step_avg:44.05ms
+step:960/1490 train_time:42300ms step_avg:44.06ms
+step:961/1490 train_time:42354ms step_avg:44.07ms
+step:962/1490 train_time:42414ms step_avg:44.09ms
+step:963/1490 train_time:42469ms step_avg:44.10ms
+step:964/1490 train_time:42529ms step_avg:44.12ms
+step:965/1490 train_time:42583ms step_avg:44.13ms
+step:966/1490 train_time:42642ms step_avg:44.14ms
+step:967/1490 train_time:42697ms step_avg:44.15ms
+step:968/1490 train_time:42760ms step_avg:44.17ms
+step:969/1490 train_time:42838ms step_avg:44.21ms
+step:970/1490 train_time:42925ms step_avg:44.25ms
+step:971/1490 train_time:43005ms step_avg:44.29ms
+step:972/1490 train_time:43090ms step_avg:44.33ms
+step:973/1490 train_time:43171ms step_avg:44.37ms
+step:974/1490 train_time:43255ms step_avg:44.41ms
+step:975/1490 train_time:43335ms step_avg:44.45ms
+step:976/1490 train_time:43420ms step_avg:44.49ms
+step:977/1490 train_time:43500ms step_avg:44.52ms
+step:978/1490 train_time:43587ms step_avg:44.57ms
+step:979/1490 train_time:43668ms step_avg:44.60ms
+step:980/1490 train_time:43754ms step_avg:44.65ms
+step:981/1490 train_time:43836ms step_avg:44.68ms
+step:982/1490 train_time:43920ms step_avg:44.73ms
+step:983/1490 train_time:44001ms step_avg:44.76ms
+step:984/1490 train_time:44085ms step_avg:44.80ms
+step:985/1490 train_time:44165ms step_avg:44.84ms
+step:986/1490 train_time:44251ms step_avg:44.88ms
+step:987/1490 train_time:44332ms step_avg:44.92ms
+step:988/1490 train_time:44416ms step_avg:44.96ms
+step:989/1490 train_time:44495ms step_avg:44.99ms
+step:990/1490 train_time:44582ms step_avg:45.03ms
+step:991/1490 train_time:44664ms step_avg:45.07ms
+step:992/1490 train_time:44749ms step_avg:45.11ms
+step:993/1490 train_time:44831ms step_avg:45.15ms
+step:994/1490 train_time:44916ms step_avg:45.19ms
+step:995/1490 train_time:44996ms step_avg:45.22ms
+step:996/1490 train_time:45081ms step_avg:45.26ms
+step:997/1490 train_time:45161ms step_avg:45.30ms
+step:998/1490 train_time:45246ms step_avg:45.34ms
+step:999/1490 train_time:45325ms step_avg:45.37ms
+step:1000/1490 train_time:45410ms step_avg:45.41ms
+step:1000/1490 val_loss:3.5160 train_time:45513ms step_avg:45.51ms
+step:1001/1490 train_time:45531ms step_avg:45.49ms
+step:1002/1490 train_time:45578ms step_avg:45.49ms
+step:1003/1490 train_time:45665ms step_avg:45.53ms
+step:1004/1490 train_time:45754ms step_avg:45.57ms
+step:1005/1490 train_time:45835ms step_avg:45.61ms
+step:1006/1490 train_time:45918ms step_avg:45.64ms
+step:1007/1490 train_time:45998ms step_avg:45.68ms
+step:1008/1490 train_time:46084ms step_avg:45.72ms
+step:1009/1490 train_time:46163ms step_avg:45.75ms
+step:1010/1490 train_time:46248ms step_avg:45.79ms
+step:1011/1490 train_time:46328ms step_avg:45.82ms
+step:1012/1490 train_time:46414ms step_avg:45.86ms
+step:1013/1490 train_time:46496ms step_avg:45.90ms
+step:1014/1490 train_time:46583ms step_avg:45.94ms
+step:1015/1490 train_time:46666ms step_avg:45.98ms
+step:1016/1490 train_time:46754ms step_avg:46.02ms
+step:1017/1490 train_time:46833ms step_avg:46.05ms
+step:1018/1490 train_time:46918ms step_avg:46.09ms
+step:1019/1490 train_time:46999ms step_avg:46.12ms
+step:1020/1490 train_time:47086ms step_avg:46.16ms
+step:1021/1490 train_time:47165ms step_avg:46.19ms
+step:1022/1490 train_time:47250ms step_avg:46.23ms
+step:1023/1490 train_time:47329ms step_avg:46.26ms
+step:1024/1490 train_time:47414ms step_avg:46.30ms
+step:1025/1490 train_time:47495ms step_avg:46.34ms
+step:1026/1490 train_time:47581ms step_avg:46.38ms
+step:1027/1490 train_time:47663ms step_avg:46.41ms
+step:1028/1490 train_time:47750ms step_avg:46.45ms
+step:1029/1490 train_time:47831ms step_avg:46.48ms
+step:1030/1490 train_time:47914ms step_avg:46.52ms
+step:1031/1490 train_time:47994ms step_avg:46.55ms
+step:1032/1490 train_time:48079ms step_avg:46.59ms
+step:1033/1490 train_time:48159ms step_avg:46.62ms
+step:1034/1490 train_time:48243ms step_avg:46.66ms
+step:1035/1490 train_time:48322ms step_avg:46.69ms
+step:1036/1490 train_time:48408ms step_avg:46.73ms
+step:1037/1490 train_time:48488ms step_avg:46.76ms
+step:1038/1490 train_time:48575ms step_avg:46.80ms
+step:1039/1490 train_time:48656ms step_avg:46.83ms
+step:1040/1490 train_time:48743ms step_avg:46.87ms
+step:1041/1490 train_time:48823ms step_avg:46.90ms
+step:1042/1490 train_time:48907ms step_avg:46.94ms
+step:1043/1490 train_time:48989ms step_avg:46.97ms
+step:1044/1490 train_time:49074ms step_avg:47.01ms
+step:1045/1490 train_time:49154ms step_avg:47.04ms
+step:1046/1490 train_time:49238ms step_avg:47.07ms
+step:1047/1490 train_time:49316ms step_avg:47.10ms
+step:1048/1490 train_time:49403ms step_avg:47.14ms
+step:1049/1490 train_time:49486ms step_avg:47.17ms
+step:1050/1490 train_time:49573ms step_avg:47.21ms
+step:1051/1490 train_time:49654ms step_avg:47.24ms
+step:1052/1490 train_time:49739ms step_avg:47.28ms
+step:1053/1490 train_time:49820ms step_avg:47.31ms
+step:1054/1490 train_time:49906ms step_avg:47.35ms
+step:1055/1490 train_time:49986ms step_avg:47.38ms
+step:1056/1490 train_time:50071ms step_avg:47.42ms
+step:1057/1490 train_time:50150ms step_avg:47.45ms
+step:1058/1490 train_time:50234ms step_avg:47.48ms
+step:1059/1490 train_time:50314ms step_avg:47.51ms
+step:1060/1490 train_time:50400ms step_avg:47.55ms
+step:1061/1490 train_time:50482ms step_avg:47.58ms
+step:1062/1490 train_time:50568ms step_avg:47.62ms
+step:1063/1490 train_time:50651ms step_avg:47.65ms
+step:1064/1490 train_time:50735ms step_avg:47.68ms
+step:1065/1490 train_time:50816ms step_avg:47.71ms
+step:1066/1490 train_time:50901ms step_avg:47.75ms
+step:1067/1490 train_time:50981ms step_avg:47.78ms
+step:1068/1490 train_time:51067ms step_avg:47.82ms
+step:1069/1490 train_time:51146ms step_avg:47.85ms
+step:1070/1490 train_time:51232ms step_avg:47.88ms
+step:1071/1490 train_time:51312ms step_avg:47.91ms
+step:1072/1490 train_time:51397ms step_avg:47.94ms
+step:1073/1490 train_time:51476ms step_avg:47.97ms
+step:1074/1490 train_time:51563ms step_avg:48.01ms
+step:1075/1490 train_time:51643ms step_avg:48.04ms
+step:1076/1490 train_time:51729ms step_avg:48.08ms
+step:1077/1490 train_time:51809ms step_avg:48.10ms
+step:1078/1490 train_time:51894ms step_avg:48.14ms
+step:1079/1490 train_time:51974ms step_avg:48.17ms
+step:1080/1490 train_time:52059ms step_avg:48.20ms
+step:1081/1490 train_time:52139ms step_avg:48.23ms
+step:1082/1490 train_time:52223ms step_avg:48.27ms
+step:1083/1490 train_time:52303ms step_avg:48.29ms
+step:1084/1490 train_time:52389ms step_avg:48.33ms
+step:1085/1490 train_time:52470ms step_avg:48.36ms
+step:1086/1490 train_time:52556ms step_avg:48.39ms
+step:1087/1490 train_time:52635ms step_avg:48.42ms
+step:1088/1490 train_time:52720ms step_avg:48.46ms
+step:1089/1490 train_time:52800ms step_avg:48.49ms
+step:1090/1490 train_time:52886ms step_avg:48.52ms
+step:1091/1490 train_time:52966ms step_avg:48.55ms
+step:1092/1490 train_time:53052ms step_avg:48.58ms
+step:1093/1490 train_time:53132ms step_avg:48.61ms
+step:1094/1490 train_time:53216ms step_avg:48.64ms
+step:1095/1490 train_time:53296ms step_avg:48.67ms
+step:1096/1490 train_time:53382ms step_avg:48.71ms
+step:1097/1490 train_time:53463ms step_avg:48.74ms
+step:1098/1490 train_time:53549ms step_avg:48.77ms
+step:1099/1490 train_time:53629ms step_avg:48.80ms
+step:1100/1490 train_time:53714ms step_avg:48.83ms
+step:1101/1490 train_time:53796ms step_avg:48.86ms
+step:1102/1490 train_time:53881ms step_avg:48.89ms
+step:1103/1490 train_time:53962ms step_avg:48.92ms
+step:1104/1490 train_time:54047ms step_avg:48.96ms
+step:1105/1490 train_time:54126ms step_avg:48.98ms
+step:1106/1490 train_time:54211ms step_avg:49.02ms
+step:1107/1490 train_time:54292ms step_avg:49.04ms
+step:1108/1490 train_time:54378ms step_avg:49.08ms
+step:1109/1490 train_time:54459ms step_avg:49.11ms
+step:1110/1490 train_time:54544ms step_avg:49.14ms
+step:1111/1490 train_time:54625ms step_avg:49.17ms
+step:1112/1490 train_time:54710ms step_avg:49.20ms
+step:1113/1490 train_time:54791ms step_avg:49.23ms
+step:1114/1490 train_time:54877ms step_avg:49.26ms
+step:1115/1490 train_time:54958ms step_avg:49.29ms
+step:1116/1490 train_time:55043ms step_avg:49.32ms
+step:1117/1490 train_time:55124ms step_avg:49.35ms
+step:1118/1490 train_time:55209ms step_avg:49.38ms
+step:1119/1490 train_time:55290ms step_avg:49.41ms
+step:1120/1490 train_time:55376ms step_avg:49.44ms
+step:1121/1490 train_time:55456ms step_avg:49.47ms
+step:1122/1490 train_time:55541ms step_avg:49.50ms
+step:1123/1490 train_time:55620ms step_avg:49.53ms
+step:1124/1490 train_time:55706ms step_avg:49.56ms
+step:1125/1490 train_time:55786ms step_avg:49.59ms
+step:1126/1490 train_time:55873ms step_avg:49.62ms
+step:1127/1490 train_time:55952ms step_avg:49.65ms
+step:1128/1490 train_time:56037ms step_avg:49.68ms
+step:1129/1490 train_time:56117ms step_avg:49.70ms
+step:1130/1490 train_time:56202ms step_avg:49.74ms
+step:1131/1490 train_time:56282ms step_avg:49.76ms
+step:1132/1490 train_time:56369ms step_avg:49.80ms
+step:1133/1490 train_time:56449ms step_avg:49.82ms
+step:1134/1490 train_time:56534ms step_avg:49.85ms
+step:1135/1490 train_time:56614ms step_avg:49.88ms
+step:1136/1490 train_time:56699ms step_avg:49.91ms
+step:1137/1490 train_time:56780ms step_avg:49.94ms
+step:1138/1490 train_time:56866ms step_avg:49.97ms
+step:1139/1490 train_time:56947ms step_avg:50.00ms
+step:1140/1490 train_time:57032ms step_avg:50.03ms
+step:1141/1490 train_time:57111ms step_avg:50.05ms
+step:1142/1490 train_time:57197ms step_avg:50.09ms
+step:1143/1490 train_time:57278ms step_avg:50.11ms
+step:1144/1490 train_time:57363ms step_avg:50.14ms
+step:1145/1490 train_time:57444ms step_avg:50.17ms
+step:1146/1490 train_time:57528ms step_avg:50.20ms
+step:1147/1490 train_time:57607ms step_avg:50.22ms
+step:1148/1490 train_time:57694ms step_avg:50.26ms
+step:1149/1490 train_time:57775ms step_avg:50.28ms
+step:1150/1490 train_time:57860ms step_avg:50.31ms
+step:1151/1490 train_time:57941ms step_avg:50.34ms
+step:1152/1490 train_time:58026ms step_avg:50.37ms
+step:1153/1490 train_time:58106ms step_avg:50.40ms
+step:1154/1490 train_time:58193ms step_avg:50.43ms
+step:1155/1490 train_time:58274ms step_avg:50.45ms
+step:1156/1490 train_time:58359ms step_avg:50.48ms
+step:1157/1490 train_time:58439ms step_avg:50.51ms
+step:1158/1490 train_time:58524ms step_avg:50.54ms
+step:1159/1490 train_time:58604ms step_avg:50.56ms
+step:1160/1490 train_time:58690ms step_avg:50.60ms
+step:1161/1490 train_time:58771ms step_avg:50.62ms
+step:1162/1490 train_time:58856ms step_avg:50.65ms
+step:1163/1490 train_time:58935ms step_avg:50.68ms
+step:1164/1490 train_time:59019ms step_avg:50.70ms
+step:1165/1490 train_time:59100ms step_avg:50.73ms
+step:1166/1490 train_time:59188ms step_avg:50.76ms
+step:1167/1490 train_time:59269ms step_avg:50.79ms
+step:1168/1490 train_time:59355ms step_avg:50.82ms
+step:1169/1490 train_time:59433ms step_avg:50.84ms
+step:1170/1490 train_time:59518ms step_avg:50.87ms
+step:1171/1490 train_time:59599ms step_avg:50.90ms
+step:1172/1490 train_time:59686ms step_avg:50.93ms
+step:1173/1490 train_time:59767ms step_avg:50.95ms
+step:1174/1490 train_time:59855ms step_avg:50.98ms
+step:1175/1490 train_time:59935ms step_avg:51.01ms
+step:1176/1490 train_time:60019ms step_avg:51.04ms
+step:1177/1490 train_time:60100ms step_avg:51.06ms
+step:1178/1490 train_time:60186ms step_avg:51.09ms
+step:1179/1490 train_time:60268ms step_avg:51.12ms
+step:1180/1490 train_time:60354ms step_avg:51.15ms
+step:1181/1490 train_time:60433ms step_avg:51.17ms
+step:1182/1490 train_time:60519ms step_avg:51.20ms
+step:1183/1490 train_time:60601ms step_avg:51.23ms
+step:1184/1490 train_time:60689ms step_avg:51.26ms
+step:1185/1490 train_time:60769ms step_avg:51.28ms
+step:1186/1490 train_time:60856ms step_avg:51.31ms
+step:1187/1490 train_time:60935ms step_avg:51.34ms
+step:1188/1490 train_time:61019ms step_avg:51.36ms
+step:1189/1490 train_time:61100ms step_avg:51.39ms
+step:1190/1490 train_time:61186ms step_avg:51.42ms
+step:1191/1490 train_time:61271ms step_avg:51.44ms
+step:1192/1490 train_time:61356ms step_avg:51.47ms
+step:1193/1490 train_time:61434ms step_avg:51.50ms
+step:1194/1490 train_time:61520ms step_avg:51.52ms
+step:1195/1490 train_time:61601ms step_avg:51.55ms
+step:1196/1490 train_time:61686ms step_avg:51.58ms
+step:1197/1490 train_time:61767ms step_avg:51.60ms
+step:1198/1490 train_time:61854ms step_avg:51.63ms
+step:1199/1490 train_time:61934ms step_avg:51.65ms
+step:1200/1490 train_time:62018ms step_avg:51.68ms
+step:1201/1490 train_time:62097ms step_avg:51.70ms
+step:1202/1490 train_time:62184ms step_avg:51.73ms
+step:1203/1490 train_time:62266ms step_avg:51.76ms
+step:1204/1490 train_time:62353ms step_avg:51.79ms
+step:1205/1490 train_time:62432ms step_avg:51.81ms
+step:1206/1490 train_time:62518ms step_avg:51.84ms
+step:1207/1490 train_time:62599ms step_avg:51.86ms
+step:1208/1490 train_time:62686ms step_avg:51.89ms
+step:1209/1490 train_time:62767ms step_avg:51.92ms
+step:1210/1490 train_time:62854ms step_avg:51.95ms
+step:1211/1490 train_time:62934ms step_avg:51.97ms
+step:1212/1490 train_time:63018ms step_avg:52.00ms
+step:1213/1490 train_time:63099ms step_avg:52.02ms
+step:1214/1490 train_time:63185ms step_avg:52.05ms
+step:1215/1490 train_time:63267ms step_avg:52.07ms
+step:1216/1490 train_time:63354ms step_avg:52.10ms
+step:1217/1490 train_time:63433ms step_avg:52.12ms
+step:1218/1490 train_time:63518ms step_avg:52.15ms
+step:1219/1490 train_time:63600ms step_avg:52.17ms
+step:1220/1490 train_time:63687ms step_avg:52.20ms
+step:1221/1490 train_time:63769ms step_avg:52.23ms
+step:1222/1490 train_time:63855ms step_avg:52.25ms
+step:1223/1490 train_time:63935ms step_avg:52.28ms
+step:1224/1490 train_time:64021ms step_avg:52.30ms
+step:1225/1490 train_time:64101ms step_avg:52.33ms
+step:1226/1490 train_time:64187ms step_avg:52.35ms
+step:1227/1490 train_time:64269ms step_avg:52.38ms
+step:1228/1490 train_time:64355ms step_avg:52.41ms
+step:1229/1490 train_time:64434ms step_avg:52.43ms
+step:1230/1490 train_time:64519ms step_avg:52.45ms
+step:1231/1490 train_time:64600ms step_avg:52.48ms
+step:1232/1490 train_time:64686ms step_avg:52.50ms
+step:1233/1490 train_time:64766ms step_avg:52.53ms
+step:1234/1490 train_time:64852ms step_avg:52.55ms
+step:1235/1490 train_time:64932ms step_avg:52.58ms
+step:1236/1490 train_time:65017ms step_avg:52.60ms
+step:1237/1490 train_time:65098ms step_avg:52.63ms
+step:1238/1490 train_time:65183ms step_avg:52.65ms
+step:1239/1490 train_time:65264ms step_avg:52.67ms
+step:1240/1490 train_time:65350ms step_avg:52.70ms
+step:1241/1490 train_time:65431ms step_avg:52.72ms
+step:1242/1490 train_time:65515ms step_avg:52.75ms
+step:1243/1490 train_time:65596ms step_avg:52.77ms
+step:1244/1490 train_time:65682ms step_avg:52.80ms
+step:1245/1490 train_time:65763ms step_avg:52.82ms
+step:1246/1490 train_time:65849ms step_avg:52.85ms
+step:1247/1490 train_time:65930ms step_avg:52.87ms
+step:1248/1490 train_time:66016ms step_avg:52.90ms
+step:1249/1490 train_time:66096ms step_avg:52.92ms
+step:1250/1490 train_time:66180ms step_avg:52.94ms
+step:1250/1490 val_loss:3.3709 train_time:66284ms step_avg:53.03ms
+step:1251/1490 train_time:66302ms step_avg:53.00ms
+step:1252/1490 train_time:66350ms step_avg:53.00ms
+step:1253/1490 train_time:66437ms step_avg:53.02ms
+step:1254/1490 train_time:66523ms step_avg:53.05ms
+step:1255/1490 train_time:66602ms step_avg:53.07ms
+step:1256/1490 train_time:66688ms step_avg:53.10ms
+step:1257/1490 train_time:66768ms step_avg:53.12ms
+step:1258/1490 train_time:66853ms step_avg:53.14ms
+step:1259/1490 train_time:66933ms step_avg:53.16ms
+step:1260/1490 train_time:67017ms step_avg:53.19ms
+step:1261/1490 train_time:67097ms step_avg:53.21ms
+step:1262/1490 train_time:67182ms step_avg:53.23ms
+step:1263/1490 train_time:67264ms step_avg:53.26ms
+step:1264/1490 train_time:67355ms step_avg:53.29ms
+step:1265/1490 train_time:67437ms step_avg:53.31ms
+step:1266/1490 train_time:67523ms step_avg:53.34ms
+step:1267/1490 train_time:67603ms step_avg:53.36ms
+step:1268/1490 train_time:67688ms step_avg:53.38ms
+step:1269/1490 train_time:67768ms step_avg:53.40ms
+step:1270/1490 train_time:67854ms step_avg:53.43ms
+step:1271/1490 train_time:67932ms step_avg:53.45ms
+step:1272/1490 train_time:68017ms step_avg:53.47ms
+step:1273/1490 train_time:68097ms step_avg:53.49ms
+step:1274/1490 train_time:68183ms step_avg:53.52ms
+step:1275/1490 train_time:68263ms step_avg:53.54ms
+step:1276/1490 train_time:68350ms step_avg:53.57ms
+step:1277/1490 train_time:68432ms step_avg:53.59ms
+step:1278/1490 train_time:68520ms step_avg:53.62ms
+step:1279/1490 train_time:68600ms step_avg:53.64ms
+step:1280/1490 train_time:68685ms step_avg:53.66ms
+step:1281/1490 train_time:68764ms step_avg:53.68ms
+step:1282/1490 train_time:68848ms step_avg:53.70ms
+step:1283/1490 train_time:68928ms step_avg:53.72ms
+step:1284/1490 train_time:69013ms step_avg:53.75ms
+step:1285/1490 train_time:69093ms step_avg:53.77ms
+step:1286/1490 train_time:69179ms step_avg:53.79ms
+step:1287/1490 train_time:69259ms step_avg:53.81ms
+step:1288/1490 train_time:69344ms step_avg:53.84ms
+step:1289/1490 train_time:69425ms step_avg:53.86ms
+step:1290/1490 train_time:69511ms step_avg:53.88ms
+step:1291/1490 train_time:69591ms step_avg:53.91ms
+step:1292/1490 train_time:69678ms step_avg:53.93ms
+step:1293/1490 train_time:69760ms step_avg:53.95ms
+step:1294/1490 train_time:69844ms step_avg:53.98ms
+step:1295/1490 train_time:69922ms step_avg:53.99ms
+step:1296/1490 train_time:70007ms step_avg:54.02ms
+step:1297/1490 train_time:70088ms step_avg:54.04ms
+step:1298/1490 train_time:70174ms step_avg:54.06ms
+step:1299/1490 train_time:70255ms step_avg:54.08ms
+step:1300/1490 train_time:70341ms step_avg:54.11ms
+step:1301/1490 train_time:70423ms step_avg:54.13ms
+step:1302/1490 train_time:70508ms step_avg:54.15ms
+step:1303/1490 train_time:70589ms step_avg:54.17ms
+step:1304/1490 train_time:70675ms step_avg:54.20ms
+step:1305/1490 train_time:70755ms step_avg:54.22ms
+step:1306/1490 train_time:70839ms step_avg:54.24ms
+step:1307/1490 train_time:70918ms step_avg:54.26ms
+step:1308/1490 train_time:71004ms step_avg:54.28ms
+step:1309/1490 train_time:71083ms step_avg:54.30ms
+step:1310/1490 train_time:71168ms step_avg:54.33ms
+step:1311/1490 train_time:71248ms step_avg:54.35ms
+step:1312/1490 train_time:71335ms step_avg:54.37ms
+step:1313/1490 train_time:71415ms step_avg:54.39ms
+step:1314/1490 train_time:71502ms step_avg:54.42ms
+step:1315/1490 train_time:71583ms step_avg:54.44ms
+step:1316/1490 train_time:71668ms step_avg:54.46ms
+step:1317/1490 train_time:71748ms step_avg:54.48ms
+step:1318/1490 train_time:71832ms step_avg:54.50ms
+step:1319/1490 train_time:71913ms step_avg:54.52ms
+step:1320/1490 train_time:71998ms step_avg:54.54ms
+step:1321/1490 train_time:72078ms step_avg:54.56ms
+step:1322/1490 train_time:72164ms step_avg:54.59ms
+step:1323/1490 train_time:72244ms step_avg:54.61ms
+step:1324/1490 train_time:72329ms step_avg:54.63ms
+step:1325/1490 train_time:72410ms step_avg:54.65ms
+step:1326/1490 train_time:72496ms step_avg:54.67ms
+step:1327/1490 train_time:72578ms step_avg:54.69ms
+step:1328/1490 train_time:72663ms step_avg:54.72ms
+step:1329/1490 train_time:72742ms step_avg:54.73ms
+step:1330/1490 train_time:72827ms step_avg:54.76ms
+step:1331/1490 train_time:72909ms step_avg:54.78ms
+step:1332/1490 train_time:72994ms step_avg:54.80ms
+step:1333/1490 train_time:73076ms step_avg:54.82ms
+step:1334/1490 train_time:73161ms step_avg:54.84ms
+step:1335/1490 train_time:73241ms step_avg:54.86ms
+step:1336/1490 train_time:73326ms step_avg:54.88ms
+step:1337/1490 train_time:73406ms step_avg:54.90ms
+step:1338/1490 train_time:73492ms step_avg:54.93ms
+step:1339/1490 train_time:73572ms step_avg:54.95ms
+step:1340/1490 train_time:73659ms step_avg:54.97ms
+step:1341/1490 train_time:73738ms step_avg:54.99ms
+step:1342/1490 train_time:73822ms step_avg:55.01ms
+step:1343/1490 train_time:73903ms step_avg:55.03ms
+step:1344/1490 train_time:73988ms step_avg:55.05ms
+step:1345/1490 train_time:74069ms step_avg:55.07ms
+step:1346/1490 train_time:74155ms step_avg:55.09ms
+step:1347/1490 train_time:74235ms step_avg:55.11ms
+step:1348/1490 train_time:74321ms step_avg:55.13ms
+step:1349/1490 train_time:74402ms step_avg:55.15ms
+step:1350/1490 train_time:74488ms step_avg:55.18ms
+step:1351/1490 train_time:74568ms step_avg:55.19ms
+step:1352/1490 train_time:74654ms step_avg:55.22ms
+step:1353/1490 train_time:74733ms step_avg:55.24ms
+step:1354/1490 train_time:74819ms step_avg:55.26ms
+step:1355/1490 train_time:74899ms step_avg:55.28ms
+step:1356/1490 train_time:74984ms step_avg:55.30ms
+step:1357/1490 train_time:75064ms step_avg:55.32ms
+step:1358/1490 train_time:75149ms step_avg:55.34ms
+step:1359/1490 train_time:75228ms step_avg:55.36ms
+step:1360/1490 train_time:75314ms step_avg:55.38ms
+step:1361/1490 train_time:75395ms step_avg:55.40ms
+step:1362/1490 train_time:75479ms step_avg:55.42ms
+step:1363/1490 train_time:75563ms step_avg:55.44ms
+step:1364/1490 train_time:75648ms step_avg:55.46ms
+step:1365/1490 train_time:75728ms step_avg:55.48ms
+step:1366/1490 train_time:75814ms step_avg:55.50ms
+step:1367/1490 train_time:75894ms step_avg:55.52ms
+step:1368/1490 train_time:75980ms step_avg:55.54ms
+step:1369/1490 train_time:76059ms step_avg:55.56ms
+step:1370/1490 train_time:76145ms step_avg:55.58ms
+step:1371/1490 train_time:76223ms step_avg:55.60ms
+step:1372/1490 train_time:76310ms step_avg:55.62ms
+step:1373/1490 train_time:76390ms step_avg:55.64ms
+step:1374/1490 train_time:76477ms step_avg:55.66ms
+step:1375/1490 train_time:76558ms step_avg:55.68ms
+step:1376/1490 train_time:76644ms step_avg:55.70ms
+step:1377/1490 train_time:76723ms step_avg:55.72ms
+step:1378/1490 train_time:76808ms step_avg:55.74ms
+step:1379/1490 train_time:76889ms step_avg:55.76ms
+step:1380/1490 train_time:76976ms step_avg:55.78ms
+step:1381/1490 train_time:77056ms step_avg:55.80ms
+step:1382/1490 train_time:77140ms step_avg:55.82ms
+step:1383/1490 train_time:77221ms step_avg:55.84ms
+step:1384/1490 train_time:77307ms step_avg:55.86ms
+step:1385/1490 train_time:77387ms step_avg:55.87ms
+step:1386/1490 train_time:77474ms step_avg:55.90ms
+step:1387/1490 train_time:77554ms step_avg:55.91ms
+step:1388/1490 train_time:77640ms step_avg:55.94ms
+step:1389/1490 train_time:77720ms step_avg:55.95ms
+step:1390/1490 train_time:77806ms step_avg:55.98ms
+step:1391/1490 train_time:77885ms step_avg:55.99ms
+step:1392/1490 train_time:77971ms step_avg:56.01ms
+step:1393/1490 train_time:78051ms step_avg:56.03ms
+step:1394/1490 train_time:78136ms step_avg:56.05ms
+step:1395/1490 train_time:78215ms step_avg:56.07ms
+step:1396/1490 train_time:78301ms step_avg:56.09ms
+step:1397/1490 train_time:78382ms step_avg:56.11ms
+step:1398/1490 train_time:78468ms step_avg:56.13ms
+step:1399/1490 train_time:78547ms step_avg:56.15ms
+step:1400/1490 train_time:78633ms step_avg:56.17ms
+step:1401/1490 train_time:78714ms step_avg:56.18ms
+step:1402/1490 train_time:78799ms step_avg:56.20ms
+step:1403/1490 train_time:78879ms step_avg:56.22ms
+step:1404/1490 train_time:78966ms step_avg:56.24ms
+step:1405/1490 train_time:79045ms step_avg:56.26ms
+step:1406/1490 train_time:79129ms step_avg:56.28ms
+step:1407/1490 train_time:79210ms step_avg:56.30ms
+step:1408/1490 train_time:79297ms step_avg:56.32ms
+step:1409/1490 train_time:79379ms step_avg:56.34ms
+step:1410/1490 train_time:79464ms step_avg:56.36ms
+step:1411/1490 train_time:79543ms step_avg:56.37ms
+step:1412/1490 train_time:79628ms step_avg:56.39ms
+step:1413/1490 train_time:79709ms step_avg:56.41ms
+step:1414/1490 train_time:79795ms step_avg:56.43ms
+step:1415/1490 train_time:79875ms step_avg:56.45ms
+step:1416/1490 train_time:79961ms step_avg:56.47ms
+step:1417/1490 train_time:80040ms step_avg:56.49ms
+step:1418/1490 train_time:80124ms step_avg:56.51ms
+step:1419/1490 train_time:80205ms step_avg:56.52ms
+step:1420/1490 train_time:80290ms step_avg:56.54ms
+step:1421/1490 train_time:80371ms step_avg:56.56ms
+step:1422/1490 train_time:80460ms step_avg:56.58ms
+step:1423/1490 train_time:80539ms step_avg:56.60ms
+step:1424/1490 train_time:80623ms step_avg:56.62ms
+step:1425/1490 train_time:80703ms step_avg:56.63ms
+step:1426/1490 train_time:80788ms step_avg:56.65ms
+step:1427/1490 train_time:80869ms step_avg:56.67ms
+step:1428/1490 train_time:80955ms step_avg:56.69ms
+step:1429/1490 train_time:81034ms step_avg:56.71ms
+step:1430/1490 train_time:81120ms step_avg:56.73ms
+step:1431/1490 train_time:81201ms step_avg:56.74ms
+step:1432/1490 train_time:81285ms step_avg:56.76ms
+step:1433/1490 train_time:81366ms step_avg:56.78ms
+step:1434/1490 train_time:81452ms step_avg:56.80ms
+step:1435/1490 train_time:81532ms step_avg:56.82ms
+step:1436/1490 train_time:81617ms step_avg:56.84ms
+step:1437/1490 train_time:81697ms step_avg:56.85ms
+step:1438/1490 train_time:81784ms step_avg:56.87ms
+step:1439/1490 train_time:81864ms step_avg:56.89ms
+step:1440/1490 train_time:81948ms step_avg:56.91ms
+step:1441/1490 train_time:82029ms step_avg:56.93ms
+step:1442/1490 train_time:82115ms step_avg:56.95ms
+step:1443/1490 train_time:82196ms step_avg:56.96ms
+step:1444/1490 train_time:82282ms step_avg:56.98ms
+step:1445/1490 train_time:82362ms step_avg:57.00ms
+step:1446/1490 train_time:82448ms step_avg:57.02ms
+step:1447/1490 train_time:82528ms step_avg:57.03ms
+step:1448/1490 train_time:82614ms step_avg:57.05ms
+step:1449/1490 train_time:82694ms step_avg:57.07ms
+step:1450/1490 train_time:82782ms step_avg:57.09ms
+step:1451/1490 train_time:82867ms step_avg:57.11ms
+step:1452/1490 train_time:82953ms step_avg:57.13ms
+step:1453/1490 train_time:83032ms step_avg:57.15ms
+step:1454/1490 train_time:83119ms step_avg:57.17ms
+step:1455/1490 train_time:83200ms step_avg:57.18ms
+step:1456/1490 train_time:83285ms step_avg:57.20ms
+step:1457/1490 train_time:83365ms step_avg:57.22ms
+step:1458/1490 train_time:83451ms step_avg:57.24ms
+step:1459/1490 train_time:83531ms step_avg:57.25ms
+step:1460/1490 train_time:83619ms step_avg:57.27ms
+step:1461/1490 train_time:83699ms step_avg:57.29ms
+step:1462/1490 train_time:83785ms step_avg:57.31ms
+step:1463/1490 train_time:83866ms step_avg:57.32ms
+step:1464/1490 train_time:83952ms step_avg:57.34ms
+step:1465/1490 train_time:84033ms step_avg:57.36ms
+step:1466/1490 train_time:84118ms step_avg:57.38ms
+step:1467/1490 train_time:84199ms step_avg:57.40ms
+step:1468/1490 train_time:84286ms step_avg:57.42ms
+step:1469/1490 train_time:84366ms step_avg:57.43ms
+step:1470/1490 train_time:84451ms step_avg:57.45ms
+step:1471/1490 train_time:84531ms step_avg:57.46ms
+step:1472/1490 train_time:84616ms step_avg:57.48ms
+step:1473/1490 train_time:84699ms step_avg:57.50ms
+step:1474/1490 train_time:84785ms step_avg:57.52ms
+step:1475/1490 train_time:84865ms step_avg:57.54ms
+step:1476/1490 train_time:84950ms step_avg:57.55ms
+step:1477/1490 train_time:85031ms step_avg:57.57ms
+step:1478/1490 train_time:85116ms step_avg:57.59ms
+step:1479/1490 train_time:85199ms step_avg:57.61ms
+step:1480/1490 train_time:85284ms step_avg:57.62ms
+step:1481/1490 train_time:85363ms step_avg:57.64ms
+step:1482/1490 train_time:85450ms step_avg:57.66ms
+step:1483/1490 train_time:85529ms step_avg:57.67ms
+step:1484/1490 train_time:85617ms step_avg:57.69ms
+step:1485/1490 train_time:85699ms step_avg:57.71ms
+step:1486/1490 train_time:85786ms step_avg:57.73ms
+step:1487/1490 train_time:85867ms step_avg:57.74ms
+step:1488/1490 train_time:85953ms step_avg:57.76ms
+step:1489/1490 train_time:86034ms step_avg:57.78ms
+step:1490/1490 train_time:86119ms step_avg:57.80ms
+step:1490/1490 val_loss:3.2779 train_time:86223ms step_avg:57.87ms
+peak memory allocated: 31296 MiB reserved: 47202 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/max_num_docs/2026-03-22_18-32-10_time-188_secs_00-cu-seqlens_096b38.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/max_num_docs/2026-03-22_18-32-10_time-188_secs_00-cu-seqlens_096b38.txt
@@ -1,0 +1,4457 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 18:32:25 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   36C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            132W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   41C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1410698      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1410699      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1410700      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1410701      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1410702      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1410703      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1410704      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1410705      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8290 train_time:0ms step_avg:0.05ms
+step:1/1490 train_time:85ms step_avg:84.76ms
+step:2/1490 train_time:108ms step_avg:53.84ms
+step:3/1490 train_time:125ms step_avg:41.62ms
+step:4/1490 train_time:145ms step_avg:36.37ms
+step:5/1490 train_time:173ms step_avg:34.52ms
+step:6/1490 train_time:207ms step_avg:34.53ms
+step:7/1490 train_time:235ms step_avg:33.50ms
+step:8/1490 train_time:270ms step_avg:33.70ms
+step:9/1490 train_time:297ms step_avg:32.97ms
+step:10/1490 train_time:332ms step_avg:33.17ms
+step:11/1490 train_time:359ms step_avg:32.65ms
+step:12/1490 train_time:394ms step_avg:32.84ms
+step:13/1490 train_time:422ms step_avg:32.45ms
+step:14/1490 train_time:456ms step_avg:32.59ms
+step:15/1490 train_time:484ms step_avg:32.28ms
+step:16/1490 train_time:519ms step_avg:32.41ms
+step:17/1490 train_time:547ms step_avg:32.16ms
+step:18/1490 train_time:581ms step_avg:32.27ms
+step:19/1490 train_time:609ms step_avg:32.05ms
+step:20/1490 train_time:643ms step_avg:32.16ms
+step:21/1490 train_time:671ms step_avg:31.97ms
+step:22/1490 train_time:706ms step_avg:32.08ms
+step:23/1490 train_time:734ms step_avg:31.92ms
+step:24/1490 train_time:768ms step_avg:32.02ms
+step:25/1490 train_time:796ms step_avg:31.85ms
+step:26/1490 train_time:831ms step_avg:31.96ms
+step:27/1490 train_time:859ms step_avg:31.82ms
+step:28/1490 train_time:893ms step_avg:31.91ms
+step:29/1490 train_time:922ms step_avg:31.78ms
+step:30/1490 train_time:956ms step_avg:31.88ms
+step:31/1490 train_time:985ms step_avg:31.78ms
+step:32/1490 train_time:1021ms step_avg:31.90ms
+step:33/1490 train_time:1049ms step_avg:31.80ms
+step:34/1490 train_time:1084ms step_avg:31.89ms
+step:35/1490 train_time:1113ms step_avg:31.80ms
+step:36/1490 train_time:1148ms step_avg:31.89ms
+step:37/1490 train_time:1176ms step_avg:31.80ms
+step:38/1490 train_time:1212ms step_avg:31.90ms
+step:39/1490 train_time:1239ms step_avg:31.77ms
+step:40/1490 train_time:1274ms step_avg:31.85ms
+step:41/1490 train_time:1302ms step_avg:31.76ms
+step:42/1490 train_time:1337ms step_avg:31.84ms
+step:43/1490 train_time:1366ms step_avg:31.76ms
+step:44/1490 train_time:1401ms step_avg:31.83ms
+step:45/1490 train_time:1429ms step_avg:31.75ms
+step:46/1490 train_time:1464ms step_avg:31.82ms
+step:47/1490 train_time:1492ms step_avg:31.74ms
+step:48/1490 train_time:1526ms step_avg:31.78ms
+step:49/1490 train_time:1554ms step_avg:31.71ms
+step:50/1490 train_time:1588ms step_avg:31.76ms
+step:51/1490 train_time:1616ms step_avg:31.69ms
+step:52/1490 train_time:1651ms step_avg:31.75ms
+step:53/1490 train_time:1679ms step_avg:31.68ms
+step:54/1490 train_time:1714ms step_avg:31.74ms
+step:55/1490 train_time:1742ms step_avg:31.67ms
+step:56/1490 train_time:1776ms step_avg:31.72ms
+step:57/1490 train_time:1804ms step_avg:31.65ms
+step:58/1490 train_time:1839ms step_avg:31.70ms
+step:59/1490 train_time:1867ms step_avg:31.64ms
+step:60/1490 train_time:1901ms step_avg:31.68ms
+step:61/1490 train_time:1929ms step_avg:31.63ms
+step:62/1490 train_time:1964ms step_avg:31.68ms
+step:63/1490 train_time:1993ms step_avg:31.63ms
+step:64/1490 train_time:2027ms step_avg:31.67ms
+step:65/1490 train_time:2056ms step_avg:31.63ms
+step:66/1490 train_time:2091ms step_avg:31.68ms
+step:67/1490 train_time:2119ms step_avg:31.63ms
+step:68/1490 train_time:2154ms step_avg:31.68ms
+step:69/1490 train_time:2182ms step_avg:31.63ms
+step:70/1490 train_time:2217ms step_avg:31.67ms
+step:71/1490 train_time:2245ms step_avg:31.62ms
+step:72/1490 train_time:2281ms step_avg:31.68ms
+step:73/1490 train_time:2309ms step_avg:31.62ms
+step:74/1490 train_time:2343ms step_avg:31.66ms
+step:75/1490 train_time:2371ms step_avg:31.62ms
+step:76/1490 train_time:2406ms step_avg:31.65ms
+step:77/1490 train_time:2434ms step_avg:31.61ms
+step:78/1490 train_time:2469ms step_avg:31.66ms
+step:79/1490 train_time:2497ms step_avg:31.61ms
+step:80/1490 train_time:2531ms step_avg:31.64ms
+step:81/1490 train_time:2559ms step_avg:31.60ms
+step:82/1490 train_time:2594ms step_avg:31.63ms
+step:83/1490 train_time:2622ms step_avg:31.59ms
+step:84/1490 train_time:2657ms step_avg:31.63ms
+step:85/1490 train_time:2684ms step_avg:31.58ms
+step:86/1490 train_time:2719ms step_avg:31.61ms
+step:87/1490 train_time:2747ms step_avg:31.58ms
+step:88/1490 train_time:2782ms step_avg:31.61ms
+step:89/1490 train_time:2810ms step_avg:31.57ms
+step:90/1490 train_time:2844ms step_avg:31.60ms
+step:91/1490 train_time:2872ms step_avg:31.56ms
+step:92/1490 train_time:2906ms step_avg:31.59ms
+step:93/1490 train_time:2935ms step_avg:31.55ms
+step:94/1490 train_time:2969ms step_avg:31.58ms
+step:95/1490 train_time:2997ms step_avg:31.55ms
+step:96/1490 train_time:3032ms step_avg:31.59ms
+step:97/1490 train_time:3061ms step_avg:31.55ms
+step:98/1490 train_time:3095ms step_avg:31.59ms
+step:99/1490 train_time:3124ms step_avg:31.55ms
+step:100/1490 train_time:3159ms step_avg:31.59ms
+step:101/1490 train_time:3187ms step_avg:31.56ms
+step:102/1490 train_time:3222ms step_avg:31.58ms
+step:103/1490 train_time:3250ms step_avg:31.55ms
+step:104/1490 train_time:3285ms step_avg:31.58ms
+step:105/1490 train_time:3312ms step_avg:31.55ms
+step:106/1490 train_time:3347ms step_avg:31.58ms
+step:107/1490 train_time:3376ms step_avg:31.55ms
+step:108/1490 train_time:3411ms step_avg:31.59ms
+step:109/1490 train_time:3440ms step_avg:31.56ms
+step:110/1490 train_time:3475ms step_avg:31.59ms
+step:111/1490 train_time:3503ms step_avg:31.55ms
+step:112/1490 train_time:3537ms step_avg:31.58ms
+step:113/1490 train_time:3565ms step_avg:31.55ms
+step:114/1490 train_time:3600ms step_avg:31.58ms
+step:115/1490 train_time:3628ms step_avg:31.55ms
+step:116/1490 train_time:3663ms step_avg:31.58ms
+step:117/1490 train_time:3691ms step_avg:31.55ms
+step:118/1490 train_time:3725ms step_avg:31.57ms
+step:119/1490 train_time:3753ms step_avg:31.54ms
+step:120/1490 train_time:3788ms step_avg:31.56ms
+step:121/1490 train_time:3815ms step_avg:31.53ms
+step:122/1490 train_time:3850ms step_avg:31.56ms
+step:123/1490 train_time:3878ms step_avg:31.53ms
+step:124/1490 train_time:3913ms step_avg:31.56ms
+step:125/1490 train_time:3941ms step_avg:31.53ms
+step:126/1490 train_time:3976ms step_avg:31.56ms
+step:127/1490 train_time:4004ms step_avg:31.53ms
+step:128/1490 train_time:4039ms step_avg:31.56ms
+step:129/1490 train_time:4067ms step_avg:31.53ms
+step:130/1490 train_time:4102ms step_avg:31.56ms
+step:131/1490 train_time:4130ms step_avg:31.53ms
+step:132/1490 train_time:4165ms step_avg:31.55ms
+step:133/1490 train_time:4193ms step_avg:31.53ms
+step:134/1490 train_time:4228ms step_avg:31.55ms
+step:135/1490 train_time:4256ms step_avg:31.53ms
+step:136/1490 train_time:4291ms step_avg:31.55ms
+step:137/1490 train_time:4318ms step_avg:31.52ms
+step:138/1490 train_time:4353ms step_avg:31.54ms
+step:139/1490 train_time:4381ms step_avg:31.52ms
+step:140/1490 train_time:4416ms step_avg:31.54ms
+step:141/1490 train_time:4444ms step_avg:31.52ms
+step:142/1490 train_time:4479ms step_avg:31.54ms
+step:143/1490 train_time:4507ms step_avg:31.52ms
+step:144/1490 train_time:4542ms step_avg:31.54ms
+step:145/1490 train_time:4570ms step_avg:31.52ms
+step:146/1490 train_time:4605ms step_avg:31.54ms
+step:147/1490 train_time:4633ms step_avg:31.52ms
+step:148/1490 train_time:4668ms step_avg:31.54ms
+step:149/1490 train_time:4697ms step_avg:31.52ms
+step:150/1490 train_time:4731ms step_avg:31.54ms
+step:151/1490 train_time:4758ms step_avg:31.51ms
+step:152/1490 train_time:4793ms step_avg:31.53ms
+step:153/1490 train_time:4821ms step_avg:31.51ms
+step:154/1490 train_time:4856ms step_avg:31.53ms
+step:155/1490 train_time:4884ms step_avg:31.51ms
+step:156/1490 train_time:4919ms step_avg:31.53ms
+step:157/1490 train_time:4946ms step_avg:31.51ms
+step:158/1490 train_time:4981ms step_avg:31.52ms
+step:159/1490 train_time:5009ms step_avg:31.50ms
+step:160/1490 train_time:5043ms step_avg:31.52ms
+step:161/1490 train_time:5071ms step_avg:31.50ms
+step:162/1490 train_time:5106ms step_avg:31.52ms
+step:163/1490 train_time:5134ms step_avg:31.50ms
+step:164/1490 train_time:5169ms step_avg:31.52ms
+step:165/1490 train_time:5197ms step_avg:31.50ms
+step:166/1490 train_time:5232ms step_avg:31.52ms
+step:167/1490 train_time:5260ms step_avg:31.49ms
+step:168/1490 train_time:5295ms step_avg:31.52ms
+step:169/1490 train_time:5323ms step_avg:31.49ms
+step:170/1490 train_time:5358ms step_avg:31.52ms
+step:171/1490 train_time:5386ms step_avg:31.49ms
+step:172/1490 train_time:5420ms step_avg:31.51ms
+step:173/1490 train_time:5448ms step_avg:31.49ms
+step:174/1490 train_time:5482ms step_avg:31.51ms
+step:175/1490 train_time:5511ms step_avg:31.49ms
+step:176/1490 train_time:5545ms step_avg:31.50ms
+step:177/1490 train_time:5573ms step_avg:31.49ms
+step:178/1490 train_time:5608ms step_avg:31.50ms
+step:179/1490 train_time:5636ms step_avg:31.49ms
+step:180/1490 train_time:5671ms step_avg:31.51ms
+step:181/1490 train_time:5700ms step_avg:31.49ms
+step:182/1490 train_time:5735ms step_avg:31.51ms
+step:183/1490 train_time:5763ms step_avg:31.49ms
+step:184/1490 train_time:5798ms step_avg:31.51ms
+step:185/1490 train_time:5826ms step_avg:31.49ms
+step:186/1490 train_time:5861ms step_avg:31.51ms
+step:187/1490 train_time:5889ms step_avg:31.49ms
+step:188/1490 train_time:5923ms step_avg:31.51ms
+step:189/1490 train_time:5951ms step_avg:31.49ms
+step:190/1490 train_time:5985ms step_avg:31.50ms
+step:191/1490 train_time:6013ms step_avg:31.48ms
+step:192/1490 train_time:6048ms step_avg:31.50ms
+step:193/1490 train_time:6075ms step_avg:31.48ms
+step:194/1490 train_time:6111ms step_avg:31.50ms
+step:195/1490 train_time:6139ms step_avg:31.48ms
+step:196/1490 train_time:6174ms step_avg:31.50ms
+step:197/1490 train_time:6202ms step_avg:31.48ms
+step:198/1490 train_time:6237ms step_avg:31.50ms
+step:199/1490 train_time:6265ms step_avg:31.48ms
+step:200/1490 train_time:6300ms step_avg:31.50ms
+step:201/1490 train_time:6328ms step_avg:31.48ms
+step:202/1490 train_time:6362ms step_avg:31.49ms
+step:203/1490 train_time:6390ms step_avg:31.48ms
+step:204/1490 train_time:6424ms step_avg:31.49ms
+step:205/1490 train_time:6453ms step_avg:31.48ms
+step:206/1490 train_time:6487ms step_avg:31.49ms
+step:207/1490 train_time:6516ms step_avg:31.48ms
+step:208/1490 train_time:6550ms step_avg:31.49ms
+step:209/1490 train_time:6578ms step_avg:31.47ms
+step:210/1490 train_time:6613ms step_avg:31.49ms
+step:211/1490 train_time:6641ms step_avg:31.48ms
+step:212/1490 train_time:6677ms step_avg:31.49ms
+step:213/1490 train_time:6704ms step_avg:31.48ms
+step:214/1490 train_time:6739ms step_avg:31.49ms
+step:215/1490 train_time:6768ms step_avg:31.48ms
+step:216/1490 train_time:6803ms step_avg:31.49ms
+step:217/1490 train_time:6831ms step_avg:31.48ms
+step:218/1490 train_time:6865ms step_avg:31.49ms
+step:219/1490 train_time:6894ms step_avg:31.48ms
+step:220/1490 train_time:6928ms step_avg:31.49ms
+step:221/1490 train_time:6956ms step_avg:31.47ms
+step:222/1490 train_time:6991ms step_avg:31.49ms
+step:223/1490 train_time:7018ms step_avg:31.47ms
+step:224/1490 train_time:7053ms step_avg:31.49ms
+step:225/1490 train_time:7081ms step_avg:31.47ms
+step:226/1490 train_time:7115ms step_avg:31.48ms
+step:227/1490 train_time:7143ms step_avg:31.47ms
+step:228/1490 train_time:7178ms step_avg:31.48ms
+step:229/1490 train_time:7206ms step_avg:31.47ms
+step:230/1490 train_time:7240ms step_avg:31.48ms
+step:231/1490 train_time:7268ms step_avg:31.46ms
+step:232/1490 train_time:7303ms step_avg:31.48ms
+step:233/1490 train_time:7331ms step_avg:31.46ms
+step:234/1490 train_time:7365ms step_avg:31.48ms
+step:235/1490 train_time:7393ms step_avg:31.46ms
+step:236/1490 train_time:7427ms step_avg:31.47ms
+step:237/1490 train_time:7456ms step_avg:31.46ms
+step:238/1490 train_time:7490ms step_avg:31.47ms
+step:239/1490 train_time:7518ms step_avg:31.46ms
+step:240/1490 train_time:7553ms step_avg:31.47ms
+step:241/1490 train_time:7581ms step_avg:31.46ms
+step:242/1490 train_time:7616ms step_avg:31.47ms
+step:243/1490 train_time:7644ms step_avg:31.46ms
+step:244/1490 train_time:7678ms step_avg:31.47ms
+step:245/1490 train_time:7706ms step_avg:31.45ms
+step:246/1490 train_time:7741ms step_avg:31.47ms
+step:247/1490 train_time:7769ms step_avg:31.45ms
+step:248/1490 train_time:7804ms step_avg:31.47ms
+step:249/1490 train_time:7833ms step_avg:31.46ms
+step:250/1490 train_time:7867ms step_avg:31.47ms
+step:250/1490 val_loss:4.5005 train_time:7910ms step_avg:31.64ms
+step:251/1490 train_time:7928ms step_avg:31.59ms
+step:252/1490 train_time:7949ms step_avg:31.54ms
+step:253/1490 train_time:7964ms step_avg:31.48ms
+step:254/1490 train_time:7997ms step_avg:31.48ms
+step:255/1490 train_time:8028ms step_avg:31.48ms
+step:256/1490 train_time:8064ms step_avg:31.50ms
+step:257/1490 train_time:8092ms step_avg:31.49ms
+step:258/1490 train_time:8127ms step_avg:31.50ms
+step:259/1490 train_time:8155ms step_avg:31.49ms
+step:260/1490 train_time:8190ms step_avg:31.50ms
+step:261/1490 train_time:8218ms step_avg:31.49ms
+step:262/1490 train_time:8252ms step_avg:31.50ms
+step:263/1490 train_time:8280ms step_avg:31.48ms
+step:264/1490 train_time:8315ms step_avg:31.50ms
+step:265/1490 train_time:8342ms step_avg:31.48ms
+step:266/1490 train_time:8376ms step_avg:31.49ms
+step:267/1490 train_time:8404ms step_avg:31.48ms
+step:268/1490 train_time:8438ms step_avg:31.48ms
+step:269/1490 train_time:8466ms step_avg:31.47ms
+step:270/1490 train_time:8500ms step_avg:31.48ms
+step:271/1490 train_time:8528ms step_avg:31.47ms
+step:272/1490 train_time:8563ms step_avg:31.48ms
+step:273/1490 train_time:8590ms step_avg:31.47ms
+step:274/1490 train_time:8625ms step_avg:31.48ms
+step:275/1490 train_time:8652ms step_avg:31.46ms
+step:276/1490 train_time:8687ms step_avg:31.47ms
+step:277/1490 train_time:8715ms step_avg:31.46ms
+step:278/1490 train_time:8749ms step_avg:31.47ms
+step:279/1490 train_time:8776ms step_avg:31.46ms
+step:280/1490 train_time:8811ms step_avg:31.47ms
+step:281/1490 train_time:8839ms step_avg:31.45ms
+step:282/1490 train_time:8873ms step_avg:31.46ms
+step:283/1490 train_time:8902ms step_avg:31.45ms
+step:284/1490 train_time:8936ms step_avg:31.47ms
+step:285/1490 train_time:8966ms step_avg:31.46ms
+step:286/1490 train_time:9000ms step_avg:31.47ms
+step:287/1490 train_time:9029ms step_avg:31.46ms
+step:288/1490 train_time:9064ms step_avg:31.47ms
+step:289/1490 train_time:9093ms step_avg:31.46ms
+step:290/1490 train_time:9128ms step_avg:31.48ms
+step:291/1490 train_time:9157ms step_avg:31.47ms
+step:292/1490 train_time:9191ms step_avg:31.48ms
+step:293/1490 train_time:9219ms step_avg:31.47ms
+step:294/1490 train_time:9254ms step_avg:31.48ms
+step:295/1490 train_time:9282ms step_avg:31.46ms
+step:296/1490 train_time:9316ms step_avg:31.47ms
+step:297/1490 train_time:9345ms step_avg:31.46ms
+step:298/1490 train_time:9379ms step_avg:31.47ms
+step:299/1490 train_time:9407ms step_avg:31.46ms
+step:300/1490 train_time:9441ms step_avg:31.47ms
+step:301/1490 train_time:9469ms step_avg:31.46ms
+step:302/1490 train_time:9503ms step_avg:31.47ms
+step:303/1490 train_time:9531ms step_avg:31.46ms
+step:304/1490 train_time:9565ms step_avg:31.47ms
+step:305/1490 train_time:9593ms step_avg:31.45ms
+step:306/1490 train_time:9628ms step_avg:31.46ms
+step:307/1490 train_time:9655ms step_avg:31.45ms
+step:308/1490 train_time:9690ms step_avg:31.46ms
+step:309/1490 train_time:9718ms step_avg:31.45ms
+step:310/1490 train_time:9752ms step_avg:31.46ms
+step:311/1490 train_time:9780ms step_avg:31.45ms
+step:312/1490 train_time:9815ms step_avg:31.46ms
+step:313/1490 train_time:9843ms step_avg:31.45ms
+step:314/1490 train_time:9877ms step_avg:31.46ms
+step:315/1490 train_time:9906ms step_avg:31.45ms
+step:316/1490 train_time:9941ms step_avg:31.46ms
+step:317/1490 train_time:9969ms step_avg:31.45ms
+step:318/1490 train_time:10004ms step_avg:31.46ms
+step:319/1490 train_time:10032ms step_avg:31.45ms
+step:320/1490 train_time:10067ms step_avg:31.46ms
+step:321/1490 train_time:10096ms step_avg:31.45ms
+step:322/1490 train_time:10131ms step_avg:31.46ms
+step:323/1490 train_time:10159ms step_avg:31.45ms
+step:324/1490 train_time:10194ms step_avg:31.46ms
+step:325/1490 train_time:10222ms step_avg:31.45ms
+step:326/1490 train_time:10256ms step_avg:31.46ms
+step:327/1490 train_time:10285ms step_avg:31.45ms
+step:328/1490 train_time:10319ms step_avg:31.46ms
+step:329/1490 train_time:10347ms step_avg:31.45ms
+step:330/1490 train_time:10381ms step_avg:31.46ms
+step:331/1490 train_time:10409ms step_avg:31.45ms
+step:332/1490 train_time:10444ms step_avg:31.46ms
+step:333/1490 train_time:10471ms step_avg:31.45ms
+step:334/1490 train_time:10506ms step_avg:31.45ms
+step:335/1490 train_time:10534ms step_avg:31.44ms
+step:336/1490 train_time:10568ms step_avg:31.45ms
+step:337/1490 train_time:10596ms step_avg:31.44ms
+step:338/1490 train_time:10630ms step_avg:31.45ms
+step:339/1490 train_time:10658ms step_avg:31.44ms
+step:340/1490 train_time:10693ms step_avg:31.45ms
+step:341/1490 train_time:10721ms step_avg:31.44ms
+step:342/1490 train_time:10756ms step_avg:31.45ms
+step:343/1490 train_time:10783ms step_avg:31.44ms
+step:344/1490 train_time:10817ms step_avg:31.45ms
+step:345/1490 train_time:10845ms step_avg:31.44ms
+step:346/1490 train_time:10880ms step_avg:31.44ms
+step:347/1490 train_time:10908ms step_avg:31.44ms
+step:348/1490 train_time:10943ms step_avg:31.45ms
+step:349/1490 train_time:10971ms step_avg:31.44ms
+step:350/1490 train_time:11006ms step_avg:31.45ms
+step:351/1490 train_time:11034ms step_avg:31.44ms
+step:352/1490 train_time:11069ms step_avg:31.44ms
+step:353/1490 train_time:11097ms step_avg:31.44ms
+step:354/1490 train_time:11131ms step_avg:31.44ms
+step:355/1490 train_time:11160ms step_avg:31.44ms
+step:356/1490 train_time:11194ms step_avg:31.44ms
+step:357/1490 train_time:11223ms step_avg:31.44ms
+step:358/1490 train_time:11257ms step_avg:31.44ms
+step:359/1490 train_time:11286ms step_avg:31.44ms
+step:360/1490 train_time:11320ms step_avg:31.44ms
+step:361/1490 train_time:11348ms step_avg:31.43ms
+step:362/1490 train_time:11383ms step_avg:31.44ms
+step:363/1490 train_time:11411ms step_avg:31.43ms
+step:364/1490 train_time:11446ms step_avg:31.44ms
+step:365/1490 train_time:11474ms step_avg:31.43ms
+step:366/1490 train_time:11508ms step_avg:31.44ms
+step:367/1490 train_time:11536ms step_avg:31.43ms
+step:368/1490 train_time:11571ms step_avg:31.44ms
+step:369/1490 train_time:11599ms step_avg:31.43ms
+step:370/1490 train_time:11634ms step_avg:31.44ms
+step:371/1490 train_time:11661ms step_avg:31.43ms
+step:372/1490 train_time:11696ms step_avg:31.44ms
+step:373/1490 train_time:11724ms step_avg:31.43ms
+step:374/1490 train_time:11758ms step_avg:31.44ms
+step:375/1490 train_time:11786ms step_avg:31.43ms
+step:376/1490 train_time:11820ms step_avg:31.44ms
+step:377/1490 train_time:11848ms step_avg:31.43ms
+step:378/1490 train_time:11883ms step_avg:31.44ms
+step:379/1490 train_time:11911ms step_avg:31.43ms
+step:380/1490 train_time:11946ms step_avg:31.44ms
+step:381/1490 train_time:11974ms step_avg:31.43ms
+step:382/1490 train_time:12009ms step_avg:31.44ms
+step:383/1490 train_time:12037ms step_avg:31.43ms
+step:384/1490 train_time:12072ms step_avg:31.44ms
+step:385/1490 train_time:12100ms step_avg:31.43ms
+step:386/1490 train_time:12134ms step_avg:31.44ms
+step:387/1490 train_time:12163ms step_avg:31.43ms
+step:388/1490 train_time:12197ms step_avg:31.44ms
+step:389/1490 train_time:12225ms step_avg:31.43ms
+step:390/1490 train_time:12260ms step_avg:31.44ms
+step:391/1490 train_time:12288ms step_avg:31.43ms
+step:392/1490 train_time:12323ms step_avg:31.44ms
+step:393/1490 train_time:12350ms step_avg:31.43ms
+step:394/1490 train_time:12385ms step_avg:31.43ms
+step:395/1490 train_time:12413ms step_avg:31.42ms
+step:396/1490 train_time:12448ms step_avg:31.43ms
+step:397/1490 train_time:12476ms step_avg:31.42ms
+step:398/1490 train_time:12511ms step_avg:31.44ms
+step:399/1490 train_time:12539ms step_avg:31.42ms
+step:400/1490 train_time:12573ms step_avg:31.43ms
+step:401/1490 train_time:12601ms step_avg:31.42ms
+step:402/1490 train_time:12635ms step_avg:31.43ms
+step:403/1490 train_time:12663ms step_avg:31.42ms
+step:404/1490 train_time:12698ms step_avg:31.43ms
+step:405/1490 train_time:12726ms step_avg:31.42ms
+step:406/1490 train_time:12760ms step_avg:31.43ms
+step:407/1490 train_time:12788ms step_avg:31.42ms
+step:408/1490 train_time:12822ms step_avg:31.43ms
+step:409/1490 train_time:12850ms step_avg:31.42ms
+step:410/1490 train_time:12885ms step_avg:31.43ms
+step:411/1490 train_time:12913ms step_avg:31.42ms
+step:412/1490 train_time:12948ms step_avg:31.43ms
+step:413/1490 train_time:12976ms step_avg:31.42ms
+step:414/1490 train_time:13010ms step_avg:31.43ms
+step:415/1490 train_time:13039ms step_avg:31.42ms
+step:416/1490 train_time:13073ms step_avg:31.43ms
+step:417/1490 train_time:13102ms step_avg:31.42ms
+step:418/1490 train_time:13136ms step_avg:31.43ms
+step:419/1490 train_time:13164ms step_avg:31.42ms
+step:420/1490 train_time:13198ms step_avg:31.42ms
+step:421/1490 train_time:13226ms step_avg:31.42ms
+step:422/1490 train_time:13261ms step_avg:31.42ms
+step:423/1490 train_time:13289ms step_avg:31.42ms
+step:424/1490 train_time:13323ms step_avg:31.42ms
+step:425/1490 train_time:13351ms step_avg:31.41ms
+step:426/1490 train_time:13386ms step_avg:31.42ms
+step:427/1490 train_time:13414ms step_avg:31.41ms
+step:428/1490 train_time:13449ms step_avg:31.42ms
+step:429/1490 train_time:13477ms step_avg:31.42ms
+step:430/1490 train_time:13512ms step_avg:31.42ms
+step:431/1490 train_time:13540ms step_avg:31.42ms
+step:432/1490 train_time:13574ms step_avg:31.42ms
+step:433/1490 train_time:13602ms step_avg:31.41ms
+step:434/1490 train_time:13637ms step_avg:31.42ms
+step:435/1490 train_time:13665ms step_avg:31.41ms
+step:436/1490 train_time:13699ms step_avg:31.42ms
+step:437/1490 train_time:13727ms step_avg:31.41ms
+step:438/1490 train_time:13762ms step_avg:31.42ms
+step:439/1490 train_time:13790ms step_avg:31.41ms
+step:440/1490 train_time:13825ms step_avg:31.42ms
+step:441/1490 train_time:13853ms step_avg:31.41ms
+step:442/1490 train_time:13888ms step_avg:31.42ms
+step:443/1490 train_time:13916ms step_avg:31.41ms
+step:444/1490 train_time:13950ms step_avg:31.42ms
+step:445/1490 train_time:13978ms step_avg:31.41ms
+step:446/1490 train_time:14013ms step_avg:31.42ms
+step:447/1490 train_time:14041ms step_avg:31.41ms
+step:448/1490 train_time:14076ms step_avg:31.42ms
+step:449/1490 train_time:14104ms step_avg:31.41ms
+step:450/1490 train_time:14138ms step_avg:31.42ms
+step:451/1490 train_time:14166ms step_avg:31.41ms
+step:452/1490 train_time:14201ms step_avg:31.42ms
+step:453/1490 train_time:14229ms step_avg:31.41ms
+step:454/1490 train_time:14264ms step_avg:31.42ms
+step:455/1490 train_time:14292ms step_avg:31.41ms
+step:456/1490 train_time:14327ms step_avg:31.42ms
+step:457/1490 train_time:14355ms step_avg:31.41ms
+step:458/1490 train_time:14389ms step_avg:31.42ms
+step:459/1490 train_time:14418ms step_avg:31.41ms
+step:460/1490 train_time:14452ms step_avg:31.42ms
+step:461/1490 train_time:14480ms step_avg:31.41ms
+step:462/1490 train_time:14514ms step_avg:31.42ms
+step:463/1490 train_time:14542ms step_avg:31.41ms
+step:464/1490 train_time:14576ms step_avg:31.41ms
+step:465/1490 train_time:14605ms step_avg:31.41ms
+step:466/1490 train_time:14639ms step_avg:31.41ms
+step:467/1490 train_time:14667ms step_avg:31.41ms
+step:468/1490 train_time:14701ms step_avg:31.41ms
+step:469/1490 train_time:14730ms step_avg:31.41ms
+step:470/1490 train_time:14765ms step_avg:31.41ms
+step:471/1490 train_time:14792ms step_avg:31.41ms
+step:472/1490 train_time:14827ms step_avg:31.41ms
+step:473/1490 train_time:14855ms step_avg:31.41ms
+step:474/1490 train_time:14890ms step_avg:31.41ms
+step:475/1490 train_time:14918ms step_avg:31.41ms
+step:476/1490 train_time:14952ms step_avg:31.41ms
+step:477/1490 train_time:14981ms step_avg:31.41ms
+step:478/1490 train_time:15015ms step_avg:31.41ms
+step:479/1490 train_time:15043ms step_avg:31.40ms
+step:480/1490 train_time:15078ms step_avg:31.41ms
+step:481/1490 train_time:15105ms step_avg:31.40ms
+step:482/1490 train_time:15140ms step_avg:31.41ms
+step:483/1490 train_time:15168ms step_avg:31.40ms
+step:484/1490 train_time:15205ms step_avg:31.42ms
+step:485/1490 train_time:15257ms step_avg:31.46ms
+step:486/1490 train_time:15316ms step_avg:31.52ms
+step:487/1490 train_time:15371ms step_avg:31.56ms
+step:488/1490 train_time:15430ms step_avg:31.62ms
+step:489/1490 train_time:15484ms step_avg:31.67ms
+step:490/1490 train_time:15544ms step_avg:31.72ms
+step:491/1490 train_time:15598ms step_avg:31.77ms
+step:492/1490 train_time:15657ms step_avg:31.82ms
+step:493/1490 train_time:15712ms step_avg:31.87ms
+step:494/1490 train_time:15772ms step_avg:31.93ms
+step:495/1490 train_time:15827ms step_avg:31.97ms
+step:496/1490 train_time:15887ms step_avg:32.03ms
+step:497/1490 train_time:15941ms step_avg:32.07ms
+step:498/1490 train_time:16001ms step_avg:32.13ms
+step:499/1490 train_time:16055ms step_avg:32.17ms
+step:500/1490 train_time:16115ms step_avg:32.23ms
+step:500/1490 val_loss:4.2172 train_time:16187ms step_avg:32.37ms
+step:501/1490 train_time:16205ms step_avg:32.35ms
+step:502/1490 train_time:16231ms step_avg:32.33ms
+step:503/1490 train_time:16289ms step_avg:32.38ms
+step:504/1490 train_time:16354ms step_avg:32.45ms
+step:505/1490 train_time:16409ms step_avg:32.49ms
+step:506/1490 train_time:16468ms step_avg:32.55ms
+step:507/1490 train_time:16523ms step_avg:32.59ms
+step:508/1490 train_time:16583ms step_avg:32.64ms
+step:509/1490 train_time:16638ms step_avg:32.69ms
+step:510/1490 train_time:16696ms step_avg:32.74ms
+step:511/1490 train_time:16750ms step_avg:32.78ms
+step:512/1490 train_time:16808ms step_avg:32.83ms
+step:513/1490 train_time:16861ms step_avg:32.87ms
+step:514/1490 train_time:16920ms step_avg:32.92ms
+step:515/1490 train_time:16973ms step_avg:32.96ms
+step:516/1490 train_time:17033ms step_avg:33.01ms
+step:517/1490 train_time:17087ms step_avg:33.05ms
+step:518/1490 train_time:17147ms step_avg:33.10ms
+step:519/1490 train_time:17202ms step_avg:33.14ms
+step:520/1490 train_time:17262ms step_avg:33.20ms
+step:521/1490 train_time:17318ms step_avg:33.24ms
+step:522/1490 train_time:17379ms step_avg:33.29ms
+step:523/1490 train_time:17434ms step_avg:33.34ms
+step:524/1490 train_time:17494ms step_avg:33.39ms
+step:525/1490 train_time:17549ms step_avg:33.43ms
+step:526/1490 train_time:17608ms step_avg:33.48ms
+step:527/1490 train_time:17662ms step_avg:33.51ms
+step:528/1490 train_time:17722ms step_avg:33.56ms
+step:529/1490 train_time:17775ms step_avg:33.60ms
+step:530/1490 train_time:17834ms step_avg:33.65ms
+step:531/1490 train_time:17888ms step_avg:33.69ms
+step:532/1490 train_time:17947ms step_avg:33.73ms
+step:533/1490 train_time:18000ms step_avg:33.77ms
+step:534/1490 train_time:18059ms step_avg:33.82ms
+step:535/1490 train_time:18112ms step_avg:33.85ms
+step:536/1490 train_time:18173ms step_avg:33.91ms
+step:537/1490 train_time:18229ms step_avg:33.95ms
+step:538/1490 train_time:18289ms step_avg:33.99ms
+step:539/1490 train_time:18344ms step_avg:34.03ms
+step:540/1490 train_time:18405ms step_avg:34.08ms
+step:541/1490 train_time:18460ms step_avg:34.12ms
+step:542/1490 train_time:18521ms step_avg:34.17ms
+step:543/1490 train_time:18575ms step_avg:34.21ms
+step:544/1490 train_time:18635ms step_avg:34.26ms
+step:545/1490 train_time:18689ms step_avg:34.29ms
+step:546/1490 train_time:18747ms step_avg:34.34ms
+step:547/1490 train_time:18801ms step_avg:34.37ms
+step:548/1490 train_time:18861ms step_avg:34.42ms
+step:549/1490 train_time:18914ms step_avg:34.45ms
+step:550/1490 train_time:18973ms step_avg:34.50ms
+step:551/1490 train_time:19026ms step_avg:34.53ms
+step:552/1490 train_time:19085ms step_avg:34.57ms
+step:553/1490 train_time:19139ms step_avg:34.61ms
+step:554/1490 train_time:19199ms step_avg:34.65ms
+step:555/1490 train_time:19253ms step_avg:34.69ms
+step:556/1490 train_time:19314ms step_avg:34.74ms
+step:557/1490 train_time:19369ms step_avg:34.77ms
+step:558/1490 train_time:19430ms step_avg:34.82ms
+step:559/1490 train_time:19484ms step_avg:34.85ms
+step:560/1490 train_time:19545ms step_avg:34.90ms
+step:561/1490 train_time:19600ms step_avg:34.94ms
+step:562/1490 train_time:19659ms step_avg:34.98ms
+step:563/1490 train_time:19713ms step_avg:35.01ms
+step:564/1490 train_time:19773ms step_avg:35.06ms
+step:565/1490 train_time:19827ms step_avg:35.09ms
+step:566/1490 train_time:19885ms step_avg:35.13ms
+step:567/1490 train_time:19939ms step_avg:35.17ms
+step:568/1490 train_time:19998ms step_avg:35.21ms
+step:569/1490 train_time:20052ms step_avg:35.24ms
+step:570/1490 train_time:20112ms step_avg:35.28ms
+step:571/1490 train_time:20166ms step_avg:35.32ms
+step:572/1490 train_time:20226ms step_avg:35.36ms
+step:573/1490 train_time:20280ms step_avg:35.39ms
+step:574/1490 train_time:20340ms step_avg:35.44ms
+step:575/1490 train_time:20395ms step_avg:35.47ms
+step:576/1490 train_time:20455ms step_avg:35.51ms
+step:577/1490 train_time:20509ms step_avg:35.54ms
+step:578/1490 train_time:20570ms step_avg:35.59ms
+step:579/1490 train_time:20624ms step_avg:35.62ms
+step:580/1490 train_time:20684ms step_avg:35.66ms
+step:581/1490 train_time:20739ms step_avg:35.70ms
+step:582/1490 train_time:20798ms step_avg:35.74ms
+step:583/1490 train_time:20851ms step_avg:35.77ms
+step:584/1490 train_time:20911ms step_avg:35.81ms
+step:585/1490 train_time:20964ms step_avg:35.84ms
+step:586/1490 train_time:21023ms step_avg:35.88ms
+step:587/1490 train_time:21078ms step_avg:35.91ms
+step:588/1490 train_time:21137ms step_avg:35.95ms
+step:589/1490 train_time:21192ms step_avg:35.98ms
+step:590/1490 train_time:21252ms step_avg:36.02ms
+step:591/1490 train_time:21306ms step_avg:36.05ms
+step:592/1490 train_time:21366ms step_avg:36.09ms
+step:593/1490 train_time:21420ms step_avg:36.12ms
+step:594/1490 train_time:21480ms step_avg:36.16ms
+step:595/1490 train_time:21535ms step_avg:36.19ms
+step:596/1490 train_time:21595ms step_avg:36.23ms
+step:597/1490 train_time:21650ms step_avg:36.26ms
+step:598/1490 train_time:21709ms step_avg:36.30ms
+step:599/1490 train_time:21763ms step_avg:36.33ms
+step:600/1490 train_time:21822ms step_avg:36.37ms
+step:601/1490 train_time:21876ms step_avg:36.40ms
+step:602/1490 train_time:21936ms step_avg:36.44ms
+step:603/1490 train_time:21990ms step_avg:36.47ms
+step:604/1490 train_time:22050ms step_avg:36.51ms
+step:605/1490 train_time:22103ms step_avg:36.53ms
+step:606/1490 train_time:22162ms step_avg:36.57ms
+step:607/1490 train_time:22217ms step_avg:36.60ms
+step:608/1490 train_time:22278ms step_avg:36.64ms
+step:609/1490 train_time:22332ms step_avg:36.67ms
+step:610/1490 train_time:22392ms step_avg:36.71ms
+step:611/1490 train_time:22445ms step_avg:36.74ms
+step:612/1490 train_time:22505ms step_avg:36.77ms
+step:613/1490 train_time:22559ms step_avg:36.80ms
+step:614/1490 train_time:22618ms step_avg:36.84ms
+step:615/1490 train_time:22672ms step_avg:36.87ms
+step:616/1490 train_time:22733ms step_avg:36.90ms
+step:617/1490 train_time:22788ms step_avg:36.93ms
+step:618/1490 train_time:22847ms step_avg:36.97ms
+step:619/1490 train_time:22901ms step_avg:37.00ms
+step:620/1490 train_time:22961ms step_avg:37.03ms
+step:621/1490 train_time:23015ms step_avg:37.06ms
+step:622/1490 train_time:23075ms step_avg:37.10ms
+step:623/1490 train_time:23128ms step_avg:37.12ms
+step:624/1490 train_time:23188ms step_avg:37.16ms
+step:625/1490 train_time:23242ms step_avg:37.19ms
+step:626/1490 train_time:23302ms step_avg:37.22ms
+step:627/1490 train_time:23355ms step_avg:37.25ms
+step:628/1490 train_time:23415ms step_avg:37.29ms
+step:629/1490 train_time:23470ms step_avg:37.31ms
+step:630/1490 train_time:23529ms step_avg:37.35ms
+step:631/1490 train_time:23584ms step_avg:37.37ms
+step:632/1490 train_time:23643ms step_avg:37.41ms
+step:633/1490 train_time:23698ms step_avg:37.44ms
+step:634/1490 train_time:23757ms step_avg:37.47ms
+step:635/1490 train_time:23812ms step_avg:37.50ms
+step:636/1490 train_time:23872ms step_avg:37.53ms
+step:637/1490 train_time:23927ms step_avg:37.56ms
+step:638/1490 train_time:23986ms step_avg:37.59ms
+step:639/1490 train_time:24040ms step_avg:37.62ms
+step:640/1490 train_time:24100ms step_avg:37.66ms
+step:641/1490 train_time:24154ms step_avg:37.68ms
+step:642/1490 train_time:24214ms step_avg:37.72ms
+step:643/1490 train_time:24268ms step_avg:37.74ms
+step:644/1490 train_time:24327ms step_avg:37.78ms
+step:645/1490 train_time:24381ms step_avg:37.80ms
+step:646/1490 train_time:24442ms step_avg:37.84ms
+step:647/1490 train_time:24497ms step_avg:37.86ms
+step:648/1490 train_time:24556ms step_avg:37.89ms
+step:649/1490 train_time:24610ms step_avg:37.92ms
+step:650/1490 train_time:24670ms step_avg:37.95ms
+step:651/1490 train_time:24725ms step_avg:37.98ms
+step:652/1490 train_time:24783ms step_avg:38.01ms
+step:653/1490 train_time:24838ms step_avg:38.04ms
+step:654/1490 train_time:24898ms step_avg:38.07ms
+step:655/1490 train_time:24951ms step_avg:38.09ms
+step:656/1490 train_time:25011ms step_avg:38.13ms
+step:657/1490 train_time:25065ms step_avg:38.15ms
+step:658/1490 train_time:25124ms step_avg:38.18ms
+step:659/1490 train_time:25178ms step_avg:38.21ms
+step:660/1490 train_time:25237ms step_avg:38.24ms
+step:661/1490 train_time:25291ms step_avg:38.26ms
+step:662/1490 train_time:25351ms step_avg:38.30ms
+step:663/1490 train_time:25406ms step_avg:38.32ms
+step:664/1490 train_time:25465ms step_avg:38.35ms
+step:665/1490 train_time:25519ms step_avg:38.37ms
+step:666/1490 train_time:25580ms step_avg:38.41ms
+step:667/1490 train_time:25634ms step_avg:38.43ms
+step:668/1490 train_time:25693ms step_avg:38.46ms
+step:669/1490 train_time:25747ms step_avg:38.49ms
+step:670/1490 train_time:25807ms step_avg:38.52ms
+step:671/1490 train_time:25861ms step_avg:38.54ms
+step:672/1490 train_time:25921ms step_avg:38.57ms
+step:673/1490 train_time:25974ms step_avg:38.59ms
+step:674/1490 train_time:26034ms step_avg:38.63ms
+step:675/1490 train_time:26087ms step_avg:38.65ms
+step:676/1490 train_time:26147ms step_avg:38.68ms
+step:677/1490 train_time:26200ms step_avg:38.70ms
+step:678/1490 train_time:26261ms step_avg:38.73ms
+step:679/1490 train_time:26315ms step_avg:38.76ms
+step:680/1490 train_time:26375ms step_avg:38.79ms
+step:681/1490 train_time:26430ms step_avg:38.81ms
+step:682/1490 train_time:26489ms step_avg:38.84ms
+step:683/1490 train_time:26544ms step_avg:38.86ms
+step:684/1490 train_time:26603ms step_avg:38.89ms
+step:685/1490 train_time:26658ms step_avg:38.92ms
+step:686/1490 train_time:26716ms step_avg:38.95ms
+step:687/1490 train_time:26771ms step_avg:38.97ms
+step:688/1490 train_time:26832ms step_avg:39.00ms
+step:689/1490 train_time:26886ms step_avg:39.02ms
+step:690/1490 train_time:26946ms step_avg:39.05ms
+step:691/1490 train_time:27000ms step_avg:39.07ms
+step:692/1490 train_time:27060ms step_avg:39.10ms
+step:693/1490 train_time:27115ms step_avg:39.13ms
+step:694/1490 train_time:27175ms step_avg:39.16ms
+step:695/1490 train_time:27229ms step_avg:39.18ms
+step:696/1490 train_time:27288ms step_avg:39.21ms
+step:697/1490 train_time:27342ms step_avg:39.23ms
+step:698/1490 train_time:27402ms step_avg:39.26ms
+step:699/1490 train_time:27457ms step_avg:39.28ms
+step:700/1490 train_time:27516ms step_avg:39.31ms
+step:701/1490 train_time:27570ms step_avg:39.33ms
+step:702/1490 train_time:27630ms step_avg:39.36ms
+step:703/1490 train_time:27684ms step_avg:39.38ms
+step:704/1490 train_time:27743ms step_avg:39.41ms
+step:705/1490 train_time:27797ms step_avg:39.43ms
+step:706/1490 train_time:27857ms step_avg:39.46ms
+step:707/1490 train_time:27911ms step_avg:39.48ms
+step:708/1490 train_time:27972ms step_avg:39.51ms
+step:709/1490 train_time:28026ms step_avg:39.53ms
+step:710/1490 train_time:28086ms step_avg:39.56ms
+step:711/1490 train_time:28140ms step_avg:39.58ms
+step:712/1490 train_time:28200ms step_avg:39.61ms
+step:713/1490 train_time:28254ms step_avg:39.63ms
+step:714/1490 train_time:28314ms step_avg:39.66ms
+step:715/1490 train_time:28367ms step_avg:39.67ms
+step:716/1490 train_time:28428ms step_avg:39.70ms
+step:717/1490 train_time:28482ms step_avg:39.72ms
+step:718/1490 train_time:28542ms step_avg:39.75ms
+step:719/1490 train_time:28597ms step_avg:39.77ms
+step:720/1490 train_time:28657ms step_avg:39.80ms
+step:721/1490 train_time:28710ms step_avg:39.82ms
+step:722/1490 train_time:28770ms step_avg:39.85ms
+step:723/1490 train_time:28824ms step_avg:39.87ms
+step:724/1490 train_time:28883ms step_avg:39.89ms
+step:725/1490 train_time:28938ms step_avg:39.91ms
+step:726/1490 train_time:28997ms step_avg:39.94ms
+step:727/1490 train_time:29052ms step_avg:39.96ms
+step:728/1490 train_time:29112ms step_avg:39.99ms
+step:729/1490 train_time:29165ms step_avg:40.01ms
+step:730/1490 train_time:29225ms step_avg:40.03ms
+step:731/1490 train_time:29278ms step_avg:40.05ms
+step:732/1490 train_time:29339ms step_avg:40.08ms
+step:733/1490 train_time:29393ms step_avg:40.10ms
+step:734/1490 train_time:29453ms step_avg:40.13ms
+step:735/1490 train_time:29508ms step_avg:40.15ms
+step:736/1490 train_time:29567ms step_avg:40.17ms
+step:737/1490 train_time:29621ms step_avg:40.19ms
+step:738/1490 train_time:29681ms step_avg:40.22ms
+step:739/1490 train_time:29735ms step_avg:40.24ms
+step:740/1490 train_time:29794ms step_avg:40.26ms
+step:741/1490 train_time:29848ms step_avg:40.28ms
+step:742/1490 train_time:29908ms step_avg:40.31ms
+step:743/1490 train_time:29962ms step_avg:40.33ms
+step:744/1490 train_time:30021ms step_avg:40.35ms
+step:745/1490 train_time:30076ms step_avg:40.37ms
+step:746/1490 train_time:30135ms step_avg:40.40ms
+step:747/1490 train_time:30189ms step_avg:40.41ms
+step:748/1490 train_time:30249ms step_avg:40.44ms
+step:749/1490 train_time:30304ms step_avg:40.46ms
+step:750/1490 train_time:30363ms step_avg:40.48ms
+step:750/1490 val_loss:3.8075 train_time:30435ms step_avg:40.58ms
+step:751/1490 train_time:30452ms step_avg:40.55ms
+step:752/1490 train_time:30479ms step_avg:40.53ms
+step:753/1490 train_time:30537ms step_avg:40.55ms
+step:754/1490 train_time:30599ms step_avg:40.58ms
+step:755/1490 train_time:30654ms step_avg:40.60ms
+step:756/1490 train_time:30714ms step_avg:40.63ms
+step:757/1490 train_time:30767ms step_avg:40.64ms
+step:758/1490 train_time:30826ms step_avg:40.67ms
+step:759/1490 train_time:30880ms step_avg:40.69ms
+step:760/1490 train_time:30939ms step_avg:40.71ms
+step:761/1490 train_time:30993ms step_avg:40.73ms
+step:762/1490 train_time:31052ms step_avg:40.75ms
+step:763/1490 train_time:31105ms step_avg:40.77ms
+step:764/1490 train_time:31164ms step_avg:40.79ms
+step:765/1490 train_time:31217ms step_avg:40.81ms
+step:766/1490 train_time:31276ms step_avg:40.83ms
+step:767/1490 train_time:31329ms step_avg:40.85ms
+step:768/1490 train_time:31390ms step_avg:40.87ms
+step:769/1490 train_time:31445ms step_avg:40.89ms
+step:770/1490 train_time:31507ms step_avg:40.92ms
+step:771/1490 train_time:31564ms step_avg:40.94ms
+step:772/1490 train_time:31624ms step_avg:40.96ms
+step:773/1490 train_time:31680ms step_avg:40.98ms
+step:774/1490 train_time:31740ms step_avg:41.01ms
+step:775/1490 train_time:31793ms step_avg:41.02ms
+step:776/1490 train_time:31853ms step_avg:41.05ms
+step:777/1490 train_time:31906ms step_avg:41.06ms
+step:778/1490 train_time:31965ms step_avg:41.09ms
+step:779/1490 train_time:32019ms step_avg:41.10ms
+step:780/1490 train_time:32079ms step_avg:41.13ms
+step:781/1490 train_time:32132ms step_avg:41.14ms
+step:782/1490 train_time:32192ms step_avg:41.17ms
+step:783/1490 train_time:32245ms step_avg:41.18ms
+step:784/1490 train_time:32304ms step_avg:41.20ms
+step:785/1490 train_time:32359ms step_avg:41.22ms
+step:786/1490 train_time:32420ms step_avg:41.25ms
+step:787/1490 train_time:32475ms step_avg:41.26ms
+step:788/1490 train_time:32536ms step_avg:41.29ms
+step:789/1490 train_time:32591ms step_avg:41.31ms
+step:790/1490 train_time:32651ms step_avg:41.33ms
+step:791/1490 train_time:32705ms step_avg:41.35ms
+step:792/1490 train_time:32765ms step_avg:41.37ms
+step:793/1490 train_time:32820ms step_avg:41.39ms
+step:794/1490 train_time:32879ms step_avg:41.41ms
+step:795/1490 train_time:32933ms step_avg:41.43ms
+step:796/1490 train_time:32993ms step_avg:41.45ms
+step:797/1490 train_time:33046ms step_avg:41.46ms
+step:798/1490 train_time:33106ms step_avg:41.49ms
+step:799/1490 train_time:33160ms step_avg:41.50ms
+step:800/1490 train_time:33218ms step_avg:41.52ms
+step:801/1490 train_time:33272ms step_avg:41.54ms
+step:802/1490 train_time:33332ms step_avg:41.56ms
+step:803/1490 train_time:33386ms step_avg:41.58ms
+step:804/1490 train_time:33446ms step_avg:41.60ms
+step:805/1490 train_time:33502ms step_avg:41.62ms
+step:806/1490 train_time:33563ms step_avg:41.64ms
+step:807/1490 train_time:33618ms step_avg:41.66ms
+step:808/1490 train_time:33678ms step_avg:41.68ms
+step:809/1490 train_time:33732ms step_avg:41.70ms
+step:810/1490 train_time:33792ms step_avg:41.72ms
+step:811/1490 train_time:33846ms step_avg:41.73ms
+step:812/1490 train_time:33905ms step_avg:41.75ms
+step:813/1490 train_time:33959ms step_avg:41.77ms
+step:814/1490 train_time:34018ms step_avg:41.79ms
+step:815/1490 train_time:34072ms step_avg:41.81ms
+step:816/1490 train_time:34131ms step_avg:41.83ms
+step:817/1490 train_time:34184ms step_avg:41.84ms
+step:818/1490 train_time:34243ms step_avg:41.86ms
+step:819/1490 train_time:34297ms step_avg:41.88ms
+step:820/1490 train_time:34357ms step_avg:41.90ms
+step:821/1490 train_time:34412ms step_avg:41.91ms
+step:822/1490 train_time:34472ms step_avg:41.94ms
+step:823/1490 train_time:34527ms step_avg:41.95ms
+step:824/1490 train_time:34588ms step_avg:41.98ms
+step:825/1490 train_time:34643ms step_avg:41.99ms
+step:826/1490 train_time:34704ms step_avg:42.01ms
+step:827/1490 train_time:34759ms step_avg:42.03ms
+step:828/1490 train_time:34819ms step_avg:42.05ms
+step:829/1490 train_time:34873ms step_avg:42.07ms
+step:830/1490 train_time:34933ms step_avg:42.09ms
+step:831/1490 train_time:34987ms step_avg:42.10ms
+step:832/1490 train_time:35045ms step_avg:42.12ms
+step:833/1490 train_time:35099ms step_avg:42.14ms
+step:834/1490 train_time:35160ms step_avg:42.16ms
+step:835/1490 train_time:35213ms step_avg:42.17ms
+step:836/1490 train_time:35273ms step_avg:42.19ms
+step:837/1490 train_time:35327ms step_avg:42.21ms
+step:838/1490 train_time:35387ms step_avg:42.23ms
+step:839/1490 train_time:35441ms step_avg:42.24ms
+step:840/1490 train_time:35502ms step_avg:42.26ms
+step:841/1490 train_time:35557ms step_avg:42.28ms
+step:842/1490 train_time:35617ms step_avg:42.30ms
+step:843/1490 train_time:35672ms step_avg:42.32ms
+step:844/1490 train_time:35732ms step_avg:42.34ms
+step:845/1490 train_time:35786ms step_avg:42.35ms
+step:846/1490 train_time:35845ms step_avg:42.37ms
+step:847/1490 train_time:35899ms step_avg:42.38ms
+step:848/1490 train_time:35959ms step_avg:42.40ms
+step:849/1490 train_time:36013ms step_avg:42.42ms
+step:850/1490 train_time:36074ms step_avg:42.44ms
+step:851/1490 train_time:36128ms step_avg:42.45ms
+step:852/1490 train_time:36187ms step_avg:42.47ms
+step:853/1490 train_time:36240ms step_avg:42.49ms
+step:854/1490 train_time:36300ms step_avg:42.51ms
+step:855/1490 train_time:36354ms step_avg:42.52ms
+step:856/1490 train_time:36414ms step_avg:42.54ms
+step:857/1490 train_time:36469ms step_avg:42.55ms
+step:858/1490 train_time:36529ms step_avg:42.57ms
+step:859/1490 train_time:36584ms step_avg:42.59ms
+step:860/1490 train_time:36645ms step_avg:42.61ms
+step:861/1490 train_time:36699ms step_avg:42.62ms
+step:862/1490 train_time:36759ms step_avg:42.64ms
+step:863/1490 train_time:36812ms step_avg:42.66ms
+step:864/1490 train_time:36872ms step_avg:42.68ms
+step:865/1490 train_time:36926ms step_avg:42.69ms
+step:866/1490 train_time:36985ms step_avg:42.71ms
+step:867/1490 train_time:37039ms step_avg:42.72ms
+step:868/1490 train_time:37099ms step_avg:42.74ms
+step:869/1490 train_time:37154ms step_avg:42.75ms
+step:870/1490 train_time:37213ms step_avg:42.77ms
+step:871/1490 train_time:37266ms step_avg:42.79ms
+step:872/1490 train_time:37326ms step_avg:42.80ms
+step:873/1490 train_time:37380ms step_avg:42.82ms
+step:874/1490 train_time:37439ms step_avg:42.84ms
+step:875/1490 train_time:37493ms step_avg:42.85ms
+step:876/1490 train_time:37554ms step_avg:42.87ms
+step:877/1490 train_time:37609ms step_avg:42.88ms
+step:878/1490 train_time:37669ms step_avg:42.90ms
+step:879/1490 train_time:37723ms step_avg:42.92ms
+step:880/1490 train_time:37783ms step_avg:42.94ms
+step:881/1490 train_time:37838ms step_avg:42.95ms
+step:882/1490 train_time:37898ms step_avg:42.97ms
+step:883/1490 train_time:37952ms step_avg:42.98ms
+step:884/1490 train_time:38011ms step_avg:43.00ms
+step:885/1490 train_time:38066ms step_avg:43.01ms
+step:886/1490 train_time:38125ms step_avg:43.03ms
+step:887/1490 train_time:38179ms step_avg:43.04ms
+step:888/1490 train_time:38239ms step_avg:43.06ms
+step:889/1490 train_time:38292ms step_avg:43.07ms
+step:890/1490 train_time:38353ms step_avg:43.09ms
+step:891/1490 train_time:38407ms step_avg:43.11ms
+step:892/1490 train_time:38467ms step_avg:43.12ms
+step:893/1490 train_time:38522ms step_avg:43.14ms
+step:894/1490 train_time:38582ms step_avg:43.16ms
+step:895/1490 train_time:38636ms step_avg:43.17ms
+step:896/1490 train_time:38697ms step_avg:43.19ms
+step:897/1490 train_time:38751ms step_avg:43.20ms
+step:898/1490 train_time:38810ms step_avg:43.22ms
+step:899/1490 train_time:38865ms step_avg:43.23ms
+step:900/1490 train_time:38924ms step_avg:43.25ms
+step:901/1490 train_time:38978ms step_avg:43.26ms
+step:902/1490 train_time:39038ms step_avg:43.28ms
+step:903/1490 train_time:39093ms step_avg:43.29ms
+step:904/1490 train_time:39153ms step_avg:43.31ms
+step:905/1490 train_time:39206ms step_avg:43.32ms
+step:906/1490 train_time:39265ms step_avg:43.34ms
+step:907/1490 train_time:39320ms step_avg:43.35ms
+step:908/1490 train_time:39379ms step_avg:43.37ms
+step:909/1490 train_time:39433ms step_avg:43.38ms
+step:910/1490 train_time:39494ms step_avg:43.40ms
+step:911/1490 train_time:39549ms step_avg:43.41ms
+step:912/1490 train_time:39608ms step_avg:43.43ms
+step:913/1490 train_time:39663ms step_avg:43.44ms
+step:914/1490 train_time:39724ms step_avg:43.46ms
+step:915/1490 train_time:39779ms step_avg:43.47ms
+step:916/1490 train_time:39839ms step_avg:43.49ms
+step:917/1490 train_time:39892ms step_avg:43.50ms
+step:918/1490 train_time:39951ms step_avg:43.52ms
+step:919/1490 train_time:40005ms step_avg:43.53ms
+step:920/1490 train_time:40065ms step_avg:43.55ms
+step:921/1490 train_time:40119ms step_avg:43.56ms
+step:922/1490 train_time:40178ms step_avg:43.58ms
+step:923/1490 train_time:40232ms step_avg:43.59ms
+step:924/1490 train_time:40292ms step_avg:43.61ms
+step:925/1490 train_time:40346ms step_avg:43.62ms
+step:926/1490 train_time:40405ms step_avg:43.63ms
+step:927/1490 train_time:40460ms step_avg:43.65ms
+step:928/1490 train_time:40520ms step_avg:43.66ms
+step:929/1490 train_time:40574ms step_avg:43.68ms
+step:930/1490 train_time:40635ms step_avg:43.69ms
+step:931/1490 train_time:40690ms step_avg:43.71ms
+step:932/1490 train_time:40749ms step_avg:43.72ms
+step:933/1490 train_time:40803ms step_avg:43.73ms
+step:934/1490 train_time:40864ms step_avg:43.75ms
+step:935/1490 train_time:40918ms step_avg:43.76ms
+step:936/1490 train_time:40978ms step_avg:43.78ms
+step:937/1490 train_time:41032ms step_avg:43.79ms
+step:938/1490 train_time:41092ms step_avg:43.81ms
+step:939/1490 train_time:41145ms step_avg:43.82ms
+step:940/1490 train_time:41204ms step_avg:43.83ms
+step:941/1490 train_time:41258ms step_avg:43.84ms
+step:942/1490 train_time:41318ms step_avg:43.86ms
+step:943/1490 train_time:41372ms step_avg:43.87ms
+step:944/1490 train_time:41431ms step_avg:43.89ms
+step:945/1490 train_time:41485ms step_avg:43.90ms
+step:946/1490 train_time:41544ms step_avg:43.92ms
+step:947/1490 train_time:41598ms step_avg:43.93ms
+step:948/1490 train_time:41658ms step_avg:43.94ms
+step:949/1490 train_time:41712ms step_avg:43.95ms
+step:950/1490 train_time:41773ms step_avg:43.97ms
+step:951/1490 train_time:41827ms step_avg:43.98ms
+step:952/1490 train_time:41886ms step_avg:44.00ms
+step:953/1490 train_time:41941ms step_avg:44.01ms
+step:954/1490 train_time:42000ms step_avg:44.03ms
+step:955/1490 train_time:42054ms step_avg:44.04ms
+step:956/1490 train_time:42114ms step_avg:44.05ms
+step:957/1490 train_time:42168ms step_avg:44.06ms
+step:958/1490 train_time:42227ms step_avg:44.08ms
+step:959/1490 train_time:42281ms step_avg:44.09ms
+step:960/1490 train_time:42341ms step_avg:44.11ms
+step:961/1490 train_time:42395ms step_avg:44.12ms
+step:962/1490 train_time:42455ms step_avg:44.13ms
+step:963/1490 train_time:42509ms step_avg:44.14ms
+step:964/1490 train_time:42569ms step_avg:44.16ms
+step:965/1490 train_time:42623ms step_avg:44.17ms
+step:966/1490 train_time:42683ms step_avg:44.18ms
+step:967/1490 train_time:42737ms step_avg:44.20ms
+step:968/1490 train_time:42800ms step_avg:44.21ms
+step:969/1490 train_time:42878ms step_avg:44.25ms
+step:970/1490 train_time:42963ms step_avg:44.29ms
+step:971/1490 train_time:43043ms step_avg:44.33ms
+step:972/1490 train_time:43130ms step_avg:44.37ms
+step:973/1490 train_time:43211ms step_avg:44.41ms
+step:974/1490 train_time:43296ms step_avg:44.45ms
+step:975/1490 train_time:43376ms step_avg:44.49ms
+step:976/1490 train_time:43462ms step_avg:44.53ms
+step:977/1490 train_time:43542ms step_avg:44.57ms
+step:978/1490 train_time:43628ms step_avg:44.61ms
+step:979/1490 train_time:43708ms step_avg:44.65ms
+step:980/1490 train_time:43794ms step_avg:44.69ms
+step:981/1490 train_time:43875ms step_avg:44.72ms
+step:982/1490 train_time:43959ms step_avg:44.77ms
+step:983/1490 train_time:44041ms step_avg:44.80ms
+step:984/1490 train_time:44128ms step_avg:44.85ms
+step:985/1490 train_time:44208ms step_avg:44.88ms
+step:986/1490 train_time:44294ms step_avg:44.92ms
+step:987/1490 train_time:44373ms step_avg:44.96ms
+step:988/1490 train_time:44459ms step_avg:45.00ms
+step:989/1490 train_time:44539ms step_avg:45.03ms
+step:990/1490 train_time:44624ms step_avg:45.08ms
+step:991/1490 train_time:44704ms step_avg:45.11ms
+step:992/1490 train_time:44790ms step_avg:45.15ms
+step:993/1490 train_time:44871ms step_avg:45.19ms
+step:994/1490 train_time:44956ms step_avg:45.23ms
+step:995/1490 train_time:45036ms step_avg:45.26ms
+step:996/1490 train_time:45123ms step_avg:45.30ms
+step:997/1490 train_time:45203ms step_avg:45.34ms
+step:998/1490 train_time:45288ms step_avg:45.38ms
+step:999/1490 train_time:45368ms step_avg:45.41ms
+step:1000/1490 train_time:45453ms step_avg:45.45ms
+step:1000/1490 val_loss:3.5187 train_time:45557ms step_avg:45.56ms
+step:1001/1490 train_time:45575ms step_avg:45.53ms
+step:1002/1490 train_time:45622ms step_avg:45.53ms
+step:1003/1490 train_time:45708ms step_avg:45.57ms
+step:1004/1490 train_time:45797ms step_avg:45.61ms
+step:1005/1490 train_time:45875ms step_avg:45.65ms
+step:1006/1490 train_time:45959ms step_avg:45.68ms
+step:1007/1490 train_time:46040ms step_avg:45.72ms
+step:1008/1490 train_time:46124ms step_avg:45.76ms
+step:1009/1490 train_time:46205ms step_avg:45.79ms
+step:1010/1490 train_time:46289ms step_avg:45.83ms
+step:1011/1490 train_time:46368ms step_avg:45.86ms
+step:1012/1490 train_time:46452ms step_avg:45.90ms
+step:1013/1490 train_time:46534ms step_avg:45.94ms
+step:1014/1490 train_time:46620ms step_avg:45.98ms
+step:1015/1490 train_time:46706ms step_avg:46.02ms
+step:1016/1490 train_time:46793ms step_avg:46.06ms
+step:1017/1490 train_time:46873ms step_avg:46.09ms
+step:1018/1490 train_time:46957ms step_avg:46.13ms
+step:1019/1490 train_time:47039ms step_avg:46.16ms
+step:1020/1490 train_time:47124ms step_avg:46.20ms
+step:1021/1490 train_time:47203ms step_avg:46.23ms
+step:1022/1490 train_time:47290ms step_avg:46.27ms
+step:1023/1490 train_time:47369ms step_avg:46.30ms
+step:1024/1490 train_time:47453ms step_avg:46.34ms
+step:1025/1490 train_time:47533ms step_avg:46.37ms
+step:1026/1490 train_time:47621ms step_avg:46.41ms
+step:1027/1490 train_time:47706ms step_avg:46.45ms
+step:1028/1490 train_time:47793ms step_avg:46.49ms
+step:1029/1490 train_time:47872ms step_avg:46.52ms
+step:1030/1490 train_time:47956ms step_avg:46.56ms
+step:1031/1490 train_time:48036ms step_avg:46.59ms
+step:1032/1490 train_time:48121ms step_avg:46.63ms
+step:1033/1490 train_time:48202ms step_avg:46.66ms
+step:1034/1490 train_time:48288ms step_avg:46.70ms
+step:1035/1490 train_time:48367ms step_avg:46.73ms
+step:1036/1490 train_time:48453ms step_avg:46.77ms
+step:1037/1490 train_time:48534ms step_avg:46.80ms
+step:1038/1490 train_time:48622ms step_avg:46.84ms
+step:1039/1490 train_time:48704ms step_avg:46.88ms
+step:1040/1490 train_time:48792ms step_avg:46.92ms
+step:1041/1490 train_time:48871ms step_avg:46.95ms
+step:1042/1490 train_time:48956ms step_avg:46.98ms
+step:1043/1490 train_time:49035ms step_avg:47.01ms
+step:1044/1490 train_time:49119ms step_avg:47.05ms
+step:1045/1490 train_time:49200ms step_avg:47.08ms
+step:1046/1490 train_time:49285ms step_avg:47.12ms
+step:1047/1490 train_time:49364ms step_avg:47.15ms
+step:1048/1490 train_time:49448ms step_avg:47.18ms
+step:1049/1490 train_time:49529ms step_avg:47.22ms
+step:1050/1490 train_time:49618ms step_avg:47.25ms
+step:1051/1490 train_time:49700ms step_avg:47.29ms
+step:1052/1490 train_time:49786ms step_avg:47.32ms
+step:1053/1490 train_time:49866ms step_avg:47.36ms
+step:1054/1490 train_time:49953ms step_avg:47.39ms
+step:1055/1490 train_time:50033ms step_avg:47.42ms
+step:1056/1490 train_time:50118ms step_avg:47.46ms
+step:1057/1490 train_time:50198ms step_avg:47.49ms
+step:1058/1490 train_time:50282ms step_avg:47.53ms
+step:1059/1490 train_time:50362ms step_avg:47.56ms
+step:1060/1490 train_time:50447ms step_avg:47.59ms
+step:1061/1490 train_time:50529ms step_avg:47.62ms
+step:1062/1490 train_time:50615ms step_avg:47.66ms
+step:1063/1490 train_time:50696ms step_avg:47.69ms
+step:1064/1490 train_time:50782ms step_avg:47.73ms
+step:1065/1490 train_time:50861ms step_avg:47.76ms
+step:1066/1490 train_time:50947ms step_avg:47.79ms
+step:1067/1490 train_time:51027ms step_avg:47.82ms
+step:1068/1490 train_time:51112ms step_avg:47.86ms
+step:1069/1490 train_time:51192ms step_avg:47.89ms
+step:1070/1490 train_time:51278ms step_avg:47.92ms
+step:1071/1490 train_time:51356ms step_avg:47.95ms
+step:1072/1490 train_time:51441ms step_avg:47.99ms
+step:1073/1490 train_time:51523ms step_avg:48.02ms
+step:1074/1490 train_time:51612ms step_avg:48.06ms
+step:1075/1490 train_time:51694ms step_avg:48.09ms
+step:1076/1490 train_time:51779ms step_avg:48.12ms
+step:1077/1490 train_time:51859ms step_avg:48.15ms
+step:1078/1490 train_time:51945ms step_avg:48.19ms
+step:1079/1490 train_time:52025ms step_avg:48.22ms
+step:1080/1490 train_time:52113ms step_avg:48.25ms
+step:1081/1490 train_time:52192ms step_avg:48.28ms
+step:1082/1490 train_time:52275ms step_avg:48.31ms
+step:1083/1490 train_time:52354ms step_avg:48.34ms
+step:1084/1490 train_time:52440ms step_avg:48.38ms
+step:1085/1490 train_time:52522ms step_avg:48.41ms
+step:1086/1490 train_time:52608ms step_avg:48.44ms
+step:1087/1490 train_time:52690ms step_avg:48.47ms
+step:1088/1490 train_time:52775ms step_avg:48.51ms
+step:1089/1490 train_time:52854ms step_avg:48.53ms
+step:1090/1490 train_time:52940ms step_avg:48.57ms
+step:1091/1490 train_time:53021ms step_avg:48.60ms
+step:1092/1490 train_time:53107ms step_avg:48.63ms
+step:1093/1490 train_time:53187ms step_avg:48.66ms
+step:1094/1490 train_time:53270ms step_avg:48.69ms
+step:1095/1490 train_time:53351ms step_avg:48.72ms
+step:1096/1490 train_time:53436ms step_avg:48.76ms
+step:1097/1490 train_time:53516ms step_avg:48.78ms
+step:1098/1490 train_time:53603ms step_avg:48.82ms
+step:1099/1490 train_time:53686ms step_avg:48.85ms
+step:1100/1490 train_time:53772ms step_avg:48.88ms
+step:1101/1490 train_time:53852ms step_avg:48.91ms
+step:1102/1490 train_time:53938ms step_avg:48.95ms
+step:1103/1490 train_time:54017ms step_avg:48.97ms
+step:1104/1490 train_time:54105ms step_avg:49.01ms
+step:1105/1490 train_time:54185ms step_avg:49.04ms
+step:1106/1490 train_time:54270ms step_avg:49.07ms
+step:1107/1490 train_time:54350ms step_avg:49.10ms
+step:1108/1490 train_time:54437ms step_avg:49.13ms
+step:1109/1490 train_time:54517ms step_avg:49.16ms
+step:1110/1490 train_time:54602ms step_avg:49.19ms
+step:1111/1490 train_time:54683ms step_avg:49.22ms
+step:1112/1490 train_time:54768ms step_avg:49.25ms
+step:1113/1490 train_time:54849ms step_avg:49.28ms
+step:1114/1490 train_time:54934ms step_avg:49.31ms
+step:1115/1490 train_time:55015ms step_avg:49.34ms
+step:1116/1490 train_time:55101ms step_avg:49.37ms
+step:1117/1490 train_time:55182ms step_avg:49.40ms
+step:1118/1490 train_time:55267ms step_avg:49.43ms
+step:1119/1490 train_time:55347ms step_avg:49.46ms
+step:1120/1490 train_time:55433ms step_avg:49.49ms
+step:1121/1490 train_time:55515ms step_avg:49.52ms
+step:1122/1490 train_time:55601ms step_avg:49.56ms
+step:1123/1490 train_time:55682ms step_avg:49.58ms
+step:1124/1490 train_time:55768ms step_avg:49.62ms
+step:1125/1490 train_time:55846ms step_avg:49.64ms
+step:1126/1490 train_time:55933ms step_avg:49.67ms
+step:1127/1490 train_time:56013ms step_avg:49.70ms
+step:1128/1490 train_time:56100ms step_avg:49.73ms
+step:1129/1490 train_time:56180ms step_avg:49.76ms
+step:1130/1490 train_time:56264ms step_avg:49.79ms
+step:1131/1490 train_time:56345ms step_avg:49.82ms
+step:1132/1490 train_time:56432ms step_avg:49.85ms
+step:1133/1490 train_time:56511ms step_avg:49.88ms
+step:1134/1490 train_time:56598ms step_avg:49.91ms
+step:1135/1490 train_time:56677ms step_avg:49.94ms
+step:1136/1490 train_time:56762ms step_avg:49.97ms
+step:1137/1490 train_time:56843ms step_avg:49.99ms
+step:1138/1490 train_time:56929ms step_avg:50.03ms
+step:1139/1490 train_time:57010ms step_avg:50.05ms
+step:1140/1490 train_time:57096ms step_avg:50.08ms
+step:1141/1490 train_time:57175ms step_avg:50.11ms
+step:1142/1490 train_time:57260ms step_avg:50.14ms
+step:1143/1490 train_time:57340ms step_avg:50.17ms
+step:1144/1490 train_time:57426ms step_avg:50.20ms
+step:1145/1490 train_time:57508ms step_avg:50.23ms
+step:1146/1490 train_time:57594ms step_avg:50.26ms
+step:1147/1490 train_time:57673ms step_avg:50.28ms
+step:1148/1490 train_time:57757ms step_avg:50.31ms
+step:1149/1490 train_time:57838ms step_avg:50.34ms
+step:1150/1490 train_time:57924ms step_avg:50.37ms
+step:1151/1490 train_time:58006ms step_avg:50.40ms
+step:1152/1490 train_time:58091ms step_avg:50.43ms
+step:1153/1490 train_time:58170ms step_avg:50.45ms
+step:1154/1490 train_time:58254ms step_avg:50.48ms
+step:1155/1490 train_time:58335ms step_avg:50.51ms
+step:1156/1490 train_time:58420ms step_avg:50.54ms
+step:1157/1490 train_time:58501ms step_avg:50.56ms
+step:1158/1490 train_time:58588ms step_avg:50.59ms
+step:1159/1490 train_time:58670ms step_avg:50.62ms
+step:1160/1490 train_time:58755ms step_avg:50.65ms
+step:1161/1490 train_time:58834ms step_avg:50.68ms
+step:1162/1490 train_time:58921ms step_avg:50.71ms
+step:1163/1490 train_time:59002ms step_avg:50.73ms
+step:1164/1490 train_time:59089ms step_avg:50.76ms
+step:1165/1490 train_time:59168ms step_avg:50.79ms
+step:1166/1490 train_time:59253ms step_avg:50.82ms
+step:1167/1490 train_time:59333ms step_avg:50.84ms
+step:1168/1490 train_time:59418ms step_avg:50.87ms
+step:1169/1490 train_time:59498ms step_avg:50.90ms
+step:1170/1490 train_time:59585ms step_avg:50.93ms
+step:1171/1490 train_time:59664ms step_avg:50.95ms
+step:1172/1490 train_time:59750ms step_avg:50.98ms
+step:1173/1490 train_time:59829ms step_avg:51.01ms
+step:1174/1490 train_time:59915ms step_avg:51.03ms
+step:1175/1490 train_time:59995ms step_avg:51.06ms
+step:1176/1490 train_time:60081ms step_avg:51.09ms
+step:1177/1490 train_time:60161ms step_avg:51.11ms
+step:1178/1490 train_time:60247ms step_avg:51.14ms
+step:1179/1490 train_time:60327ms step_avg:51.17ms
+step:1180/1490 train_time:60414ms step_avg:51.20ms
+step:1181/1490 train_time:60495ms step_avg:51.22ms
+step:1182/1490 train_time:60580ms step_avg:51.25ms
+step:1183/1490 train_time:60660ms step_avg:51.28ms
+step:1184/1490 train_time:60745ms step_avg:51.31ms
+step:1185/1490 train_time:60826ms step_avg:51.33ms
+step:1186/1490 train_time:60912ms step_avg:51.36ms
+step:1187/1490 train_time:60993ms step_avg:51.38ms
+step:1188/1490 train_time:61077ms step_avg:51.41ms
+step:1189/1490 train_time:61157ms step_avg:51.44ms
+step:1190/1490 train_time:61243ms step_avg:51.46ms
+step:1191/1490 train_time:61325ms step_avg:51.49ms
+step:1192/1490 train_time:61412ms step_avg:51.52ms
+step:1193/1490 train_time:61492ms step_avg:51.54ms
+step:1194/1490 train_time:61576ms step_avg:51.57ms
+step:1195/1490 train_time:61656ms step_avg:51.59ms
+step:1196/1490 train_time:61742ms step_avg:51.62ms
+step:1197/1490 train_time:61824ms step_avg:51.65ms
+step:1198/1490 train_time:61909ms step_avg:51.68ms
+step:1199/1490 train_time:61989ms step_avg:51.70ms
+step:1200/1490 train_time:62075ms step_avg:51.73ms
+step:1201/1490 train_time:62153ms step_avg:51.75ms
+step:1202/1490 train_time:62239ms step_avg:51.78ms
+step:1203/1490 train_time:62321ms step_avg:51.80ms
+step:1204/1490 train_time:62407ms step_avg:51.83ms
+step:1205/1490 train_time:62487ms step_avg:51.86ms
+step:1206/1490 train_time:62572ms step_avg:51.88ms
+step:1207/1490 train_time:62652ms step_avg:51.91ms
+step:1208/1490 train_time:62737ms step_avg:51.93ms
+step:1209/1490 train_time:62817ms step_avg:51.96ms
+step:1210/1490 train_time:62904ms step_avg:51.99ms
+step:1211/1490 train_time:62985ms step_avg:52.01ms
+step:1212/1490 train_time:63071ms step_avg:52.04ms
+step:1213/1490 train_time:63151ms step_avg:52.06ms
+step:1214/1490 train_time:63236ms step_avg:52.09ms
+step:1215/1490 train_time:63316ms step_avg:52.11ms
+step:1216/1490 train_time:63402ms step_avg:52.14ms
+step:1217/1490 train_time:63482ms step_avg:52.16ms
+step:1218/1490 train_time:63567ms step_avg:52.19ms
+step:1219/1490 train_time:63647ms step_avg:52.21ms
+step:1220/1490 train_time:63734ms step_avg:52.24ms
+step:1221/1490 train_time:63813ms step_avg:52.26ms
+step:1222/1490 train_time:63900ms step_avg:52.29ms
+step:1223/1490 train_time:63982ms step_avg:52.32ms
+step:1224/1490 train_time:64068ms step_avg:52.34ms
+step:1225/1490 train_time:64147ms step_avg:52.37ms
+step:1226/1490 train_time:64234ms step_avg:52.39ms
+step:1227/1490 train_time:64315ms step_avg:52.42ms
+step:1228/1490 train_time:64400ms step_avg:52.44ms
+step:1229/1490 train_time:64480ms step_avg:52.47ms
+step:1230/1490 train_time:64565ms step_avg:52.49ms
+step:1231/1490 train_time:64646ms step_avg:52.52ms
+step:1232/1490 train_time:64731ms step_avg:52.54ms
+step:1233/1490 train_time:64812ms step_avg:52.56ms
+step:1234/1490 train_time:64898ms step_avg:52.59ms
+step:1235/1490 train_time:64979ms step_avg:52.61ms
+step:1236/1490 train_time:65065ms step_avg:52.64ms
+step:1237/1490 train_time:65145ms step_avg:52.66ms
+step:1238/1490 train_time:65229ms step_avg:52.69ms
+step:1239/1490 train_time:65310ms step_avg:52.71ms
+step:1240/1490 train_time:65396ms step_avg:52.74ms
+step:1241/1490 train_time:65474ms step_avg:52.76ms
+step:1242/1490 train_time:65560ms step_avg:52.79ms
+step:1243/1490 train_time:65642ms step_avg:52.81ms
+step:1244/1490 train_time:65727ms step_avg:52.84ms
+step:1245/1490 train_time:65807ms step_avg:52.86ms
+step:1246/1490 train_time:65893ms step_avg:52.88ms
+step:1247/1490 train_time:65973ms step_avg:52.91ms
+step:1248/1490 train_time:66059ms step_avg:52.93ms
+step:1249/1490 train_time:66138ms step_avg:52.95ms
+step:1250/1490 train_time:66224ms step_avg:52.98ms
+step:1250/1490 val_loss:3.3730 train_time:66327ms step_avg:53.06ms
+step:1251/1490 train_time:66344ms step_avg:53.03ms
+step:1252/1490 train_time:66396ms step_avg:53.03ms
+step:1253/1490 train_time:66485ms step_avg:53.06ms
+step:1254/1490 train_time:66570ms step_avg:53.09ms
+step:1255/1490 train_time:66650ms step_avg:53.11ms
+step:1256/1490 train_time:66737ms step_avg:53.13ms
+step:1257/1490 train_time:66817ms step_avg:53.16ms
+step:1258/1490 train_time:66902ms step_avg:53.18ms
+step:1259/1490 train_time:66980ms step_avg:53.20ms
+step:1260/1490 train_time:67064ms step_avg:53.23ms
+step:1261/1490 train_time:67144ms step_avg:53.25ms
+step:1262/1490 train_time:67229ms step_avg:53.27ms
+step:1263/1490 train_time:67310ms step_avg:53.29ms
+step:1264/1490 train_time:67399ms step_avg:53.32ms
+step:1265/1490 train_time:67483ms step_avg:53.35ms
+step:1266/1490 train_time:67568ms step_avg:53.37ms
+step:1267/1490 train_time:67648ms step_avg:53.39ms
+step:1268/1490 train_time:67734ms step_avg:53.42ms
+step:1269/1490 train_time:67814ms step_avg:53.44ms
+step:1270/1490 train_time:67900ms step_avg:53.46ms
+step:1271/1490 train_time:67979ms step_avg:53.48ms
+step:1272/1490 train_time:68064ms step_avg:53.51ms
+step:1273/1490 train_time:68142ms step_avg:53.53ms
+step:1274/1490 train_time:68228ms step_avg:53.55ms
+step:1275/1490 train_time:68308ms step_avg:53.58ms
+step:1276/1490 train_time:68396ms step_avg:53.60ms
+step:1277/1490 train_time:68477ms step_avg:53.62ms
+step:1278/1490 train_time:68564ms step_avg:53.65ms
+step:1279/1490 train_time:68646ms step_avg:53.67ms
+step:1280/1490 train_time:68732ms step_avg:53.70ms
+step:1281/1490 train_time:68813ms step_avg:53.72ms
+step:1282/1490 train_time:68899ms step_avg:53.74ms
+step:1283/1490 train_time:68978ms step_avg:53.76ms
+step:1284/1490 train_time:69063ms step_avg:53.79ms
+step:1285/1490 train_time:69141ms step_avg:53.81ms
+step:1286/1490 train_time:69226ms step_avg:53.83ms
+step:1287/1490 train_time:69308ms step_avg:53.85ms
+step:1288/1490 train_time:69393ms step_avg:53.88ms
+step:1289/1490 train_time:69474ms step_avg:53.90ms
+step:1290/1490 train_time:69561ms step_avg:53.92ms
+step:1291/1490 train_time:69641ms step_avg:53.94ms
+step:1292/1490 train_time:69727ms step_avg:53.97ms
+step:1293/1490 train_time:69808ms step_avg:53.99ms
+step:1294/1490 train_time:69892ms step_avg:54.01ms
+step:1295/1490 train_time:69971ms step_avg:54.03ms
+step:1296/1490 train_time:70056ms step_avg:54.06ms
+step:1297/1490 train_time:70135ms step_avg:54.08ms
+step:1298/1490 train_time:70222ms step_avg:54.10ms
+step:1299/1490 train_time:70305ms step_avg:54.12ms
+step:1300/1490 train_time:70390ms step_avg:54.15ms
+step:1301/1490 train_time:70470ms step_avg:54.17ms
+step:1302/1490 train_time:70556ms step_avg:54.19ms
+step:1303/1490 train_time:70637ms step_avg:54.21ms
+step:1304/1490 train_time:70724ms step_avg:54.24ms
+step:1305/1490 train_time:70804ms step_avg:54.26ms
+step:1306/1490 train_time:70889ms step_avg:54.28ms
+step:1307/1490 train_time:70967ms step_avg:54.30ms
+step:1308/1490 train_time:71052ms step_avg:54.32ms
+step:1309/1490 train_time:71133ms step_avg:54.34ms
+step:1310/1490 train_time:71219ms step_avg:54.37ms
+step:1311/1490 train_time:71301ms step_avg:54.39ms
+step:1312/1490 train_time:71386ms step_avg:54.41ms
+step:1313/1490 train_time:71466ms step_avg:54.43ms
+step:1314/1490 train_time:71552ms step_avg:54.45ms
+step:1315/1490 train_time:71633ms step_avg:54.47ms
+step:1316/1490 train_time:71720ms step_avg:54.50ms
+step:1317/1490 train_time:71801ms step_avg:54.52ms
+step:1318/1490 train_time:71885ms step_avg:54.54ms
+step:1319/1490 train_time:71964ms step_avg:54.56ms
+step:1320/1490 train_time:72050ms step_avg:54.58ms
+step:1321/1490 train_time:72130ms step_avg:54.60ms
+step:1322/1490 train_time:72215ms step_avg:54.63ms
+step:1323/1490 train_time:72296ms step_avg:54.65ms
+step:1324/1490 train_time:72382ms step_avg:54.67ms
+step:1325/1490 train_time:72461ms step_avg:54.69ms
+step:1326/1490 train_time:72547ms step_avg:54.71ms
+step:1327/1490 train_time:72627ms step_avg:54.73ms
+step:1328/1490 train_time:72713ms step_avg:54.75ms
+step:1329/1490 train_time:72794ms step_avg:54.77ms
+step:1330/1490 train_time:72879ms step_avg:54.80ms
+step:1331/1490 train_time:72959ms step_avg:54.82ms
+step:1332/1490 train_time:73046ms step_avg:54.84ms
+step:1333/1490 train_time:73125ms step_avg:54.86ms
+step:1334/1490 train_time:73210ms step_avg:54.88ms
+step:1335/1490 train_time:73290ms step_avg:54.90ms
+step:1336/1490 train_time:73376ms step_avg:54.92ms
+step:1337/1490 train_time:73457ms step_avg:54.94ms
+step:1338/1490 train_time:73543ms step_avg:54.96ms
+step:1339/1490 train_time:73623ms step_avg:54.98ms
+step:1340/1490 train_time:73708ms step_avg:55.01ms
+step:1341/1490 train_time:73788ms step_avg:55.02ms
+step:1342/1490 train_time:73873ms step_avg:55.05ms
+step:1343/1490 train_time:73954ms step_avg:55.07ms
+step:1344/1490 train_time:74040ms step_avg:55.09ms
+step:1345/1490 train_time:74121ms step_avg:55.11ms
+step:1346/1490 train_time:74205ms step_avg:55.13ms
+step:1347/1490 train_time:74284ms step_avg:55.15ms
+step:1348/1490 train_time:74369ms step_avg:55.17ms
+step:1349/1490 train_time:74451ms step_avg:55.19ms
+step:1350/1490 train_time:74539ms step_avg:55.21ms
+step:1351/1490 train_time:74620ms step_avg:55.23ms
+step:1352/1490 train_time:74705ms step_avg:55.26ms
+step:1353/1490 train_time:74785ms step_avg:55.27ms
+step:1354/1490 train_time:74870ms step_avg:55.30ms
+step:1355/1490 train_time:74952ms step_avg:55.31ms
+step:1356/1490 train_time:75038ms step_avg:55.34ms
+step:1357/1490 train_time:75118ms step_avg:55.36ms
+step:1358/1490 train_time:75205ms step_avg:55.38ms
+step:1359/1490 train_time:75283ms step_avg:55.40ms
+step:1360/1490 train_time:75368ms step_avg:55.42ms
+step:1361/1490 train_time:75449ms step_avg:55.44ms
+step:1362/1490 train_time:75534ms step_avg:55.46ms
+step:1363/1490 train_time:75617ms step_avg:55.48ms
+step:1364/1490 train_time:75704ms step_avg:55.50ms
+step:1365/1490 train_time:75785ms step_avg:55.52ms
+step:1366/1490 train_time:75869ms step_avg:55.54ms
+step:1367/1490 train_time:75949ms step_avg:55.56ms
+step:1368/1490 train_time:76035ms step_avg:55.58ms
+step:1369/1490 train_time:76116ms step_avg:55.60ms
+step:1370/1490 train_time:76202ms step_avg:55.62ms
+step:1371/1490 train_time:76282ms step_avg:55.64ms
+step:1372/1490 train_time:76366ms step_avg:55.66ms
+step:1373/1490 train_time:76446ms step_avg:55.68ms
+step:1374/1490 train_time:76532ms step_avg:55.70ms
+step:1375/1490 train_time:76613ms step_avg:55.72ms
+step:1376/1490 train_time:76699ms step_avg:55.74ms
+step:1377/1490 train_time:76781ms step_avg:55.76ms
+step:1378/1490 train_time:76866ms step_avg:55.78ms
+step:1379/1490 train_time:76946ms step_avg:55.80ms
+step:1380/1490 train_time:77031ms step_avg:55.82ms
+step:1381/1490 train_time:77111ms step_avg:55.84ms
+step:1382/1490 train_time:77198ms step_avg:55.86ms
+step:1383/1490 train_time:77277ms step_avg:55.88ms
+step:1384/1490 train_time:77364ms step_avg:55.90ms
+step:1385/1490 train_time:77445ms step_avg:55.92ms
+step:1386/1490 train_time:77530ms step_avg:55.94ms
+step:1387/1490 train_time:77611ms step_avg:55.96ms
+step:1388/1490 train_time:77698ms step_avg:55.98ms
+step:1389/1490 train_time:77777ms step_avg:56.00ms
+step:1390/1490 train_time:77864ms step_avg:56.02ms
+step:1391/1490 train_time:77944ms step_avg:56.03ms
+step:1392/1490 train_time:78030ms step_avg:56.06ms
+step:1393/1490 train_time:78110ms step_avg:56.07ms
+step:1394/1490 train_time:78197ms step_avg:56.10ms
+step:1395/1490 train_time:78278ms step_avg:56.11ms
+step:1396/1490 train_time:78362ms step_avg:56.13ms
+step:1397/1490 train_time:78443ms step_avg:56.15ms
+step:1398/1490 train_time:78529ms step_avg:56.17ms
+step:1399/1490 train_time:78609ms step_avg:56.19ms
+step:1400/1490 train_time:78694ms step_avg:56.21ms
+step:1401/1490 train_time:78777ms step_avg:56.23ms
+step:1402/1490 train_time:78863ms step_avg:56.25ms
+step:1403/1490 train_time:78943ms step_avg:56.27ms
+step:1404/1490 train_time:79027ms step_avg:56.29ms
+step:1405/1490 train_time:79108ms step_avg:56.30ms
+step:1406/1490 train_time:79194ms step_avg:56.33ms
+step:1407/1490 train_time:79276ms step_avg:56.34ms
+step:1408/1490 train_time:79362ms step_avg:56.37ms
+step:1409/1490 train_time:79443ms step_avg:56.38ms
+step:1410/1490 train_time:79530ms step_avg:56.40ms
+step:1411/1490 train_time:79609ms step_avg:56.42ms
+step:1412/1490 train_time:79694ms step_avg:56.44ms
+step:1413/1490 train_time:79775ms step_avg:56.46ms
+step:1414/1490 train_time:79861ms step_avg:56.48ms
+step:1415/1490 train_time:79942ms step_avg:56.50ms
+step:1416/1490 train_time:80028ms step_avg:56.52ms
+step:1417/1490 train_time:80108ms step_avg:56.53ms
+step:1418/1490 train_time:80193ms step_avg:56.55ms
+step:1419/1490 train_time:80273ms step_avg:56.57ms
+step:1420/1490 train_time:80359ms step_avg:56.59ms
+step:1421/1490 train_time:80440ms step_avg:56.61ms
+step:1422/1490 train_time:80525ms step_avg:56.63ms
+step:1423/1490 train_time:80605ms step_avg:56.64ms
+step:1424/1490 train_time:80690ms step_avg:56.66ms
+step:1425/1490 train_time:80771ms step_avg:56.68ms
+step:1426/1490 train_time:80857ms step_avg:56.70ms
+step:1427/1490 train_time:80937ms step_avg:56.72ms
+step:1428/1490 train_time:81025ms step_avg:56.74ms
+step:1429/1490 train_time:81106ms step_avg:56.76ms
+step:1430/1490 train_time:81189ms step_avg:56.78ms
+step:1431/1490 train_time:81271ms step_avg:56.79ms
+step:1432/1490 train_time:81357ms step_avg:56.81ms
+step:1433/1490 train_time:81437ms step_avg:56.83ms
+step:1434/1490 train_time:81523ms step_avg:56.85ms
+step:1435/1490 train_time:81603ms step_avg:56.87ms
+step:1436/1490 train_time:81688ms step_avg:56.89ms
+step:1437/1490 train_time:81767ms step_avg:56.90ms
+step:1438/1490 train_time:81852ms step_avg:56.92ms
+step:1439/1490 train_time:81934ms step_avg:56.94ms
+step:1440/1490 train_time:82019ms step_avg:56.96ms
+step:1441/1490 train_time:82100ms step_avg:56.97ms
+step:1442/1490 train_time:82186ms step_avg:56.99ms
+step:1443/1490 train_time:82266ms step_avg:57.01ms
+step:1444/1490 train_time:82351ms step_avg:57.03ms
+step:1445/1490 train_time:82433ms step_avg:57.05ms
+step:1446/1490 train_time:82521ms step_avg:57.07ms
+step:1447/1490 train_time:82601ms step_avg:57.08ms
+step:1448/1490 train_time:82685ms step_avg:57.10ms
+step:1449/1490 train_time:82765ms step_avg:57.12ms
+step:1450/1490 train_time:82850ms step_avg:57.14ms
+step:1451/1490 train_time:82934ms step_avg:57.16ms
+step:1452/1490 train_time:83022ms step_avg:57.18ms
+step:1453/1490 train_time:83103ms step_avg:57.19ms
+step:1454/1490 train_time:83188ms step_avg:57.21ms
+step:1455/1490 train_time:83268ms step_avg:57.23ms
+step:1456/1490 train_time:83353ms step_avg:57.25ms
+step:1457/1490 train_time:83437ms step_avg:57.27ms
+step:1458/1490 train_time:83525ms step_avg:57.29ms
+step:1459/1490 train_time:83606ms step_avg:57.30ms
+step:1460/1490 train_time:83692ms step_avg:57.32ms
+step:1461/1490 train_time:83772ms step_avg:57.34ms
+step:1462/1490 train_time:83858ms step_avg:57.36ms
+step:1463/1490 train_time:83940ms step_avg:57.37ms
+step:1464/1490 train_time:84026ms step_avg:57.39ms
+step:1465/1490 train_time:84107ms step_avg:57.41ms
+step:1466/1490 train_time:84193ms step_avg:57.43ms
+step:1467/1490 train_time:84273ms step_avg:57.45ms
+step:1468/1490 train_time:84359ms step_avg:57.47ms
+step:1469/1490 train_time:84440ms step_avg:57.48ms
+step:1470/1490 train_time:84527ms step_avg:57.50ms
+step:1471/1490 train_time:84607ms step_avg:57.52ms
+step:1472/1490 train_time:84692ms step_avg:57.54ms
+step:1473/1490 train_time:84772ms step_avg:57.55ms
+step:1474/1490 train_time:84858ms step_avg:57.57ms
+step:1475/1490 train_time:84938ms step_avg:57.59ms
+step:1476/1490 train_time:85024ms step_avg:57.60ms
+step:1477/1490 train_time:85106ms step_avg:57.62ms
+step:1478/1490 train_time:85191ms step_avg:57.64ms
+step:1479/1490 train_time:85272ms step_avg:57.66ms
+step:1480/1490 train_time:85359ms step_avg:57.67ms
+step:1481/1490 train_time:85441ms step_avg:57.69ms
+step:1482/1490 train_time:85526ms step_avg:57.71ms
+step:1483/1490 train_time:85606ms step_avg:57.73ms
+step:1484/1490 train_time:85692ms step_avg:57.74ms
+step:1485/1490 train_time:85774ms step_avg:57.76ms
+step:1486/1490 train_time:85861ms step_avg:57.78ms
+step:1487/1490 train_time:85942ms step_avg:57.80ms
+step:1488/1490 train_time:86027ms step_avg:57.81ms
+step:1489/1490 train_time:86108ms step_avg:57.83ms
+step:1490/1490 train_time:86192ms step_avg:57.85ms
+step:1490/1490 val_loss:3.2792 train_time:86296ms step_avg:57.92ms
+peak memory allocated: 31296 MiB reserved: 47042 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/max_num_docs/2026-03-22_18-35-20_time-184_secs_00-cu-seqlens_adc782.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/max_num_docs/2026-03-22_18-35-20_time-184_secs_00-cu-seqlens_adc782.txt
@@ -1,0 +1,4457 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 18:35:35 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            132W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   40C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1425542      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1425543      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1425544      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1425545      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1425546      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1425547      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1425548      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1425549      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8272 train_time:0ms step_avg:0.04ms
+step:1/1490 train_time:89ms step_avg:88.56ms
+step:2/1490 train_time:110ms step_avg:54.91ms
+step:3/1490 train_time:127ms step_avg:42.17ms
+step:4/1490 train_time:157ms step_avg:39.13ms
+step:5/1490 train_time:184ms step_avg:36.75ms
+step:6/1490 train_time:219ms step_avg:36.44ms
+step:7/1490 train_time:246ms step_avg:35.14ms
+step:8/1490 train_time:281ms step_avg:35.11ms
+step:9/1490 train_time:308ms step_avg:34.24ms
+step:10/1490 train_time:343ms step_avg:34.33ms
+step:11/1490 train_time:371ms step_avg:33.72ms
+step:12/1490 train_time:405ms step_avg:33.75ms
+step:13/1490 train_time:433ms step_avg:33.33ms
+step:14/1490 train_time:467ms step_avg:33.39ms
+step:15/1490 train_time:496ms step_avg:33.05ms
+step:16/1490 train_time:530ms step_avg:33.12ms
+step:17/1490 train_time:558ms step_avg:32.83ms
+step:18/1490 train_time:592ms step_avg:32.89ms
+step:19/1490 train_time:620ms step_avg:32.64ms
+step:20/1490 train_time:654ms step_avg:32.71ms
+step:21/1490 train_time:682ms step_avg:32.48ms
+step:22/1490 train_time:716ms step_avg:32.57ms
+step:23/1490 train_time:744ms step_avg:32.36ms
+step:24/1490 train_time:779ms step_avg:32.46ms
+step:25/1490 train_time:807ms step_avg:32.29ms
+step:26/1490 train_time:842ms step_avg:32.38ms
+step:27/1490 train_time:870ms step_avg:32.22ms
+step:28/1490 train_time:904ms step_avg:32.29ms
+step:29/1490 train_time:932ms step_avg:32.15ms
+step:30/1490 train_time:967ms step_avg:32.23ms
+step:31/1490 train_time:997ms step_avg:32.16ms
+step:32/1490 train_time:1032ms step_avg:32.24ms
+step:33/1490 train_time:1061ms step_avg:32.16ms
+step:34/1490 train_time:1096ms step_avg:32.23ms
+step:35/1490 train_time:1125ms step_avg:32.14ms
+step:36/1490 train_time:1160ms step_avg:32.23ms
+step:37/1490 train_time:1189ms step_avg:32.13ms
+step:38/1490 train_time:1223ms step_avg:32.19ms
+step:39/1490 train_time:1252ms step_avg:32.10ms
+step:40/1490 train_time:1286ms step_avg:32.16ms
+step:41/1490 train_time:1315ms step_avg:32.07ms
+step:42/1490 train_time:1350ms step_avg:32.14ms
+step:43/1490 train_time:1378ms step_avg:32.05ms
+step:44/1490 train_time:1412ms step_avg:32.09ms
+step:45/1490 train_time:1441ms step_avg:32.01ms
+step:46/1490 train_time:1475ms step_avg:32.06ms
+step:47/1490 train_time:1503ms step_avg:31.97ms
+step:48/1490 train_time:1538ms step_avg:32.03ms
+step:49/1490 train_time:1566ms step_avg:31.96ms
+step:50/1490 train_time:1601ms step_avg:32.01ms
+step:51/1490 train_time:1629ms step_avg:31.93ms
+step:52/1490 train_time:1663ms step_avg:31.98ms
+step:53/1490 train_time:1691ms step_avg:31.90ms
+step:54/1490 train_time:1725ms step_avg:31.95ms
+step:55/1490 train_time:1753ms step_avg:31.88ms
+step:56/1490 train_time:1787ms step_avg:31.92ms
+step:57/1490 train_time:1816ms step_avg:31.86ms
+step:58/1490 train_time:1850ms step_avg:31.90ms
+step:59/1490 train_time:1878ms step_avg:31.84ms
+step:60/1490 train_time:1912ms step_avg:31.87ms
+step:61/1490 train_time:1940ms step_avg:31.80ms
+step:62/1490 train_time:1975ms step_avg:31.85ms
+step:63/1490 train_time:2003ms step_avg:31.80ms
+step:64/1490 train_time:2039ms step_avg:31.85ms
+step:65/1490 train_time:2067ms step_avg:31.80ms
+step:66/1490 train_time:2102ms step_avg:31.85ms
+step:67/1490 train_time:2131ms step_avg:31.81ms
+step:68/1490 train_time:2166ms step_avg:31.86ms
+step:69/1490 train_time:2195ms step_avg:31.81ms
+step:70/1490 train_time:2229ms step_avg:31.84ms
+step:71/1490 train_time:2257ms step_avg:31.80ms
+step:72/1490 train_time:2292ms step_avg:31.83ms
+step:73/1490 train_time:2321ms step_avg:31.79ms
+step:74/1490 train_time:2355ms step_avg:31.83ms
+step:75/1490 train_time:2384ms step_avg:31.78ms
+step:76/1490 train_time:2419ms step_avg:31.82ms
+step:77/1490 train_time:2447ms step_avg:31.78ms
+step:78/1490 train_time:2481ms step_avg:31.81ms
+step:79/1490 train_time:2509ms step_avg:31.76ms
+step:80/1490 train_time:2544ms step_avg:31.80ms
+step:81/1490 train_time:2573ms step_avg:31.76ms
+step:82/1490 train_time:2607ms step_avg:31.79ms
+step:83/1490 train_time:2635ms step_avg:31.75ms
+step:84/1490 train_time:2669ms step_avg:31.78ms
+step:85/1490 train_time:2697ms step_avg:31.73ms
+step:86/1490 train_time:2731ms step_avg:31.76ms
+step:87/1490 train_time:2760ms step_avg:31.72ms
+step:88/1490 train_time:2794ms step_avg:31.75ms
+step:89/1490 train_time:2823ms step_avg:31.71ms
+step:90/1490 train_time:2857ms step_avg:31.74ms
+step:91/1490 train_time:2885ms step_avg:31.70ms
+step:92/1490 train_time:2919ms step_avg:31.73ms
+step:93/1490 train_time:2947ms step_avg:31.69ms
+step:94/1490 train_time:2982ms step_avg:31.72ms
+step:95/1490 train_time:3010ms step_avg:31.69ms
+step:96/1490 train_time:3045ms step_avg:31.72ms
+step:97/1490 train_time:3074ms step_avg:31.69ms
+step:98/1490 train_time:3108ms step_avg:31.71ms
+step:99/1490 train_time:3137ms step_avg:31.68ms
+step:100/1490 train_time:3171ms step_avg:31.71ms
+step:101/1490 train_time:3199ms step_avg:31.68ms
+step:102/1490 train_time:3234ms step_avg:31.71ms
+step:103/1490 train_time:3263ms step_avg:31.68ms
+step:104/1490 train_time:3298ms step_avg:31.71ms
+step:105/1490 train_time:3326ms step_avg:31.68ms
+step:106/1490 train_time:3361ms step_avg:31.71ms
+step:107/1490 train_time:3389ms step_avg:31.67ms
+step:108/1490 train_time:3424ms step_avg:31.70ms
+step:109/1490 train_time:3452ms step_avg:31.67ms
+step:110/1490 train_time:3486ms step_avg:31.69ms
+step:111/1490 train_time:3515ms step_avg:31.66ms
+step:112/1490 train_time:3549ms step_avg:31.69ms
+step:113/1490 train_time:3578ms step_avg:31.66ms
+step:114/1490 train_time:3612ms step_avg:31.68ms
+step:115/1490 train_time:3640ms step_avg:31.66ms
+step:116/1490 train_time:3674ms step_avg:31.68ms
+step:117/1490 train_time:3703ms step_avg:31.65ms
+step:118/1490 train_time:3737ms step_avg:31.67ms
+step:119/1490 train_time:3766ms step_avg:31.64ms
+step:120/1490 train_time:3800ms step_avg:31.67ms
+step:121/1490 train_time:3828ms step_avg:31.64ms
+step:122/1490 train_time:3863ms step_avg:31.66ms
+step:123/1490 train_time:3891ms step_avg:31.63ms
+step:124/1490 train_time:3925ms step_avg:31.65ms
+step:125/1490 train_time:3953ms step_avg:31.63ms
+step:126/1490 train_time:3988ms step_avg:31.65ms
+step:127/1490 train_time:4016ms step_avg:31.62ms
+step:128/1490 train_time:4051ms step_avg:31.65ms
+step:129/1490 train_time:4079ms step_avg:31.62ms
+step:130/1490 train_time:4113ms step_avg:31.64ms
+step:131/1490 train_time:4142ms step_avg:31.62ms
+step:132/1490 train_time:4177ms step_avg:31.64ms
+step:133/1490 train_time:4205ms step_avg:31.62ms
+step:134/1490 train_time:4240ms step_avg:31.64ms
+step:135/1490 train_time:4269ms step_avg:31.62ms
+step:136/1490 train_time:4303ms step_avg:31.64ms
+step:137/1490 train_time:4332ms step_avg:31.62ms
+step:138/1490 train_time:4366ms step_avg:31.64ms
+step:139/1490 train_time:4394ms step_avg:31.61ms
+step:140/1490 train_time:4428ms step_avg:31.63ms
+step:141/1490 train_time:4457ms step_avg:31.61ms
+step:142/1490 train_time:4491ms step_avg:31.63ms
+step:143/1490 train_time:4520ms step_avg:31.61ms
+step:144/1490 train_time:4554ms step_avg:31.63ms
+step:145/1490 train_time:4583ms step_avg:31.60ms
+step:146/1490 train_time:4617ms step_avg:31.62ms
+step:147/1490 train_time:4645ms step_avg:31.60ms
+step:148/1490 train_time:4680ms step_avg:31.62ms
+step:149/1490 train_time:4708ms step_avg:31.60ms
+step:150/1490 train_time:4743ms step_avg:31.62ms
+step:151/1490 train_time:4771ms step_avg:31.59ms
+step:152/1490 train_time:4805ms step_avg:31.61ms
+step:153/1490 train_time:4834ms step_avg:31.59ms
+step:154/1490 train_time:4870ms step_avg:31.62ms
+step:155/1490 train_time:4896ms step_avg:31.59ms
+step:156/1490 train_time:4931ms step_avg:31.61ms
+step:157/1490 train_time:4959ms step_avg:31.59ms
+step:158/1490 train_time:4994ms step_avg:31.60ms
+step:159/1490 train_time:5022ms step_avg:31.58ms
+step:160/1490 train_time:5056ms step_avg:31.60ms
+step:161/1490 train_time:5085ms step_avg:31.58ms
+step:162/1490 train_time:5120ms step_avg:31.60ms
+step:163/1490 train_time:5148ms step_avg:31.58ms
+step:164/1490 train_time:5184ms step_avg:31.61ms
+step:165/1490 train_time:5211ms step_avg:31.58ms
+step:166/1490 train_time:5246ms step_avg:31.60ms
+step:167/1490 train_time:5274ms step_avg:31.58ms
+step:168/1490 train_time:5308ms step_avg:31.60ms
+step:169/1490 train_time:5336ms step_avg:31.58ms
+step:170/1490 train_time:5371ms step_avg:31.59ms
+step:171/1490 train_time:5399ms step_avg:31.57ms
+step:172/1490 train_time:5433ms step_avg:31.59ms
+step:173/1490 train_time:5462ms step_avg:31.57ms
+step:174/1490 train_time:5496ms step_avg:31.59ms
+step:175/1490 train_time:5524ms step_avg:31.57ms
+step:176/1490 train_time:5559ms step_avg:31.58ms
+step:177/1490 train_time:5587ms step_avg:31.56ms
+step:178/1490 train_time:5621ms step_avg:31.58ms
+step:179/1490 train_time:5650ms step_avg:31.56ms
+step:180/1490 train_time:5684ms step_avg:31.58ms
+step:181/1490 train_time:5712ms step_avg:31.56ms
+step:182/1490 train_time:5747ms step_avg:31.58ms
+step:183/1490 train_time:5775ms step_avg:31.56ms
+step:184/1490 train_time:5809ms step_avg:31.57ms
+step:185/1490 train_time:5838ms step_avg:31.56ms
+step:186/1490 train_time:5872ms step_avg:31.57ms
+step:187/1490 train_time:5900ms step_avg:31.55ms
+step:188/1490 train_time:5934ms step_avg:31.57ms
+step:189/1490 train_time:5963ms step_avg:31.55ms
+step:190/1490 train_time:5997ms step_avg:31.57ms
+step:191/1490 train_time:6025ms step_avg:31.55ms
+step:192/1490 train_time:6060ms step_avg:31.56ms
+step:193/1490 train_time:6088ms step_avg:31.55ms
+step:194/1490 train_time:6123ms step_avg:31.56ms
+step:195/1490 train_time:6151ms step_avg:31.54ms
+step:196/1490 train_time:6185ms step_avg:31.56ms
+step:197/1490 train_time:6214ms step_avg:31.54ms
+step:198/1490 train_time:6249ms step_avg:31.56ms
+step:199/1490 train_time:6277ms step_avg:31.54ms
+step:200/1490 train_time:6311ms step_avg:31.56ms
+step:201/1490 train_time:6340ms step_avg:31.54ms
+step:202/1490 train_time:6374ms step_avg:31.55ms
+step:203/1490 train_time:6402ms step_avg:31.54ms
+step:204/1490 train_time:6436ms step_avg:31.55ms
+step:205/1490 train_time:6465ms step_avg:31.53ms
+step:206/1490 train_time:6499ms step_avg:31.55ms
+step:207/1490 train_time:6527ms step_avg:31.53ms
+step:208/1490 train_time:6563ms step_avg:31.55ms
+step:209/1490 train_time:6591ms step_avg:31.54ms
+step:210/1490 train_time:6626ms step_avg:31.55ms
+step:211/1490 train_time:6654ms step_avg:31.53ms
+step:212/1490 train_time:6688ms step_avg:31.55ms
+step:213/1490 train_time:6717ms step_avg:31.53ms
+step:214/1490 train_time:6751ms step_avg:31.55ms
+step:215/1490 train_time:6779ms step_avg:31.53ms
+step:216/1490 train_time:6813ms step_avg:31.54ms
+step:217/1490 train_time:6841ms step_avg:31.53ms
+step:218/1490 train_time:6876ms step_avg:31.54ms
+step:219/1490 train_time:6904ms step_avg:31.52ms
+step:220/1490 train_time:6939ms step_avg:31.54ms
+step:221/1490 train_time:6967ms step_avg:31.52ms
+step:222/1490 train_time:7001ms step_avg:31.54ms
+step:223/1490 train_time:7029ms step_avg:31.52ms
+step:224/1490 train_time:7064ms step_avg:31.54ms
+step:225/1490 train_time:7092ms step_avg:31.52ms
+step:226/1490 train_time:7126ms step_avg:31.53ms
+step:227/1490 train_time:7155ms step_avg:31.52ms
+step:228/1490 train_time:7189ms step_avg:31.53ms
+step:229/1490 train_time:7217ms step_avg:31.52ms
+step:230/1490 train_time:7252ms step_avg:31.53ms
+step:231/1490 train_time:7280ms step_avg:31.52ms
+step:232/1490 train_time:7314ms step_avg:31.53ms
+step:233/1490 train_time:7342ms step_avg:31.51ms
+step:234/1490 train_time:7376ms step_avg:31.52ms
+step:235/1490 train_time:7405ms step_avg:31.51ms
+step:236/1490 train_time:7439ms step_avg:31.52ms
+step:237/1490 train_time:7467ms step_avg:31.51ms
+step:238/1490 train_time:7502ms step_avg:31.52ms
+step:239/1490 train_time:7530ms step_avg:31.51ms
+step:240/1490 train_time:7564ms step_avg:31.52ms
+step:241/1490 train_time:7593ms step_avg:31.50ms
+step:242/1490 train_time:7627ms step_avg:31.52ms
+step:243/1490 train_time:7655ms step_avg:31.50ms
+step:244/1490 train_time:7689ms step_avg:31.51ms
+step:245/1490 train_time:7717ms step_avg:31.50ms
+step:246/1490 train_time:7752ms step_avg:31.51ms
+step:247/1490 train_time:7781ms step_avg:31.50ms
+step:248/1490 train_time:7814ms step_avg:31.51ms
+step:249/1490 train_time:7843ms step_avg:31.50ms
+step:250/1490 train_time:7877ms step_avg:31.51ms
+step:250/1490 val_loss:4.5038 train_time:7920ms step_avg:31.68ms
+step:251/1490 train_time:7936ms step_avg:31.62ms
+step:252/1490 train_time:7953ms step_avg:31.56ms
+step:253/1490 train_time:7970ms step_avg:31.50ms
+step:254/1490 train_time:8005ms step_avg:31.52ms
+step:255/1490 train_time:8035ms step_avg:31.51ms
+step:256/1490 train_time:8072ms step_avg:31.53ms
+step:257/1490 train_time:8101ms step_avg:31.52ms
+step:258/1490 train_time:8136ms step_avg:31.53ms
+step:259/1490 train_time:8163ms step_avg:31.52ms
+step:260/1490 train_time:8198ms step_avg:31.53ms
+step:261/1490 train_time:8226ms step_avg:31.52ms
+step:262/1490 train_time:8260ms step_avg:31.53ms
+step:263/1490 train_time:8288ms step_avg:31.51ms
+step:264/1490 train_time:8322ms step_avg:31.52ms
+step:265/1490 train_time:8350ms step_avg:31.51ms
+step:266/1490 train_time:8384ms step_avg:31.52ms
+step:267/1490 train_time:8412ms step_avg:31.51ms
+step:268/1490 train_time:8447ms step_avg:31.52ms
+step:269/1490 train_time:8475ms step_avg:31.50ms
+step:270/1490 train_time:8509ms step_avg:31.51ms
+step:271/1490 train_time:8537ms step_avg:31.50ms
+step:272/1490 train_time:8572ms step_avg:31.51ms
+step:273/1490 train_time:8600ms step_avg:31.50ms
+step:274/1490 train_time:8634ms step_avg:31.51ms
+step:275/1490 train_time:8662ms step_avg:31.50ms
+step:276/1490 train_time:8696ms step_avg:31.51ms
+step:277/1490 train_time:8724ms step_avg:31.49ms
+step:278/1490 train_time:8757ms step_avg:31.50ms
+step:279/1490 train_time:8785ms step_avg:31.49ms
+step:280/1490 train_time:8819ms step_avg:31.50ms
+step:281/1490 train_time:8848ms step_avg:31.49ms
+step:282/1490 train_time:8882ms step_avg:31.50ms
+step:283/1490 train_time:8911ms step_avg:31.49ms
+step:284/1490 train_time:8946ms step_avg:31.50ms
+step:285/1490 train_time:8975ms step_avg:31.49ms
+step:286/1490 train_time:9010ms step_avg:31.50ms
+step:287/1490 train_time:9039ms step_avg:31.49ms
+step:288/1490 train_time:9074ms step_avg:31.51ms
+step:289/1490 train_time:9102ms step_avg:31.50ms
+step:290/1490 train_time:9137ms step_avg:31.51ms
+step:291/1490 train_time:9165ms step_avg:31.50ms
+step:292/1490 train_time:9199ms step_avg:31.51ms
+step:293/1490 train_time:9228ms step_avg:31.49ms
+step:294/1490 train_time:9262ms step_avg:31.50ms
+step:295/1490 train_time:9290ms step_avg:31.49ms
+step:296/1490 train_time:9325ms step_avg:31.50ms
+step:297/1490 train_time:9353ms step_avg:31.49ms
+step:298/1490 train_time:9388ms step_avg:31.50ms
+step:299/1490 train_time:9416ms step_avg:31.49ms
+step:300/1490 train_time:9451ms step_avg:31.50ms
+step:301/1490 train_time:9479ms step_avg:31.49ms
+step:302/1490 train_time:9513ms step_avg:31.50ms
+step:303/1490 train_time:9542ms step_avg:31.49ms
+step:304/1490 train_time:9576ms step_avg:31.50ms
+step:305/1490 train_time:9604ms step_avg:31.49ms
+step:306/1490 train_time:9638ms step_avg:31.50ms
+step:307/1490 train_time:9666ms step_avg:31.49ms
+step:308/1490 train_time:9700ms step_avg:31.49ms
+step:309/1490 train_time:9728ms step_avg:31.48ms
+step:310/1490 train_time:9762ms step_avg:31.49ms
+step:311/1490 train_time:9791ms step_avg:31.48ms
+step:312/1490 train_time:9825ms step_avg:31.49ms
+step:313/1490 train_time:9853ms step_avg:31.48ms
+step:314/1490 train_time:9888ms step_avg:31.49ms
+step:315/1490 train_time:9916ms step_avg:31.48ms
+step:316/1490 train_time:9951ms step_avg:31.49ms
+step:317/1490 train_time:9979ms step_avg:31.48ms
+step:318/1490 train_time:10014ms step_avg:31.49ms
+step:319/1490 train_time:10043ms step_avg:31.48ms
+step:320/1490 train_time:10077ms step_avg:31.49ms
+step:321/1490 train_time:10106ms step_avg:31.48ms
+step:322/1490 train_time:10140ms step_avg:31.49ms
+step:323/1490 train_time:10169ms step_avg:31.48ms
+step:324/1490 train_time:10203ms step_avg:31.49ms
+step:325/1490 train_time:10231ms step_avg:31.48ms
+step:326/1490 train_time:10266ms step_avg:31.49ms
+step:327/1490 train_time:10294ms step_avg:31.48ms
+step:328/1490 train_time:10328ms step_avg:31.49ms
+step:329/1490 train_time:10356ms step_avg:31.48ms
+step:330/1490 train_time:10391ms step_avg:31.49ms
+step:331/1490 train_time:10420ms step_avg:31.48ms
+step:332/1490 train_time:10454ms step_avg:31.49ms
+step:333/1490 train_time:10482ms step_avg:31.48ms
+step:334/1490 train_time:10517ms step_avg:31.49ms
+step:335/1490 train_time:10544ms step_avg:31.48ms
+step:336/1490 train_time:10579ms step_avg:31.48ms
+step:337/1490 train_time:10607ms step_avg:31.47ms
+step:338/1490 train_time:10641ms step_avg:31.48ms
+step:339/1490 train_time:10669ms step_avg:31.47ms
+step:340/1490 train_time:10703ms step_avg:31.48ms
+step:341/1490 train_time:10731ms step_avg:31.47ms
+step:342/1490 train_time:10765ms step_avg:31.48ms
+step:343/1490 train_time:10793ms step_avg:31.47ms
+step:344/1490 train_time:10828ms step_avg:31.48ms
+step:345/1490 train_time:10856ms step_avg:31.47ms
+step:346/1490 train_time:10890ms step_avg:31.48ms
+step:347/1490 train_time:10918ms step_avg:31.47ms
+step:348/1490 train_time:10953ms step_avg:31.47ms
+step:349/1490 train_time:10981ms step_avg:31.47ms
+step:350/1490 train_time:11016ms step_avg:31.47ms
+step:351/1490 train_time:11044ms step_avg:31.46ms
+step:352/1490 train_time:11078ms step_avg:31.47ms
+step:353/1490 train_time:11107ms step_avg:31.46ms
+step:354/1490 train_time:11141ms step_avg:31.47ms
+step:355/1490 train_time:11170ms step_avg:31.46ms
+step:356/1490 train_time:11204ms step_avg:31.47ms
+step:357/1490 train_time:11233ms step_avg:31.46ms
+step:358/1490 train_time:11267ms step_avg:31.47ms
+step:359/1490 train_time:11296ms step_avg:31.46ms
+step:360/1490 train_time:11330ms step_avg:31.47ms
+step:361/1490 train_time:11358ms step_avg:31.46ms
+step:362/1490 train_time:11393ms step_avg:31.47ms
+step:363/1490 train_time:11421ms step_avg:31.46ms
+step:364/1490 train_time:11455ms step_avg:31.47ms
+step:365/1490 train_time:11483ms step_avg:31.46ms
+step:366/1490 train_time:11517ms step_avg:31.47ms
+step:367/1490 train_time:11546ms step_avg:31.46ms
+step:368/1490 train_time:11580ms step_avg:31.47ms
+step:369/1490 train_time:11608ms step_avg:31.46ms
+step:370/1490 train_time:11643ms step_avg:31.47ms
+step:371/1490 train_time:11671ms step_avg:31.46ms
+step:372/1490 train_time:11705ms step_avg:31.47ms
+step:373/1490 train_time:11733ms step_avg:31.46ms
+step:374/1490 train_time:11768ms step_avg:31.46ms
+step:375/1490 train_time:11796ms step_avg:31.46ms
+step:376/1490 train_time:11831ms step_avg:31.46ms
+step:377/1490 train_time:11859ms step_avg:31.46ms
+step:378/1490 train_time:11893ms step_avg:31.46ms
+step:379/1490 train_time:11921ms step_avg:31.46ms
+step:380/1490 train_time:11956ms step_avg:31.46ms
+step:381/1490 train_time:11984ms step_avg:31.45ms
+step:382/1490 train_time:12018ms step_avg:31.46ms
+step:383/1490 train_time:12046ms step_avg:31.45ms
+step:384/1490 train_time:12081ms step_avg:31.46ms
+step:385/1490 train_time:12109ms step_avg:31.45ms
+step:386/1490 train_time:12144ms step_avg:31.46ms
+step:387/1490 train_time:12172ms step_avg:31.45ms
+step:388/1490 train_time:12207ms step_avg:31.46ms
+step:389/1490 train_time:12235ms step_avg:31.45ms
+step:390/1490 train_time:12270ms step_avg:31.46ms
+step:391/1490 train_time:12298ms step_avg:31.45ms
+step:392/1490 train_time:12332ms step_avg:31.46ms
+step:393/1490 train_time:12360ms step_avg:31.45ms
+step:394/1490 train_time:12395ms step_avg:31.46ms
+step:395/1490 train_time:12424ms step_avg:31.45ms
+step:396/1490 train_time:12458ms step_avg:31.46ms
+step:397/1490 train_time:12486ms step_avg:31.45ms
+step:398/1490 train_time:12520ms step_avg:31.46ms
+step:399/1490 train_time:12548ms step_avg:31.45ms
+step:400/1490 train_time:12583ms step_avg:31.46ms
+step:401/1490 train_time:12611ms step_avg:31.45ms
+step:402/1490 train_time:12646ms step_avg:31.46ms
+step:403/1490 train_time:12674ms step_avg:31.45ms
+step:404/1490 train_time:12708ms step_avg:31.46ms
+step:405/1490 train_time:12736ms step_avg:31.45ms
+step:406/1490 train_time:12771ms step_avg:31.45ms
+step:407/1490 train_time:12799ms step_avg:31.45ms
+step:408/1490 train_time:12833ms step_avg:31.45ms
+step:409/1490 train_time:12861ms step_avg:31.44ms
+step:410/1490 train_time:12895ms step_avg:31.45ms
+step:411/1490 train_time:12924ms step_avg:31.44ms
+step:412/1490 train_time:12958ms step_avg:31.45ms
+step:413/1490 train_time:12986ms step_avg:31.44ms
+step:414/1490 train_time:13020ms step_avg:31.45ms
+step:415/1490 train_time:13048ms step_avg:31.44ms
+step:416/1490 train_time:13083ms step_avg:31.45ms
+step:417/1490 train_time:13112ms step_avg:31.44ms
+step:418/1490 train_time:13146ms step_avg:31.45ms
+step:419/1490 train_time:13174ms step_avg:31.44ms
+step:420/1490 train_time:13209ms step_avg:31.45ms
+step:421/1490 train_time:13237ms step_avg:31.44ms
+step:422/1490 train_time:13272ms step_avg:31.45ms
+step:423/1490 train_time:13300ms step_avg:31.44ms
+step:424/1490 train_time:13334ms step_avg:31.45ms
+step:425/1490 train_time:13363ms step_avg:31.44ms
+step:426/1490 train_time:13397ms step_avg:31.45ms
+step:427/1490 train_time:13425ms step_avg:31.44ms
+step:428/1490 train_time:13459ms step_avg:31.45ms
+step:429/1490 train_time:13487ms step_avg:31.44ms
+step:430/1490 train_time:13522ms step_avg:31.45ms
+step:431/1490 train_time:13550ms step_avg:31.44ms
+step:432/1490 train_time:13584ms step_avg:31.45ms
+step:433/1490 train_time:13613ms step_avg:31.44ms
+step:434/1490 train_time:13648ms step_avg:31.45ms
+step:435/1490 train_time:13676ms step_avg:31.44ms
+step:436/1490 train_time:13711ms step_avg:31.45ms
+step:437/1490 train_time:13738ms step_avg:31.44ms
+step:438/1490 train_time:13773ms step_avg:31.44ms
+step:439/1490 train_time:13801ms step_avg:31.44ms
+step:440/1490 train_time:13835ms step_avg:31.44ms
+step:441/1490 train_time:13863ms step_avg:31.44ms
+step:442/1490 train_time:13897ms step_avg:31.44ms
+step:443/1490 train_time:13925ms step_avg:31.43ms
+step:444/1490 train_time:13959ms step_avg:31.44ms
+step:445/1490 train_time:13988ms step_avg:31.43ms
+step:446/1490 train_time:14022ms step_avg:31.44ms
+step:447/1490 train_time:14051ms step_avg:31.43ms
+step:448/1490 train_time:14085ms step_avg:31.44ms
+step:449/1490 train_time:14114ms step_avg:31.43ms
+step:450/1490 train_time:14149ms step_avg:31.44ms
+step:451/1490 train_time:14177ms step_avg:31.43ms
+step:452/1490 train_time:14211ms step_avg:31.44ms
+step:453/1490 train_time:14240ms step_avg:31.43ms
+step:454/1490 train_time:14274ms step_avg:31.44ms
+step:455/1490 train_time:14302ms step_avg:31.43ms
+step:456/1490 train_time:14336ms step_avg:31.44ms
+step:457/1490 train_time:14365ms step_avg:31.43ms
+step:458/1490 train_time:14399ms step_avg:31.44ms
+step:459/1490 train_time:14427ms step_avg:31.43ms
+step:460/1490 train_time:14461ms step_avg:31.44ms
+step:461/1490 train_time:14489ms step_avg:31.43ms
+step:462/1490 train_time:14523ms step_avg:31.43ms
+step:463/1490 train_time:14551ms step_avg:31.43ms
+step:464/1490 train_time:14587ms step_avg:31.44ms
+step:465/1490 train_time:14615ms step_avg:31.43ms
+step:466/1490 train_time:14650ms step_avg:31.44ms
+step:467/1490 train_time:14678ms step_avg:31.43ms
+step:468/1490 train_time:14712ms step_avg:31.44ms
+step:469/1490 train_time:14741ms step_avg:31.43ms
+step:470/1490 train_time:14775ms step_avg:31.44ms
+step:471/1490 train_time:14803ms step_avg:31.43ms
+step:472/1490 train_time:14838ms step_avg:31.44ms
+step:473/1490 train_time:14866ms step_avg:31.43ms
+step:474/1490 train_time:14900ms step_avg:31.43ms
+step:475/1490 train_time:14928ms step_avg:31.43ms
+step:476/1490 train_time:14962ms step_avg:31.43ms
+step:477/1490 train_time:14990ms step_avg:31.43ms
+step:478/1490 train_time:15024ms step_avg:31.43ms
+step:479/1490 train_time:15053ms step_avg:31.43ms
+step:480/1490 train_time:15088ms step_avg:31.43ms
+step:481/1490 train_time:15116ms step_avg:31.43ms
+step:482/1490 train_time:15152ms step_avg:31.44ms
+step:483/1490 train_time:15179ms step_avg:31.43ms
+step:484/1490 train_time:15216ms step_avg:31.44ms
+step:485/1490 train_time:15268ms step_avg:31.48ms
+step:486/1490 train_time:15327ms step_avg:31.54ms
+step:487/1490 train_time:15381ms step_avg:31.58ms
+step:488/1490 train_time:15441ms step_avg:31.64ms
+step:489/1490 train_time:15495ms step_avg:31.69ms
+step:490/1490 train_time:15555ms step_avg:31.74ms
+step:491/1490 train_time:15609ms step_avg:31.79ms
+step:492/1490 train_time:15669ms step_avg:31.85ms
+step:493/1490 train_time:15724ms step_avg:31.90ms
+step:494/1490 train_time:15784ms step_avg:31.95ms
+step:495/1490 train_time:15838ms step_avg:32.00ms
+step:496/1490 train_time:15898ms step_avg:32.05ms
+step:497/1490 train_time:15951ms step_avg:32.10ms
+step:498/1490 train_time:16011ms step_avg:32.15ms
+step:499/1490 train_time:16066ms step_avg:32.20ms
+step:500/1490 train_time:16126ms step_avg:32.25ms
+step:500/1490 val_loss:4.2198 train_time:16197ms step_avg:32.39ms
+step:501/1490 train_time:16214ms step_avg:32.36ms
+step:502/1490 train_time:16241ms step_avg:32.35ms
+step:503/1490 train_time:16300ms step_avg:32.41ms
+step:504/1490 train_time:16363ms step_avg:32.47ms
+step:505/1490 train_time:16421ms step_avg:32.52ms
+step:506/1490 train_time:16481ms step_avg:32.57ms
+step:507/1490 train_time:16535ms step_avg:32.61ms
+step:508/1490 train_time:16593ms step_avg:32.66ms
+step:509/1490 train_time:16647ms step_avg:32.71ms
+step:510/1490 train_time:16705ms step_avg:32.76ms
+step:511/1490 train_time:16759ms step_avg:32.80ms
+step:512/1490 train_time:16819ms step_avg:32.85ms
+step:513/1490 train_time:16871ms step_avg:32.89ms
+step:514/1490 train_time:16930ms step_avg:32.94ms
+step:515/1490 train_time:16983ms step_avg:32.98ms
+step:516/1490 train_time:17041ms step_avg:33.03ms
+step:517/1490 train_time:17094ms step_avg:33.06ms
+step:518/1490 train_time:17154ms step_avg:33.12ms
+step:519/1490 train_time:17209ms step_avg:33.16ms
+step:520/1490 train_time:17270ms step_avg:33.21ms
+step:521/1490 train_time:17326ms step_avg:33.26ms
+step:522/1490 train_time:17388ms step_avg:33.31ms
+step:523/1490 train_time:17444ms step_avg:33.35ms
+step:524/1490 train_time:17504ms step_avg:33.40ms
+step:525/1490 train_time:17558ms step_avg:33.44ms
+step:526/1490 train_time:17618ms step_avg:33.49ms
+step:527/1490 train_time:17671ms step_avg:33.53ms
+step:528/1490 train_time:17731ms step_avg:33.58ms
+step:529/1490 train_time:17785ms step_avg:33.62ms
+step:530/1490 train_time:17843ms step_avg:33.67ms
+step:531/1490 train_time:17896ms step_avg:33.70ms
+step:532/1490 train_time:17955ms step_avg:33.75ms
+step:533/1490 train_time:18008ms step_avg:33.79ms
+step:534/1490 train_time:18067ms step_avg:33.83ms
+step:535/1490 train_time:18121ms step_avg:33.87ms
+step:536/1490 train_time:18181ms step_avg:33.92ms
+step:537/1490 train_time:18236ms step_avg:33.96ms
+step:538/1490 train_time:18297ms step_avg:34.01ms
+step:539/1490 train_time:18353ms step_avg:34.05ms
+step:540/1490 train_time:18414ms step_avg:34.10ms
+step:541/1490 train_time:18469ms step_avg:34.14ms
+step:542/1490 train_time:18529ms step_avg:34.19ms
+step:543/1490 train_time:18583ms step_avg:34.22ms
+step:544/1490 train_time:18642ms step_avg:34.27ms
+step:545/1490 train_time:18696ms step_avg:34.30ms
+step:546/1490 train_time:18755ms step_avg:34.35ms
+step:547/1490 train_time:18809ms step_avg:34.39ms
+step:548/1490 train_time:18869ms step_avg:34.43ms
+step:549/1490 train_time:18922ms step_avg:34.47ms
+step:550/1490 train_time:18980ms step_avg:34.51ms
+step:551/1490 train_time:19033ms step_avg:34.54ms
+step:552/1490 train_time:19092ms step_avg:34.59ms
+step:553/1490 train_time:19147ms step_avg:34.62ms
+step:554/1490 train_time:19206ms step_avg:34.67ms
+step:555/1490 train_time:19261ms step_avg:34.70ms
+step:556/1490 train_time:19323ms step_avg:34.75ms
+step:557/1490 train_time:19377ms step_avg:34.79ms
+step:558/1490 train_time:19437ms step_avg:34.83ms
+step:559/1490 train_time:19492ms step_avg:34.87ms
+step:560/1490 train_time:19552ms step_avg:34.91ms
+step:561/1490 train_time:19606ms step_avg:34.95ms
+step:562/1490 train_time:19665ms step_avg:34.99ms
+step:563/1490 train_time:19719ms step_avg:35.03ms
+step:564/1490 train_time:19779ms step_avg:35.07ms
+step:565/1490 train_time:19833ms step_avg:35.10ms
+step:566/1490 train_time:19892ms step_avg:35.14ms
+step:567/1490 train_time:19945ms step_avg:35.18ms
+step:568/1490 train_time:20004ms step_avg:35.22ms
+step:569/1490 train_time:20057ms step_avg:35.25ms
+step:570/1490 train_time:20117ms step_avg:35.29ms
+step:571/1490 train_time:20171ms step_avg:35.33ms
+step:572/1490 train_time:20232ms step_avg:35.37ms
+step:573/1490 train_time:20287ms step_avg:35.40ms
+step:574/1490 train_time:20346ms step_avg:35.45ms
+step:575/1490 train_time:20400ms step_avg:35.48ms
+step:576/1490 train_time:20461ms step_avg:35.52ms
+step:577/1490 train_time:20516ms step_avg:35.56ms
+step:578/1490 train_time:20575ms step_avg:35.60ms
+step:579/1490 train_time:20629ms step_avg:35.63ms
+step:580/1490 train_time:20689ms step_avg:35.67ms
+step:581/1490 train_time:20743ms step_avg:35.70ms
+step:582/1490 train_time:20802ms step_avg:35.74ms
+step:583/1490 train_time:20857ms step_avg:35.77ms
+step:584/1490 train_time:20916ms step_avg:35.82ms
+step:585/1490 train_time:20970ms step_avg:35.85ms
+step:586/1490 train_time:21029ms step_avg:35.89ms
+step:587/1490 train_time:21082ms step_avg:35.92ms
+step:588/1490 train_time:21142ms step_avg:35.96ms
+step:589/1490 train_time:21197ms step_avg:35.99ms
+step:590/1490 train_time:21256ms step_avg:36.03ms
+step:591/1490 train_time:21311ms step_avg:36.06ms
+step:592/1490 train_time:21371ms step_avg:36.10ms
+step:593/1490 train_time:21425ms step_avg:36.13ms
+step:594/1490 train_time:21485ms step_avg:36.17ms
+step:595/1490 train_time:21538ms step_avg:36.20ms
+step:596/1490 train_time:21598ms step_avg:36.24ms
+step:597/1490 train_time:21653ms step_avg:36.27ms
+step:598/1490 train_time:21713ms step_avg:36.31ms
+step:599/1490 train_time:21766ms step_avg:36.34ms
+step:600/1490 train_time:21826ms step_avg:36.38ms
+step:601/1490 train_time:21880ms step_avg:36.41ms
+step:602/1490 train_time:21939ms step_avg:36.44ms
+step:603/1490 train_time:21993ms step_avg:36.47ms
+step:604/1490 train_time:22053ms step_avg:36.51ms
+step:605/1490 train_time:22107ms step_avg:36.54ms
+step:606/1490 train_time:22166ms step_avg:36.58ms
+step:607/1490 train_time:22221ms step_avg:36.61ms
+step:608/1490 train_time:22281ms step_avg:36.65ms
+step:609/1490 train_time:22335ms step_avg:36.68ms
+step:610/1490 train_time:22395ms step_avg:36.71ms
+step:611/1490 train_time:22449ms step_avg:36.74ms
+step:612/1490 train_time:22509ms step_avg:36.78ms
+step:613/1490 train_time:22562ms step_avg:36.81ms
+step:614/1490 train_time:22623ms step_avg:36.85ms
+step:615/1490 train_time:22677ms step_avg:36.87ms
+step:616/1490 train_time:22737ms step_avg:36.91ms
+step:617/1490 train_time:22791ms step_avg:36.94ms
+step:618/1490 train_time:22851ms step_avg:36.98ms
+step:619/1490 train_time:22904ms step_avg:37.00ms
+step:620/1490 train_time:22964ms step_avg:37.04ms
+step:621/1490 train_time:23019ms step_avg:37.07ms
+step:622/1490 train_time:23078ms step_avg:37.10ms
+step:623/1490 train_time:23132ms step_avg:37.13ms
+step:624/1490 train_time:23192ms step_avg:37.17ms
+step:625/1490 train_time:23246ms step_avg:37.19ms
+step:626/1490 train_time:23305ms step_avg:37.23ms
+step:627/1490 train_time:23359ms step_avg:37.26ms
+step:628/1490 train_time:23419ms step_avg:37.29ms
+step:629/1490 train_time:23473ms step_avg:37.32ms
+step:630/1490 train_time:23533ms step_avg:37.35ms
+step:631/1490 train_time:23586ms step_avg:37.38ms
+step:632/1490 train_time:23646ms step_avg:37.41ms
+step:633/1490 train_time:23701ms step_avg:37.44ms
+step:634/1490 train_time:23760ms step_avg:37.48ms
+step:635/1490 train_time:23815ms step_avg:37.50ms
+step:636/1490 train_time:23874ms step_avg:37.54ms
+step:637/1490 train_time:23928ms step_avg:37.56ms
+step:638/1490 train_time:23988ms step_avg:37.60ms
+step:639/1490 train_time:24041ms step_avg:37.62ms
+step:640/1490 train_time:24101ms step_avg:37.66ms
+step:641/1490 train_time:24155ms step_avg:37.68ms
+step:642/1490 train_time:24216ms step_avg:37.72ms
+step:643/1490 train_time:24269ms step_avg:37.74ms
+step:644/1490 train_time:24329ms step_avg:37.78ms
+step:645/1490 train_time:24383ms step_avg:37.80ms
+step:646/1490 train_time:24442ms step_avg:37.84ms
+step:647/1490 train_time:24497ms step_avg:37.86ms
+step:648/1490 train_time:24557ms step_avg:37.90ms
+step:649/1490 train_time:24612ms step_avg:37.92ms
+step:650/1490 train_time:24671ms step_avg:37.96ms
+step:651/1490 train_time:24725ms step_avg:37.98ms
+step:652/1490 train_time:24785ms step_avg:38.01ms
+step:653/1490 train_time:24838ms step_avg:38.04ms
+step:654/1490 train_time:24898ms step_avg:38.07ms
+step:655/1490 train_time:24952ms step_avg:38.10ms
+step:656/1490 train_time:25011ms step_avg:38.13ms
+step:657/1490 train_time:25065ms step_avg:38.15ms
+step:658/1490 train_time:25125ms step_avg:38.18ms
+step:659/1490 train_time:25179ms step_avg:38.21ms
+step:660/1490 train_time:25239ms step_avg:38.24ms
+step:661/1490 train_time:25293ms step_avg:38.26ms
+step:662/1490 train_time:25353ms step_avg:38.30ms
+step:663/1490 train_time:25407ms step_avg:38.32ms
+step:664/1490 train_time:25467ms step_avg:38.35ms
+step:665/1490 train_time:25520ms step_avg:38.38ms
+step:666/1490 train_time:25580ms step_avg:38.41ms
+step:667/1490 train_time:25634ms step_avg:38.43ms
+step:668/1490 train_time:25694ms step_avg:38.46ms
+step:669/1490 train_time:25748ms step_avg:38.49ms
+step:670/1490 train_time:25807ms step_avg:38.52ms
+step:671/1490 train_time:25860ms step_avg:38.54ms
+step:672/1490 train_time:25921ms step_avg:38.57ms
+step:673/1490 train_time:25975ms step_avg:38.60ms
+step:674/1490 train_time:26034ms step_avg:38.63ms
+step:675/1490 train_time:26089ms step_avg:38.65ms
+step:676/1490 train_time:26148ms step_avg:38.68ms
+step:677/1490 train_time:26202ms step_avg:38.70ms
+step:678/1490 train_time:26261ms step_avg:38.73ms
+step:679/1490 train_time:26316ms step_avg:38.76ms
+step:680/1490 train_time:26376ms step_avg:38.79ms
+step:681/1490 train_time:26430ms step_avg:38.81ms
+step:682/1490 train_time:26490ms step_avg:38.84ms
+step:683/1490 train_time:26543ms step_avg:38.86ms
+step:684/1490 train_time:26603ms step_avg:38.89ms
+step:685/1490 train_time:26658ms step_avg:38.92ms
+step:686/1490 train_time:26717ms step_avg:38.95ms
+step:687/1490 train_time:26771ms step_avg:38.97ms
+step:688/1490 train_time:26831ms step_avg:39.00ms
+step:689/1490 train_time:26884ms step_avg:39.02ms
+step:690/1490 train_time:26943ms step_avg:39.05ms
+step:691/1490 train_time:26999ms step_avg:39.07ms
+step:692/1490 train_time:27059ms step_avg:39.10ms
+step:693/1490 train_time:27113ms step_avg:39.12ms
+step:694/1490 train_time:27172ms step_avg:39.15ms
+step:695/1490 train_time:27225ms step_avg:39.17ms
+step:696/1490 train_time:27285ms step_avg:39.20ms
+step:697/1490 train_time:27338ms step_avg:39.22ms
+step:698/1490 train_time:27398ms step_avg:39.25ms
+step:699/1490 train_time:27452ms step_avg:39.27ms
+step:700/1490 train_time:27514ms step_avg:39.31ms
+step:701/1490 train_time:27567ms step_avg:39.33ms
+step:702/1490 train_time:27627ms step_avg:39.35ms
+step:703/1490 train_time:27682ms step_avg:39.38ms
+step:704/1490 train_time:27741ms step_avg:39.40ms
+step:705/1490 train_time:27795ms step_avg:39.43ms
+step:706/1490 train_time:27854ms step_avg:39.45ms
+step:707/1490 train_time:27909ms step_avg:39.48ms
+step:708/1490 train_time:27969ms step_avg:39.50ms
+step:709/1490 train_time:28022ms step_avg:39.52ms
+step:710/1490 train_time:28082ms step_avg:39.55ms
+step:711/1490 train_time:28137ms step_avg:39.57ms
+step:712/1490 train_time:28197ms step_avg:39.60ms
+step:713/1490 train_time:28251ms step_avg:39.62ms
+step:714/1490 train_time:28311ms step_avg:39.65ms
+step:715/1490 train_time:28364ms step_avg:39.67ms
+step:716/1490 train_time:28424ms step_avg:39.70ms
+step:717/1490 train_time:28479ms step_avg:39.72ms
+step:718/1490 train_time:28538ms step_avg:39.75ms
+step:719/1490 train_time:28593ms step_avg:39.77ms
+step:720/1490 train_time:28652ms step_avg:39.79ms
+step:721/1490 train_time:28707ms step_avg:39.82ms
+step:722/1490 train_time:28767ms step_avg:39.84ms
+step:723/1490 train_time:28821ms step_avg:39.86ms
+step:724/1490 train_time:28881ms step_avg:39.89ms
+step:725/1490 train_time:28936ms step_avg:39.91ms
+step:726/1490 train_time:28995ms step_avg:39.94ms
+step:727/1490 train_time:29049ms step_avg:39.96ms
+step:728/1490 train_time:29108ms step_avg:39.98ms
+step:729/1490 train_time:29162ms step_avg:40.00ms
+step:730/1490 train_time:29222ms step_avg:40.03ms
+step:731/1490 train_time:29277ms step_avg:40.05ms
+step:732/1490 train_time:29337ms step_avg:40.08ms
+step:733/1490 train_time:29391ms step_avg:40.10ms
+step:734/1490 train_time:29450ms step_avg:40.12ms
+step:735/1490 train_time:29504ms step_avg:40.14ms
+step:736/1490 train_time:29563ms step_avg:40.17ms
+step:737/1490 train_time:29617ms step_avg:40.19ms
+step:738/1490 train_time:29677ms step_avg:40.21ms
+step:739/1490 train_time:29731ms step_avg:40.23ms
+step:740/1490 train_time:29791ms step_avg:40.26ms
+step:741/1490 train_time:29846ms step_avg:40.28ms
+step:742/1490 train_time:29906ms step_avg:40.30ms
+step:743/1490 train_time:29960ms step_avg:40.32ms
+step:744/1490 train_time:30019ms step_avg:40.35ms
+step:745/1490 train_time:30073ms step_avg:40.37ms
+step:746/1490 train_time:30132ms step_avg:40.39ms
+step:747/1490 train_time:30186ms step_avg:40.41ms
+step:748/1490 train_time:30247ms step_avg:40.44ms
+step:749/1490 train_time:30300ms step_avg:40.45ms
+step:750/1490 train_time:30360ms step_avg:40.48ms
+step:750/1490 val_loss:3.8083 train_time:30431ms step_avg:40.58ms
+step:751/1490 train_time:30449ms step_avg:40.54ms
+step:752/1490 train_time:30475ms step_avg:40.53ms
+step:753/1490 train_time:30534ms step_avg:40.55ms
+step:754/1490 train_time:30597ms step_avg:40.58ms
+step:755/1490 train_time:30651ms step_avg:40.60ms
+step:756/1490 train_time:30711ms step_avg:40.62ms
+step:757/1490 train_time:30765ms step_avg:40.64ms
+step:758/1490 train_time:30824ms step_avg:40.66ms
+step:759/1490 train_time:30877ms step_avg:40.68ms
+step:760/1490 train_time:30938ms step_avg:40.71ms
+step:761/1490 train_time:30992ms step_avg:40.73ms
+step:762/1490 train_time:31052ms step_avg:40.75ms
+step:763/1490 train_time:31105ms step_avg:40.77ms
+step:764/1490 train_time:31164ms step_avg:40.79ms
+step:765/1490 train_time:31217ms step_avg:40.81ms
+step:766/1490 train_time:31276ms step_avg:40.83ms
+step:767/1490 train_time:31329ms step_avg:40.85ms
+step:768/1490 train_time:31390ms step_avg:40.87ms
+step:769/1490 train_time:31446ms step_avg:40.89ms
+step:770/1490 train_time:31507ms step_avg:40.92ms
+step:771/1490 train_time:31563ms step_avg:40.94ms
+step:772/1490 train_time:31625ms step_avg:40.96ms
+step:773/1490 train_time:31680ms step_avg:40.98ms
+step:774/1490 train_time:31740ms step_avg:41.01ms
+step:775/1490 train_time:31794ms step_avg:41.02ms
+step:776/1490 train_time:31854ms step_avg:41.05ms
+step:777/1490 train_time:31907ms step_avg:41.06ms
+step:778/1490 train_time:31966ms step_avg:41.09ms
+step:779/1490 train_time:32021ms step_avg:41.10ms
+step:780/1490 train_time:32080ms step_avg:41.13ms
+step:781/1490 train_time:32133ms step_avg:41.14ms
+step:782/1490 train_time:32193ms step_avg:41.17ms
+step:783/1490 train_time:32247ms step_avg:41.18ms
+step:784/1490 train_time:32306ms step_avg:41.21ms
+step:785/1490 train_time:32360ms step_avg:41.22ms
+step:786/1490 train_time:32419ms step_avg:41.25ms
+step:787/1490 train_time:32475ms step_avg:41.26ms
+step:788/1490 train_time:32537ms step_avg:41.29ms
+step:789/1490 train_time:32592ms step_avg:41.31ms
+step:790/1490 train_time:32652ms step_avg:41.33ms
+step:791/1490 train_time:32706ms step_avg:41.35ms
+step:792/1490 train_time:32766ms step_avg:41.37ms
+step:793/1490 train_time:32821ms step_avg:41.39ms
+step:794/1490 train_time:32880ms step_avg:41.41ms
+step:795/1490 train_time:32934ms step_avg:41.43ms
+step:796/1490 train_time:32993ms step_avg:41.45ms
+step:797/1490 train_time:33047ms step_avg:41.46ms
+step:798/1490 train_time:33106ms step_avg:41.49ms
+step:799/1490 train_time:33160ms step_avg:41.50ms
+step:800/1490 train_time:33219ms step_avg:41.52ms
+step:801/1490 train_time:33273ms step_avg:41.54ms
+step:802/1490 train_time:33333ms step_avg:41.56ms
+step:803/1490 train_time:33388ms step_avg:41.58ms
+step:804/1490 train_time:33448ms step_avg:41.60ms
+step:805/1490 train_time:33502ms step_avg:41.62ms
+step:806/1490 train_time:33563ms step_avg:41.64ms
+step:807/1490 train_time:33618ms step_avg:41.66ms
+step:808/1490 train_time:33678ms step_avg:41.68ms
+step:809/1490 train_time:33733ms step_avg:41.70ms
+step:810/1490 train_time:33793ms step_avg:41.72ms
+step:811/1490 train_time:33847ms step_avg:41.74ms
+step:812/1490 train_time:33907ms step_avg:41.76ms
+step:813/1490 train_time:33960ms step_avg:41.77ms
+step:814/1490 train_time:34020ms step_avg:41.79ms
+step:815/1490 train_time:34073ms step_avg:41.81ms
+step:816/1490 train_time:34133ms step_avg:41.83ms
+step:817/1490 train_time:34187ms step_avg:41.84ms
+step:818/1490 train_time:34246ms step_avg:41.87ms
+step:819/1490 train_time:34300ms step_avg:41.88ms
+step:820/1490 train_time:34361ms step_avg:41.90ms
+step:821/1490 train_time:34415ms step_avg:41.92ms
+step:822/1490 train_time:34475ms step_avg:41.94ms
+step:823/1490 train_time:34530ms step_avg:41.96ms
+step:824/1490 train_time:34590ms step_avg:41.98ms
+step:825/1490 train_time:34644ms step_avg:41.99ms
+step:826/1490 train_time:34705ms step_avg:42.02ms
+step:827/1490 train_time:34759ms step_avg:42.03ms
+step:828/1490 train_time:34820ms step_avg:42.05ms
+step:829/1490 train_time:34874ms step_avg:42.07ms
+step:830/1490 train_time:34934ms step_avg:42.09ms
+step:831/1490 train_time:34988ms step_avg:42.10ms
+step:832/1490 train_time:35047ms step_avg:42.12ms
+step:833/1490 train_time:35101ms step_avg:42.14ms
+step:834/1490 train_time:35161ms step_avg:42.16ms
+step:835/1490 train_time:35215ms step_avg:42.17ms
+step:836/1490 train_time:35275ms step_avg:42.20ms
+step:837/1490 train_time:35329ms step_avg:42.21ms
+step:838/1490 train_time:35388ms step_avg:42.23ms
+step:839/1490 train_time:35443ms step_avg:42.24ms
+step:840/1490 train_time:35504ms step_avg:42.27ms
+step:841/1490 train_time:35558ms step_avg:42.28ms
+step:842/1490 train_time:35618ms step_avg:42.30ms
+step:843/1490 train_time:35673ms step_avg:42.32ms
+step:844/1490 train_time:35733ms step_avg:42.34ms
+step:845/1490 train_time:35788ms step_avg:42.35ms
+step:846/1490 train_time:35847ms step_avg:42.37ms
+step:847/1490 train_time:35901ms step_avg:42.39ms
+step:848/1490 train_time:35962ms step_avg:42.41ms
+step:849/1490 train_time:36016ms step_avg:42.42ms
+step:850/1490 train_time:36076ms step_avg:42.44ms
+step:851/1490 train_time:36130ms step_avg:42.46ms
+step:852/1490 train_time:36190ms step_avg:42.48ms
+step:853/1490 train_time:36244ms step_avg:42.49ms
+step:854/1490 train_time:36304ms step_avg:42.51ms
+step:855/1490 train_time:36358ms step_avg:42.52ms
+step:856/1490 train_time:36418ms step_avg:42.54ms
+step:857/1490 train_time:36471ms step_avg:42.56ms
+step:858/1490 train_time:36531ms step_avg:42.58ms
+step:859/1490 train_time:36585ms step_avg:42.59ms
+step:860/1490 train_time:36646ms step_avg:42.61ms
+step:861/1490 train_time:36700ms step_avg:42.62ms
+step:862/1490 train_time:36760ms step_avg:42.64ms
+step:863/1490 train_time:36814ms step_avg:42.66ms
+step:864/1490 train_time:36874ms step_avg:42.68ms
+step:865/1490 train_time:36928ms step_avg:42.69ms
+step:866/1490 train_time:36987ms step_avg:42.71ms
+step:867/1490 train_time:37042ms step_avg:42.72ms
+step:868/1490 train_time:37101ms step_avg:42.74ms
+step:869/1490 train_time:37154ms step_avg:42.76ms
+step:870/1490 train_time:37214ms step_avg:42.78ms
+step:871/1490 train_time:37268ms step_avg:42.79ms
+step:872/1490 train_time:37327ms step_avg:42.81ms
+step:873/1490 train_time:37381ms step_avg:42.82ms
+step:874/1490 train_time:37442ms step_avg:42.84ms
+step:875/1490 train_time:37496ms step_avg:42.85ms
+step:876/1490 train_time:37556ms step_avg:42.87ms
+step:877/1490 train_time:37610ms step_avg:42.88ms
+step:878/1490 train_time:37669ms step_avg:42.90ms
+step:879/1490 train_time:37723ms step_avg:42.92ms
+step:880/1490 train_time:37783ms step_avg:42.93ms
+step:881/1490 train_time:37837ms step_avg:42.95ms
+step:882/1490 train_time:37897ms step_avg:42.97ms
+step:883/1490 train_time:37951ms step_avg:42.98ms
+step:884/1490 train_time:38010ms step_avg:43.00ms
+step:885/1490 train_time:38064ms step_avg:43.01ms
+step:886/1490 train_time:38124ms step_avg:43.03ms
+step:887/1490 train_time:38178ms step_avg:43.04ms
+step:888/1490 train_time:38238ms step_avg:43.06ms
+step:889/1490 train_time:38292ms step_avg:43.07ms
+step:890/1490 train_time:38352ms step_avg:43.09ms
+step:891/1490 train_time:38406ms step_avg:43.10ms
+step:892/1490 train_time:38465ms step_avg:43.12ms
+step:893/1490 train_time:38520ms step_avg:43.14ms
+step:894/1490 train_time:38580ms step_avg:43.15ms
+step:895/1490 train_time:38633ms step_avg:43.17ms
+step:896/1490 train_time:38694ms step_avg:43.19ms
+step:897/1490 train_time:38748ms step_avg:43.20ms
+step:898/1490 train_time:38808ms step_avg:43.22ms
+step:899/1490 train_time:38862ms step_avg:43.23ms
+step:900/1490 train_time:38921ms step_avg:43.25ms
+step:901/1490 train_time:38976ms step_avg:43.26ms
+step:902/1490 train_time:39036ms step_avg:43.28ms
+step:903/1490 train_time:39090ms step_avg:43.29ms
+step:904/1490 train_time:39150ms step_avg:43.31ms
+step:905/1490 train_time:39204ms step_avg:43.32ms
+step:906/1490 train_time:39264ms step_avg:43.34ms
+step:907/1490 train_time:39318ms step_avg:43.35ms
+step:908/1490 train_time:39378ms step_avg:43.37ms
+step:909/1490 train_time:39433ms step_avg:43.38ms
+step:910/1490 train_time:39492ms step_avg:43.40ms
+step:911/1490 train_time:39546ms step_avg:43.41ms
+step:912/1490 train_time:39606ms step_avg:43.43ms
+step:913/1490 train_time:39661ms step_avg:43.44ms
+step:914/1490 train_time:39721ms step_avg:43.46ms
+step:915/1490 train_time:39775ms step_avg:43.47ms
+step:916/1490 train_time:39835ms step_avg:43.49ms
+step:917/1490 train_time:39889ms step_avg:43.50ms
+step:918/1490 train_time:39948ms step_avg:43.52ms
+step:919/1490 train_time:40002ms step_avg:43.53ms
+step:920/1490 train_time:40062ms step_avg:43.55ms
+step:921/1490 train_time:40116ms step_avg:43.56ms
+step:922/1490 train_time:40176ms step_avg:43.57ms
+step:923/1490 train_time:40230ms step_avg:43.59ms
+step:924/1490 train_time:40290ms step_avg:43.60ms
+step:925/1490 train_time:40344ms step_avg:43.61ms
+step:926/1490 train_time:40403ms step_avg:43.63ms
+step:927/1490 train_time:40457ms step_avg:43.64ms
+step:928/1490 train_time:40517ms step_avg:43.66ms
+step:929/1490 train_time:40571ms step_avg:43.67ms
+step:930/1490 train_time:40631ms step_avg:43.69ms
+step:931/1490 train_time:40686ms step_avg:43.70ms
+step:932/1490 train_time:40745ms step_avg:43.72ms
+step:933/1490 train_time:40800ms step_avg:43.73ms
+step:934/1490 train_time:40860ms step_avg:43.75ms
+step:935/1490 train_time:40914ms step_avg:43.76ms
+step:936/1490 train_time:40974ms step_avg:43.78ms
+step:937/1490 train_time:41028ms step_avg:43.79ms
+step:938/1490 train_time:41088ms step_avg:43.80ms
+step:939/1490 train_time:41142ms step_avg:43.81ms
+step:940/1490 train_time:41201ms step_avg:43.83ms
+step:941/1490 train_time:41256ms step_avg:43.84ms
+step:942/1490 train_time:41316ms step_avg:43.86ms
+step:943/1490 train_time:41370ms step_avg:43.87ms
+step:944/1490 train_time:41429ms step_avg:43.89ms
+step:945/1490 train_time:41483ms step_avg:43.90ms
+step:946/1490 train_time:41543ms step_avg:43.91ms
+step:947/1490 train_time:41597ms step_avg:43.93ms
+step:948/1490 train_time:41657ms step_avg:43.94ms
+step:949/1490 train_time:41711ms step_avg:43.95ms
+step:950/1490 train_time:41770ms step_avg:43.97ms
+step:951/1490 train_time:41825ms step_avg:43.98ms
+step:952/1490 train_time:41884ms step_avg:44.00ms
+step:953/1490 train_time:41939ms step_avg:44.01ms
+step:954/1490 train_time:41998ms step_avg:44.02ms
+step:955/1490 train_time:42052ms step_avg:44.03ms
+step:956/1490 train_time:42112ms step_avg:44.05ms
+step:957/1490 train_time:42166ms step_avg:44.06ms
+step:958/1490 train_time:42226ms step_avg:44.08ms
+step:959/1490 train_time:42281ms step_avg:44.09ms
+step:960/1490 train_time:42341ms step_avg:44.10ms
+step:961/1490 train_time:42395ms step_avg:44.12ms
+step:962/1490 train_time:42455ms step_avg:44.13ms
+step:963/1490 train_time:42509ms step_avg:44.14ms
+step:964/1490 train_time:42569ms step_avg:44.16ms
+step:965/1490 train_time:42622ms step_avg:44.17ms
+step:966/1490 train_time:42683ms step_avg:44.18ms
+step:967/1490 train_time:42737ms step_avg:44.20ms
+step:968/1490 train_time:42800ms step_avg:44.21ms
+step:969/1490 train_time:42878ms step_avg:44.25ms
+step:970/1490 train_time:42965ms step_avg:44.29ms
+step:971/1490 train_time:43043ms step_avg:44.33ms
+step:972/1490 train_time:43129ms step_avg:44.37ms
+step:973/1490 train_time:43210ms step_avg:44.41ms
+step:974/1490 train_time:43296ms step_avg:44.45ms
+step:975/1490 train_time:43376ms step_avg:44.49ms
+step:976/1490 train_time:43463ms step_avg:44.53ms
+step:977/1490 train_time:43543ms step_avg:44.57ms
+step:978/1490 train_time:43627ms step_avg:44.61ms
+step:979/1490 train_time:43708ms step_avg:44.65ms
+step:980/1490 train_time:43794ms step_avg:44.69ms
+step:981/1490 train_time:43875ms step_avg:44.72ms
+step:982/1490 train_time:43961ms step_avg:44.77ms
+step:983/1490 train_time:44040ms step_avg:44.80ms
+step:984/1490 train_time:44125ms step_avg:44.84ms
+step:985/1490 train_time:44206ms step_avg:44.88ms
+step:986/1490 train_time:44293ms step_avg:44.92ms
+step:987/1490 train_time:44374ms step_avg:44.96ms
+step:988/1490 train_time:44459ms step_avg:45.00ms
+step:989/1490 train_time:44540ms step_avg:45.03ms
+step:990/1490 train_time:44624ms step_avg:45.07ms
+step:991/1490 train_time:44704ms step_avg:45.11ms
+step:992/1490 train_time:44790ms step_avg:45.15ms
+step:993/1490 train_time:44871ms step_avg:45.19ms
+step:994/1490 train_time:44956ms step_avg:45.23ms
+step:995/1490 train_time:45035ms step_avg:45.26ms
+step:996/1490 train_time:45120ms step_avg:45.30ms
+step:997/1490 train_time:45199ms step_avg:45.34ms
+step:998/1490 train_time:45286ms step_avg:45.38ms
+step:999/1490 train_time:45367ms step_avg:45.41ms
+step:1000/1490 train_time:45452ms step_avg:45.45ms
+step:1000/1490 val_loss:3.5151 train_time:45555ms step_avg:45.56ms
+step:1001/1490 train_time:45572ms step_avg:45.53ms
+step:1002/1490 train_time:45622ms step_avg:45.53ms
+step:1003/1490 train_time:45708ms step_avg:45.57ms
+step:1004/1490 train_time:45795ms step_avg:45.61ms
+step:1005/1490 train_time:45876ms step_avg:45.65ms
+step:1006/1490 train_time:45960ms step_avg:45.69ms
+step:1007/1490 train_time:46039ms step_avg:45.72ms
+step:1008/1490 train_time:46122ms step_avg:45.76ms
+step:1009/1490 train_time:46202ms step_avg:45.79ms
+step:1010/1490 train_time:46287ms step_avg:45.83ms
+step:1011/1490 train_time:46367ms step_avg:45.86ms
+step:1012/1490 train_time:46451ms step_avg:45.90ms
+step:1013/1490 train_time:46533ms step_avg:45.94ms
+step:1014/1490 train_time:46620ms step_avg:45.98ms
+step:1015/1490 train_time:46703ms step_avg:46.01ms
+step:1016/1490 train_time:46790ms step_avg:46.05ms
+step:1017/1490 train_time:46870ms step_avg:46.09ms
+step:1018/1490 train_time:46955ms step_avg:46.12ms
+step:1019/1490 train_time:47033ms step_avg:46.16ms
+step:1020/1490 train_time:47119ms step_avg:46.19ms
+step:1021/1490 train_time:47198ms step_avg:46.23ms
+step:1022/1490 train_time:47282ms step_avg:46.26ms
+step:1023/1490 train_time:47362ms step_avg:46.30ms
+step:1024/1490 train_time:47448ms step_avg:46.34ms
+step:1025/1490 train_time:47528ms step_avg:46.37ms
+step:1026/1490 train_time:47615ms step_avg:46.41ms
+step:1027/1490 train_time:47698ms step_avg:46.44ms
+step:1028/1490 train_time:47784ms step_avg:46.48ms
+step:1029/1490 train_time:47865ms step_avg:46.52ms
+step:1030/1490 train_time:47950ms step_avg:46.55ms
+step:1031/1490 train_time:48029ms step_avg:46.58ms
+step:1032/1490 train_time:48113ms step_avg:46.62ms
+step:1033/1490 train_time:48192ms step_avg:46.65ms
+step:1034/1490 train_time:48277ms step_avg:46.69ms
+step:1035/1490 train_time:48358ms step_avg:46.72ms
+step:1036/1490 train_time:48443ms step_avg:46.76ms
+step:1037/1490 train_time:48523ms step_avg:46.79ms
+step:1038/1490 train_time:48610ms step_avg:46.83ms
+step:1039/1490 train_time:48692ms step_avg:46.86ms
+step:1040/1490 train_time:48781ms step_avg:46.90ms
+step:1041/1490 train_time:48864ms step_avg:46.94ms
+step:1042/1490 train_time:48948ms step_avg:46.98ms
+step:1043/1490 train_time:49028ms step_avg:47.01ms
+step:1044/1490 train_time:49113ms step_avg:47.04ms
+step:1045/1490 train_time:49192ms step_avg:47.07ms
+step:1046/1490 train_time:49278ms step_avg:47.11ms
+step:1047/1490 train_time:49358ms step_avg:47.14ms
+step:1048/1490 train_time:49443ms step_avg:47.18ms
+step:1049/1490 train_time:49523ms step_avg:47.21ms
+step:1050/1490 train_time:49611ms step_avg:47.25ms
+step:1051/1490 train_time:49692ms step_avg:47.28ms
+step:1052/1490 train_time:49779ms step_avg:47.32ms
+step:1053/1490 train_time:49860ms step_avg:47.35ms
+step:1054/1490 train_time:49944ms step_avg:47.39ms
+step:1055/1490 train_time:50025ms step_avg:47.42ms
+step:1056/1490 train_time:50111ms step_avg:47.45ms
+step:1057/1490 train_time:50191ms step_avg:47.48ms
+step:1058/1490 train_time:50276ms step_avg:47.52ms
+step:1059/1490 train_time:50355ms step_avg:47.55ms
+step:1060/1490 train_time:50440ms step_avg:47.59ms
+step:1061/1490 train_time:50522ms step_avg:47.62ms
+step:1062/1490 train_time:50608ms step_avg:47.65ms
+step:1063/1490 train_time:50688ms step_avg:47.68ms
+step:1064/1490 train_time:50775ms step_avg:47.72ms
+step:1065/1490 train_time:50855ms step_avg:47.75ms
+step:1066/1490 train_time:50941ms step_avg:47.79ms
+step:1067/1490 train_time:51021ms step_avg:47.82ms
+step:1068/1490 train_time:51106ms step_avg:47.85ms
+step:1069/1490 train_time:51186ms step_avg:47.88ms
+step:1070/1490 train_time:51271ms step_avg:47.92ms
+step:1071/1490 train_time:51349ms step_avg:47.95ms
+step:1072/1490 train_time:51434ms step_avg:47.98ms
+step:1073/1490 train_time:51514ms step_avg:48.01ms
+step:1074/1490 train_time:51601ms step_avg:48.05ms
+step:1075/1490 train_time:51682ms step_avg:48.08ms
+step:1076/1490 train_time:51769ms step_avg:48.11ms
+step:1077/1490 train_time:51850ms step_avg:48.14ms
+step:1078/1490 train_time:51935ms step_avg:48.18ms
+step:1079/1490 train_time:52016ms step_avg:48.21ms
+step:1080/1490 train_time:52101ms step_avg:48.24ms
+step:1081/1490 train_time:52182ms step_avg:48.27ms
+step:1082/1490 train_time:52266ms step_avg:48.31ms
+step:1083/1490 train_time:52345ms step_avg:48.33ms
+step:1084/1490 train_time:52431ms step_avg:48.37ms
+step:1085/1490 train_time:52511ms step_avg:48.40ms
+step:1086/1490 train_time:52596ms step_avg:48.43ms
+step:1087/1490 train_time:52677ms step_avg:48.46ms
+step:1088/1490 train_time:52763ms step_avg:48.50ms
+step:1089/1490 train_time:52843ms step_avg:48.52ms
+step:1090/1490 train_time:52929ms step_avg:48.56ms
+step:1091/1490 train_time:53010ms step_avg:48.59ms
+step:1092/1490 train_time:53096ms step_avg:48.62ms
+step:1093/1490 train_time:53176ms step_avg:48.65ms
+step:1094/1490 train_time:53262ms step_avg:48.69ms
+step:1095/1490 train_time:53342ms step_avg:48.71ms
+step:1096/1490 train_time:53427ms step_avg:48.75ms
+step:1097/1490 train_time:53508ms step_avg:48.78ms
+step:1098/1490 train_time:53594ms step_avg:48.81ms
+step:1099/1490 train_time:53675ms step_avg:48.84ms
+step:1100/1490 train_time:53761ms step_avg:48.87ms
+step:1101/1490 train_time:53842ms step_avg:48.90ms
+step:1102/1490 train_time:53927ms step_avg:48.94ms
+step:1103/1490 train_time:54009ms step_avg:48.97ms
+step:1104/1490 train_time:54095ms step_avg:49.00ms
+step:1105/1490 train_time:54174ms step_avg:49.03ms
+step:1106/1490 train_time:54259ms step_avg:49.06ms
+step:1107/1490 train_time:54339ms step_avg:49.09ms
+step:1108/1490 train_time:54425ms step_avg:49.12ms
+step:1109/1490 train_time:54507ms step_avg:49.15ms
+step:1110/1490 train_time:54592ms step_avg:49.18ms
+step:1111/1490 train_time:54672ms step_avg:49.21ms
+step:1112/1490 train_time:54758ms step_avg:49.24ms
+step:1113/1490 train_time:54840ms step_avg:49.27ms
+step:1114/1490 train_time:54926ms step_avg:49.30ms
+step:1115/1490 train_time:55005ms step_avg:49.33ms
+step:1116/1490 train_time:55091ms step_avg:49.36ms
+step:1117/1490 train_time:55171ms step_avg:49.39ms
+step:1118/1490 train_time:55255ms step_avg:49.42ms
+step:1119/1490 train_time:55336ms step_avg:49.45ms
+step:1120/1490 train_time:55423ms step_avg:49.48ms
+step:1121/1490 train_time:55503ms step_avg:49.51ms
+step:1122/1490 train_time:55588ms step_avg:49.54ms
+step:1123/1490 train_time:55669ms step_avg:49.57ms
+step:1124/1490 train_time:55753ms step_avg:49.60ms
+step:1125/1490 train_time:55832ms step_avg:49.63ms
+step:1126/1490 train_time:55919ms step_avg:49.66ms
+step:1127/1490 train_time:55999ms step_avg:49.69ms
+step:1128/1490 train_time:56085ms step_avg:49.72ms
+step:1129/1490 train_time:56164ms step_avg:49.75ms
+step:1130/1490 train_time:56249ms step_avg:49.78ms
+step:1131/1490 train_time:56330ms step_avg:49.81ms
+step:1132/1490 train_time:56416ms step_avg:49.84ms
+step:1133/1490 train_time:56496ms step_avg:49.86ms
+step:1134/1490 train_time:56582ms step_avg:49.90ms
+step:1135/1490 train_time:56662ms step_avg:49.92ms
+step:1136/1490 train_time:56748ms step_avg:49.95ms
+step:1137/1490 train_time:56829ms step_avg:49.98ms
+step:1138/1490 train_time:56914ms step_avg:50.01ms
+step:1139/1490 train_time:56995ms step_avg:50.04ms
+step:1140/1490 train_time:57082ms step_avg:50.07ms
+step:1141/1490 train_time:57162ms step_avg:50.10ms
+step:1142/1490 train_time:57247ms step_avg:50.13ms
+step:1143/1490 train_time:57327ms step_avg:50.15ms
+step:1144/1490 train_time:57413ms step_avg:50.19ms
+step:1145/1490 train_time:57492ms step_avg:50.21ms
+step:1146/1490 train_time:57579ms step_avg:50.24ms
+step:1147/1490 train_time:57659ms step_avg:50.27ms
+step:1148/1490 train_time:57745ms step_avg:50.30ms
+step:1149/1490 train_time:57825ms step_avg:50.33ms
+step:1150/1490 train_time:57911ms step_avg:50.36ms
+step:1151/1490 train_time:57991ms step_avg:50.38ms
+step:1152/1490 train_time:58077ms step_avg:50.41ms
+step:1153/1490 train_time:58158ms step_avg:50.44ms
+step:1154/1490 train_time:58246ms step_avg:50.47ms
+step:1155/1490 train_time:58327ms step_avg:50.50ms
+step:1156/1490 train_time:58412ms step_avg:50.53ms
+step:1157/1490 train_time:58491ms step_avg:50.55ms
+step:1158/1490 train_time:58577ms step_avg:50.58ms
+step:1159/1490 train_time:58659ms step_avg:50.61ms
+step:1160/1490 train_time:58744ms step_avg:50.64ms
+step:1161/1490 train_time:58823ms step_avg:50.67ms
+step:1162/1490 train_time:58910ms step_avg:50.70ms
+step:1163/1490 train_time:58990ms step_avg:50.72ms
+step:1164/1490 train_time:59075ms step_avg:50.75ms
+step:1165/1490 train_time:59155ms step_avg:50.78ms
+step:1166/1490 train_time:59240ms step_avg:50.81ms
+step:1167/1490 train_time:59322ms step_avg:50.83ms
+step:1168/1490 train_time:59408ms step_avg:50.86ms
+step:1169/1490 train_time:59487ms step_avg:50.89ms
+step:1170/1490 train_time:59572ms step_avg:50.92ms
+step:1171/1490 train_time:59651ms step_avg:50.94ms
+step:1172/1490 train_time:59738ms step_avg:50.97ms
+step:1173/1490 train_time:59819ms step_avg:51.00ms
+step:1174/1490 train_time:59906ms step_avg:51.03ms
+step:1175/1490 train_time:59986ms step_avg:51.05ms
+step:1176/1490 train_time:60071ms step_avg:51.08ms
+step:1177/1490 train_time:60150ms step_avg:51.10ms
+step:1178/1490 train_time:60236ms step_avg:51.13ms
+step:1179/1490 train_time:60317ms step_avg:51.16ms
+step:1180/1490 train_time:60403ms step_avg:51.19ms
+step:1181/1490 train_time:60484ms step_avg:51.21ms
+step:1182/1490 train_time:60570ms step_avg:51.24ms
+step:1183/1490 train_time:60650ms step_avg:51.27ms
+step:1184/1490 train_time:60734ms step_avg:51.30ms
+step:1185/1490 train_time:60814ms step_avg:51.32ms
+step:1186/1490 train_time:60902ms step_avg:51.35ms
+step:1187/1490 train_time:60983ms step_avg:51.38ms
+step:1188/1490 train_time:61067ms step_avg:51.40ms
+step:1189/1490 train_time:61146ms step_avg:51.43ms
+step:1190/1490 train_time:61231ms step_avg:51.45ms
+step:1191/1490 train_time:61311ms step_avg:51.48ms
+step:1192/1490 train_time:61398ms step_avg:51.51ms
+step:1193/1490 train_time:61478ms step_avg:51.53ms
+step:1194/1490 train_time:61565ms step_avg:51.56ms
+step:1195/1490 train_time:61644ms step_avg:51.59ms
+step:1196/1490 train_time:61730ms step_avg:51.61ms
+step:1197/1490 train_time:61810ms step_avg:51.64ms
+step:1198/1490 train_time:61896ms step_avg:51.67ms
+step:1199/1490 train_time:61978ms step_avg:51.69ms
+step:1200/1490 train_time:62064ms step_avg:51.72ms
+step:1201/1490 train_time:62142ms step_avg:51.74ms
+step:1202/1490 train_time:62227ms step_avg:51.77ms
+step:1203/1490 train_time:62309ms step_avg:51.79ms
+step:1204/1490 train_time:62395ms step_avg:51.82ms
+step:1205/1490 train_time:62476ms step_avg:51.85ms
+step:1206/1490 train_time:62563ms step_avg:51.88ms
+step:1207/1490 train_time:62642ms step_avg:51.90ms
+step:1208/1490 train_time:62727ms step_avg:51.93ms
+step:1209/1490 train_time:62806ms step_avg:51.95ms
+step:1210/1490 train_time:62892ms step_avg:51.98ms
+step:1211/1490 train_time:62973ms step_avg:52.00ms
+step:1212/1490 train_time:63058ms step_avg:52.03ms
+step:1213/1490 train_time:63138ms step_avg:52.05ms
+step:1214/1490 train_time:63224ms step_avg:52.08ms
+step:1215/1490 train_time:63304ms step_avg:52.10ms
+step:1216/1490 train_time:63390ms step_avg:52.13ms
+step:1217/1490 train_time:63471ms step_avg:52.15ms
+step:1218/1490 train_time:63554ms step_avg:52.18ms
+step:1219/1490 train_time:63635ms step_avg:52.20ms
+step:1220/1490 train_time:63720ms step_avg:52.23ms
+step:1221/1490 train_time:63801ms step_avg:52.25ms
+step:1222/1490 train_time:63887ms step_avg:52.28ms
+step:1223/1490 train_time:63969ms step_avg:52.31ms
+step:1224/1490 train_time:64054ms step_avg:52.33ms
+step:1225/1490 train_time:64133ms step_avg:52.35ms
+step:1226/1490 train_time:64218ms step_avg:52.38ms
+step:1227/1490 train_time:64299ms step_avg:52.40ms
+step:1228/1490 train_time:64384ms step_avg:52.43ms
+step:1229/1490 train_time:64466ms step_avg:52.45ms
+step:1230/1490 train_time:64551ms step_avg:52.48ms
+step:1231/1490 train_time:64631ms step_avg:52.50ms
+step:1232/1490 train_time:64716ms step_avg:52.53ms
+step:1233/1490 train_time:64796ms step_avg:52.55ms
+step:1234/1490 train_time:64882ms step_avg:52.58ms
+step:1235/1490 train_time:64963ms step_avg:52.60ms
+step:1236/1490 train_time:65048ms step_avg:52.63ms
+step:1237/1490 train_time:65128ms step_avg:52.65ms
+step:1238/1490 train_time:65212ms step_avg:52.68ms
+step:1239/1490 train_time:65292ms step_avg:52.70ms
+step:1240/1490 train_time:65379ms step_avg:52.72ms
+step:1241/1490 train_time:65459ms step_avg:52.75ms
+step:1242/1490 train_time:65544ms step_avg:52.77ms
+step:1243/1490 train_time:65625ms step_avg:52.80ms
+step:1244/1490 train_time:65711ms step_avg:52.82ms
+step:1245/1490 train_time:65791ms step_avg:52.84ms
+step:1246/1490 train_time:65876ms step_avg:52.87ms
+step:1247/1490 train_time:65956ms step_avg:52.89ms
+step:1248/1490 train_time:66042ms step_avg:52.92ms
+step:1249/1490 train_time:66123ms step_avg:52.94ms
+step:1250/1490 train_time:66209ms step_avg:52.97ms
+step:1250/1490 val_loss:3.3701 train_time:66311ms step_avg:53.05ms
+step:1251/1490 train_time:66328ms step_avg:53.02ms
+step:1252/1490 train_time:66378ms step_avg:53.02ms
+step:1253/1490 train_time:66464ms step_avg:53.04ms
+step:1254/1490 train_time:66551ms step_avg:53.07ms
+step:1255/1490 train_time:66632ms step_avg:53.09ms
+step:1256/1490 train_time:66717ms step_avg:53.12ms
+step:1257/1490 train_time:66797ms step_avg:53.14ms
+step:1258/1490 train_time:66880ms step_avg:53.16ms
+step:1259/1490 train_time:66959ms step_avg:53.18ms
+step:1260/1490 train_time:67042ms step_avg:53.21ms
+step:1261/1490 train_time:67121ms step_avg:53.23ms
+step:1262/1490 train_time:67207ms step_avg:53.25ms
+step:1263/1490 train_time:67289ms step_avg:53.28ms
+step:1264/1490 train_time:67376ms step_avg:53.30ms
+step:1265/1490 train_time:67458ms step_avg:53.33ms
+step:1266/1490 train_time:67545ms step_avg:53.35ms
+step:1267/1490 train_time:67625ms step_avg:53.37ms
+step:1268/1490 train_time:67712ms step_avg:53.40ms
+step:1269/1490 train_time:67792ms step_avg:53.42ms
+step:1270/1490 train_time:67877ms step_avg:53.45ms
+step:1271/1490 train_time:67956ms step_avg:53.47ms
+step:1272/1490 train_time:68041ms step_avg:53.49ms
+step:1273/1490 train_time:68119ms step_avg:53.51ms
+step:1274/1490 train_time:68204ms step_avg:53.54ms
+step:1275/1490 train_time:68285ms step_avg:53.56ms
+step:1276/1490 train_time:68373ms step_avg:53.58ms
+step:1277/1490 train_time:68455ms step_avg:53.61ms
+step:1278/1490 train_time:68540ms step_avg:53.63ms
+step:1279/1490 train_time:68621ms step_avg:53.65ms
+step:1280/1490 train_time:68707ms step_avg:53.68ms
+step:1281/1490 train_time:68788ms step_avg:53.70ms
+step:1282/1490 train_time:68873ms step_avg:53.72ms
+step:1283/1490 train_time:68952ms step_avg:53.74ms
+step:1284/1490 train_time:69037ms step_avg:53.77ms
+step:1285/1490 train_time:69117ms step_avg:53.79ms
+step:1286/1490 train_time:69201ms step_avg:53.81ms
+step:1287/1490 train_time:69281ms step_avg:53.83ms
+step:1288/1490 train_time:69369ms step_avg:53.86ms
+step:1289/1490 train_time:69449ms step_avg:53.88ms
+step:1290/1490 train_time:69536ms step_avg:53.90ms
+step:1291/1490 train_time:69617ms step_avg:53.92ms
+step:1292/1490 train_time:69702ms step_avg:53.95ms
+step:1293/1490 train_time:69782ms step_avg:53.97ms
+step:1294/1490 train_time:69866ms step_avg:53.99ms
+step:1295/1490 train_time:69945ms step_avg:54.01ms
+step:1296/1490 train_time:70030ms step_avg:54.04ms
+step:1297/1490 train_time:70111ms step_avg:54.06ms
+step:1298/1490 train_time:70196ms step_avg:54.08ms
+step:1299/1490 train_time:70276ms step_avg:54.10ms
+step:1300/1490 train_time:70360ms step_avg:54.12ms
+step:1301/1490 train_time:70441ms step_avg:54.14ms
+step:1302/1490 train_time:70527ms step_avg:54.17ms
+step:1303/1490 train_time:70610ms step_avg:54.19ms
+step:1304/1490 train_time:70698ms step_avg:54.22ms
+step:1305/1490 train_time:70780ms step_avg:54.24ms
+step:1306/1490 train_time:70865ms step_avg:54.26ms
+step:1307/1490 train_time:70944ms step_avg:54.28ms
+step:1308/1490 train_time:71028ms step_avg:54.30ms
+step:1309/1490 train_time:71108ms step_avg:54.32ms
+step:1310/1490 train_time:71193ms step_avg:54.35ms
+step:1311/1490 train_time:71274ms step_avg:54.37ms
+step:1312/1490 train_time:71360ms step_avg:54.39ms
+step:1313/1490 train_time:71440ms step_avg:54.41ms
+step:1314/1490 train_time:71526ms step_avg:54.43ms
+step:1315/1490 train_time:71608ms step_avg:54.45ms
+step:1316/1490 train_time:71695ms step_avg:54.48ms
+step:1317/1490 train_time:71776ms step_avg:54.50ms
+step:1318/1490 train_time:71861ms step_avg:54.52ms
+step:1319/1490 train_time:71940ms step_avg:54.54ms
+step:1320/1490 train_time:72024ms step_avg:54.56ms
+step:1321/1490 train_time:72104ms step_avg:54.58ms
+step:1322/1490 train_time:72189ms step_avg:54.61ms
+step:1323/1490 train_time:72269ms step_avg:54.63ms
+step:1324/1490 train_time:72355ms step_avg:54.65ms
+step:1325/1490 train_time:72437ms step_avg:54.67ms
+step:1326/1490 train_time:72521ms step_avg:54.69ms
+step:1327/1490 train_time:72601ms step_avg:54.71ms
+step:1328/1490 train_time:72688ms step_avg:54.74ms
+step:1329/1490 train_time:72769ms step_avg:54.75ms
+step:1330/1490 train_time:72854ms step_avg:54.78ms
+step:1331/1490 train_time:72935ms step_avg:54.80ms
+step:1332/1490 train_time:73021ms step_avg:54.82ms
+step:1333/1490 train_time:73101ms step_avg:54.84ms
+step:1334/1490 train_time:73187ms step_avg:54.86ms
+step:1335/1490 train_time:73268ms step_avg:54.88ms
+step:1336/1490 train_time:73353ms step_avg:54.91ms
+step:1337/1490 train_time:73433ms step_avg:54.92ms
+step:1338/1490 train_time:73520ms step_avg:54.95ms
+step:1339/1490 train_time:73601ms step_avg:54.97ms
+step:1340/1490 train_time:73687ms step_avg:54.99ms
+step:1341/1490 train_time:73768ms step_avg:55.01ms
+step:1342/1490 train_time:73852ms step_avg:55.03ms
+step:1343/1490 train_time:73933ms step_avg:55.05ms
+step:1344/1490 train_time:74019ms step_avg:55.07ms
+step:1345/1490 train_time:74099ms step_avg:55.09ms
+step:1346/1490 train_time:74184ms step_avg:55.11ms
+step:1347/1490 train_time:74263ms step_avg:55.13ms
+step:1348/1490 train_time:74348ms step_avg:55.15ms
+step:1349/1490 train_time:74430ms step_avg:55.17ms
+step:1350/1490 train_time:74516ms step_avg:55.20ms
+step:1351/1490 train_time:74596ms step_avg:55.22ms
+step:1352/1490 train_time:74681ms step_avg:55.24ms
+step:1353/1490 train_time:74760ms step_avg:55.26ms
+step:1354/1490 train_time:74847ms step_avg:55.28ms
+step:1355/1490 train_time:74929ms step_avg:55.30ms
+step:1356/1490 train_time:75016ms step_avg:55.32ms
+step:1357/1490 train_time:75096ms step_avg:55.34ms
+step:1358/1490 train_time:75181ms step_avg:55.36ms
+step:1359/1490 train_time:75260ms step_avg:55.38ms
+step:1360/1490 train_time:75344ms step_avg:55.40ms
+step:1361/1490 train_time:75425ms step_avg:55.42ms
+step:1362/1490 train_time:75512ms step_avg:55.44ms
+step:1363/1490 train_time:75592ms step_avg:55.46ms
+step:1364/1490 train_time:75679ms step_avg:55.48ms
+step:1365/1490 train_time:75759ms step_avg:55.50ms
+step:1366/1490 train_time:75845ms step_avg:55.52ms
+step:1367/1490 train_time:75926ms step_avg:55.54ms
+step:1368/1490 train_time:76013ms step_avg:55.56ms
+step:1369/1490 train_time:76093ms step_avg:55.58ms
+step:1370/1490 train_time:76179ms step_avg:55.61ms
+step:1371/1490 train_time:76260ms step_avg:55.62ms
+step:1372/1490 train_time:76345ms step_avg:55.65ms
+step:1373/1490 train_time:76424ms step_avg:55.66ms
+step:1374/1490 train_time:76510ms step_avg:55.68ms
+step:1375/1490 train_time:76590ms step_avg:55.70ms
+step:1376/1490 train_time:76676ms step_avg:55.72ms
+step:1377/1490 train_time:76756ms step_avg:55.74ms
+step:1378/1490 train_time:76841ms step_avg:55.76ms
+step:1379/1490 train_time:76922ms step_avg:55.78ms
+step:1380/1490 train_time:77008ms step_avg:55.80ms
+step:1381/1490 train_time:77088ms step_avg:55.82ms
+step:1382/1490 train_time:77174ms step_avg:55.84ms
+step:1383/1490 train_time:77253ms step_avg:55.86ms
+step:1384/1490 train_time:77339ms step_avg:55.88ms
+step:1385/1490 train_time:77419ms step_avg:55.90ms
+step:1386/1490 train_time:77505ms step_avg:55.92ms
+step:1387/1490 train_time:77586ms step_avg:55.94ms
+step:1388/1490 train_time:77673ms step_avg:55.96ms
+step:1389/1490 train_time:77752ms step_avg:55.98ms
+step:1390/1490 train_time:77837ms step_avg:56.00ms
+step:1391/1490 train_time:77916ms step_avg:56.01ms
+step:1392/1490 train_time:78002ms step_avg:56.04ms
+step:1393/1490 train_time:78083ms step_avg:56.05ms
+step:1394/1490 train_time:78168ms step_avg:56.07ms
+step:1395/1490 train_time:78248ms step_avg:56.09ms
+step:1396/1490 train_time:78334ms step_avg:56.11ms
+step:1397/1490 train_time:78414ms step_avg:56.13ms
+step:1398/1490 train_time:78500ms step_avg:56.15ms
+step:1399/1490 train_time:78580ms step_avg:56.17ms
+step:1400/1490 train_time:78665ms step_avg:56.19ms
+step:1401/1490 train_time:78744ms step_avg:56.21ms
+step:1402/1490 train_time:78831ms step_avg:56.23ms
+step:1403/1490 train_time:78913ms step_avg:56.25ms
+step:1404/1490 train_time:78999ms step_avg:56.27ms
+step:1405/1490 train_time:79080ms step_avg:56.28ms
+step:1406/1490 train_time:79165ms step_avg:56.31ms
+step:1407/1490 train_time:79246ms step_avg:56.32ms
+step:1408/1490 train_time:79331ms step_avg:56.34ms
+step:1409/1490 train_time:79411ms step_avg:56.36ms
+step:1410/1490 train_time:79497ms step_avg:56.38ms
+step:1411/1490 train_time:79577ms step_avg:56.40ms
+step:1412/1490 train_time:79662ms step_avg:56.42ms
+step:1413/1490 train_time:79741ms step_avg:56.43ms
+step:1414/1490 train_time:79828ms step_avg:56.46ms
+step:1415/1490 train_time:79908ms step_avg:56.47ms
+step:1416/1490 train_time:79993ms step_avg:56.49ms
+step:1417/1490 train_time:80075ms step_avg:56.51ms
+step:1418/1490 train_time:80159ms step_avg:56.53ms
+step:1419/1490 train_time:80239ms step_avg:56.55ms
+step:1420/1490 train_time:80326ms step_avg:56.57ms
+step:1421/1490 train_time:80407ms step_avg:56.58ms
+step:1422/1490 train_time:80493ms step_avg:56.61ms
+step:1423/1490 train_time:80572ms step_avg:56.62ms
+step:1424/1490 train_time:80657ms step_avg:56.64ms
+step:1425/1490 train_time:80737ms step_avg:56.66ms
+step:1426/1490 train_time:80824ms step_avg:56.68ms
+step:1427/1490 train_time:80904ms step_avg:56.70ms
+step:1428/1490 train_time:80990ms step_avg:56.72ms
+step:1429/1490 train_time:81071ms step_avg:56.73ms
+step:1430/1490 train_time:81157ms step_avg:56.75ms
+step:1431/1490 train_time:81237ms step_avg:56.77ms
+step:1432/1490 train_time:81322ms step_avg:56.79ms
+step:1433/1490 train_time:81402ms step_avg:56.81ms
+step:1434/1490 train_time:81490ms step_avg:56.83ms
+step:1435/1490 train_time:81571ms step_avg:56.84ms
+step:1436/1490 train_time:81658ms step_avg:56.86ms
+step:1437/1490 train_time:81737ms step_avg:56.88ms
+step:1438/1490 train_time:81824ms step_avg:56.90ms
+step:1439/1490 train_time:81904ms step_avg:56.92ms
+step:1440/1490 train_time:81989ms step_avg:56.94ms
+step:1441/1490 train_time:82070ms step_avg:56.95ms
+step:1442/1490 train_time:82156ms step_avg:56.97ms
+step:1443/1490 train_time:82235ms step_avg:56.99ms
+step:1444/1490 train_time:82321ms step_avg:57.01ms
+step:1445/1490 train_time:82401ms step_avg:57.02ms
+step:1446/1490 train_time:82488ms step_avg:57.05ms
+step:1447/1490 train_time:82569ms step_avg:57.06ms
+step:1448/1490 train_time:82654ms step_avg:57.08ms
+step:1449/1490 train_time:82735ms step_avg:57.10ms
+step:1450/1490 train_time:82821ms step_avg:57.12ms
+step:1451/1490 train_time:82905ms step_avg:57.14ms
+step:1452/1490 train_time:82993ms step_avg:57.16ms
+step:1453/1490 train_time:83075ms step_avg:57.17ms
+step:1454/1490 train_time:83160ms step_avg:57.19ms
+step:1455/1490 train_time:83242ms step_avg:57.21ms
+step:1456/1490 train_time:83327ms step_avg:57.23ms
+step:1457/1490 train_time:83408ms step_avg:57.25ms
+step:1458/1490 train_time:83493ms step_avg:57.27ms
+step:1459/1490 train_time:83574ms step_avg:57.28ms
+step:1460/1490 train_time:83660ms step_avg:57.30ms
+step:1461/1490 train_time:83740ms step_avg:57.32ms
+step:1462/1490 train_time:83826ms step_avg:57.34ms
+step:1463/1490 train_time:83907ms step_avg:57.35ms
+step:1464/1490 train_time:83992ms step_avg:57.37ms
+step:1465/1490 train_time:84073ms step_avg:57.39ms
+step:1466/1490 train_time:84159ms step_avg:57.41ms
+step:1467/1490 train_time:84242ms step_avg:57.42ms
+step:1468/1490 train_time:84327ms step_avg:57.44ms
+step:1469/1490 train_time:84408ms step_avg:57.46ms
+step:1470/1490 train_time:84495ms step_avg:57.48ms
+step:1471/1490 train_time:84575ms step_avg:57.50ms
+step:1472/1490 train_time:84661ms step_avg:57.51ms
+step:1473/1490 train_time:84742ms step_avg:57.53ms
+step:1474/1490 train_time:84828ms step_avg:57.55ms
+step:1475/1490 train_time:84909ms step_avg:57.57ms
+step:1476/1490 train_time:84997ms step_avg:57.59ms
+step:1477/1490 train_time:85078ms step_avg:57.60ms
+step:1478/1490 train_time:85163ms step_avg:57.62ms
+step:1479/1490 train_time:85242ms step_avg:57.64ms
+step:1480/1490 train_time:85329ms step_avg:57.65ms
+step:1481/1490 train_time:85409ms step_avg:57.67ms
+step:1482/1490 train_time:85495ms step_avg:57.69ms
+step:1483/1490 train_time:85576ms step_avg:57.70ms
+step:1484/1490 train_time:85661ms step_avg:57.72ms
+step:1485/1490 train_time:85742ms step_avg:57.74ms
+step:1486/1490 train_time:85828ms step_avg:57.76ms
+step:1487/1490 train_time:85909ms step_avg:57.77ms
+step:1488/1490 train_time:85996ms step_avg:57.79ms
+step:1489/1490 train_time:86078ms step_avg:57.81ms
+step:1490/1490 train_time:86162ms step_avg:57.83ms
+step:1490/1490 val_loss:3.2772 train_time:86264ms step_avg:57.90ms
+peak memory allocated: 31277 MiB reserved: 47122 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/max_num_docs/2026-03-22_18-38-26_time-187_secs_00-cu-seqlens_5941b3.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/max_num_docs/2026-03-22_18-38-26_time-187_secs_00-cu-seqlens_5941b3.txt
@@ -1,0 +1,4457 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 18:38:41 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   36C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            133W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   40C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1440679      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1440680      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1440681      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1440682      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1440683      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1440684      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1440685      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1440686      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8303 train_time:0ms step_avg:0.05ms
+step:1/1490 train_time:78ms step_avg:77.95ms
+step:2/1490 train_time:101ms step_avg:50.72ms
+step:3/1490 train_time:118ms step_avg:39.47ms
+step:4/1490 train_time:139ms step_avg:34.67ms
+step:5/1490 train_time:166ms step_avg:33.12ms
+step:6/1490 train_time:200ms step_avg:33.39ms
+step:7/1490 train_time:228ms step_avg:32.51ms
+step:8/1490 train_time:263ms step_avg:32.84ms
+step:9/1490 train_time:290ms step_avg:32.20ms
+step:10/1490 train_time:324ms step_avg:32.42ms
+step:11/1490 train_time:352ms step_avg:31.97ms
+step:12/1490 train_time:386ms step_avg:32.21ms
+step:13/1490 train_time:414ms step_avg:31.87ms
+step:14/1490 train_time:449ms step_avg:32.06ms
+step:15/1490 train_time:477ms step_avg:31.79ms
+step:16/1490 train_time:511ms step_avg:31.95ms
+step:17/1490 train_time:539ms step_avg:31.72ms
+step:18/1490 train_time:573ms step_avg:31.85ms
+step:19/1490 train_time:602ms step_avg:31.67ms
+step:20/1490 train_time:636ms step_avg:31.79ms
+step:21/1490 train_time:664ms step_avg:31.61ms
+step:22/1490 train_time:698ms step_avg:31.73ms
+step:23/1490 train_time:726ms step_avg:31.56ms
+step:24/1490 train_time:760ms step_avg:31.67ms
+step:25/1490 train_time:788ms step_avg:31.51ms
+step:26/1490 train_time:824ms step_avg:31.68ms
+step:27/1490 train_time:850ms step_avg:31.50ms
+step:28/1490 train_time:885ms step_avg:31.60ms
+step:29/1490 train_time:913ms step_avg:31.48ms
+step:30/1490 train_time:948ms step_avg:31.60ms
+step:31/1490 train_time:977ms step_avg:31.53ms
+step:32/1490 train_time:1013ms step_avg:31.65ms
+step:33/1490 train_time:1042ms step_avg:31.57ms
+step:34/1490 train_time:1076ms step_avg:31.66ms
+step:35/1490 train_time:1106ms step_avg:31.59ms
+step:36/1490 train_time:1141ms step_avg:31.70ms
+step:37/1490 train_time:1169ms step_avg:31.61ms
+step:38/1490 train_time:1205ms step_avg:31.70ms
+step:39/1490 train_time:1233ms step_avg:31.60ms
+step:40/1490 train_time:1268ms step_avg:31.70ms
+step:41/1490 train_time:1296ms step_avg:31.61ms
+step:42/1490 train_time:1330ms step_avg:31.67ms
+step:43/1490 train_time:1359ms step_avg:31.60ms
+step:44/1490 train_time:1393ms step_avg:31.66ms
+step:45/1490 train_time:1421ms step_avg:31.58ms
+step:46/1490 train_time:1455ms step_avg:31.64ms
+step:47/1490 train_time:1483ms step_avg:31.56ms
+step:48/1490 train_time:1517ms step_avg:31.60ms
+step:49/1490 train_time:1545ms step_avg:31.54ms
+step:50/1490 train_time:1580ms step_avg:31.61ms
+step:51/1490 train_time:1608ms step_avg:31.54ms
+step:52/1490 train_time:1643ms step_avg:31.60ms
+step:53/1490 train_time:1671ms step_avg:31.52ms
+step:54/1490 train_time:1706ms step_avg:31.58ms
+step:55/1490 train_time:1733ms step_avg:31.51ms
+step:56/1490 train_time:1768ms step_avg:31.57ms
+step:57/1490 train_time:1795ms step_avg:31.50ms
+step:58/1490 train_time:1830ms step_avg:31.55ms
+step:59/1490 train_time:1858ms step_avg:31.48ms
+step:60/1490 train_time:1892ms step_avg:31.53ms
+step:61/1490 train_time:1920ms step_avg:31.48ms
+step:62/1490 train_time:1955ms step_avg:31.54ms
+step:63/1490 train_time:1983ms step_avg:31.48ms
+step:64/1490 train_time:2017ms step_avg:31.52ms
+step:65/1490 train_time:2046ms step_avg:31.48ms
+step:66/1490 train_time:2081ms step_avg:31.53ms
+step:67/1490 train_time:2109ms step_avg:31.48ms
+step:68/1490 train_time:2145ms step_avg:31.54ms
+step:69/1490 train_time:2173ms step_avg:31.49ms
+step:70/1490 train_time:2208ms step_avg:31.54ms
+step:71/1490 train_time:2236ms step_avg:31.50ms
+step:72/1490 train_time:2271ms step_avg:31.54ms
+step:73/1490 train_time:2300ms step_avg:31.50ms
+step:74/1490 train_time:2334ms step_avg:31.54ms
+step:75/1490 train_time:2362ms step_avg:31.50ms
+step:76/1490 train_time:2396ms step_avg:31.53ms
+step:77/1490 train_time:2425ms step_avg:31.49ms
+step:78/1490 train_time:2459ms step_avg:31.53ms
+step:79/1490 train_time:2487ms step_avg:31.48ms
+step:80/1490 train_time:2522ms step_avg:31.52ms
+step:81/1490 train_time:2550ms step_avg:31.48ms
+step:82/1490 train_time:2585ms step_avg:31.52ms
+step:83/1490 train_time:2613ms step_avg:31.48ms
+step:84/1490 train_time:2647ms step_avg:31.51ms
+step:85/1490 train_time:2675ms step_avg:31.48ms
+step:86/1490 train_time:2710ms step_avg:31.51ms
+step:87/1490 train_time:2738ms step_avg:31.47ms
+step:88/1490 train_time:2772ms step_avg:31.50ms
+step:89/1490 train_time:2800ms step_avg:31.47ms
+step:90/1490 train_time:2834ms step_avg:31.49ms
+step:91/1490 train_time:2863ms step_avg:31.46ms
+step:92/1490 train_time:2897ms step_avg:31.49ms
+step:93/1490 train_time:2925ms step_avg:31.45ms
+step:94/1490 train_time:2960ms step_avg:31.49ms
+step:95/1490 train_time:2988ms step_avg:31.46ms
+step:96/1490 train_time:3023ms step_avg:31.49ms
+step:97/1490 train_time:3051ms step_avg:31.45ms
+step:98/1490 train_time:3086ms step_avg:31.49ms
+step:99/1490 train_time:3114ms step_avg:31.46ms
+step:100/1490 train_time:3149ms step_avg:31.49ms
+step:101/1490 train_time:3177ms step_avg:31.46ms
+step:102/1490 train_time:3212ms step_avg:31.49ms
+step:103/1490 train_time:3240ms step_avg:31.46ms
+step:104/1490 train_time:3274ms step_avg:31.48ms
+step:105/1490 train_time:3303ms step_avg:31.46ms
+step:106/1490 train_time:3338ms step_avg:31.49ms
+step:107/1490 train_time:3365ms step_avg:31.45ms
+step:108/1490 train_time:3400ms step_avg:31.48ms
+step:109/1490 train_time:3428ms step_avg:31.45ms
+step:110/1490 train_time:3463ms step_avg:31.48ms
+step:111/1490 train_time:3491ms step_avg:31.45ms
+step:112/1490 train_time:3526ms step_avg:31.48ms
+step:113/1490 train_time:3554ms step_avg:31.45ms
+step:114/1490 train_time:3588ms step_avg:31.48ms
+step:115/1490 train_time:3616ms step_avg:31.44ms
+step:116/1490 train_time:3650ms step_avg:31.47ms
+step:117/1490 train_time:3679ms step_avg:31.44ms
+step:118/1490 train_time:3713ms step_avg:31.47ms
+step:119/1490 train_time:3742ms step_avg:31.44ms
+step:120/1490 train_time:3776ms step_avg:31.47ms
+step:121/1490 train_time:3804ms step_avg:31.44ms
+step:122/1490 train_time:3838ms step_avg:31.46ms
+step:123/1490 train_time:3866ms step_avg:31.43ms
+step:124/1490 train_time:3901ms step_avg:31.46ms
+step:125/1490 train_time:3929ms step_avg:31.43ms
+step:126/1490 train_time:3963ms step_avg:31.45ms
+step:127/1490 train_time:3991ms step_avg:31.43ms
+step:128/1490 train_time:4027ms step_avg:31.46ms
+step:129/1490 train_time:4055ms step_avg:31.43ms
+step:130/1490 train_time:4089ms step_avg:31.46ms
+step:131/1490 train_time:4117ms step_avg:31.43ms
+step:132/1490 train_time:4152ms step_avg:31.45ms
+step:133/1490 train_time:4180ms step_avg:31.43ms
+step:134/1490 train_time:4215ms step_avg:31.45ms
+step:135/1490 train_time:4243ms step_avg:31.43ms
+step:136/1490 train_time:4277ms step_avg:31.45ms
+step:137/1490 train_time:4305ms step_avg:31.43ms
+step:138/1490 train_time:4340ms step_avg:31.45ms
+step:139/1490 train_time:4368ms step_avg:31.42ms
+step:140/1490 train_time:4403ms step_avg:31.45ms
+step:141/1490 train_time:4431ms step_avg:31.42ms
+step:142/1490 train_time:4465ms step_avg:31.45ms
+step:143/1490 train_time:4493ms step_avg:31.42ms
+step:144/1490 train_time:4528ms step_avg:31.44ms
+step:145/1490 train_time:4556ms step_avg:31.42ms
+step:146/1490 train_time:4590ms step_avg:31.44ms
+step:147/1490 train_time:4619ms step_avg:31.42ms
+step:148/1490 train_time:4653ms step_avg:31.44ms
+step:149/1490 train_time:4681ms step_avg:31.42ms
+step:150/1490 train_time:4716ms step_avg:31.44ms
+step:151/1490 train_time:4744ms step_avg:31.42ms
+step:152/1490 train_time:4779ms step_avg:31.44ms
+step:153/1490 train_time:4806ms step_avg:31.41ms
+step:154/1490 train_time:4841ms step_avg:31.43ms
+step:155/1490 train_time:4869ms step_avg:31.41ms
+step:156/1490 train_time:4904ms step_avg:31.43ms
+step:157/1490 train_time:4931ms step_avg:31.41ms
+step:158/1490 train_time:4966ms step_avg:31.43ms
+step:159/1490 train_time:4994ms step_avg:31.41ms
+step:160/1490 train_time:5028ms step_avg:31.43ms
+step:161/1490 train_time:5056ms step_avg:31.40ms
+step:162/1490 train_time:5092ms step_avg:31.43ms
+step:163/1490 train_time:5119ms step_avg:31.40ms
+step:164/1490 train_time:5153ms step_avg:31.42ms
+step:165/1490 train_time:5182ms step_avg:31.41ms
+step:166/1490 train_time:5216ms step_avg:31.42ms
+step:167/1490 train_time:5245ms step_avg:31.41ms
+step:168/1490 train_time:5279ms step_avg:31.42ms
+step:169/1490 train_time:5307ms step_avg:31.40ms
+step:170/1490 train_time:5343ms step_avg:31.43ms
+step:171/1490 train_time:5371ms step_avg:31.41ms
+step:172/1490 train_time:5406ms step_avg:31.43ms
+step:173/1490 train_time:5434ms step_avg:31.41ms
+step:174/1490 train_time:5468ms step_avg:31.43ms
+step:175/1490 train_time:5497ms step_avg:31.41ms
+step:176/1490 train_time:5531ms step_avg:31.43ms
+step:177/1490 train_time:5560ms step_avg:31.41ms
+step:178/1490 train_time:5594ms step_avg:31.43ms
+step:179/1490 train_time:5623ms step_avg:31.41ms
+step:180/1490 train_time:5657ms step_avg:31.43ms
+step:181/1490 train_time:5686ms step_avg:31.41ms
+step:182/1490 train_time:5720ms step_avg:31.43ms
+step:183/1490 train_time:5748ms step_avg:31.41ms
+step:184/1490 train_time:5783ms step_avg:31.43ms
+step:185/1490 train_time:5810ms step_avg:31.41ms
+step:186/1490 train_time:5845ms step_avg:31.43ms
+step:187/1490 train_time:5873ms step_avg:31.41ms
+step:188/1490 train_time:5908ms step_avg:31.43ms
+step:189/1490 train_time:5936ms step_avg:31.41ms
+step:190/1490 train_time:5970ms step_avg:31.42ms
+step:191/1490 train_time:5999ms step_avg:31.41ms
+step:192/1490 train_time:6033ms step_avg:31.42ms
+step:193/1490 train_time:6061ms step_avg:31.41ms
+step:194/1490 train_time:6095ms step_avg:31.42ms
+step:195/1490 train_time:6123ms step_avg:31.40ms
+step:196/1490 train_time:6158ms step_avg:31.42ms
+step:197/1490 train_time:6186ms step_avg:31.40ms
+step:198/1490 train_time:6220ms step_avg:31.42ms
+step:199/1490 train_time:6249ms step_avg:31.40ms
+step:200/1490 train_time:6284ms step_avg:31.42ms
+step:201/1490 train_time:6312ms step_avg:31.40ms
+step:202/1490 train_time:6347ms step_avg:31.42ms
+step:203/1490 train_time:6375ms step_avg:31.40ms
+step:204/1490 train_time:6409ms step_avg:31.42ms
+step:205/1490 train_time:6438ms step_avg:31.40ms
+step:206/1490 train_time:6472ms step_avg:31.42ms
+step:207/1490 train_time:6500ms step_avg:31.40ms
+step:208/1490 train_time:6534ms step_avg:31.41ms
+step:209/1490 train_time:6562ms step_avg:31.40ms
+step:210/1490 train_time:6596ms step_avg:31.41ms
+step:211/1490 train_time:6625ms step_avg:31.40ms
+step:212/1490 train_time:6659ms step_avg:31.41ms
+step:213/1490 train_time:6688ms step_avg:31.40ms
+step:214/1490 train_time:6723ms step_avg:31.42ms
+step:215/1490 train_time:6751ms step_avg:31.40ms
+step:216/1490 train_time:6786ms step_avg:31.42ms
+step:217/1490 train_time:6814ms step_avg:31.40ms
+step:218/1490 train_time:6849ms step_avg:31.42ms
+step:219/1490 train_time:6877ms step_avg:31.40ms
+step:220/1490 train_time:6912ms step_avg:31.42ms
+step:221/1490 train_time:6940ms step_avg:31.40ms
+step:222/1490 train_time:6974ms step_avg:31.41ms
+step:223/1490 train_time:7002ms step_avg:31.40ms
+step:224/1490 train_time:7036ms step_avg:31.41ms
+step:225/1490 train_time:7064ms step_avg:31.40ms
+step:226/1490 train_time:7098ms step_avg:31.41ms
+step:227/1490 train_time:7127ms step_avg:31.39ms
+step:228/1490 train_time:7162ms step_avg:31.41ms
+step:229/1490 train_time:7190ms step_avg:31.40ms
+step:230/1490 train_time:7225ms step_avg:31.41ms
+step:231/1490 train_time:7253ms step_avg:31.40ms
+step:232/1490 train_time:7288ms step_avg:31.41ms
+step:233/1490 train_time:7316ms step_avg:31.40ms
+step:234/1490 train_time:7350ms step_avg:31.41ms
+step:235/1490 train_time:7379ms step_avg:31.40ms
+step:236/1490 train_time:7413ms step_avg:31.41ms
+step:237/1490 train_time:7442ms step_avg:31.40ms
+step:238/1490 train_time:7476ms step_avg:31.41ms
+step:239/1490 train_time:7504ms step_avg:31.40ms
+step:240/1490 train_time:7538ms step_avg:31.41ms
+step:241/1490 train_time:7566ms step_avg:31.39ms
+step:242/1490 train_time:7600ms step_avg:31.40ms
+step:243/1490 train_time:7628ms step_avg:31.39ms
+step:244/1490 train_time:7662ms step_avg:31.40ms
+step:245/1490 train_time:7690ms step_avg:31.39ms
+step:246/1490 train_time:7725ms step_avg:31.40ms
+step:247/1490 train_time:7753ms step_avg:31.39ms
+step:248/1490 train_time:7788ms step_avg:31.40ms
+step:249/1490 train_time:7816ms step_avg:31.39ms
+step:250/1490 train_time:7850ms step_avg:31.40ms
+step:250/1490 val_loss:4.5079 train_time:7893ms step_avg:31.57ms
+step:251/1490 train_time:7911ms step_avg:31.52ms
+step:252/1490 train_time:7929ms step_avg:31.46ms
+step:253/1490 train_time:7947ms step_avg:31.41ms
+step:254/1490 train_time:7981ms step_avg:31.42ms
+step:255/1490 train_time:8010ms step_avg:31.41ms
+step:256/1490 train_time:8047ms step_avg:31.43ms
+step:257/1490 train_time:8075ms step_avg:31.42ms
+step:258/1490 train_time:8109ms step_avg:31.43ms
+step:259/1490 train_time:8137ms step_avg:31.42ms
+step:260/1490 train_time:8172ms step_avg:31.43ms
+step:261/1490 train_time:8201ms step_avg:31.42ms
+step:262/1490 train_time:8236ms step_avg:31.43ms
+step:263/1490 train_time:8263ms step_avg:31.42ms
+step:264/1490 train_time:8297ms step_avg:31.43ms
+step:265/1490 train_time:8325ms step_avg:31.42ms
+step:266/1490 train_time:8360ms step_avg:31.43ms
+step:267/1490 train_time:8388ms step_avg:31.41ms
+step:268/1490 train_time:8422ms step_avg:31.43ms
+step:269/1490 train_time:8450ms step_avg:31.41ms
+step:270/1490 train_time:8484ms step_avg:31.42ms
+step:271/1490 train_time:8512ms step_avg:31.41ms
+step:272/1490 train_time:8546ms step_avg:31.42ms
+step:273/1490 train_time:8574ms step_avg:31.41ms
+step:274/1490 train_time:8608ms step_avg:31.42ms
+step:275/1490 train_time:8636ms step_avg:31.40ms
+step:276/1490 train_time:8670ms step_avg:31.41ms
+step:277/1490 train_time:8698ms step_avg:31.40ms
+step:278/1490 train_time:8732ms step_avg:31.41ms
+step:279/1490 train_time:8759ms step_avg:31.40ms
+step:280/1490 train_time:8793ms step_avg:31.40ms
+step:281/1490 train_time:8822ms step_avg:31.39ms
+step:282/1490 train_time:8856ms step_avg:31.40ms
+step:283/1490 train_time:8885ms step_avg:31.40ms
+step:284/1490 train_time:8920ms step_avg:31.41ms
+step:285/1490 train_time:8948ms step_avg:31.40ms
+step:286/1490 train_time:8983ms step_avg:31.41ms
+step:287/1490 train_time:9012ms step_avg:31.40ms
+step:288/1490 train_time:9047ms step_avg:31.41ms
+step:289/1490 train_time:9075ms step_avg:31.40ms
+step:290/1490 train_time:9109ms step_avg:31.41ms
+step:291/1490 train_time:9138ms step_avg:31.40ms
+step:292/1490 train_time:9172ms step_avg:31.41ms
+step:293/1490 train_time:9201ms step_avg:31.40ms
+step:294/1490 train_time:9235ms step_avg:31.41ms
+step:295/1490 train_time:9264ms step_avg:31.40ms
+step:296/1490 train_time:9298ms step_avg:31.41ms
+step:297/1490 train_time:9326ms step_avg:31.40ms
+step:298/1490 train_time:9361ms step_avg:31.41ms
+step:299/1490 train_time:9390ms step_avg:31.40ms
+step:300/1490 train_time:9424ms step_avg:31.41ms
+step:301/1490 train_time:9452ms step_avg:31.40ms
+step:302/1490 train_time:9486ms step_avg:31.41ms
+step:303/1490 train_time:9515ms step_avg:31.40ms
+step:304/1490 train_time:9549ms step_avg:31.41ms
+step:305/1490 train_time:9578ms step_avg:31.40ms
+step:306/1490 train_time:9611ms step_avg:31.41ms
+step:307/1490 train_time:9639ms step_avg:31.40ms
+step:308/1490 train_time:9674ms step_avg:31.41ms
+step:309/1490 train_time:9701ms step_avg:31.40ms
+step:310/1490 train_time:9736ms step_avg:31.41ms
+step:311/1490 train_time:9763ms step_avg:31.39ms
+step:312/1490 train_time:9797ms step_avg:31.40ms
+step:313/1490 train_time:9825ms step_avg:31.39ms
+step:314/1490 train_time:9860ms step_avg:31.40ms
+step:315/1490 train_time:9888ms step_avg:31.39ms
+step:316/1490 train_time:9923ms step_avg:31.40ms
+step:317/1490 train_time:9951ms step_avg:31.39ms
+step:318/1490 train_time:9986ms step_avg:31.40ms
+step:319/1490 train_time:10014ms step_avg:31.39ms
+step:320/1490 train_time:10049ms step_avg:31.40ms
+step:321/1490 train_time:10077ms step_avg:31.39ms
+step:322/1490 train_time:10112ms step_avg:31.40ms
+step:323/1490 train_time:10140ms step_avg:31.39ms
+step:324/1490 train_time:10175ms step_avg:31.40ms
+step:325/1490 train_time:10203ms step_avg:31.39ms
+step:326/1490 train_time:10238ms step_avg:31.40ms
+step:327/1490 train_time:10266ms step_avg:31.39ms
+step:328/1490 train_time:10300ms step_avg:31.40ms
+step:329/1490 train_time:10328ms step_avg:31.39ms
+step:330/1490 train_time:10363ms step_avg:31.40ms
+step:331/1490 train_time:10391ms step_avg:31.39ms
+step:332/1490 train_time:10427ms step_avg:31.41ms
+step:333/1490 train_time:10454ms step_avg:31.39ms
+step:334/1490 train_time:10488ms step_avg:31.40ms
+step:335/1490 train_time:10516ms step_avg:31.39ms
+step:336/1490 train_time:10550ms step_avg:31.40ms
+step:337/1490 train_time:10578ms step_avg:31.39ms
+step:338/1490 train_time:10612ms step_avg:31.40ms
+step:339/1490 train_time:10640ms step_avg:31.39ms
+step:340/1490 train_time:10674ms step_avg:31.40ms
+step:341/1490 train_time:10703ms step_avg:31.39ms
+step:342/1490 train_time:10737ms step_avg:31.40ms
+step:343/1490 train_time:10766ms step_avg:31.39ms
+step:344/1490 train_time:10800ms step_avg:31.40ms
+step:345/1490 train_time:10828ms step_avg:31.39ms
+step:346/1490 train_time:10863ms step_avg:31.40ms
+step:347/1490 train_time:10891ms step_avg:31.39ms
+step:348/1490 train_time:10926ms step_avg:31.40ms
+step:349/1490 train_time:10953ms step_avg:31.39ms
+step:350/1490 train_time:10988ms step_avg:31.39ms
+step:351/1490 train_time:11017ms step_avg:31.39ms
+step:352/1490 train_time:11051ms step_avg:31.39ms
+step:353/1490 train_time:11079ms step_avg:31.39ms
+step:354/1490 train_time:11113ms step_avg:31.39ms
+step:355/1490 train_time:11141ms step_avg:31.38ms
+step:356/1490 train_time:11176ms step_avg:31.39ms
+step:357/1490 train_time:11204ms step_avg:31.38ms
+step:358/1490 train_time:11239ms step_avg:31.39ms
+step:359/1490 train_time:11267ms step_avg:31.38ms
+step:360/1490 train_time:11302ms step_avg:31.39ms
+step:361/1490 train_time:11330ms step_avg:31.38ms
+step:362/1490 train_time:11364ms step_avg:31.39ms
+step:363/1490 train_time:11393ms step_avg:31.38ms
+step:364/1490 train_time:11427ms step_avg:31.39ms
+step:365/1490 train_time:11455ms step_avg:31.38ms
+step:366/1490 train_time:11489ms step_avg:31.39ms
+step:367/1490 train_time:11518ms step_avg:31.38ms
+step:368/1490 train_time:11552ms step_avg:31.39ms
+step:369/1490 train_time:11580ms step_avg:31.38ms
+step:370/1490 train_time:11614ms step_avg:31.39ms
+step:371/1490 train_time:11643ms step_avg:31.38ms
+step:372/1490 train_time:11677ms step_avg:31.39ms
+step:373/1490 train_time:11705ms step_avg:31.38ms
+step:374/1490 train_time:11740ms step_avg:31.39ms
+step:375/1490 train_time:11768ms step_avg:31.38ms
+step:376/1490 train_time:11802ms step_avg:31.39ms
+step:377/1490 train_time:11830ms step_avg:31.38ms
+step:378/1490 train_time:11865ms step_avg:31.39ms
+step:379/1490 train_time:11893ms step_avg:31.38ms
+step:380/1490 train_time:11927ms step_avg:31.39ms
+step:381/1490 train_time:11955ms step_avg:31.38ms
+step:382/1490 train_time:11989ms step_avg:31.39ms
+step:383/1490 train_time:12018ms step_avg:31.38ms
+step:384/1490 train_time:12052ms step_avg:31.39ms
+step:385/1490 train_time:12081ms step_avg:31.38ms
+step:386/1490 train_time:12115ms step_avg:31.39ms
+step:387/1490 train_time:12143ms step_avg:31.38ms
+step:388/1490 train_time:12178ms step_avg:31.39ms
+step:389/1490 train_time:12206ms step_avg:31.38ms
+step:390/1490 train_time:12241ms step_avg:31.39ms
+step:391/1490 train_time:12269ms step_avg:31.38ms
+step:392/1490 train_time:12303ms step_avg:31.39ms
+step:393/1490 train_time:12331ms step_avg:31.38ms
+step:394/1490 train_time:12366ms step_avg:31.39ms
+step:395/1490 train_time:12394ms step_avg:31.38ms
+step:396/1490 train_time:12428ms step_avg:31.38ms
+step:397/1490 train_time:12456ms step_avg:31.38ms
+step:398/1490 train_time:12490ms step_avg:31.38ms
+step:399/1490 train_time:12519ms step_avg:31.38ms
+step:400/1490 train_time:12553ms step_avg:31.38ms
+step:401/1490 train_time:12581ms step_avg:31.37ms
+step:402/1490 train_time:12616ms step_avg:31.38ms
+step:403/1490 train_time:12644ms step_avg:31.37ms
+step:404/1490 train_time:12678ms step_avg:31.38ms
+step:405/1490 train_time:12706ms step_avg:31.37ms
+step:406/1490 train_time:12741ms step_avg:31.38ms
+step:407/1490 train_time:12769ms step_avg:31.37ms
+step:408/1490 train_time:12803ms step_avg:31.38ms
+step:409/1490 train_time:12831ms step_avg:31.37ms
+step:410/1490 train_time:12865ms step_avg:31.38ms
+step:411/1490 train_time:12894ms step_avg:31.37ms
+step:412/1490 train_time:12928ms step_avg:31.38ms
+step:413/1490 train_time:12956ms step_avg:31.37ms
+step:414/1490 train_time:12990ms step_avg:31.38ms
+step:415/1490 train_time:13019ms step_avg:31.37ms
+step:416/1490 train_time:13053ms step_avg:31.38ms
+step:417/1490 train_time:13081ms step_avg:31.37ms
+step:418/1490 train_time:13115ms step_avg:31.38ms
+step:419/1490 train_time:13144ms step_avg:31.37ms
+step:420/1490 train_time:13178ms step_avg:31.38ms
+step:421/1490 train_time:13206ms step_avg:31.37ms
+step:422/1490 train_time:13241ms step_avg:31.38ms
+step:423/1490 train_time:13269ms step_avg:31.37ms
+step:424/1490 train_time:13304ms step_avg:31.38ms
+step:425/1490 train_time:13332ms step_avg:31.37ms
+step:426/1490 train_time:13366ms step_avg:31.38ms
+step:427/1490 train_time:13394ms step_avg:31.37ms
+step:428/1490 train_time:13428ms step_avg:31.37ms
+step:429/1490 train_time:13457ms step_avg:31.37ms
+step:430/1490 train_time:13491ms step_avg:31.37ms
+step:431/1490 train_time:13519ms step_avg:31.37ms
+step:432/1490 train_time:13554ms step_avg:31.37ms
+step:433/1490 train_time:13582ms step_avg:31.37ms
+step:434/1490 train_time:13617ms step_avg:31.37ms
+step:435/1490 train_time:13645ms step_avg:31.37ms
+step:436/1490 train_time:13680ms step_avg:31.38ms
+step:437/1490 train_time:13708ms step_avg:31.37ms
+step:438/1490 train_time:13743ms step_avg:31.38ms
+step:439/1490 train_time:13771ms step_avg:31.37ms
+step:440/1490 train_time:13805ms step_avg:31.38ms
+step:441/1490 train_time:13833ms step_avg:31.37ms
+step:442/1490 train_time:13867ms step_avg:31.37ms
+step:443/1490 train_time:13895ms step_avg:31.37ms
+step:444/1490 train_time:13930ms step_avg:31.37ms
+step:445/1490 train_time:13958ms step_avg:31.37ms
+step:446/1490 train_time:13992ms step_avg:31.37ms
+step:447/1490 train_time:14020ms step_avg:31.36ms
+step:448/1490 train_time:14054ms step_avg:31.37ms
+step:449/1490 train_time:14083ms step_avg:31.36ms
+step:450/1490 train_time:14117ms step_avg:31.37ms
+step:451/1490 train_time:14145ms step_avg:31.36ms
+step:452/1490 train_time:14180ms step_avg:31.37ms
+step:453/1490 train_time:14208ms step_avg:31.36ms
+step:454/1490 train_time:14243ms step_avg:31.37ms
+step:455/1490 train_time:14271ms step_avg:31.36ms
+step:456/1490 train_time:14305ms step_avg:31.37ms
+step:457/1490 train_time:14333ms step_avg:31.36ms
+step:458/1490 train_time:14367ms step_avg:31.37ms
+step:459/1490 train_time:14396ms step_avg:31.36ms
+step:460/1490 train_time:14430ms step_avg:31.37ms
+step:461/1490 train_time:14459ms step_avg:31.36ms
+step:462/1490 train_time:14494ms step_avg:31.37ms
+step:463/1490 train_time:14521ms step_avg:31.36ms
+step:464/1490 train_time:14555ms step_avg:31.37ms
+step:465/1490 train_time:14584ms step_avg:31.36ms
+step:466/1490 train_time:14618ms step_avg:31.37ms
+step:467/1490 train_time:14646ms step_avg:31.36ms
+step:468/1490 train_time:14681ms step_avg:31.37ms
+step:469/1490 train_time:14709ms step_avg:31.36ms
+step:470/1490 train_time:14744ms step_avg:31.37ms
+step:471/1490 train_time:14772ms step_avg:31.36ms
+step:472/1490 train_time:14806ms step_avg:31.37ms
+step:473/1490 train_time:14834ms step_avg:31.36ms
+step:474/1490 train_time:14868ms step_avg:31.37ms
+step:475/1490 train_time:14896ms step_avg:31.36ms
+step:476/1490 train_time:14930ms step_avg:31.37ms
+step:477/1490 train_time:14959ms step_avg:31.36ms
+step:478/1490 train_time:14993ms step_avg:31.37ms
+step:479/1490 train_time:15021ms step_avg:31.36ms
+step:480/1490 train_time:15055ms step_avg:31.37ms
+step:481/1490 train_time:15083ms step_avg:31.36ms
+step:482/1490 train_time:15118ms step_avg:31.37ms
+step:483/1490 train_time:15146ms step_avg:31.36ms
+step:484/1490 train_time:15184ms step_avg:31.37ms
+step:485/1490 train_time:15236ms step_avg:31.41ms
+step:486/1490 train_time:15295ms step_avg:31.47ms
+step:487/1490 train_time:15349ms step_avg:31.52ms
+step:488/1490 train_time:15410ms step_avg:31.58ms
+step:489/1490 train_time:15464ms step_avg:31.62ms
+step:490/1490 train_time:15524ms step_avg:31.68ms
+step:491/1490 train_time:15577ms step_avg:31.73ms
+step:492/1490 train_time:15637ms step_avg:31.78ms
+step:493/1490 train_time:15691ms step_avg:31.83ms
+step:494/1490 train_time:15751ms step_avg:31.89ms
+step:495/1490 train_time:15806ms step_avg:31.93ms
+step:496/1490 train_time:15866ms step_avg:31.99ms
+step:497/1490 train_time:15920ms step_avg:32.03ms
+step:498/1490 train_time:15979ms step_avg:32.09ms
+step:499/1490 train_time:16034ms step_avg:32.13ms
+step:500/1490 train_time:16093ms step_avg:32.19ms
+step:500/1490 val_loss:4.2289 train_time:16167ms step_avg:32.33ms
+step:501/1490 train_time:16187ms step_avg:32.31ms
+step:502/1490 train_time:16211ms step_avg:32.29ms
+step:503/1490 train_time:16270ms step_avg:32.35ms
+step:504/1490 train_time:16331ms step_avg:32.40ms
+step:505/1490 train_time:16389ms step_avg:32.45ms
+step:506/1490 train_time:16448ms step_avg:32.51ms
+step:507/1490 train_time:16502ms step_avg:32.55ms
+step:508/1490 train_time:16561ms step_avg:32.60ms
+step:509/1490 train_time:16614ms step_avg:32.64ms
+step:510/1490 train_time:16673ms step_avg:32.69ms
+step:511/1490 train_time:16726ms step_avg:32.73ms
+step:512/1490 train_time:16786ms step_avg:32.78ms
+step:513/1490 train_time:16839ms step_avg:32.82ms
+step:514/1490 train_time:16897ms step_avg:32.87ms
+step:515/1490 train_time:16950ms step_avg:32.91ms
+step:516/1490 train_time:17009ms step_avg:32.96ms
+step:517/1490 train_time:17062ms step_avg:33.00ms
+step:518/1490 train_time:17122ms step_avg:33.05ms
+step:519/1490 train_time:17176ms step_avg:33.09ms
+step:520/1490 train_time:17238ms step_avg:33.15ms
+step:521/1490 train_time:17295ms step_avg:33.19ms
+step:522/1490 train_time:17355ms step_avg:33.25ms
+step:523/1490 train_time:17411ms step_avg:33.29ms
+step:524/1490 train_time:17471ms step_avg:33.34ms
+step:525/1490 train_time:17526ms step_avg:33.38ms
+step:526/1490 train_time:17585ms step_avg:33.43ms
+step:527/1490 train_time:17639ms step_avg:33.47ms
+step:528/1490 train_time:17698ms step_avg:33.52ms
+step:529/1490 train_time:17751ms step_avg:33.56ms
+step:530/1490 train_time:17811ms step_avg:33.61ms
+step:531/1490 train_time:17864ms step_avg:33.64ms
+step:532/1490 train_time:17923ms step_avg:33.69ms
+step:533/1490 train_time:17977ms step_avg:33.73ms
+step:534/1490 train_time:18035ms step_avg:33.77ms
+step:535/1490 train_time:18089ms step_avg:33.81ms
+step:536/1490 train_time:18150ms step_avg:33.86ms
+step:537/1490 train_time:18204ms step_avg:33.90ms
+step:538/1490 train_time:18265ms step_avg:33.95ms
+step:539/1490 train_time:18321ms step_avg:33.99ms
+step:540/1490 train_time:18382ms step_avg:34.04ms
+step:541/1490 train_time:18437ms step_avg:34.08ms
+step:542/1490 train_time:18497ms step_avg:34.13ms
+step:543/1490 train_time:18550ms step_avg:34.16ms
+step:544/1490 train_time:18610ms step_avg:34.21ms
+step:545/1490 train_time:18664ms step_avg:34.25ms
+step:546/1490 train_time:18723ms step_avg:34.29ms
+step:547/1490 train_time:18777ms step_avg:34.33ms
+step:548/1490 train_time:18836ms step_avg:34.37ms
+step:549/1490 train_time:18889ms step_avg:34.41ms
+step:550/1490 train_time:18948ms step_avg:34.45ms
+step:551/1490 train_time:19002ms step_avg:34.49ms
+step:552/1490 train_time:19062ms step_avg:34.53ms
+step:553/1490 train_time:19116ms step_avg:34.57ms
+step:554/1490 train_time:19175ms step_avg:34.61ms
+step:555/1490 train_time:19230ms step_avg:34.65ms
+step:556/1490 train_time:19291ms step_avg:34.70ms
+step:557/1490 train_time:19345ms step_avg:34.73ms
+step:558/1490 train_time:19406ms step_avg:34.78ms
+step:559/1490 train_time:19460ms step_avg:34.81ms
+step:560/1490 train_time:19520ms step_avg:34.86ms
+step:561/1490 train_time:19574ms step_avg:34.89ms
+step:562/1490 train_time:19633ms step_avg:34.93ms
+step:563/1490 train_time:19687ms step_avg:34.97ms
+step:564/1490 train_time:19748ms step_avg:35.01ms
+step:565/1490 train_time:19802ms step_avg:35.05ms
+step:566/1490 train_time:19862ms step_avg:35.09ms
+step:567/1490 train_time:19916ms step_avg:35.12ms
+step:568/1490 train_time:19974ms step_avg:35.17ms
+step:569/1490 train_time:20028ms step_avg:35.20ms
+step:570/1490 train_time:20089ms step_avg:35.24ms
+step:571/1490 train_time:20142ms step_avg:35.28ms
+step:572/1490 train_time:20203ms step_avg:35.32ms
+step:573/1490 train_time:20257ms step_avg:35.35ms
+step:574/1490 train_time:20318ms step_avg:35.40ms
+step:575/1490 train_time:20372ms step_avg:35.43ms
+step:576/1490 train_time:20431ms step_avg:35.47ms
+step:577/1490 train_time:20485ms step_avg:35.50ms
+step:578/1490 train_time:20546ms step_avg:35.55ms
+step:579/1490 train_time:20600ms step_avg:35.58ms
+step:580/1490 train_time:20659ms step_avg:35.62ms
+step:581/1490 train_time:20713ms step_avg:35.65ms
+step:582/1490 train_time:20772ms step_avg:35.69ms
+step:583/1490 train_time:20827ms step_avg:35.72ms
+step:584/1490 train_time:20887ms step_avg:35.76ms
+step:585/1490 train_time:20940ms step_avg:35.79ms
+step:586/1490 train_time:21000ms step_avg:35.84ms
+step:587/1490 train_time:21053ms step_avg:35.87ms
+step:588/1490 train_time:21112ms step_avg:35.91ms
+step:589/1490 train_time:21167ms step_avg:35.94ms
+step:590/1490 train_time:21226ms step_avg:35.98ms
+step:591/1490 train_time:21280ms step_avg:36.01ms
+step:592/1490 train_time:21340ms step_avg:36.05ms
+step:593/1490 train_time:21395ms step_avg:36.08ms
+step:594/1490 train_time:21454ms step_avg:36.12ms
+step:595/1490 train_time:21510ms step_avg:36.15ms
+step:596/1490 train_time:21570ms step_avg:36.19ms
+step:597/1490 train_time:21624ms step_avg:36.22ms
+step:598/1490 train_time:21684ms step_avg:36.26ms
+step:599/1490 train_time:21738ms step_avg:36.29ms
+step:600/1490 train_time:21797ms step_avg:36.33ms
+step:601/1490 train_time:21851ms step_avg:36.36ms
+step:602/1490 train_time:21910ms step_avg:36.40ms
+step:603/1490 train_time:21965ms step_avg:36.43ms
+step:604/1490 train_time:22024ms step_avg:36.46ms
+step:605/1490 train_time:22078ms step_avg:36.49ms
+step:606/1490 train_time:22137ms step_avg:36.53ms
+step:607/1490 train_time:22191ms step_avg:36.56ms
+step:608/1490 train_time:22251ms step_avg:36.60ms
+step:609/1490 train_time:22306ms step_avg:36.63ms
+step:610/1490 train_time:22365ms step_avg:36.66ms
+step:611/1490 train_time:22419ms step_avg:36.69ms
+step:612/1490 train_time:22479ms step_avg:36.73ms
+step:613/1490 train_time:22533ms step_avg:36.76ms
+step:614/1490 train_time:22594ms step_avg:36.80ms
+step:615/1490 train_time:22648ms step_avg:36.83ms
+step:616/1490 train_time:22708ms step_avg:36.86ms
+step:617/1490 train_time:22761ms step_avg:36.89ms
+step:618/1490 train_time:22822ms step_avg:36.93ms
+step:619/1490 train_time:22876ms step_avg:36.96ms
+step:620/1490 train_time:22935ms step_avg:36.99ms
+step:621/1490 train_time:22989ms step_avg:37.02ms
+step:622/1490 train_time:23049ms step_avg:37.06ms
+step:623/1490 train_time:23103ms step_avg:37.08ms
+step:624/1490 train_time:23163ms step_avg:37.12ms
+step:625/1490 train_time:23218ms step_avg:37.15ms
+step:626/1490 train_time:23277ms step_avg:37.18ms
+step:627/1490 train_time:23330ms step_avg:37.21ms
+step:628/1490 train_time:23391ms step_avg:37.25ms
+step:629/1490 train_time:23445ms step_avg:37.27ms
+step:630/1490 train_time:23505ms step_avg:37.31ms
+step:631/1490 train_time:23559ms step_avg:37.34ms
+step:632/1490 train_time:23618ms step_avg:37.37ms
+step:633/1490 train_time:23672ms step_avg:37.40ms
+step:634/1490 train_time:23731ms step_avg:37.43ms
+step:635/1490 train_time:23786ms step_avg:37.46ms
+step:636/1490 train_time:23846ms step_avg:37.49ms
+step:637/1490 train_time:23900ms step_avg:37.52ms
+step:638/1490 train_time:23960ms step_avg:37.55ms
+step:639/1490 train_time:24013ms step_avg:37.58ms
+step:640/1490 train_time:24072ms step_avg:37.61ms
+step:641/1490 train_time:24127ms step_avg:37.64ms
+step:642/1490 train_time:24187ms step_avg:37.68ms
+step:643/1490 train_time:24241ms step_avg:37.70ms
+step:644/1490 train_time:24301ms step_avg:37.73ms
+step:645/1490 train_time:24355ms step_avg:37.76ms
+step:646/1490 train_time:24414ms step_avg:37.79ms
+step:647/1490 train_time:24469ms step_avg:37.82ms
+step:648/1490 train_time:24528ms step_avg:37.85ms
+step:649/1490 train_time:24582ms step_avg:37.88ms
+step:650/1490 train_time:24642ms step_avg:37.91ms
+step:651/1490 train_time:24696ms step_avg:37.94ms
+step:652/1490 train_time:24755ms step_avg:37.97ms
+step:653/1490 train_time:24810ms step_avg:37.99ms
+step:654/1490 train_time:24869ms step_avg:38.03ms
+step:655/1490 train_time:24922ms step_avg:38.05ms
+step:656/1490 train_time:24983ms step_avg:38.08ms
+step:657/1490 train_time:25037ms step_avg:38.11ms
+step:658/1490 train_time:25096ms step_avg:38.14ms
+step:659/1490 train_time:25150ms step_avg:38.16ms
+step:660/1490 train_time:25209ms step_avg:38.20ms
+step:661/1490 train_time:25263ms step_avg:38.22ms
+step:662/1490 train_time:25323ms step_avg:38.25ms
+step:663/1490 train_time:25377ms step_avg:38.28ms
+step:664/1490 train_time:25436ms step_avg:38.31ms
+step:665/1490 train_time:25490ms step_avg:38.33ms
+step:666/1490 train_time:25551ms step_avg:38.36ms
+step:667/1490 train_time:25606ms step_avg:38.39ms
+step:668/1490 train_time:25665ms step_avg:38.42ms
+step:669/1490 train_time:25719ms step_avg:38.44ms
+step:670/1490 train_time:25779ms step_avg:38.48ms
+step:671/1490 train_time:25832ms step_avg:38.50ms
+step:672/1490 train_time:25892ms step_avg:38.53ms
+step:673/1490 train_time:25946ms step_avg:38.55ms
+step:674/1490 train_time:26006ms step_avg:38.58ms
+step:675/1490 train_time:26060ms step_avg:38.61ms
+step:676/1490 train_time:26119ms step_avg:38.64ms
+step:677/1490 train_time:26172ms step_avg:38.66ms
+step:678/1490 train_time:26233ms step_avg:38.69ms
+step:679/1490 train_time:26288ms step_avg:38.72ms
+step:680/1490 train_time:26348ms step_avg:38.75ms
+step:681/1490 train_time:26401ms step_avg:38.77ms
+step:682/1490 train_time:26461ms step_avg:38.80ms
+step:683/1490 train_time:26515ms step_avg:38.82ms
+step:684/1490 train_time:26574ms step_avg:38.85ms
+step:685/1490 train_time:26629ms step_avg:38.87ms
+step:686/1490 train_time:26689ms step_avg:38.91ms
+step:687/1490 train_time:26743ms step_avg:38.93ms
+step:688/1490 train_time:26803ms step_avg:38.96ms
+step:689/1490 train_time:26857ms step_avg:38.98ms
+step:690/1490 train_time:26916ms step_avg:39.01ms
+step:691/1490 train_time:26970ms step_avg:39.03ms
+step:692/1490 train_time:27030ms step_avg:39.06ms
+step:693/1490 train_time:27084ms step_avg:39.08ms
+step:694/1490 train_time:27144ms step_avg:39.11ms
+step:695/1490 train_time:27198ms step_avg:39.13ms
+step:696/1490 train_time:27257ms step_avg:39.16ms
+step:697/1490 train_time:27311ms step_avg:39.18ms
+step:698/1490 train_time:27371ms step_avg:39.21ms
+step:699/1490 train_time:27426ms step_avg:39.24ms
+step:700/1490 train_time:27486ms step_avg:39.27ms
+step:701/1490 train_time:27540ms step_avg:39.29ms
+step:702/1490 train_time:27600ms step_avg:39.32ms
+step:703/1490 train_time:27654ms step_avg:39.34ms
+step:704/1490 train_time:27713ms step_avg:39.37ms
+step:705/1490 train_time:27767ms step_avg:39.39ms
+step:706/1490 train_time:27828ms step_avg:39.42ms
+step:707/1490 train_time:27883ms step_avg:39.44ms
+step:708/1490 train_time:27943ms step_avg:39.47ms
+step:709/1490 train_time:27997ms step_avg:39.49ms
+step:710/1490 train_time:28056ms step_avg:39.52ms
+step:711/1490 train_time:28111ms step_avg:39.54ms
+step:712/1490 train_time:28169ms step_avg:39.56ms
+step:713/1490 train_time:28224ms step_avg:39.58ms
+step:714/1490 train_time:28285ms step_avg:39.61ms
+step:715/1490 train_time:28339ms step_avg:39.64ms
+step:716/1490 train_time:28399ms step_avg:39.66ms
+step:717/1490 train_time:28453ms step_avg:39.68ms
+step:718/1490 train_time:28512ms step_avg:39.71ms
+step:719/1490 train_time:28566ms step_avg:39.73ms
+step:720/1490 train_time:28626ms step_avg:39.76ms
+step:721/1490 train_time:28680ms step_avg:39.78ms
+step:722/1490 train_time:28740ms step_avg:39.81ms
+step:723/1490 train_time:28793ms step_avg:39.82ms
+step:724/1490 train_time:28852ms step_avg:39.85ms
+step:725/1490 train_time:28907ms step_avg:39.87ms
+step:726/1490 train_time:28966ms step_avg:39.90ms
+step:727/1490 train_time:29020ms step_avg:39.92ms
+step:728/1490 train_time:29080ms step_avg:39.95ms
+step:729/1490 train_time:29134ms step_avg:39.96ms
+step:730/1490 train_time:29195ms step_avg:39.99ms
+step:731/1490 train_time:29249ms step_avg:40.01ms
+step:732/1490 train_time:29308ms step_avg:40.04ms
+step:733/1490 train_time:29363ms step_avg:40.06ms
+step:734/1490 train_time:29422ms step_avg:40.09ms
+step:735/1490 train_time:29477ms step_avg:40.10ms
+step:736/1490 train_time:29536ms step_avg:40.13ms
+step:737/1490 train_time:29590ms step_avg:40.15ms
+step:738/1490 train_time:29650ms step_avg:40.18ms
+step:739/1490 train_time:29704ms step_avg:40.19ms
+step:740/1490 train_time:29764ms step_avg:40.22ms
+step:741/1490 train_time:29819ms step_avg:40.24ms
+step:742/1490 train_time:29878ms step_avg:40.27ms
+step:743/1490 train_time:29931ms step_avg:40.28ms
+step:744/1490 train_time:29992ms step_avg:40.31ms
+step:745/1490 train_time:30046ms step_avg:40.33ms
+step:746/1490 train_time:30105ms step_avg:40.36ms
+step:747/1490 train_time:30159ms step_avg:40.37ms
+step:748/1490 train_time:30218ms step_avg:40.40ms
+step:749/1490 train_time:30273ms step_avg:40.42ms
+step:750/1490 train_time:30332ms step_avg:40.44ms
+step:750/1490 val_loss:3.8069 train_time:30406ms step_avg:40.54ms
+step:751/1490 train_time:30425ms step_avg:40.51ms
+step:752/1490 train_time:30450ms step_avg:40.49ms
+step:753/1490 train_time:30507ms step_avg:40.51ms
+step:754/1490 train_time:30568ms step_avg:40.54ms
+step:755/1490 train_time:30622ms step_avg:40.56ms
+step:756/1490 train_time:30682ms step_avg:40.58ms
+step:757/1490 train_time:30736ms step_avg:40.60ms
+step:758/1490 train_time:30795ms step_avg:40.63ms
+step:759/1490 train_time:30849ms step_avg:40.64ms
+step:760/1490 train_time:30909ms step_avg:40.67ms
+step:761/1490 train_time:30962ms step_avg:40.69ms
+step:762/1490 train_time:31020ms step_avg:40.71ms
+step:763/1490 train_time:31074ms step_avg:40.73ms
+step:764/1490 train_time:31134ms step_avg:40.75ms
+step:765/1490 train_time:31187ms step_avg:40.77ms
+step:766/1490 train_time:31246ms step_avg:40.79ms
+step:767/1490 train_time:31300ms step_avg:40.81ms
+step:768/1490 train_time:31361ms step_avg:40.83ms
+step:769/1490 train_time:31417ms step_avg:40.85ms
+step:770/1490 train_time:31477ms step_avg:40.88ms
+step:771/1490 train_time:31533ms step_avg:40.90ms
+step:772/1490 train_time:31593ms step_avg:40.92ms
+step:773/1490 train_time:31649ms step_avg:40.94ms
+step:774/1490 train_time:31708ms step_avg:40.97ms
+step:775/1490 train_time:31762ms step_avg:40.98ms
+step:776/1490 train_time:31822ms step_avg:41.01ms
+step:777/1490 train_time:31876ms step_avg:41.02ms
+step:778/1490 train_time:31935ms step_avg:41.05ms
+step:779/1490 train_time:31989ms step_avg:41.06ms
+step:780/1490 train_time:32048ms step_avg:41.09ms
+step:781/1490 train_time:32101ms step_avg:41.10ms
+step:782/1490 train_time:32160ms step_avg:41.13ms
+step:783/1490 train_time:32213ms step_avg:41.14ms
+step:784/1490 train_time:32272ms step_avg:41.16ms
+step:785/1490 train_time:32327ms step_avg:41.18ms
+step:786/1490 train_time:32387ms step_avg:41.20ms
+step:787/1490 train_time:32442ms step_avg:41.22ms
+step:788/1490 train_time:32503ms step_avg:41.25ms
+step:789/1490 train_time:32558ms step_avg:41.27ms
+step:790/1490 train_time:32618ms step_avg:41.29ms
+step:791/1490 train_time:32672ms step_avg:41.30ms
+step:792/1490 train_time:32732ms step_avg:41.33ms
+step:793/1490 train_time:32786ms step_avg:41.34ms
+step:794/1490 train_time:32846ms step_avg:41.37ms
+step:795/1490 train_time:32901ms step_avg:41.38ms
+step:796/1490 train_time:32960ms step_avg:41.41ms
+step:797/1490 train_time:33013ms step_avg:41.42ms
+step:798/1490 train_time:33072ms step_avg:41.44ms
+step:799/1490 train_time:33127ms step_avg:41.46ms
+step:800/1490 train_time:33186ms step_avg:41.48ms
+step:801/1490 train_time:33241ms step_avg:41.50ms
+step:802/1490 train_time:33301ms step_avg:41.52ms
+step:803/1490 train_time:33355ms step_avg:41.54ms
+step:804/1490 train_time:33416ms step_avg:41.56ms
+step:805/1490 train_time:33470ms step_avg:41.58ms
+step:806/1490 train_time:33530ms step_avg:41.60ms
+step:807/1490 train_time:33584ms step_avg:41.62ms
+step:808/1490 train_time:33644ms step_avg:41.64ms
+step:809/1490 train_time:33698ms step_avg:41.65ms
+step:810/1490 train_time:33757ms step_avg:41.68ms
+step:811/1490 train_time:33812ms step_avg:41.69ms
+step:812/1490 train_time:33871ms step_avg:41.71ms
+step:813/1490 train_time:33924ms step_avg:41.73ms
+step:814/1490 train_time:33983ms step_avg:41.75ms
+step:815/1490 train_time:34038ms step_avg:41.76ms
+step:816/1490 train_time:34096ms step_avg:41.78ms
+step:817/1490 train_time:34151ms step_avg:41.80ms
+step:818/1490 train_time:34211ms step_avg:41.82ms
+step:819/1490 train_time:34264ms step_avg:41.84ms
+step:820/1490 train_time:34324ms step_avg:41.86ms
+step:821/1490 train_time:34379ms step_avg:41.87ms
+step:822/1490 train_time:34438ms step_avg:41.90ms
+step:823/1490 train_time:34492ms step_avg:41.91ms
+step:824/1490 train_time:34552ms step_avg:41.93ms
+step:825/1490 train_time:34606ms step_avg:41.95ms
+step:826/1490 train_time:34666ms step_avg:41.97ms
+step:827/1490 train_time:34720ms step_avg:41.98ms
+step:828/1490 train_time:34779ms step_avg:42.00ms
+step:829/1490 train_time:34833ms step_avg:42.02ms
+step:830/1490 train_time:34892ms step_avg:42.04ms
+step:831/1490 train_time:34946ms step_avg:42.05ms
+step:832/1490 train_time:35006ms step_avg:42.07ms
+step:833/1490 train_time:35060ms step_avg:42.09ms
+step:834/1490 train_time:35119ms step_avg:42.11ms
+step:835/1490 train_time:35173ms step_avg:42.12ms
+step:836/1490 train_time:35233ms step_avg:42.14ms
+step:837/1490 train_time:35287ms step_avg:42.16ms
+step:838/1490 train_time:35347ms step_avg:42.18ms
+step:839/1490 train_time:35402ms step_avg:42.19ms
+step:840/1490 train_time:35461ms step_avg:42.22ms
+step:841/1490 train_time:35516ms step_avg:42.23ms
+step:842/1490 train_time:35575ms step_avg:42.25ms
+step:843/1490 train_time:35630ms step_avg:42.27ms
+step:844/1490 train_time:35690ms step_avg:42.29ms
+step:845/1490 train_time:35745ms step_avg:42.30ms
+step:846/1490 train_time:35805ms step_avg:42.32ms
+step:847/1490 train_time:35859ms step_avg:42.34ms
+step:848/1490 train_time:35919ms step_avg:42.36ms
+step:849/1490 train_time:35972ms step_avg:42.37ms
+step:850/1490 train_time:36031ms step_avg:42.39ms
+step:851/1490 train_time:36084ms step_avg:42.40ms
+step:852/1490 train_time:36144ms step_avg:42.42ms
+step:853/1490 train_time:36198ms step_avg:42.44ms
+step:854/1490 train_time:36257ms step_avg:42.46ms
+step:855/1490 train_time:36312ms step_avg:42.47ms
+step:856/1490 train_time:36371ms step_avg:42.49ms
+step:857/1490 train_time:36425ms step_avg:42.50ms
+step:858/1490 train_time:36486ms step_avg:42.52ms
+step:859/1490 train_time:36540ms step_avg:42.54ms
+step:860/1490 train_time:36600ms step_avg:42.56ms
+step:861/1490 train_time:36653ms step_avg:42.57ms
+step:862/1490 train_time:36713ms step_avg:42.59ms
+step:863/1490 train_time:36767ms step_avg:42.60ms
+step:864/1490 train_time:36827ms step_avg:42.62ms
+step:865/1490 train_time:36880ms step_avg:42.64ms
+step:866/1490 train_time:36940ms step_avg:42.66ms
+step:867/1490 train_time:36994ms step_avg:42.67ms
+step:868/1490 train_time:37053ms step_avg:42.69ms
+step:869/1490 train_time:37108ms step_avg:42.70ms
+step:870/1490 train_time:37167ms step_avg:42.72ms
+step:871/1490 train_time:37220ms step_avg:42.73ms
+step:872/1490 train_time:37280ms step_avg:42.75ms
+step:873/1490 train_time:37334ms step_avg:42.77ms
+step:874/1490 train_time:37393ms step_avg:42.78ms
+step:875/1490 train_time:37449ms step_avg:42.80ms
+step:876/1490 train_time:37509ms step_avg:42.82ms
+step:877/1490 train_time:37562ms step_avg:42.83ms
+step:878/1490 train_time:37622ms step_avg:42.85ms
+step:879/1490 train_time:37676ms step_avg:42.86ms
+step:880/1490 train_time:37736ms step_avg:42.88ms
+step:881/1490 train_time:37791ms step_avg:42.90ms
+step:882/1490 train_time:37850ms step_avg:42.91ms
+step:883/1490 train_time:37904ms step_avg:42.93ms
+step:884/1490 train_time:37965ms step_avg:42.95ms
+step:885/1490 train_time:38018ms step_avg:42.96ms
+step:886/1490 train_time:38077ms step_avg:42.98ms
+step:887/1490 train_time:38131ms step_avg:42.99ms
+step:888/1490 train_time:38190ms step_avg:43.01ms
+step:889/1490 train_time:38244ms step_avg:43.02ms
+step:890/1490 train_time:38304ms step_avg:43.04ms
+step:891/1490 train_time:38359ms step_avg:43.05ms
+step:892/1490 train_time:38417ms step_avg:43.07ms
+step:893/1490 train_time:38471ms step_avg:43.08ms
+step:894/1490 train_time:38531ms step_avg:43.10ms
+step:895/1490 train_time:38585ms step_avg:43.11ms
+step:896/1490 train_time:38645ms step_avg:43.13ms
+step:897/1490 train_time:38700ms step_avg:43.14ms
+step:898/1490 train_time:38760ms step_avg:43.16ms
+step:899/1490 train_time:38813ms step_avg:43.17ms
+step:900/1490 train_time:38873ms step_avg:43.19ms
+step:901/1490 train_time:38928ms step_avg:43.20ms
+step:902/1490 train_time:38986ms step_avg:43.22ms
+step:903/1490 train_time:39040ms step_avg:43.23ms
+step:904/1490 train_time:39100ms step_avg:43.25ms
+step:905/1490 train_time:39154ms step_avg:43.26ms
+step:906/1490 train_time:39215ms step_avg:43.28ms
+step:907/1490 train_time:39269ms step_avg:43.30ms
+step:908/1490 train_time:39329ms step_avg:43.31ms
+step:909/1490 train_time:39383ms step_avg:43.33ms
+step:910/1490 train_time:39443ms step_avg:43.34ms
+step:911/1490 train_time:39497ms step_avg:43.36ms
+step:912/1490 train_time:39556ms step_avg:43.37ms
+step:913/1490 train_time:39610ms step_avg:43.38ms
+step:914/1490 train_time:39669ms step_avg:43.40ms
+step:915/1490 train_time:39723ms step_avg:43.41ms
+step:916/1490 train_time:39784ms step_avg:43.43ms
+step:917/1490 train_time:39838ms step_avg:43.44ms
+step:918/1490 train_time:39898ms step_avg:43.46ms
+step:919/1490 train_time:39951ms step_avg:43.47ms
+step:920/1490 train_time:40011ms step_avg:43.49ms
+step:921/1490 train_time:40065ms step_avg:43.50ms
+step:922/1490 train_time:40125ms step_avg:43.52ms
+step:923/1490 train_time:40178ms step_avg:43.53ms
+step:924/1490 train_time:40238ms step_avg:43.55ms
+step:925/1490 train_time:40292ms step_avg:43.56ms
+step:926/1490 train_time:40352ms step_avg:43.58ms
+step:927/1490 train_time:40406ms step_avg:43.59ms
+step:928/1490 train_time:40465ms step_avg:43.60ms
+step:929/1490 train_time:40519ms step_avg:43.62ms
+step:930/1490 train_time:40578ms step_avg:43.63ms
+step:931/1490 train_time:40632ms step_avg:43.64ms
+step:932/1490 train_time:40691ms step_avg:43.66ms
+step:933/1490 train_time:40746ms step_avg:43.67ms
+step:934/1490 train_time:40807ms step_avg:43.69ms
+step:935/1490 train_time:40861ms step_avg:43.70ms
+step:936/1490 train_time:40920ms step_avg:43.72ms
+step:937/1490 train_time:40975ms step_avg:43.73ms
+step:938/1490 train_time:41034ms step_avg:43.75ms
+step:939/1490 train_time:41087ms step_avg:43.76ms
+step:940/1490 train_time:41148ms step_avg:43.77ms
+step:941/1490 train_time:41202ms step_avg:43.79ms
+step:942/1490 train_time:41262ms step_avg:43.80ms
+step:943/1490 train_time:41316ms step_avg:43.81ms
+step:944/1490 train_time:41375ms step_avg:43.83ms
+step:945/1490 train_time:41430ms step_avg:43.84ms
+step:946/1490 train_time:41489ms step_avg:43.86ms
+step:947/1490 train_time:41543ms step_avg:43.87ms
+step:948/1490 train_time:41602ms step_avg:43.88ms
+step:949/1490 train_time:41656ms step_avg:43.89ms
+step:950/1490 train_time:41717ms step_avg:43.91ms
+step:951/1490 train_time:41772ms step_avg:43.92ms
+step:952/1490 train_time:41831ms step_avg:43.94ms
+step:953/1490 train_time:41886ms step_avg:43.95ms
+step:954/1490 train_time:41945ms step_avg:43.97ms
+step:955/1490 train_time:41999ms step_avg:43.98ms
+step:956/1490 train_time:42058ms step_avg:43.99ms
+step:957/1490 train_time:42112ms step_avg:44.00ms
+step:958/1490 train_time:42172ms step_avg:44.02ms
+step:959/1490 train_time:42226ms step_avg:44.03ms
+step:960/1490 train_time:42286ms step_avg:44.05ms
+step:961/1490 train_time:42340ms step_avg:44.06ms
+step:962/1490 train_time:42399ms step_avg:44.07ms
+step:963/1490 train_time:42453ms step_avg:44.08ms
+step:964/1490 train_time:42513ms step_avg:44.10ms
+step:965/1490 train_time:42567ms step_avg:44.11ms
+step:966/1490 train_time:42627ms step_avg:44.13ms
+step:967/1490 train_time:42681ms step_avg:44.14ms
+step:968/1490 train_time:42744ms step_avg:44.16ms
+step:969/1490 train_time:42822ms step_avg:44.19ms
+step:970/1490 train_time:42909ms step_avg:44.24ms
+step:971/1490 train_time:42990ms step_avg:44.27ms
+step:972/1490 train_time:43074ms step_avg:44.32ms
+step:973/1490 train_time:43154ms step_avg:44.35ms
+step:974/1490 train_time:43239ms step_avg:44.39ms
+step:975/1490 train_time:43320ms step_avg:44.43ms
+step:976/1490 train_time:43406ms step_avg:44.47ms
+step:977/1490 train_time:43487ms step_avg:44.51ms
+step:978/1490 train_time:43573ms step_avg:44.55ms
+step:979/1490 train_time:43653ms step_avg:44.59ms
+step:980/1490 train_time:43738ms step_avg:44.63ms
+step:981/1490 train_time:43818ms step_avg:44.67ms
+step:982/1490 train_time:43903ms step_avg:44.71ms
+step:983/1490 train_time:43984ms step_avg:44.74ms
+step:984/1490 train_time:44072ms step_avg:44.79ms
+step:985/1490 train_time:44153ms step_avg:44.82ms
+step:986/1490 train_time:44238ms step_avg:44.87ms
+step:987/1490 train_time:44318ms step_avg:44.90ms
+step:988/1490 train_time:44402ms step_avg:44.94ms
+step:989/1490 train_time:44483ms step_avg:44.98ms
+step:990/1490 train_time:44569ms step_avg:45.02ms
+step:991/1490 train_time:44650ms step_avg:45.06ms
+step:992/1490 train_time:44737ms step_avg:45.10ms
+step:993/1490 train_time:44815ms step_avg:45.13ms
+step:994/1490 train_time:44900ms step_avg:45.17ms
+step:995/1490 train_time:44981ms step_avg:45.21ms
+step:996/1490 train_time:45066ms step_avg:45.25ms
+step:997/1490 train_time:45145ms step_avg:45.28ms
+step:998/1490 train_time:45231ms step_avg:45.32ms
+step:999/1490 train_time:45310ms step_avg:45.36ms
+step:1000/1490 train_time:45395ms step_avg:45.39ms
+step:1000/1490 val_loss:3.5169 train_time:45498ms step_avg:45.50ms
+step:1001/1490 train_time:45517ms step_avg:45.47ms
+step:1002/1490 train_time:45565ms step_avg:45.47ms
+step:1003/1490 train_time:45650ms step_avg:45.51ms
+step:1004/1490 train_time:45738ms step_avg:45.56ms
+step:1005/1490 train_time:45819ms step_avg:45.59ms
+step:1006/1490 train_time:45902ms step_avg:45.63ms
+step:1007/1490 train_time:45983ms step_avg:45.66ms
+step:1008/1490 train_time:46067ms step_avg:45.70ms
+step:1009/1490 train_time:46147ms step_avg:45.74ms
+step:1010/1490 train_time:46231ms step_avg:45.77ms
+step:1011/1490 train_time:46311ms step_avg:45.81ms
+step:1012/1490 train_time:46396ms step_avg:45.85ms
+step:1013/1490 train_time:46479ms step_avg:45.88ms
+step:1014/1490 train_time:46568ms step_avg:45.92ms
+step:1015/1490 train_time:46650ms step_avg:45.96ms
+step:1016/1490 train_time:46735ms step_avg:46.00ms
+step:1017/1490 train_time:46816ms step_avg:46.03ms
+step:1018/1490 train_time:46902ms step_avg:46.07ms
+step:1019/1490 train_time:46980ms step_avg:46.10ms
+step:1020/1490 train_time:47066ms step_avg:46.14ms
+step:1021/1490 train_time:47146ms step_avg:46.18ms
+step:1022/1490 train_time:47231ms step_avg:46.21ms
+step:1023/1490 train_time:47309ms step_avg:46.25ms
+step:1024/1490 train_time:47394ms step_avg:46.28ms
+step:1025/1490 train_time:47475ms step_avg:46.32ms
+step:1026/1490 train_time:47564ms step_avg:46.36ms
+step:1027/1490 train_time:47647ms step_avg:46.39ms
+step:1028/1490 train_time:47732ms step_avg:46.43ms
+step:1029/1490 train_time:47812ms step_avg:46.46ms
+step:1030/1490 train_time:47897ms step_avg:46.50ms
+step:1031/1490 train_time:47978ms step_avg:46.54ms
+step:1032/1490 train_time:48065ms step_avg:46.57ms
+step:1033/1490 train_time:48144ms step_avg:46.61ms
+step:1034/1490 train_time:48229ms step_avg:46.64ms
+step:1035/1490 train_time:48307ms step_avg:46.67ms
+step:1036/1490 train_time:48394ms step_avg:46.71ms
+step:1037/1490 train_time:48475ms step_avg:46.75ms
+step:1038/1490 train_time:48562ms step_avg:46.78ms
+step:1039/1490 train_time:48644ms step_avg:46.82ms
+step:1040/1490 train_time:48728ms step_avg:46.85ms
+step:1041/1490 train_time:48808ms step_avg:46.89ms
+step:1042/1490 train_time:48895ms step_avg:46.92ms
+step:1043/1490 train_time:48976ms step_avg:46.96ms
+step:1044/1490 train_time:49062ms step_avg:46.99ms
+step:1045/1490 train_time:49141ms step_avg:47.02ms
+step:1046/1490 train_time:49226ms step_avg:47.06ms
+step:1047/1490 train_time:49305ms step_avg:47.09ms
+step:1048/1490 train_time:49391ms step_avg:47.13ms
+step:1049/1490 train_time:49470ms step_avg:47.16ms
+step:1050/1490 train_time:49557ms step_avg:47.20ms
+step:1051/1490 train_time:49639ms step_avg:47.23ms
+step:1052/1490 train_time:49726ms step_avg:47.27ms
+step:1053/1490 train_time:49805ms step_avg:47.30ms
+step:1054/1490 train_time:49890ms step_avg:47.33ms
+step:1055/1490 train_time:49970ms step_avg:47.36ms
+step:1056/1490 train_time:50055ms step_avg:47.40ms
+step:1057/1490 train_time:50136ms step_avg:47.43ms
+step:1058/1490 train_time:50220ms step_avg:47.47ms
+step:1059/1490 train_time:50300ms step_avg:47.50ms
+step:1060/1490 train_time:50385ms step_avg:47.53ms
+step:1061/1490 train_time:50465ms step_avg:47.56ms
+step:1062/1490 train_time:50552ms step_avg:47.60ms
+step:1063/1490 train_time:50632ms step_avg:47.63ms
+step:1064/1490 train_time:50718ms step_avg:47.67ms
+step:1065/1490 train_time:50798ms step_avg:47.70ms
+step:1066/1490 train_time:50883ms step_avg:47.73ms
+step:1067/1490 train_time:50963ms step_avg:47.76ms
+step:1068/1490 train_time:51048ms step_avg:47.80ms
+step:1069/1490 train_time:51127ms step_avg:47.83ms
+step:1070/1490 train_time:51213ms step_avg:47.86ms
+step:1071/1490 train_time:51292ms step_avg:47.89ms
+step:1072/1490 train_time:51378ms step_avg:47.93ms
+step:1073/1490 train_time:51458ms step_avg:47.96ms
+step:1074/1490 train_time:51545ms step_avg:47.99ms
+step:1075/1490 train_time:51626ms step_avg:48.02ms
+step:1076/1490 train_time:51711ms step_avg:48.06ms
+step:1077/1490 train_time:51791ms step_avg:48.09ms
+step:1078/1490 train_time:51878ms step_avg:48.12ms
+step:1079/1490 train_time:51958ms step_avg:48.15ms
+step:1080/1490 train_time:52045ms step_avg:48.19ms
+step:1081/1490 train_time:52123ms step_avg:48.22ms
+step:1082/1490 train_time:52207ms step_avg:48.25ms
+step:1083/1490 train_time:52287ms step_avg:48.28ms
+step:1084/1490 train_time:52373ms step_avg:48.31ms
+step:1085/1490 train_time:52454ms step_avg:48.34ms
+step:1086/1490 train_time:52539ms step_avg:48.38ms
+step:1087/1490 train_time:52619ms step_avg:48.41ms
+step:1088/1490 train_time:52705ms step_avg:48.44ms
+step:1089/1490 train_time:52786ms step_avg:48.47ms
+step:1090/1490 train_time:52873ms step_avg:48.51ms
+step:1091/1490 train_time:52954ms step_avg:48.54ms
+step:1092/1490 train_time:53040ms step_avg:48.57ms
+step:1093/1490 train_time:53120ms step_avg:48.60ms
+step:1094/1490 train_time:53204ms step_avg:48.63ms
+step:1095/1490 train_time:53286ms step_avg:48.66ms
+step:1096/1490 train_time:53371ms step_avg:48.70ms
+step:1097/1490 train_time:53451ms step_avg:48.72ms
+step:1098/1490 train_time:53535ms step_avg:48.76ms
+step:1099/1490 train_time:53616ms step_avg:48.79ms
+step:1100/1490 train_time:53702ms step_avg:48.82ms
+step:1101/1490 train_time:53782ms step_avg:48.85ms
+step:1102/1490 train_time:53868ms step_avg:48.88ms
+step:1103/1490 train_time:53949ms step_avg:48.91ms
+step:1104/1490 train_time:54035ms step_avg:48.94ms
+step:1105/1490 train_time:54115ms step_avg:48.97ms
+step:1106/1490 train_time:54199ms step_avg:49.00ms
+step:1107/1490 train_time:54280ms step_avg:49.03ms
+step:1108/1490 train_time:54367ms step_avg:49.07ms
+step:1109/1490 train_time:54447ms step_avg:49.10ms
+step:1110/1490 train_time:54531ms step_avg:49.13ms
+step:1111/1490 train_time:54610ms step_avg:49.15ms
+step:1112/1490 train_time:54696ms step_avg:49.19ms
+step:1113/1490 train_time:54779ms step_avg:49.22ms
+step:1114/1490 train_time:54864ms step_avg:49.25ms
+step:1115/1490 train_time:54945ms step_avg:49.28ms
+step:1116/1490 train_time:55030ms step_avg:49.31ms
+step:1117/1490 train_time:55109ms step_avg:49.34ms
+step:1118/1490 train_time:55195ms step_avg:49.37ms
+step:1119/1490 train_time:55277ms step_avg:49.40ms
+step:1120/1490 train_time:55364ms step_avg:49.43ms
+step:1121/1490 train_time:55443ms step_avg:49.46ms
+step:1122/1490 train_time:55528ms step_avg:49.49ms
+step:1123/1490 train_time:55607ms step_avg:49.52ms
+step:1124/1490 train_time:55693ms step_avg:49.55ms
+step:1125/1490 train_time:55775ms step_avg:49.58ms
+step:1126/1490 train_time:55862ms step_avg:49.61ms
+step:1127/1490 train_time:55942ms step_avg:49.64ms
+step:1128/1490 train_time:56026ms step_avg:49.67ms
+step:1129/1490 train_time:56106ms step_avg:49.70ms
+step:1130/1490 train_time:56192ms step_avg:49.73ms
+step:1131/1490 train_time:56272ms step_avg:49.75ms
+step:1132/1490 train_time:56359ms step_avg:49.79ms
+step:1133/1490 train_time:56438ms step_avg:49.81ms
+step:1134/1490 train_time:56522ms step_avg:49.84ms
+step:1135/1490 train_time:56602ms step_avg:49.87ms
+step:1136/1490 train_time:56689ms step_avg:49.90ms
+step:1137/1490 train_time:56769ms step_avg:49.93ms
+step:1138/1490 train_time:56855ms step_avg:49.96ms
+step:1139/1490 train_time:56935ms step_avg:49.99ms
+step:1140/1490 train_time:57020ms step_avg:50.02ms
+step:1141/1490 train_time:57100ms step_avg:50.04ms
+step:1142/1490 train_time:57186ms step_avg:50.08ms
+step:1143/1490 train_time:57265ms step_avg:50.10ms
+step:1144/1490 train_time:57351ms step_avg:50.13ms
+step:1145/1490 train_time:57431ms step_avg:50.16ms
+step:1146/1490 train_time:57517ms step_avg:50.19ms
+step:1147/1490 train_time:57596ms step_avg:50.21ms
+step:1148/1490 train_time:57683ms step_avg:50.25ms
+step:1149/1490 train_time:57764ms step_avg:50.27ms
+step:1150/1490 train_time:57849ms step_avg:50.30ms
+step:1151/1490 train_time:57928ms step_avg:50.33ms
+step:1152/1490 train_time:58012ms step_avg:50.36ms
+step:1153/1490 train_time:58092ms step_avg:50.38ms
+step:1154/1490 train_time:58180ms step_avg:50.42ms
+step:1155/1490 train_time:58261ms step_avg:50.44ms
+step:1156/1490 train_time:58346ms step_avg:50.47ms
+step:1157/1490 train_time:58425ms step_avg:50.50ms
+step:1158/1490 train_time:58510ms step_avg:50.53ms
+step:1159/1490 train_time:58590ms step_avg:50.55ms
+step:1160/1490 train_time:58676ms step_avg:50.58ms
+step:1161/1490 train_time:58755ms step_avg:50.61ms
+step:1162/1490 train_time:58842ms step_avg:50.64ms
+step:1163/1490 train_time:58922ms step_avg:50.66ms
+step:1164/1490 train_time:59006ms step_avg:50.69ms
+step:1165/1490 train_time:59086ms step_avg:50.72ms
+step:1166/1490 train_time:59173ms step_avg:50.75ms
+step:1167/1490 train_time:59255ms step_avg:50.78ms
+step:1168/1490 train_time:59340ms step_avg:50.80ms
+step:1169/1490 train_time:59419ms step_avg:50.83ms
+step:1170/1490 train_time:59505ms step_avg:50.86ms
+step:1171/1490 train_time:59585ms step_avg:50.88ms
+step:1172/1490 train_time:59671ms step_avg:50.91ms
+step:1173/1490 train_time:59751ms step_avg:50.94ms
+step:1174/1490 train_time:59836ms step_avg:50.97ms
+step:1175/1490 train_time:59915ms step_avg:50.99ms
+step:1176/1490 train_time:60001ms step_avg:51.02ms
+step:1177/1490 train_time:60082ms step_avg:51.05ms
+step:1178/1490 train_time:60168ms step_avg:51.08ms
+step:1179/1490 train_time:60248ms step_avg:51.10ms
+step:1180/1490 train_time:60334ms step_avg:51.13ms
+step:1181/1490 train_time:60414ms step_avg:51.16ms
+step:1182/1490 train_time:60499ms step_avg:51.18ms
+step:1183/1490 train_time:60578ms step_avg:51.21ms
+step:1184/1490 train_time:60667ms step_avg:51.24ms
+step:1185/1490 train_time:60747ms step_avg:51.26ms
+step:1186/1490 train_time:60832ms step_avg:51.29ms
+step:1187/1490 train_time:60911ms step_avg:51.31ms
+step:1188/1490 train_time:60996ms step_avg:51.34ms
+step:1189/1490 train_time:61076ms step_avg:51.37ms
+step:1190/1490 train_time:61163ms step_avg:51.40ms
+step:1191/1490 train_time:61244ms step_avg:51.42ms
+step:1192/1490 train_time:61328ms step_avg:51.45ms
+step:1193/1490 train_time:61407ms step_avg:51.47ms
+step:1194/1490 train_time:61493ms step_avg:51.50ms
+step:1195/1490 train_time:61574ms step_avg:51.53ms
+step:1196/1490 train_time:61660ms step_avg:51.55ms
+step:1197/1490 train_time:61740ms step_avg:51.58ms
+step:1198/1490 train_time:61825ms step_avg:51.61ms
+step:1199/1490 train_time:61904ms step_avg:51.63ms
+step:1200/1490 train_time:61991ms step_avg:51.66ms
+step:1201/1490 train_time:62071ms step_avg:51.68ms
+step:1202/1490 train_time:62159ms step_avg:51.71ms
+step:1203/1490 train_time:62238ms step_avg:51.74ms
+step:1204/1490 train_time:62325ms step_avg:51.76ms
+step:1205/1490 train_time:62404ms step_avg:51.79ms
+step:1206/1490 train_time:62489ms step_avg:51.82ms
+step:1207/1490 train_time:62569ms step_avg:51.84ms
+step:1208/1490 train_time:62655ms step_avg:51.87ms
+step:1209/1490 train_time:62734ms step_avg:51.89ms
+step:1210/1490 train_time:62819ms step_avg:51.92ms
+step:1211/1490 train_time:62899ms step_avg:51.94ms
+step:1212/1490 train_time:62984ms step_avg:51.97ms
+step:1213/1490 train_time:63064ms step_avg:51.99ms
+step:1214/1490 train_time:63152ms step_avg:52.02ms
+step:1215/1490 train_time:63232ms step_avg:52.04ms
+step:1216/1490 train_time:63318ms step_avg:52.07ms
+step:1217/1490 train_time:63399ms step_avg:52.09ms
+step:1218/1490 train_time:63483ms step_avg:52.12ms
+step:1219/1490 train_time:63565ms step_avg:52.14ms
+step:1220/1490 train_time:63650ms step_avg:52.17ms
+step:1221/1490 train_time:63729ms step_avg:52.19ms
+step:1222/1490 train_time:63814ms step_avg:52.22ms
+step:1223/1490 train_time:63895ms step_avg:52.24ms
+step:1224/1490 train_time:63982ms step_avg:52.27ms
+step:1225/1490 train_time:64064ms step_avg:52.30ms
+step:1226/1490 train_time:64148ms step_avg:52.32ms
+step:1227/1490 train_time:64227ms step_avg:52.34ms
+step:1228/1490 train_time:64312ms step_avg:52.37ms
+step:1229/1490 train_time:64394ms step_avg:52.40ms
+step:1230/1490 train_time:64479ms step_avg:52.42ms
+step:1231/1490 train_time:64560ms step_avg:52.45ms
+step:1232/1490 train_time:64647ms step_avg:52.47ms
+step:1233/1490 train_time:64726ms step_avg:52.50ms
+step:1234/1490 train_time:64810ms step_avg:52.52ms
+step:1235/1490 train_time:64890ms step_avg:52.54ms
+step:1236/1490 train_time:64976ms step_avg:52.57ms
+step:1237/1490 train_time:65057ms step_avg:52.59ms
+step:1238/1490 train_time:65143ms step_avg:52.62ms
+step:1239/1490 train_time:65223ms step_avg:52.64ms
+step:1240/1490 train_time:65307ms step_avg:52.67ms
+step:1241/1490 train_time:65387ms step_avg:52.69ms
+step:1242/1490 train_time:65472ms step_avg:52.72ms
+step:1243/1490 train_time:65553ms step_avg:52.74ms
+step:1244/1490 train_time:65640ms step_avg:52.76ms
+step:1245/1490 train_time:65718ms step_avg:52.79ms
+step:1246/1490 train_time:65804ms step_avg:52.81ms
+step:1247/1490 train_time:65883ms step_avg:52.83ms
+step:1248/1490 train_time:65969ms step_avg:52.86ms
+step:1249/1490 train_time:66051ms step_avg:52.88ms
+step:1250/1490 train_time:66137ms step_avg:52.91ms
+step:1250/1490 val_loss:3.3724 train_time:66240ms step_avg:52.99ms
+step:1251/1490 train_time:66256ms step_avg:52.96ms
+step:1252/1490 train_time:66304ms step_avg:52.96ms
+step:1253/1490 train_time:66391ms step_avg:52.99ms
+step:1254/1490 train_time:66478ms step_avg:53.01ms
+step:1255/1490 train_time:66559ms step_avg:53.04ms
+step:1256/1490 train_time:66644ms step_avg:53.06ms
+step:1257/1490 train_time:66723ms step_avg:53.08ms
+step:1258/1490 train_time:66807ms step_avg:53.11ms
+step:1259/1490 train_time:66887ms step_avg:53.13ms
+step:1260/1490 train_time:66972ms step_avg:53.15ms
+step:1261/1490 train_time:67051ms step_avg:53.17ms
+step:1262/1490 train_time:67135ms step_avg:53.20ms
+step:1263/1490 train_time:67217ms step_avg:53.22ms
+step:1264/1490 train_time:67304ms step_avg:53.25ms
+step:1265/1490 train_time:67387ms step_avg:53.27ms
+step:1266/1490 train_time:67475ms step_avg:53.30ms
+step:1267/1490 train_time:67557ms step_avg:53.32ms
+step:1268/1490 train_time:67642ms step_avg:53.35ms
+step:1269/1490 train_time:67720ms step_avg:53.37ms
+step:1270/1490 train_time:67805ms step_avg:53.39ms
+step:1271/1490 train_time:67885ms step_avg:53.41ms
+step:1272/1490 train_time:67970ms step_avg:53.44ms
+step:1273/1490 train_time:68049ms step_avg:53.46ms
+step:1274/1490 train_time:68135ms step_avg:53.48ms
+step:1275/1490 train_time:68214ms step_avg:53.50ms
+step:1276/1490 train_time:68302ms step_avg:53.53ms
+step:1277/1490 train_time:68384ms step_avg:53.55ms
+step:1278/1490 train_time:68470ms step_avg:53.58ms
+step:1279/1490 train_time:68551ms step_avg:53.60ms
+step:1280/1490 train_time:68636ms step_avg:53.62ms
+step:1281/1490 train_time:68715ms step_avg:53.64ms
+step:1282/1490 train_time:68800ms step_avg:53.67ms
+step:1283/1490 train_time:68880ms step_avg:53.69ms
+step:1284/1490 train_time:68965ms step_avg:53.71ms
+step:1285/1490 train_time:69046ms step_avg:53.73ms
+step:1286/1490 train_time:69130ms step_avg:53.76ms
+step:1287/1490 train_time:69211ms step_avg:53.78ms
+step:1288/1490 train_time:69300ms step_avg:53.80ms
+step:1289/1490 train_time:69381ms step_avg:53.83ms
+step:1290/1490 train_time:69467ms step_avg:53.85ms
+step:1291/1490 train_time:69548ms step_avg:53.87ms
+step:1292/1490 train_time:69633ms step_avg:53.90ms
+step:1293/1490 train_time:69712ms step_avg:53.91ms
+step:1294/1490 train_time:69798ms step_avg:53.94ms
+step:1295/1490 train_time:69877ms step_avg:53.96ms
+step:1296/1490 train_time:69962ms step_avg:53.98ms
+step:1297/1490 train_time:70041ms step_avg:54.00ms
+step:1298/1490 train_time:70125ms step_avg:54.03ms
+step:1299/1490 train_time:70206ms step_avg:54.05ms
+step:1300/1490 train_time:70293ms step_avg:54.07ms
+step:1301/1490 train_time:70375ms step_avg:54.09ms
+step:1302/1490 train_time:70460ms step_avg:54.12ms
+step:1303/1490 train_time:70540ms step_avg:54.14ms
+step:1304/1490 train_time:70625ms step_avg:54.16ms
+step:1305/1490 train_time:70706ms step_avg:54.18ms
+step:1306/1490 train_time:70791ms step_avg:54.20ms
+step:1307/1490 train_time:70871ms step_avg:54.22ms
+step:1308/1490 train_time:70956ms step_avg:54.25ms
+step:1309/1490 train_time:71036ms step_avg:54.27ms
+step:1310/1490 train_time:71120ms step_avg:54.29ms
+step:1311/1490 train_time:71200ms step_avg:54.31ms
+step:1312/1490 train_time:71286ms step_avg:54.33ms
+step:1313/1490 train_time:71369ms step_avg:54.36ms
+step:1314/1490 train_time:71455ms step_avg:54.38ms
+step:1315/1490 train_time:71536ms step_avg:54.40ms
+step:1316/1490 train_time:71621ms step_avg:54.42ms
+step:1317/1490 train_time:71701ms step_avg:54.44ms
+step:1318/1490 train_time:71786ms step_avg:54.47ms
+step:1319/1490 train_time:71868ms step_avg:54.49ms
+step:1320/1490 train_time:71952ms step_avg:54.51ms
+step:1321/1490 train_time:72032ms step_avg:54.53ms
+step:1322/1490 train_time:72117ms step_avg:54.55ms
+step:1323/1490 train_time:72198ms step_avg:54.57ms
+step:1324/1490 train_time:72283ms step_avg:54.59ms
+step:1325/1490 train_time:72365ms step_avg:54.62ms
+step:1326/1490 train_time:72450ms step_avg:54.64ms
+step:1327/1490 train_time:72530ms step_avg:54.66ms
+step:1328/1490 train_time:72616ms step_avg:54.68ms
+step:1329/1490 train_time:72697ms step_avg:54.70ms
+step:1330/1490 train_time:72783ms step_avg:54.72ms
+step:1331/1490 train_time:72863ms step_avg:54.74ms
+step:1332/1490 train_time:72949ms step_avg:54.77ms
+step:1333/1490 train_time:73029ms step_avg:54.79ms
+step:1334/1490 train_time:73115ms step_avg:54.81ms
+step:1335/1490 train_time:73196ms step_avg:54.83ms
+step:1336/1490 train_time:73282ms step_avg:54.85ms
+step:1337/1490 train_time:73362ms step_avg:54.87ms
+step:1338/1490 train_time:73447ms step_avg:54.89ms
+step:1339/1490 train_time:73529ms step_avg:54.91ms
+step:1340/1490 train_time:73614ms step_avg:54.94ms
+step:1341/1490 train_time:73693ms step_avg:54.95ms
+step:1342/1490 train_time:73779ms step_avg:54.98ms
+step:1343/1490 train_time:73859ms step_avg:55.00ms
+step:1344/1490 train_time:73944ms step_avg:55.02ms
+step:1345/1490 train_time:74024ms step_avg:55.04ms
+step:1346/1490 train_time:74110ms step_avg:55.06ms
+step:1347/1490 train_time:74191ms step_avg:55.08ms
+step:1348/1490 train_time:74277ms step_avg:55.10ms
+step:1349/1490 train_time:74358ms step_avg:55.12ms
+step:1350/1490 train_time:74443ms step_avg:55.14ms
+step:1351/1490 train_time:74522ms step_avg:55.16ms
+step:1352/1490 train_time:74608ms step_avg:55.18ms
+step:1353/1490 train_time:74689ms step_avg:55.20ms
+step:1354/1490 train_time:74774ms step_avg:55.22ms
+step:1355/1490 train_time:74854ms step_avg:55.24ms
+step:1356/1490 train_time:74940ms step_avg:55.27ms
+step:1357/1490 train_time:75019ms step_avg:55.28ms
+step:1358/1490 train_time:75104ms step_avg:55.30ms
+step:1359/1490 train_time:75186ms step_avg:55.32ms
+step:1360/1490 train_time:75273ms step_avg:55.35ms
+step:1361/1490 train_time:75353ms step_avg:55.37ms
+step:1362/1490 train_time:75437ms step_avg:55.39ms
+step:1363/1490 train_time:75517ms step_avg:55.41ms
+step:1364/1490 train_time:75602ms step_avg:55.43ms
+step:1365/1490 train_time:75683ms step_avg:55.45ms
+step:1366/1490 train_time:75769ms step_avg:55.47ms
+step:1367/1490 train_time:75850ms step_avg:55.49ms
+step:1368/1490 train_time:75935ms step_avg:55.51ms
+step:1369/1490 train_time:76013ms step_avg:55.52ms
+step:1370/1490 train_time:76100ms step_avg:55.55ms
+step:1371/1490 train_time:76180ms step_avg:55.57ms
+step:1372/1490 train_time:76266ms step_avg:55.59ms
+step:1373/1490 train_time:76347ms step_avg:55.61ms
+step:1374/1490 train_time:76432ms step_avg:55.63ms
+step:1375/1490 train_time:76512ms step_avg:55.65ms
+step:1376/1490 train_time:76597ms step_avg:55.67ms
+step:1377/1490 train_time:76677ms step_avg:55.68ms
+step:1378/1490 train_time:76763ms step_avg:55.71ms
+step:1379/1490 train_time:76843ms step_avg:55.72ms
+step:1380/1490 train_time:76929ms step_avg:55.75ms
+step:1381/1490 train_time:77010ms step_avg:55.76ms
+step:1382/1490 train_time:77095ms step_avg:55.78ms
+step:1383/1490 train_time:77175ms step_avg:55.80ms
+step:1384/1490 train_time:77262ms step_avg:55.82ms
+step:1385/1490 train_time:77341ms step_avg:55.84ms
+step:1386/1490 train_time:77426ms step_avg:55.86ms
+step:1387/1490 train_time:77508ms step_avg:55.88ms
+step:1388/1490 train_time:77596ms step_avg:55.90ms
+step:1389/1490 train_time:77675ms step_avg:55.92ms
+step:1390/1490 train_time:77762ms step_avg:55.94ms
+step:1391/1490 train_time:77841ms step_avg:55.96ms
+step:1392/1490 train_time:77927ms step_avg:55.98ms
+step:1393/1490 train_time:78009ms step_avg:56.00ms
+step:1394/1490 train_time:78095ms step_avg:56.02ms
+step:1395/1490 train_time:78174ms step_avg:56.04ms
+step:1396/1490 train_time:78261ms step_avg:56.06ms
+step:1397/1490 train_time:78340ms step_avg:56.08ms
+step:1398/1490 train_time:78424ms step_avg:56.10ms
+step:1399/1490 train_time:78506ms step_avg:56.12ms
+step:1400/1490 train_time:78592ms step_avg:56.14ms
+step:1401/1490 train_time:78673ms step_avg:56.15ms
+step:1402/1490 train_time:78759ms step_avg:56.18ms
+step:1403/1490 train_time:78839ms step_avg:56.19ms
+step:1404/1490 train_time:78924ms step_avg:56.21ms
+step:1405/1490 train_time:79006ms step_avg:56.23ms
+step:1406/1490 train_time:79092ms step_avg:56.25ms
+step:1407/1490 train_time:79173ms step_avg:56.27ms
+step:1408/1490 train_time:79258ms step_avg:56.29ms
+step:1409/1490 train_time:79337ms step_avg:56.31ms
+step:1410/1490 train_time:79422ms step_avg:56.33ms
+step:1411/1490 train_time:79503ms step_avg:56.34ms
+step:1412/1490 train_time:79588ms step_avg:56.37ms
+step:1413/1490 train_time:79670ms step_avg:56.38ms
+step:1414/1490 train_time:79756ms step_avg:56.40ms
+step:1415/1490 train_time:79836ms step_avg:56.42ms
+step:1416/1490 train_time:79922ms step_avg:56.44ms
+step:1417/1490 train_time:80001ms step_avg:56.46ms
+step:1418/1490 train_time:80087ms step_avg:56.48ms
+step:1419/1490 train_time:80169ms step_avg:56.50ms
+step:1420/1490 train_time:80255ms step_avg:56.52ms
+step:1421/1490 train_time:80334ms step_avg:56.53ms
+step:1422/1490 train_time:80420ms step_avg:56.55ms
+step:1423/1490 train_time:80500ms step_avg:56.57ms
+step:1424/1490 train_time:80585ms step_avg:56.59ms
+step:1425/1490 train_time:80666ms step_avg:56.61ms
+step:1426/1490 train_time:80753ms step_avg:56.63ms
+step:1427/1490 train_time:80834ms step_avg:56.65ms
+step:1428/1490 train_time:80917ms step_avg:56.66ms
+step:1429/1490 train_time:80997ms step_avg:56.68ms
+step:1430/1490 train_time:81084ms step_avg:56.70ms
+step:1431/1490 train_time:81165ms step_avg:56.72ms
+step:1432/1490 train_time:81250ms step_avg:56.74ms
+step:1433/1490 train_time:81329ms step_avg:56.75ms
+step:1434/1490 train_time:81415ms step_avg:56.78ms
+step:1435/1490 train_time:81494ms step_avg:56.79ms
+step:1436/1490 train_time:81581ms step_avg:56.81ms
+step:1437/1490 train_time:81661ms step_avg:56.83ms
+step:1438/1490 train_time:81747ms step_avg:56.85ms
+step:1439/1490 train_time:81827ms step_avg:56.86ms
+step:1440/1490 train_time:81914ms step_avg:56.88ms
+step:1441/1490 train_time:81994ms step_avg:56.90ms
+step:1442/1490 train_time:82080ms step_avg:56.92ms
+step:1443/1490 train_time:82160ms step_avg:56.94ms
+step:1444/1490 train_time:82245ms step_avg:56.96ms
+step:1445/1490 train_time:82326ms step_avg:56.97ms
+step:1446/1490 train_time:82412ms step_avg:56.99ms
+step:1447/1490 train_time:82493ms step_avg:57.01ms
+step:1448/1490 train_time:82578ms step_avg:57.03ms
+step:1449/1490 train_time:82658ms step_avg:57.04ms
+step:1450/1490 train_time:82743ms step_avg:57.06ms
+step:1451/1490 train_time:82828ms step_avg:57.08ms
+step:1452/1490 train_time:82917ms step_avg:57.11ms
+step:1453/1490 train_time:82997ms step_avg:57.12ms
+step:1454/1490 train_time:83084ms step_avg:57.14ms
+step:1455/1490 train_time:83164ms step_avg:57.16ms
+step:1456/1490 train_time:83250ms step_avg:57.18ms
+step:1457/1490 train_time:83330ms step_avg:57.19ms
+step:1458/1490 train_time:83417ms step_avg:57.21ms
+step:1459/1490 train_time:83498ms step_avg:57.23ms
+step:1460/1490 train_time:83584ms step_avg:57.25ms
+step:1461/1490 train_time:83665ms step_avg:57.27ms
+step:1462/1490 train_time:83750ms step_avg:57.28ms
+step:1463/1490 train_time:83831ms step_avg:57.30ms
+step:1464/1490 train_time:83917ms step_avg:57.32ms
+step:1465/1490 train_time:83998ms step_avg:57.34ms
+step:1466/1490 train_time:84083ms step_avg:57.36ms
+step:1467/1490 train_time:84164ms step_avg:57.37ms
+step:1468/1490 train_time:84249ms step_avg:57.39ms
+step:1469/1490 train_time:84329ms step_avg:57.41ms
+step:1470/1490 train_time:84414ms step_avg:57.42ms
+step:1471/1490 train_time:84495ms step_avg:57.44ms
+step:1472/1490 train_time:84582ms step_avg:57.46ms
+step:1473/1490 train_time:84663ms step_avg:57.48ms
+step:1474/1490 train_time:84750ms step_avg:57.50ms
+step:1475/1490 train_time:84830ms step_avg:57.51ms
+step:1476/1490 train_time:84916ms step_avg:57.53ms
+step:1477/1490 train_time:84997ms step_avg:57.55ms
+step:1478/1490 train_time:85083ms step_avg:57.57ms
+step:1479/1490 train_time:85164ms step_avg:57.58ms
+step:1480/1490 train_time:85250ms step_avg:57.60ms
+step:1481/1490 train_time:85330ms step_avg:57.62ms
+step:1482/1490 train_time:85417ms step_avg:57.64ms
+step:1483/1490 train_time:85498ms step_avg:57.65ms
+step:1484/1490 train_time:85584ms step_avg:57.67ms
+step:1485/1490 train_time:85665ms step_avg:57.69ms
+step:1486/1490 train_time:85751ms step_avg:57.71ms
+step:1487/1490 train_time:85830ms step_avg:57.72ms
+step:1488/1490 train_time:85916ms step_avg:57.74ms
+step:1489/1490 train_time:85998ms step_avg:57.76ms
+step:1490/1490 train_time:86082ms step_avg:57.77ms
+step:1490/1490 val_loss:3.2798 train_time:86186ms step_avg:57.84ms
+peak memory allocated: 31296 MiB reserved: 47042 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/muon-beta2/2026-03-22_19-23-54_time-187_secs_04-muon-beta2_2c309d.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/muon-beta2/2026-03-22_19-23-54_time-187_secs_04-muon-beta2_2c309d.txt
@@ -1,0 +1,4456 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,  # from nanochat autoresearch (was 0.95)
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 19:24:09 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   33C    P0            117W /  700W |    1520MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   31C    P0            117W /  700W |    1520MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   29C    P0            119W /  700W |    1520MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   32C    P0            123W /  700W |    1520MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   31C    P0            116W /  700W |    1520MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   29C    P0            114W /  700W |    1520MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   31C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   28C    P0            114W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1642696      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1642697      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1642698      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1642699      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1642700      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1642701      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1642702      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1642703      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8288 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:86ms step_avg:85.55ms
+step:2/1490 train_time:109ms step_avg:54.30ms
+step:3/1490 train_time:126ms step_avg:42.03ms
+step:4/1490 train_time:148ms step_avg:37.04ms
+step:5/1490 train_time:175ms step_avg:35.07ms
+step:6/1490 train_time:210ms step_avg:35.03ms
+step:7/1490 train_time:238ms step_avg:33.95ms
+step:8/1490 train_time:273ms step_avg:34.08ms
+step:9/1490 train_time:300ms step_avg:33.32ms
+step:10/1490 train_time:335ms step_avg:33.47ms
+step:11/1490 train_time:362ms step_avg:32.95ms
+step:12/1490 train_time:397ms step_avg:33.10ms
+step:13/1490 train_time:425ms step_avg:32.72ms
+step:14/1490 train_time:460ms step_avg:32.86ms
+step:15/1490 train_time:488ms step_avg:32.56ms
+step:16/1490 train_time:523ms step_avg:32.69ms
+step:17/1490 train_time:551ms step_avg:32.42ms
+step:18/1490 train_time:586ms step_avg:32.53ms
+step:19/1490 train_time:614ms step_avg:32.31ms
+step:20/1490 train_time:648ms step_avg:32.41ms
+step:21/1490 train_time:676ms step_avg:32.21ms
+step:22/1490 train_time:711ms step_avg:32.31ms
+step:23/1490 train_time:739ms step_avg:32.12ms
+step:24/1490 train_time:774ms step_avg:32.23ms
+step:25/1490 train_time:802ms step_avg:32.07ms
+step:26/1490 train_time:836ms step_avg:32.16ms
+step:27/1490 train_time:865ms step_avg:32.02ms
+step:28/1490 train_time:899ms step_avg:32.12ms
+step:29/1490 train_time:928ms step_avg:31.99ms
+step:30/1490 train_time:963ms step_avg:32.09ms
+step:31/1490 train_time:991ms step_avg:31.98ms
+step:32/1490 train_time:1027ms step_avg:32.08ms
+step:33/1490 train_time:1056ms step_avg:31.99ms
+step:34/1490 train_time:1090ms step_avg:32.07ms
+step:35/1490 train_time:1119ms step_avg:31.97ms
+step:36/1490 train_time:1154ms step_avg:32.06ms
+step:37/1490 train_time:1183ms step_avg:31.97ms
+step:38/1490 train_time:1217ms step_avg:32.04ms
+step:39/1490 train_time:1246ms step_avg:31.95ms
+step:40/1490 train_time:1281ms step_avg:32.02ms
+step:41/1490 train_time:1310ms step_avg:31.94ms
+step:42/1490 train_time:1344ms step_avg:32.00ms
+step:43/1490 train_time:1373ms step_avg:31.92ms
+step:44/1490 train_time:1407ms step_avg:31.98ms
+step:45/1490 train_time:1435ms step_avg:31.90ms
+step:46/1490 train_time:1471ms step_avg:31.97ms
+step:47/1490 train_time:1499ms step_avg:31.89ms
+step:48/1490 train_time:1533ms step_avg:31.94ms
+step:49/1490 train_time:1562ms step_avg:31.87ms
+step:50/1490 train_time:1597ms step_avg:31.94ms
+step:51/1490 train_time:1626ms step_avg:31.88ms
+step:52/1490 train_time:1660ms step_avg:31.92ms
+step:53/1490 train_time:1688ms step_avg:31.85ms
+step:54/1490 train_time:1723ms step_avg:31.90ms
+step:55/1490 train_time:1751ms step_avg:31.83ms
+step:56/1490 train_time:1785ms step_avg:31.88ms
+step:57/1490 train_time:1813ms step_avg:31.82ms
+step:58/1490 train_time:1848ms step_avg:31.86ms
+step:59/1490 train_time:1877ms step_avg:31.81ms
+step:60/1490 train_time:1911ms step_avg:31.86ms
+step:61/1490 train_time:1940ms step_avg:31.80ms
+step:62/1490 train_time:1975ms step_avg:31.85ms
+step:63/1490 train_time:2003ms step_avg:31.79ms
+step:64/1490 train_time:2038ms step_avg:31.84ms
+step:65/1490 train_time:2067ms step_avg:31.79ms
+step:66/1490 train_time:2102ms step_avg:31.84ms
+step:67/1490 train_time:2130ms step_avg:31.80ms
+step:68/1490 train_time:2165ms step_avg:31.84ms
+step:69/1490 train_time:2193ms step_avg:31.78ms
+step:70/1490 train_time:2227ms step_avg:31.82ms
+step:71/1490 train_time:2256ms step_avg:31.77ms
+step:72/1490 train_time:2291ms step_avg:31.81ms
+step:73/1490 train_time:2319ms step_avg:31.77ms
+step:74/1490 train_time:2354ms step_avg:31.81ms
+step:75/1490 train_time:2382ms step_avg:31.76ms
+step:76/1490 train_time:2417ms step_avg:31.80ms
+step:77/1490 train_time:2445ms step_avg:31.76ms
+step:78/1490 train_time:2480ms step_avg:31.80ms
+step:79/1490 train_time:2509ms step_avg:31.75ms
+step:80/1490 train_time:2543ms step_avg:31.79ms
+step:81/1490 train_time:2572ms step_avg:31.75ms
+step:82/1490 train_time:2606ms step_avg:31.78ms
+step:83/1490 train_time:2634ms step_avg:31.74ms
+step:84/1490 train_time:2669ms step_avg:31.78ms
+step:85/1490 train_time:2697ms step_avg:31.73ms
+step:86/1490 train_time:2732ms step_avg:31.76ms
+step:87/1490 train_time:2760ms step_avg:31.72ms
+step:88/1490 train_time:2794ms step_avg:31.75ms
+step:89/1490 train_time:2823ms step_avg:31.72ms
+step:90/1490 train_time:2857ms step_avg:31.75ms
+step:91/1490 train_time:2886ms step_avg:31.71ms
+step:92/1490 train_time:2920ms step_avg:31.74ms
+step:93/1490 train_time:2949ms step_avg:31.70ms
+step:94/1490 train_time:2983ms step_avg:31.73ms
+step:95/1490 train_time:3011ms step_avg:31.70ms
+step:96/1490 train_time:3046ms step_avg:31.72ms
+step:97/1490 train_time:3074ms step_avg:31.69ms
+step:98/1490 train_time:3109ms step_avg:31.72ms
+step:99/1490 train_time:3137ms step_avg:31.69ms
+step:100/1490 train_time:3172ms step_avg:31.72ms
+step:101/1490 train_time:3200ms step_avg:31.68ms
+step:102/1490 train_time:3235ms step_avg:31.71ms
+step:103/1490 train_time:3263ms step_avg:31.68ms
+step:104/1490 train_time:3298ms step_avg:31.71ms
+step:105/1490 train_time:3327ms step_avg:31.68ms
+step:106/1490 train_time:3361ms step_avg:31.71ms
+step:107/1490 train_time:3390ms step_avg:31.69ms
+step:108/1490 train_time:3425ms step_avg:31.71ms
+step:109/1490 train_time:3454ms step_avg:31.68ms
+step:110/1490 train_time:3488ms step_avg:31.71ms
+step:111/1490 train_time:3517ms step_avg:31.68ms
+step:112/1490 train_time:3551ms step_avg:31.71ms
+step:113/1490 train_time:3579ms step_avg:31.67ms
+step:114/1490 train_time:3614ms step_avg:31.70ms
+step:115/1490 train_time:3642ms step_avg:31.67ms
+step:116/1490 train_time:3678ms step_avg:31.70ms
+step:117/1490 train_time:3706ms step_avg:31.67ms
+step:118/1490 train_time:3740ms step_avg:31.70ms
+step:119/1490 train_time:3768ms step_avg:31.67ms
+step:120/1490 train_time:3803ms step_avg:31.69ms
+step:121/1490 train_time:3831ms step_avg:31.66ms
+step:122/1490 train_time:3866ms step_avg:31.69ms
+step:123/1490 train_time:3894ms step_avg:31.66ms
+step:124/1490 train_time:3928ms step_avg:31.68ms
+step:125/1490 train_time:3956ms step_avg:31.65ms
+step:126/1490 train_time:3992ms step_avg:31.68ms
+step:127/1490 train_time:4020ms step_avg:31.65ms
+step:128/1490 train_time:4054ms step_avg:31.67ms
+step:129/1490 train_time:4083ms step_avg:31.65ms
+step:130/1490 train_time:4117ms step_avg:31.67ms
+step:131/1490 train_time:4146ms step_avg:31.65ms
+step:132/1490 train_time:4180ms step_avg:31.67ms
+step:133/1490 train_time:4209ms step_avg:31.64ms
+step:134/1490 train_time:4243ms step_avg:31.66ms
+step:135/1490 train_time:4271ms step_avg:31.64ms
+step:136/1490 train_time:4306ms step_avg:31.66ms
+step:137/1490 train_time:4334ms step_avg:31.64ms
+step:138/1490 train_time:4368ms step_avg:31.65ms
+step:139/1490 train_time:4397ms step_avg:31.63ms
+step:140/1490 train_time:4432ms step_avg:31.66ms
+step:141/1490 train_time:4460ms step_avg:31.63ms
+step:142/1490 train_time:4495ms step_avg:31.65ms
+step:143/1490 train_time:4523ms step_avg:31.63ms
+step:144/1490 train_time:4558ms step_avg:31.65ms
+step:145/1490 train_time:4586ms step_avg:31.63ms
+step:146/1490 train_time:4621ms step_avg:31.65ms
+step:147/1490 train_time:4649ms step_avg:31.62ms
+step:148/1490 train_time:4683ms step_avg:31.64ms
+step:149/1490 train_time:4712ms step_avg:31.62ms
+step:150/1490 train_time:4746ms step_avg:31.64ms
+step:151/1490 train_time:4774ms step_avg:31.62ms
+step:152/1490 train_time:4808ms step_avg:31.63ms
+step:153/1490 train_time:4837ms step_avg:31.61ms
+step:154/1490 train_time:4872ms step_avg:31.64ms
+step:155/1490 train_time:4900ms step_avg:31.61ms
+step:156/1490 train_time:4935ms step_avg:31.63ms
+step:157/1490 train_time:4963ms step_avg:31.61ms
+step:158/1490 train_time:4998ms step_avg:31.63ms
+step:159/1490 train_time:5026ms step_avg:31.61ms
+step:160/1490 train_time:5061ms step_avg:31.63ms
+step:161/1490 train_time:5089ms step_avg:31.61ms
+step:162/1490 train_time:5123ms step_avg:31.63ms
+step:163/1490 train_time:5152ms step_avg:31.61ms
+step:164/1490 train_time:5187ms step_avg:31.63ms
+step:165/1490 train_time:5215ms step_avg:31.61ms
+step:166/1490 train_time:5250ms step_avg:31.63ms
+step:167/1490 train_time:5278ms step_avg:31.61ms
+step:168/1490 train_time:5313ms step_avg:31.63ms
+step:169/1490 train_time:5341ms step_avg:31.60ms
+step:170/1490 train_time:5376ms step_avg:31.62ms
+step:171/1490 train_time:5404ms step_avg:31.60ms
+step:172/1490 train_time:5439ms step_avg:31.62ms
+step:173/1490 train_time:5468ms step_avg:31.61ms
+step:174/1490 train_time:5502ms step_avg:31.62ms
+step:175/1490 train_time:5531ms step_avg:31.60ms
+step:176/1490 train_time:5565ms step_avg:31.62ms
+step:177/1490 train_time:5593ms step_avg:31.60ms
+step:178/1490 train_time:5628ms step_avg:31.62ms
+step:179/1490 train_time:5656ms step_avg:31.60ms
+step:180/1490 train_time:5691ms step_avg:31.62ms
+step:181/1490 train_time:5719ms step_avg:31.60ms
+step:182/1490 train_time:5754ms step_avg:31.62ms
+step:183/1490 train_time:5782ms step_avg:31.60ms
+step:184/1490 train_time:5817ms step_avg:31.61ms
+step:185/1490 train_time:5845ms step_avg:31.60ms
+step:186/1490 train_time:5880ms step_avg:31.61ms
+step:187/1490 train_time:5908ms step_avg:31.59ms
+step:188/1490 train_time:5943ms step_avg:31.61ms
+step:189/1490 train_time:5971ms step_avg:31.59ms
+step:190/1490 train_time:6005ms step_avg:31.61ms
+step:191/1490 train_time:6033ms step_avg:31.59ms
+step:192/1490 train_time:6068ms step_avg:31.60ms
+step:193/1490 train_time:6096ms step_avg:31.59ms
+step:194/1490 train_time:6132ms step_avg:31.61ms
+step:195/1490 train_time:6160ms step_avg:31.59ms
+step:196/1490 train_time:6194ms step_avg:31.60ms
+step:197/1490 train_time:6223ms step_avg:31.59ms
+step:198/1490 train_time:6258ms step_avg:31.60ms
+step:199/1490 train_time:6286ms step_avg:31.59ms
+step:200/1490 train_time:6320ms step_avg:31.60ms
+step:201/1490 train_time:6349ms step_avg:31.59ms
+step:202/1490 train_time:6384ms step_avg:31.60ms
+step:203/1490 train_time:6412ms step_avg:31.59ms
+step:204/1490 train_time:6447ms step_avg:31.60ms
+step:205/1490 train_time:6475ms step_avg:31.59ms
+step:206/1490 train_time:6509ms step_avg:31.60ms
+step:207/1490 train_time:6538ms step_avg:31.58ms
+step:208/1490 train_time:6572ms step_avg:31.60ms
+step:209/1490 train_time:6600ms step_avg:31.58ms
+step:210/1490 train_time:6635ms step_avg:31.59ms
+step:211/1490 train_time:6663ms step_avg:31.58ms
+step:212/1490 train_time:6698ms step_avg:31.59ms
+step:213/1490 train_time:6726ms step_avg:31.58ms
+step:214/1490 train_time:6761ms step_avg:31.59ms
+step:215/1490 train_time:6789ms step_avg:31.58ms
+step:216/1490 train_time:6823ms step_avg:31.59ms
+step:217/1490 train_time:6852ms step_avg:31.58ms
+step:218/1490 train_time:6887ms step_avg:31.59ms
+step:219/1490 train_time:6914ms step_avg:31.57ms
+step:220/1490 train_time:6949ms step_avg:31.58ms
+step:221/1490 train_time:6977ms step_avg:31.57ms
+step:222/1490 train_time:7011ms step_avg:31.58ms
+step:223/1490 train_time:7039ms step_avg:31.57ms
+step:224/1490 train_time:7074ms step_avg:31.58ms
+step:225/1490 train_time:7102ms step_avg:31.57ms
+step:226/1490 train_time:7137ms step_avg:31.58ms
+step:227/1490 train_time:7166ms step_avg:31.57ms
+step:228/1490 train_time:7201ms step_avg:31.58ms
+step:229/1490 train_time:7229ms step_avg:31.57ms
+step:230/1490 train_time:7263ms step_avg:31.58ms
+step:231/1490 train_time:7292ms step_avg:31.57ms
+step:232/1490 train_time:7326ms step_avg:31.58ms
+step:233/1490 train_time:7355ms step_avg:31.56ms
+step:234/1490 train_time:7389ms step_avg:31.58ms
+step:235/1490 train_time:7417ms step_avg:31.56ms
+step:236/1490 train_time:7452ms step_avg:31.58ms
+step:237/1490 train_time:7480ms step_avg:31.56ms
+step:238/1490 train_time:7515ms step_avg:31.58ms
+step:239/1490 train_time:7543ms step_avg:31.56ms
+step:240/1490 train_time:7578ms step_avg:31.58ms
+step:241/1490 train_time:7606ms step_avg:31.56ms
+step:242/1490 train_time:7641ms step_avg:31.57ms
+step:243/1490 train_time:7669ms step_avg:31.56ms
+step:244/1490 train_time:7704ms step_avg:31.57ms
+step:245/1490 train_time:7732ms step_avg:31.56ms
+step:246/1490 train_time:7766ms step_avg:31.57ms
+step:247/1490 train_time:7795ms step_avg:31.56ms
+step:248/1490 train_time:7829ms step_avg:31.57ms
+step:249/1490 train_time:7857ms step_avg:31.56ms
+step:250/1490 train_time:7892ms step_avg:31.57ms
+step:250/1490 val_loss:4.5109 train_time:7935ms step_avg:31.74ms
+step:251/1490 train_time:7955ms step_avg:31.69ms
+step:252/1490 train_time:7975ms step_avg:31.65ms
+step:253/1490 train_time:7989ms step_avg:31.58ms
+step:254/1490 train_time:8022ms step_avg:31.58ms
+step:255/1490 train_time:8052ms step_avg:31.57ms
+step:256/1490 train_time:8087ms step_avg:31.59ms
+step:257/1490 train_time:8115ms step_avg:31.58ms
+step:258/1490 train_time:8150ms step_avg:31.59ms
+step:259/1490 train_time:8178ms step_avg:31.58ms
+step:260/1490 train_time:8213ms step_avg:31.59ms
+step:261/1490 train_time:8241ms step_avg:31.58ms
+step:262/1490 train_time:8276ms step_avg:31.59ms
+step:263/1490 train_time:8304ms step_avg:31.57ms
+step:264/1490 train_time:8339ms step_avg:31.59ms
+step:265/1490 train_time:8367ms step_avg:31.57ms
+step:266/1490 train_time:8401ms step_avg:31.58ms
+step:267/1490 train_time:8429ms step_avg:31.57ms
+step:268/1490 train_time:8464ms step_avg:31.58ms
+step:269/1490 train_time:8492ms step_avg:31.57ms
+step:270/1490 train_time:8526ms step_avg:31.58ms
+step:271/1490 train_time:8554ms step_avg:31.57ms
+step:272/1490 train_time:8588ms step_avg:31.57ms
+step:273/1490 train_time:8617ms step_avg:31.56ms
+step:274/1490 train_time:8651ms step_avg:31.57ms
+step:275/1490 train_time:8679ms step_avg:31.56ms
+step:276/1490 train_time:8714ms step_avg:31.57ms
+step:277/1490 train_time:8742ms step_avg:31.56ms
+step:278/1490 train_time:8776ms step_avg:31.57ms
+step:279/1490 train_time:8804ms step_avg:31.56ms
+step:280/1490 train_time:8839ms step_avg:31.57ms
+step:281/1490 train_time:8867ms step_avg:31.55ms
+step:282/1490 train_time:8901ms step_avg:31.56ms
+step:283/1490 train_time:8930ms step_avg:31.56ms
+step:284/1490 train_time:8965ms step_avg:31.57ms
+step:285/1490 train_time:8993ms step_avg:31.56ms
+step:286/1490 train_time:9028ms step_avg:31.57ms
+step:287/1490 train_time:9057ms step_avg:31.56ms
+step:288/1490 train_time:9092ms step_avg:31.57ms
+step:289/1490 train_time:9120ms step_avg:31.56ms
+step:290/1490 train_time:9155ms step_avg:31.57ms
+step:291/1490 train_time:9183ms step_avg:31.56ms
+step:292/1490 train_time:9218ms step_avg:31.57ms
+step:293/1490 train_time:9247ms step_avg:31.56ms
+step:294/1490 train_time:9281ms step_avg:31.57ms
+step:295/1490 train_time:9309ms step_avg:31.56ms
+step:296/1490 train_time:9344ms step_avg:31.57ms
+step:297/1490 train_time:9372ms step_avg:31.56ms
+step:298/1490 train_time:9406ms step_avg:31.57ms
+step:299/1490 train_time:9435ms step_avg:31.56ms
+step:300/1490 train_time:9470ms step_avg:31.57ms
+step:301/1490 train_time:9498ms step_avg:31.56ms
+step:302/1490 train_time:9533ms step_avg:31.57ms
+step:303/1490 train_time:9561ms step_avg:31.55ms
+step:304/1490 train_time:9595ms step_avg:31.56ms
+step:305/1490 train_time:9624ms step_avg:31.55ms
+step:306/1490 train_time:9658ms step_avg:31.56ms
+step:307/1490 train_time:9686ms step_avg:31.55ms
+step:308/1490 train_time:9721ms step_avg:31.56ms
+step:309/1490 train_time:9749ms step_avg:31.55ms
+step:310/1490 train_time:9784ms step_avg:31.56ms
+step:311/1490 train_time:9812ms step_avg:31.55ms
+step:312/1490 train_time:9846ms step_avg:31.56ms
+step:313/1490 train_time:9874ms step_avg:31.55ms
+step:314/1490 train_time:9908ms step_avg:31.55ms
+step:315/1490 train_time:9937ms step_avg:31.54ms
+step:316/1490 train_time:9972ms step_avg:31.56ms
+step:317/1490 train_time:10000ms step_avg:31.55ms
+step:318/1490 train_time:10035ms step_avg:31.56ms
+step:319/1490 train_time:10064ms step_avg:31.55ms
+step:320/1490 train_time:10099ms step_avg:31.56ms
+step:321/1490 train_time:10127ms step_avg:31.55ms
+step:322/1490 train_time:10162ms step_avg:31.56ms
+step:323/1490 train_time:10191ms step_avg:31.55ms
+step:324/1490 train_time:10225ms step_avg:31.56ms
+step:325/1490 train_time:10254ms step_avg:31.55ms
+step:326/1490 train_time:10288ms step_avg:31.56ms
+step:327/1490 train_time:10317ms step_avg:31.55ms
+step:328/1490 train_time:10351ms step_avg:31.56ms
+step:329/1490 train_time:10379ms step_avg:31.55ms
+step:330/1490 train_time:10414ms step_avg:31.56ms
+step:331/1490 train_time:10442ms step_avg:31.55ms
+step:332/1490 train_time:10477ms step_avg:31.56ms
+step:333/1490 train_time:10505ms step_avg:31.55ms
+step:334/1490 train_time:10540ms step_avg:31.56ms
+step:335/1490 train_time:10568ms step_avg:31.55ms
+step:336/1490 train_time:10602ms step_avg:31.55ms
+step:337/1490 train_time:10630ms step_avg:31.54ms
+step:338/1490 train_time:10665ms step_avg:31.55ms
+step:339/1490 train_time:10693ms step_avg:31.54ms
+step:340/1490 train_time:10727ms step_avg:31.55ms
+step:341/1490 train_time:10756ms step_avg:31.54ms
+step:342/1490 train_time:10790ms step_avg:31.55ms
+step:343/1490 train_time:10818ms step_avg:31.54ms
+step:344/1490 train_time:10853ms step_avg:31.55ms
+step:345/1490 train_time:10881ms step_avg:31.54ms
+step:346/1490 train_time:10915ms step_avg:31.55ms
+step:347/1490 train_time:10944ms step_avg:31.54ms
+step:348/1490 train_time:10978ms step_avg:31.55ms
+step:349/1490 train_time:11006ms step_avg:31.54ms
+step:350/1490 train_time:11042ms step_avg:31.55ms
+step:351/1490 train_time:11070ms step_avg:31.54ms
+step:352/1490 train_time:11105ms step_avg:31.55ms
+step:353/1490 train_time:11133ms step_avg:31.54ms
+step:354/1490 train_time:11168ms step_avg:31.55ms
+step:355/1490 train_time:11196ms step_avg:31.54ms
+step:356/1490 train_time:11231ms step_avg:31.55ms
+step:357/1490 train_time:11259ms step_avg:31.54ms
+step:358/1490 train_time:11294ms step_avg:31.55ms
+step:359/1490 train_time:11322ms step_avg:31.54ms
+step:360/1490 train_time:11357ms step_avg:31.55ms
+step:361/1490 train_time:11385ms step_avg:31.54ms
+step:362/1490 train_time:11420ms step_avg:31.55ms
+step:363/1490 train_time:11448ms step_avg:31.54ms
+step:364/1490 train_time:11483ms step_avg:31.55ms
+step:365/1490 train_time:11511ms step_avg:31.54ms
+step:366/1490 train_time:11546ms step_avg:31.55ms
+step:367/1490 train_time:11574ms step_avg:31.54ms
+step:368/1490 train_time:11608ms step_avg:31.54ms
+step:369/1490 train_time:11636ms step_avg:31.53ms
+step:370/1490 train_time:11671ms step_avg:31.54ms
+step:371/1490 train_time:11699ms step_avg:31.53ms
+step:372/1490 train_time:11734ms step_avg:31.54ms
+step:373/1490 train_time:11762ms step_avg:31.53ms
+step:374/1490 train_time:11796ms step_avg:31.54ms
+step:375/1490 train_time:11825ms step_avg:31.53ms
+step:376/1490 train_time:11859ms step_avg:31.54ms
+step:377/1490 train_time:11888ms step_avg:31.53ms
+step:378/1490 train_time:11922ms step_avg:31.54ms
+step:379/1490 train_time:11950ms step_avg:31.53ms
+step:380/1490 train_time:11985ms step_avg:31.54ms
+step:381/1490 train_time:12013ms step_avg:31.53ms
+step:382/1490 train_time:12048ms step_avg:31.54ms
+step:383/1490 train_time:12076ms step_avg:31.53ms
+step:384/1490 train_time:12110ms step_avg:31.54ms
+step:385/1490 train_time:12139ms step_avg:31.53ms
+step:386/1490 train_time:12174ms step_avg:31.54ms
+step:387/1490 train_time:12202ms step_avg:31.53ms
+step:388/1490 train_time:12237ms step_avg:31.54ms
+step:389/1490 train_time:12265ms step_avg:31.53ms
+step:390/1490 train_time:12300ms step_avg:31.54ms
+step:391/1490 train_time:12328ms step_avg:31.53ms
+step:392/1490 train_time:12363ms step_avg:31.54ms
+step:393/1490 train_time:12391ms step_avg:31.53ms
+step:394/1490 train_time:12425ms step_avg:31.54ms
+step:395/1490 train_time:12453ms step_avg:31.53ms
+step:396/1490 train_time:12487ms step_avg:31.53ms
+step:397/1490 train_time:12516ms step_avg:31.53ms
+step:398/1490 train_time:12550ms step_avg:31.53ms
+step:399/1490 train_time:12578ms step_avg:31.52ms
+step:400/1490 train_time:12613ms step_avg:31.53ms
+step:401/1490 train_time:12641ms step_avg:31.52ms
+step:402/1490 train_time:12676ms step_avg:31.53ms
+step:403/1490 train_time:12703ms step_avg:31.52ms
+step:404/1490 train_time:12738ms step_avg:31.53ms
+step:405/1490 train_time:12766ms step_avg:31.52ms
+step:406/1490 train_time:12801ms step_avg:31.53ms
+step:407/1490 train_time:12830ms step_avg:31.52ms
+step:408/1490 train_time:12864ms step_avg:31.53ms
+step:409/1490 train_time:12893ms step_avg:31.52ms
+step:410/1490 train_time:12927ms step_avg:31.53ms
+step:411/1490 train_time:12955ms step_avg:31.52ms
+step:412/1490 train_time:12990ms step_avg:31.53ms
+step:413/1490 train_time:13018ms step_avg:31.52ms
+step:414/1490 train_time:13052ms step_avg:31.53ms
+step:415/1490 train_time:13080ms step_avg:31.52ms
+step:416/1490 train_time:13115ms step_avg:31.53ms
+step:417/1490 train_time:13143ms step_avg:31.52ms
+step:418/1490 train_time:13178ms step_avg:31.53ms
+step:419/1490 train_time:13207ms step_avg:31.52ms
+step:420/1490 train_time:13242ms step_avg:31.53ms
+step:421/1490 train_time:13270ms step_avg:31.52ms
+step:422/1490 train_time:13304ms step_avg:31.53ms
+step:423/1490 train_time:13333ms step_avg:31.52ms
+step:424/1490 train_time:13367ms step_avg:31.53ms
+step:425/1490 train_time:13395ms step_avg:31.52ms
+step:426/1490 train_time:13430ms step_avg:31.53ms
+step:427/1490 train_time:13458ms step_avg:31.52ms
+step:428/1490 train_time:13493ms step_avg:31.53ms
+step:429/1490 train_time:13521ms step_avg:31.52ms
+step:430/1490 train_time:13556ms step_avg:31.53ms
+step:431/1490 train_time:13585ms step_avg:31.52ms
+step:432/1490 train_time:13619ms step_avg:31.53ms
+step:433/1490 train_time:13648ms step_avg:31.52ms
+step:434/1490 train_time:13682ms step_avg:31.53ms
+step:435/1490 train_time:13710ms step_avg:31.52ms
+step:436/1490 train_time:13745ms step_avg:31.53ms
+step:437/1490 train_time:13773ms step_avg:31.52ms
+step:438/1490 train_time:13807ms step_avg:31.52ms
+step:439/1490 train_time:13836ms step_avg:31.52ms
+step:440/1490 train_time:13870ms step_avg:31.52ms
+step:441/1490 train_time:13898ms step_avg:31.51ms
+step:442/1490 train_time:13933ms step_avg:31.52ms
+step:443/1490 train_time:13961ms step_avg:31.52ms
+step:444/1490 train_time:13996ms step_avg:31.52ms
+step:445/1490 train_time:14025ms step_avg:31.52ms
+step:446/1490 train_time:14059ms step_avg:31.52ms
+step:447/1490 train_time:14088ms step_avg:31.52ms
+step:448/1490 train_time:14122ms step_avg:31.52ms
+step:449/1490 train_time:14151ms step_avg:31.52ms
+step:450/1490 train_time:14185ms step_avg:31.52ms
+step:451/1490 train_time:14213ms step_avg:31.52ms
+step:452/1490 train_time:14248ms step_avg:31.52ms
+step:453/1490 train_time:14276ms step_avg:31.51ms
+step:454/1490 train_time:14310ms step_avg:31.52ms
+step:455/1490 train_time:14339ms step_avg:31.51ms
+step:456/1490 train_time:14373ms step_avg:31.52ms
+step:457/1490 train_time:14401ms step_avg:31.51ms
+step:458/1490 train_time:14436ms step_avg:31.52ms
+step:459/1490 train_time:14464ms step_avg:31.51ms
+step:460/1490 train_time:14499ms step_avg:31.52ms
+step:461/1490 train_time:14527ms step_avg:31.51ms
+step:462/1490 train_time:14562ms step_avg:31.52ms
+step:463/1490 train_time:14590ms step_avg:31.51ms
+step:464/1490 train_time:14625ms step_avg:31.52ms
+step:465/1490 train_time:14653ms step_avg:31.51ms
+step:466/1490 train_time:14687ms step_avg:31.52ms
+step:467/1490 train_time:14716ms step_avg:31.51ms
+step:468/1490 train_time:14751ms step_avg:31.52ms
+step:469/1490 train_time:14778ms step_avg:31.51ms
+step:470/1490 train_time:14813ms step_avg:31.52ms
+step:471/1490 train_time:14841ms step_avg:31.51ms
+step:472/1490 train_time:14876ms step_avg:31.52ms
+step:473/1490 train_time:14904ms step_avg:31.51ms
+step:474/1490 train_time:14939ms step_avg:31.52ms
+step:475/1490 train_time:14967ms step_avg:31.51ms
+step:476/1490 train_time:15001ms step_avg:31.52ms
+step:477/1490 train_time:15030ms step_avg:31.51ms
+step:478/1490 train_time:15064ms step_avg:31.52ms
+step:479/1490 train_time:15093ms step_avg:31.51ms
+step:480/1490 train_time:15127ms step_avg:31.51ms
+step:481/1490 train_time:15155ms step_avg:31.51ms
+step:482/1490 train_time:15190ms step_avg:31.51ms
+step:483/1490 train_time:15219ms step_avg:31.51ms
+step:484/1490 train_time:15256ms step_avg:31.52ms
+step:485/1490 train_time:15308ms step_avg:31.56ms
+step:486/1490 train_time:15368ms step_avg:31.62ms
+step:487/1490 train_time:15422ms step_avg:31.67ms
+step:488/1490 train_time:15481ms step_avg:31.72ms
+step:489/1490 train_time:15536ms step_avg:31.77ms
+step:490/1490 train_time:15595ms step_avg:31.83ms
+step:491/1490 train_time:15650ms step_avg:31.87ms
+step:492/1490 train_time:15709ms step_avg:31.93ms
+step:493/1490 train_time:15763ms step_avg:31.97ms
+step:494/1490 train_time:15822ms step_avg:32.03ms
+step:495/1490 train_time:15877ms step_avg:32.07ms
+step:496/1490 train_time:15938ms step_avg:32.13ms
+step:497/1490 train_time:15993ms step_avg:32.18ms
+step:498/1490 train_time:16052ms step_avg:32.23ms
+step:499/1490 train_time:16107ms step_avg:32.28ms
+step:500/1490 train_time:16167ms step_avg:32.33ms
+step:500/1490 val_loss:4.2097 train_time:16240ms step_avg:32.48ms
+step:501/1490 train_time:16258ms step_avg:32.45ms
+step:502/1490 train_time:16284ms step_avg:32.44ms
+step:503/1490 train_time:16341ms step_avg:32.49ms
+step:504/1490 train_time:16403ms step_avg:32.55ms
+step:505/1490 train_time:16458ms step_avg:32.59ms
+step:506/1490 train_time:16518ms step_avg:32.64ms
+step:507/1490 train_time:16572ms step_avg:32.69ms
+step:508/1490 train_time:16632ms step_avg:32.74ms
+step:509/1490 train_time:16686ms step_avg:32.78ms
+step:510/1490 train_time:16745ms step_avg:32.83ms
+step:511/1490 train_time:16799ms step_avg:32.87ms
+step:512/1490 train_time:16858ms step_avg:32.93ms
+step:513/1490 train_time:16911ms step_avg:32.97ms
+step:514/1490 train_time:16970ms step_avg:33.02ms
+step:515/1490 train_time:17024ms step_avg:33.06ms
+step:516/1490 train_time:17084ms step_avg:33.11ms
+step:517/1490 train_time:17137ms step_avg:33.15ms
+step:518/1490 train_time:17199ms step_avg:33.20ms
+step:519/1490 train_time:17254ms step_avg:33.25ms
+step:520/1490 train_time:17316ms step_avg:33.30ms
+step:521/1490 train_time:17373ms step_avg:33.35ms
+step:522/1490 train_time:17434ms step_avg:33.40ms
+step:523/1490 train_time:17489ms step_avg:33.44ms
+step:524/1490 train_time:17548ms step_avg:33.49ms
+step:525/1490 train_time:17603ms step_avg:33.53ms
+step:526/1490 train_time:17662ms step_avg:33.58ms
+step:527/1490 train_time:17716ms step_avg:33.62ms
+step:528/1490 train_time:17776ms step_avg:33.67ms
+step:529/1490 train_time:17831ms step_avg:33.71ms
+step:530/1490 train_time:17890ms step_avg:33.76ms
+step:531/1490 train_time:17944ms step_avg:33.79ms
+step:532/1490 train_time:18003ms step_avg:33.84ms
+step:533/1490 train_time:18056ms step_avg:33.88ms
+step:534/1490 train_time:18116ms step_avg:33.93ms
+step:535/1490 train_time:18170ms step_avg:33.96ms
+step:536/1490 train_time:18231ms step_avg:34.01ms
+step:537/1490 train_time:18286ms step_avg:34.05ms
+step:538/1490 train_time:18346ms step_avg:34.10ms
+step:539/1490 train_time:18401ms step_avg:34.14ms
+step:540/1490 train_time:18461ms step_avg:34.19ms
+step:541/1490 train_time:18515ms step_avg:34.22ms
+step:542/1490 train_time:18577ms step_avg:34.27ms
+step:543/1490 train_time:18632ms step_avg:34.31ms
+step:544/1490 train_time:18691ms step_avg:34.36ms
+step:545/1490 train_time:18744ms step_avg:34.39ms
+step:546/1490 train_time:18805ms step_avg:34.44ms
+step:547/1490 train_time:18858ms step_avg:34.48ms
+step:548/1490 train_time:18918ms step_avg:34.52ms
+step:549/1490 train_time:18973ms step_avg:34.56ms
+step:550/1490 train_time:19032ms step_avg:34.60ms
+step:551/1490 train_time:19086ms step_avg:34.64ms
+step:552/1490 train_time:19147ms step_avg:34.69ms
+step:553/1490 train_time:19202ms step_avg:34.72ms
+step:554/1490 train_time:19262ms step_avg:34.77ms
+step:555/1490 train_time:19316ms step_avg:34.80ms
+step:556/1490 train_time:19380ms step_avg:34.86ms
+step:557/1490 train_time:19434ms step_avg:34.89ms
+step:558/1490 train_time:19494ms step_avg:34.94ms
+step:559/1490 train_time:19549ms step_avg:34.97ms
+step:560/1490 train_time:19609ms step_avg:35.02ms
+step:561/1490 train_time:19663ms step_avg:35.05ms
+step:562/1490 train_time:19723ms step_avg:35.09ms
+step:563/1490 train_time:19777ms step_avg:35.13ms
+step:564/1490 train_time:19837ms step_avg:35.17ms
+step:565/1490 train_time:19891ms step_avg:35.20ms
+step:566/1490 train_time:19951ms step_avg:35.25ms
+step:567/1490 train_time:20005ms step_avg:35.28ms
+step:568/1490 train_time:20064ms step_avg:35.32ms
+step:569/1490 train_time:20118ms step_avg:35.36ms
+step:570/1490 train_time:20178ms step_avg:35.40ms
+step:571/1490 train_time:20233ms step_avg:35.43ms
+step:572/1490 train_time:20294ms step_avg:35.48ms
+step:573/1490 train_time:20349ms step_avg:35.51ms
+step:574/1490 train_time:20409ms step_avg:35.56ms
+step:575/1490 train_time:20463ms step_avg:35.59ms
+step:576/1490 train_time:20524ms step_avg:35.63ms
+step:577/1490 train_time:20578ms step_avg:35.66ms
+step:578/1490 train_time:20639ms step_avg:35.71ms
+step:579/1490 train_time:20693ms step_avg:35.74ms
+step:580/1490 train_time:20753ms step_avg:35.78ms
+step:581/1490 train_time:20806ms step_avg:35.81ms
+step:582/1490 train_time:20866ms step_avg:35.85ms
+step:583/1490 train_time:20921ms step_avg:35.88ms
+step:584/1490 train_time:20982ms step_avg:35.93ms
+step:585/1490 train_time:21035ms step_avg:35.96ms
+step:586/1490 train_time:21095ms step_avg:36.00ms
+step:587/1490 train_time:21149ms step_avg:36.03ms
+step:588/1490 train_time:21209ms step_avg:36.07ms
+step:589/1490 train_time:21263ms step_avg:36.10ms
+step:590/1490 train_time:21323ms step_avg:36.14ms
+step:591/1490 train_time:21378ms step_avg:36.17ms
+step:592/1490 train_time:21439ms step_avg:36.21ms
+step:593/1490 train_time:21494ms step_avg:36.25ms
+step:594/1490 train_time:21554ms step_avg:36.29ms
+step:595/1490 train_time:21608ms step_avg:36.32ms
+step:596/1490 train_time:21669ms step_avg:36.36ms
+step:597/1490 train_time:21724ms step_avg:36.39ms
+step:598/1490 train_time:21783ms step_avg:36.43ms
+step:599/1490 train_time:21837ms step_avg:36.46ms
+step:600/1490 train_time:21897ms step_avg:36.50ms
+step:601/1490 train_time:21952ms step_avg:36.53ms
+step:602/1490 train_time:22011ms step_avg:36.56ms
+step:603/1490 train_time:22065ms step_avg:36.59ms
+step:604/1490 train_time:22125ms step_avg:36.63ms
+step:605/1490 train_time:22179ms step_avg:36.66ms
+step:606/1490 train_time:22240ms step_avg:36.70ms
+step:607/1490 train_time:22295ms step_avg:36.73ms
+step:608/1490 train_time:22355ms step_avg:36.77ms
+step:609/1490 train_time:22410ms step_avg:36.80ms
+step:610/1490 train_time:22470ms step_avg:36.84ms
+step:611/1490 train_time:22525ms step_avg:36.87ms
+step:612/1490 train_time:22584ms step_avg:36.90ms
+step:613/1490 train_time:22638ms step_avg:36.93ms
+step:614/1490 train_time:22699ms step_avg:36.97ms
+step:615/1490 train_time:22753ms step_avg:37.00ms
+step:616/1490 train_time:22813ms step_avg:37.03ms
+step:617/1490 train_time:22867ms step_avg:37.06ms
+step:618/1490 train_time:22927ms step_avg:37.10ms
+step:619/1490 train_time:22982ms step_avg:37.13ms
+step:620/1490 train_time:23041ms step_avg:37.16ms
+step:621/1490 train_time:23095ms step_avg:37.19ms
+step:622/1490 train_time:23154ms step_avg:37.23ms
+step:623/1490 train_time:23210ms step_avg:37.25ms
+step:624/1490 train_time:23270ms step_avg:37.29ms
+step:625/1490 train_time:23325ms step_avg:37.32ms
+step:626/1490 train_time:23385ms step_avg:37.36ms
+step:627/1490 train_time:23439ms step_avg:37.38ms
+step:628/1490 train_time:23500ms step_avg:37.42ms
+step:629/1490 train_time:23554ms step_avg:37.45ms
+step:630/1490 train_time:23614ms step_avg:37.48ms
+step:631/1490 train_time:23668ms step_avg:37.51ms
+step:632/1490 train_time:23728ms step_avg:37.54ms
+step:633/1490 train_time:23783ms step_avg:37.57ms
+step:634/1490 train_time:23842ms step_avg:37.61ms
+step:635/1490 train_time:23897ms step_avg:37.63ms
+step:636/1490 train_time:23957ms step_avg:37.67ms
+step:637/1490 train_time:24010ms step_avg:37.69ms
+step:638/1490 train_time:24070ms step_avg:37.73ms
+step:639/1490 train_time:24125ms step_avg:37.75ms
+step:640/1490 train_time:24185ms step_avg:37.79ms
+step:641/1490 train_time:24239ms step_avg:37.81ms
+step:642/1490 train_time:24299ms step_avg:37.85ms
+step:643/1490 train_time:24354ms step_avg:37.87ms
+step:644/1490 train_time:24413ms step_avg:37.91ms
+step:645/1490 train_time:24468ms step_avg:37.94ms
+step:646/1490 train_time:24529ms step_avg:37.97ms
+step:647/1490 train_time:24584ms step_avg:38.00ms
+step:648/1490 train_time:24643ms step_avg:38.03ms
+step:649/1490 train_time:24697ms step_avg:38.05ms
+step:650/1490 train_time:24758ms step_avg:38.09ms
+step:651/1490 train_time:24812ms step_avg:38.11ms
+step:652/1490 train_time:24871ms step_avg:38.15ms
+step:653/1490 train_time:24926ms step_avg:38.17ms
+step:654/1490 train_time:24988ms step_avg:38.21ms
+step:655/1490 train_time:25043ms step_avg:38.23ms
+step:656/1490 train_time:25103ms step_avg:38.27ms
+step:657/1490 train_time:25157ms step_avg:38.29ms
+step:658/1490 train_time:25216ms step_avg:38.32ms
+step:659/1490 train_time:25271ms step_avg:38.35ms
+step:660/1490 train_time:25331ms step_avg:38.38ms
+step:661/1490 train_time:25386ms step_avg:38.40ms
+step:662/1490 train_time:25445ms step_avg:38.44ms
+step:663/1490 train_time:25500ms step_avg:38.46ms
+step:664/1490 train_time:25560ms step_avg:38.49ms
+step:665/1490 train_time:25614ms step_avg:38.52ms
+step:666/1490 train_time:25674ms step_avg:38.55ms
+step:667/1490 train_time:25729ms step_avg:38.57ms
+step:668/1490 train_time:25788ms step_avg:38.60ms
+step:669/1490 train_time:25842ms step_avg:38.63ms
+step:670/1490 train_time:25902ms step_avg:38.66ms
+step:671/1490 train_time:25957ms step_avg:38.68ms
+step:672/1490 train_time:26017ms step_avg:38.72ms
+step:673/1490 train_time:26072ms step_avg:38.74ms
+step:674/1490 train_time:26132ms step_avg:38.77ms
+step:675/1490 train_time:26186ms step_avg:38.79ms
+step:676/1490 train_time:26245ms step_avg:38.82ms
+step:677/1490 train_time:26300ms step_avg:38.85ms
+step:678/1490 train_time:26360ms step_avg:38.88ms
+step:679/1490 train_time:26414ms step_avg:38.90ms
+step:680/1490 train_time:26475ms step_avg:38.93ms
+step:681/1490 train_time:26529ms step_avg:38.96ms
+step:682/1490 train_time:26590ms step_avg:38.99ms
+step:683/1490 train_time:26645ms step_avg:39.01ms
+step:684/1490 train_time:26704ms step_avg:39.04ms
+step:685/1490 train_time:26758ms step_avg:39.06ms
+step:686/1490 train_time:26818ms step_avg:39.09ms
+step:687/1490 train_time:26873ms step_avg:39.12ms
+step:688/1490 train_time:26933ms step_avg:39.15ms
+step:689/1490 train_time:26986ms step_avg:39.17ms
+step:690/1490 train_time:27046ms step_avg:39.20ms
+step:691/1490 train_time:27101ms step_avg:39.22ms
+step:692/1490 train_time:27161ms step_avg:39.25ms
+step:693/1490 train_time:27215ms step_avg:39.27ms
+step:694/1490 train_time:27276ms step_avg:39.30ms
+step:695/1490 train_time:27331ms step_avg:39.33ms
+step:696/1490 train_time:27391ms step_avg:39.36ms
+step:697/1490 train_time:27445ms step_avg:39.38ms
+step:698/1490 train_time:27505ms step_avg:39.41ms
+step:699/1490 train_time:27560ms step_avg:39.43ms
+step:700/1490 train_time:27620ms step_avg:39.46ms
+step:701/1490 train_time:27674ms step_avg:39.48ms
+step:702/1490 train_time:27733ms step_avg:39.51ms
+step:703/1490 train_time:27788ms step_avg:39.53ms
+step:704/1490 train_time:27848ms step_avg:39.56ms
+step:705/1490 train_time:27903ms step_avg:39.58ms
+step:706/1490 train_time:27962ms step_avg:39.61ms
+step:707/1490 train_time:28016ms step_avg:39.63ms
+step:708/1490 train_time:28076ms step_avg:39.66ms
+step:709/1490 train_time:28130ms step_avg:39.68ms
+step:710/1490 train_time:28189ms step_avg:39.70ms
+step:711/1490 train_time:28244ms step_avg:39.72ms
+step:712/1490 train_time:28304ms step_avg:39.75ms
+step:713/1490 train_time:28357ms step_avg:39.77ms
+step:714/1490 train_time:28418ms step_avg:39.80ms
+step:715/1490 train_time:28473ms step_avg:39.82ms
+step:716/1490 train_time:28533ms step_avg:39.85ms
+step:717/1490 train_time:28589ms step_avg:39.87ms
+step:718/1490 train_time:28649ms step_avg:39.90ms
+step:719/1490 train_time:28703ms step_avg:39.92ms
+step:720/1490 train_time:28762ms step_avg:39.95ms
+step:721/1490 train_time:28817ms step_avg:39.97ms
+step:722/1490 train_time:28877ms step_avg:40.00ms
+step:723/1490 train_time:28931ms step_avg:40.02ms
+step:724/1490 train_time:28992ms step_avg:40.04ms
+step:725/1490 train_time:29045ms step_avg:40.06ms
+step:726/1490 train_time:29105ms step_avg:40.09ms
+step:727/1490 train_time:29159ms step_avg:40.11ms
+step:728/1490 train_time:29219ms step_avg:40.14ms
+step:729/1490 train_time:29274ms step_avg:40.16ms
+step:730/1490 train_time:29334ms step_avg:40.18ms
+step:731/1490 train_time:29387ms step_avg:40.20ms
+step:732/1490 train_time:29448ms step_avg:40.23ms
+step:733/1490 train_time:29503ms step_avg:40.25ms
+step:734/1490 train_time:29563ms step_avg:40.28ms
+step:735/1490 train_time:29617ms step_avg:40.30ms
+step:736/1490 train_time:29677ms step_avg:40.32ms
+step:737/1490 train_time:29732ms step_avg:40.34ms
+step:738/1490 train_time:29793ms step_avg:40.37ms
+step:739/1490 train_time:29847ms step_avg:40.39ms
+step:740/1490 train_time:29907ms step_avg:40.42ms
+step:741/1490 train_time:29961ms step_avg:40.43ms
+step:742/1490 train_time:30022ms step_avg:40.46ms
+step:743/1490 train_time:30076ms step_avg:40.48ms
+step:744/1490 train_time:30136ms step_avg:40.50ms
+step:745/1490 train_time:30190ms step_avg:40.52ms
+step:746/1490 train_time:30249ms step_avg:40.55ms
+step:747/1490 train_time:30304ms step_avg:40.57ms
+step:748/1490 train_time:30363ms step_avg:40.59ms
+step:749/1490 train_time:30417ms step_avg:40.61ms
+step:750/1490 train_time:30478ms step_avg:40.64ms
+step:750/1490 val_loss:3.8043 train_time:30550ms step_avg:40.73ms
+step:751/1490 train_time:30566ms step_avg:40.70ms
+step:752/1490 train_time:30593ms step_avg:40.68ms
+step:753/1490 train_time:30648ms step_avg:40.70ms
+step:754/1490 train_time:30711ms step_avg:40.73ms
+step:755/1490 train_time:30766ms step_avg:40.75ms
+step:756/1490 train_time:30826ms step_avg:40.78ms
+step:757/1490 train_time:30881ms step_avg:40.79ms
+step:758/1490 train_time:30940ms step_avg:40.82ms
+step:759/1490 train_time:30993ms step_avg:40.83ms
+step:760/1490 train_time:31052ms step_avg:40.86ms
+step:761/1490 train_time:31106ms step_avg:40.88ms
+step:762/1490 train_time:31166ms step_avg:40.90ms
+step:763/1490 train_time:31219ms step_avg:40.92ms
+step:764/1490 train_time:31278ms step_avg:40.94ms
+step:765/1490 train_time:31332ms step_avg:40.96ms
+step:766/1490 train_time:31391ms step_avg:40.98ms
+step:767/1490 train_time:31447ms step_avg:41.00ms
+step:768/1490 train_time:31507ms step_avg:41.03ms
+step:769/1490 train_time:31563ms step_avg:41.04ms
+step:770/1490 train_time:31624ms step_avg:41.07ms
+step:771/1490 train_time:31678ms step_avg:41.09ms
+step:772/1490 train_time:31740ms step_avg:41.11ms
+step:773/1490 train_time:31795ms step_avg:41.13ms
+step:774/1490 train_time:31854ms step_avg:41.15ms
+step:775/1490 train_time:31909ms step_avg:41.17ms
+step:776/1490 train_time:31968ms step_avg:41.20ms
+step:777/1490 train_time:32022ms step_avg:41.21ms
+step:778/1490 train_time:32081ms step_avg:41.24ms
+step:779/1490 train_time:32135ms step_avg:41.25ms
+step:780/1490 train_time:32194ms step_avg:41.27ms
+step:781/1490 train_time:32247ms step_avg:41.29ms
+step:782/1490 train_time:32307ms step_avg:41.31ms
+step:783/1490 train_time:32360ms step_avg:41.33ms
+step:784/1490 train_time:32420ms step_avg:41.35ms
+step:785/1490 train_time:32474ms step_avg:41.37ms
+step:786/1490 train_time:32534ms step_avg:41.39ms
+step:787/1490 train_time:32589ms step_avg:41.41ms
+step:788/1490 train_time:32650ms step_avg:41.43ms
+step:789/1490 train_time:32705ms step_avg:41.45ms
+step:790/1490 train_time:32764ms step_avg:41.47ms
+step:791/1490 train_time:32818ms step_avg:41.49ms
+step:792/1490 train_time:32879ms step_avg:41.51ms
+step:793/1490 train_time:32933ms step_avg:41.53ms
+step:794/1490 train_time:32992ms step_avg:41.55ms
+step:795/1490 train_time:33046ms step_avg:41.57ms
+step:796/1490 train_time:33106ms step_avg:41.59ms
+step:797/1490 train_time:33159ms step_avg:41.61ms
+step:798/1490 train_time:33219ms step_avg:41.63ms
+step:799/1490 train_time:33274ms step_avg:41.64ms
+step:800/1490 train_time:33333ms step_avg:41.67ms
+step:801/1490 train_time:33387ms step_avg:41.68ms
+step:802/1490 train_time:33447ms step_avg:41.70ms
+step:803/1490 train_time:33502ms step_avg:41.72ms
+step:804/1490 train_time:33562ms step_avg:41.74ms
+step:805/1490 train_time:33618ms step_avg:41.76ms
+step:806/1490 train_time:33678ms step_avg:41.78ms
+step:807/1490 train_time:33732ms step_avg:41.80ms
+step:808/1490 train_time:33792ms step_avg:41.82ms
+step:809/1490 train_time:33847ms step_avg:41.84ms
+step:810/1490 train_time:33907ms step_avg:41.86ms
+step:811/1490 train_time:33961ms step_avg:41.88ms
+step:812/1490 train_time:34021ms step_avg:41.90ms
+step:813/1490 train_time:34075ms step_avg:41.91ms
+step:814/1490 train_time:34135ms step_avg:41.93ms
+step:815/1490 train_time:34188ms step_avg:41.95ms
+step:816/1490 train_time:34248ms step_avg:41.97ms
+step:817/1490 train_time:34302ms step_avg:41.99ms
+step:818/1490 train_time:34362ms step_avg:42.01ms
+step:819/1490 train_time:34416ms step_avg:42.02ms
+step:820/1490 train_time:34475ms step_avg:42.04ms
+step:821/1490 train_time:34529ms step_avg:42.06ms
+step:822/1490 train_time:34589ms step_avg:42.08ms
+step:823/1490 train_time:34644ms step_avg:42.09ms
+step:824/1490 train_time:34704ms step_avg:42.12ms
+step:825/1490 train_time:34758ms step_avg:42.13ms
+step:826/1490 train_time:34818ms step_avg:42.15ms
+step:827/1490 train_time:34872ms step_avg:42.17ms
+step:828/1490 train_time:34932ms step_avg:42.19ms
+step:829/1490 train_time:34986ms step_avg:42.20ms
+step:830/1490 train_time:35046ms step_avg:42.22ms
+step:831/1490 train_time:35101ms step_avg:42.24ms
+step:832/1490 train_time:35161ms step_avg:42.26ms
+step:833/1490 train_time:35215ms step_avg:42.27ms
+step:834/1490 train_time:35275ms step_avg:42.30ms
+step:835/1490 train_time:35328ms step_avg:42.31ms
+step:836/1490 train_time:35389ms step_avg:42.33ms
+step:837/1490 train_time:35443ms step_avg:42.35ms
+step:838/1490 train_time:35503ms step_avg:42.37ms
+step:839/1490 train_time:35557ms step_avg:42.38ms
+step:840/1490 train_time:35618ms step_avg:42.40ms
+step:841/1490 train_time:35672ms step_avg:42.42ms
+step:842/1490 train_time:35732ms step_avg:42.44ms
+step:843/1490 train_time:35786ms step_avg:42.45ms
+step:844/1490 train_time:35846ms step_avg:42.47ms
+step:845/1490 train_time:35900ms step_avg:42.49ms
+step:846/1490 train_time:35961ms step_avg:42.51ms
+step:847/1490 train_time:36015ms step_avg:42.52ms
+step:848/1490 train_time:36075ms step_avg:42.54ms
+step:849/1490 train_time:36129ms step_avg:42.55ms
+step:850/1490 train_time:36188ms step_avg:42.57ms
+step:851/1490 train_time:36243ms step_avg:42.59ms
+step:852/1490 train_time:36303ms step_avg:42.61ms
+step:853/1490 train_time:36357ms step_avg:42.62ms
+step:854/1490 train_time:36416ms step_avg:42.64ms
+step:855/1490 train_time:36470ms step_avg:42.66ms
+step:856/1490 train_time:36530ms step_avg:42.68ms
+step:857/1490 train_time:36585ms step_avg:42.69ms
+step:858/1490 train_time:36644ms step_avg:42.71ms
+step:859/1490 train_time:36699ms step_avg:42.72ms
+step:860/1490 train_time:36759ms step_avg:42.74ms
+step:861/1490 train_time:36813ms step_avg:42.76ms
+step:862/1490 train_time:36873ms step_avg:42.78ms
+step:863/1490 train_time:36928ms step_avg:42.79ms
+step:864/1490 train_time:36987ms step_avg:42.81ms
+step:865/1490 train_time:37042ms step_avg:42.82ms
+step:866/1490 train_time:37103ms step_avg:42.84ms
+step:867/1490 train_time:37157ms step_avg:42.86ms
+step:868/1490 train_time:37216ms step_avg:42.88ms
+step:869/1490 train_time:37271ms step_avg:42.89ms
+step:870/1490 train_time:37330ms step_avg:42.91ms
+step:871/1490 train_time:37384ms step_avg:42.92ms
+step:872/1490 train_time:37443ms step_avg:42.94ms
+step:873/1490 train_time:37498ms step_avg:42.95ms
+step:874/1490 train_time:37559ms step_avg:42.97ms
+step:875/1490 train_time:37613ms step_avg:42.99ms
+step:876/1490 train_time:37674ms step_avg:43.01ms
+step:877/1490 train_time:37728ms step_avg:43.02ms
+step:878/1490 train_time:37789ms step_avg:43.04ms
+step:879/1490 train_time:37844ms step_avg:43.05ms
+step:880/1490 train_time:37904ms step_avg:43.07ms
+step:881/1490 train_time:37957ms step_avg:43.08ms
+step:882/1490 train_time:38017ms step_avg:43.10ms
+step:883/1490 train_time:38072ms step_avg:43.12ms
+step:884/1490 train_time:38131ms step_avg:43.14ms
+step:885/1490 train_time:38186ms step_avg:43.15ms
+step:886/1490 train_time:38245ms step_avg:43.17ms
+step:887/1490 train_time:38299ms step_avg:43.18ms
+step:888/1490 train_time:38360ms step_avg:43.20ms
+step:889/1490 train_time:38414ms step_avg:43.21ms
+step:890/1490 train_time:38473ms step_avg:43.23ms
+step:891/1490 train_time:38527ms step_avg:43.24ms
+step:892/1490 train_time:38588ms step_avg:43.26ms
+step:893/1490 train_time:38643ms step_avg:43.27ms
+step:894/1490 train_time:38703ms step_avg:43.29ms
+step:895/1490 train_time:38757ms step_avg:43.30ms
+step:896/1490 train_time:38817ms step_avg:43.32ms
+step:897/1490 train_time:38872ms step_avg:43.34ms
+step:898/1490 train_time:38931ms step_avg:43.35ms
+step:899/1490 train_time:38984ms step_avg:43.36ms
+step:900/1490 train_time:39045ms step_avg:43.38ms
+step:901/1490 train_time:39099ms step_avg:43.40ms
+step:902/1490 train_time:39159ms step_avg:43.41ms
+step:903/1490 train_time:39213ms step_avg:43.43ms
+step:904/1490 train_time:39273ms step_avg:43.44ms
+step:905/1490 train_time:39327ms step_avg:43.45ms
+step:906/1490 train_time:39387ms step_avg:43.47ms
+step:907/1490 train_time:39441ms step_avg:43.49ms
+step:908/1490 train_time:39502ms step_avg:43.50ms
+step:909/1490 train_time:39556ms step_avg:43.52ms
+step:910/1490 train_time:39616ms step_avg:43.53ms
+step:911/1490 train_time:39671ms step_avg:43.55ms
+step:912/1490 train_time:39731ms step_avg:43.57ms
+step:913/1490 train_time:39786ms step_avg:43.58ms
+step:914/1490 train_time:39845ms step_avg:43.59ms
+step:915/1490 train_time:39899ms step_avg:43.61ms
+step:916/1490 train_time:39960ms step_avg:43.62ms
+step:917/1490 train_time:40014ms step_avg:43.64ms
+step:918/1490 train_time:40073ms step_avg:43.65ms
+step:919/1490 train_time:40128ms step_avg:43.66ms
+step:920/1490 train_time:40187ms step_avg:43.68ms
+step:921/1490 train_time:40241ms step_avg:43.69ms
+step:922/1490 train_time:40302ms step_avg:43.71ms
+step:923/1490 train_time:40356ms step_avg:43.72ms
+step:924/1490 train_time:40416ms step_avg:43.74ms
+step:925/1490 train_time:40471ms step_avg:43.75ms
+step:926/1490 train_time:40530ms step_avg:43.77ms
+step:927/1490 train_time:40584ms step_avg:43.78ms
+step:928/1490 train_time:40644ms step_avg:43.80ms
+step:929/1490 train_time:40697ms step_avg:43.81ms
+step:930/1490 train_time:40759ms step_avg:43.83ms
+step:931/1490 train_time:40813ms step_avg:43.84ms
+step:932/1490 train_time:40873ms step_avg:43.86ms
+step:933/1490 train_time:40927ms step_avg:43.87ms
+step:934/1490 train_time:40988ms step_avg:43.88ms
+step:935/1490 train_time:41043ms step_avg:43.90ms
+step:936/1490 train_time:41103ms step_avg:43.91ms
+step:937/1490 train_time:41157ms step_avg:43.92ms
+step:938/1490 train_time:41217ms step_avg:43.94ms
+step:939/1490 train_time:41271ms step_avg:43.95ms
+step:940/1490 train_time:41330ms step_avg:43.97ms
+step:941/1490 train_time:41384ms step_avg:43.98ms
+step:942/1490 train_time:41443ms step_avg:43.99ms
+step:943/1490 train_time:41498ms step_avg:44.01ms
+step:944/1490 train_time:41558ms step_avg:44.02ms
+step:945/1490 train_time:41612ms step_avg:44.03ms
+step:946/1490 train_time:41671ms step_avg:44.05ms
+step:947/1490 train_time:41726ms step_avg:44.06ms
+step:948/1490 train_time:41787ms step_avg:44.08ms
+step:949/1490 train_time:41840ms step_avg:44.09ms
+step:950/1490 train_time:41901ms step_avg:44.11ms
+step:951/1490 train_time:41955ms step_avg:44.12ms
+step:952/1490 train_time:42015ms step_avg:44.13ms
+step:953/1490 train_time:42068ms step_avg:44.14ms
+step:954/1490 train_time:42128ms step_avg:44.16ms
+step:955/1490 train_time:42182ms step_avg:44.17ms
+step:956/1490 train_time:42242ms step_avg:44.19ms
+step:957/1490 train_time:42296ms step_avg:44.20ms
+step:958/1490 train_time:42356ms step_avg:44.21ms
+step:959/1490 train_time:42410ms step_avg:44.22ms
+step:960/1490 train_time:42470ms step_avg:44.24ms
+step:961/1490 train_time:42524ms step_avg:44.25ms
+step:962/1490 train_time:42583ms step_avg:44.26ms
+step:963/1490 train_time:42637ms step_avg:44.28ms
+step:964/1490 train_time:42698ms step_avg:44.29ms
+step:965/1490 train_time:42752ms step_avg:44.30ms
+step:966/1490 train_time:42812ms step_avg:44.32ms
+step:967/1490 train_time:42867ms step_avg:44.33ms
+step:968/1490 train_time:42930ms step_avg:44.35ms
+step:969/1490 train_time:43010ms step_avg:44.39ms
+step:970/1490 train_time:43095ms step_avg:44.43ms
+step:971/1490 train_time:43178ms step_avg:44.47ms
+step:972/1490 train_time:43263ms step_avg:44.51ms
+step:973/1490 train_time:43344ms step_avg:44.55ms
+step:974/1490 train_time:43431ms step_avg:44.59ms
+step:975/1490 train_time:43511ms step_avg:44.63ms
+step:976/1490 train_time:43598ms step_avg:44.67ms
+step:977/1490 train_time:43679ms step_avg:44.71ms
+step:978/1490 train_time:43765ms step_avg:44.75ms
+step:979/1490 train_time:43847ms step_avg:44.79ms
+step:980/1490 train_time:43933ms step_avg:44.83ms
+step:981/1490 train_time:44014ms step_avg:44.87ms
+step:982/1490 train_time:44100ms step_avg:44.91ms
+step:983/1490 train_time:44181ms step_avg:44.95ms
+step:984/1490 train_time:44267ms step_avg:44.99ms
+step:985/1490 train_time:44348ms step_avg:45.02ms
+step:986/1490 train_time:44434ms step_avg:45.07ms
+step:987/1490 train_time:44516ms step_avg:45.10ms
+step:988/1490 train_time:44603ms step_avg:45.14ms
+step:989/1490 train_time:44683ms step_avg:45.18ms
+step:990/1490 train_time:44769ms step_avg:45.22ms
+step:991/1490 train_time:44849ms step_avg:45.26ms
+step:992/1490 train_time:44936ms step_avg:45.30ms
+step:993/1490 train_time:45018ms step_avg:45.34ms
+step:994/1490 train_time:45104ms step_avg:45.38ms
+step:995/1490 train_time:45185ms step_avg:45.41ms
+step:996/1490 train_time:45271ms step_avg:45.45ms
+step:997/1490 train_time:45352ms step_avg:45.49ms
+step:998/1490 train_time:45438ms step_avg:45.53ms
+step:999/1490 train_time:45518ms step_avg:45.56ms
+step:1000/1490 train_time:45605ms step_avg:45.61ms
+step:1000/1490 val_loss:3.5155 train_time:45708ms step_avg:45.71ms
+step:1001/1490 train_time:45725ms step_avg:45.68ms
+step:1002/1490 train_time:45775ms step_avg:45.68ms
+step:1003/1490 train_time:45859ms step_avg:45.72ms
+step:1004/1490 train_time:45948ms step_avg:45.77ms
+step:1005/1490 train_time:46030ms step_avg:45.80ms
+step:1006/1490 train_time:46114ms step_avg:45.84ms
+step:1007/1490 train_time:46194ms step_avg:45.87ms
+step:1008/1490 train_time:46279ms step_avg:45.91ms
+step:1009/1490 train_time:46359ms step_avg:45.95ms
+step:1010/1490 train_time:46443ms step_avg:45.98ms
+step:1011/1490 train_time:46525ms step_avg:46.02ms
+step:1012/1490 train_time:46610ms step_avg:46.06ms
+step:1013/1490 train_time:46695ms step_avg:46.10ms
+step:1014/1490 train_time:46783ms step_avg:46.14ms
+step:1015/1490 train_time:46865ms step_avg:46.17ms
+step:1016/1490 train_time:46952ms step_avg:46.21ms
+step:1017/1490 train_time:47033ms step_avg:46.25ms
+step:1018/1490 train_time:47120ms step_avg:46.29ms
+step:1019/1490 train_time:47201ms step_avg:46.32ms
+step:1020/1490 train_time:47286ms step_avg:46.36ms
+step:1021/1490 train_time:47364ms step_avg:46.39ms
+step:1022/1490 train_time:47450ms step_avg:46.43ms
+step:1023/1490 train_time:47530ms step_avg:46.46ms
+step:1024/1490 train_time:47616ms step_avg:46.50ms
+step:1025/1490 train_time:47698ms step_avg:46.53ms
+step:1026/1490 train_time:47787ms step_avg:46.58ms
+step:1027/1490 train_time:47870ms step_avg:46.61ms
+step:1028/1490 train_time:47957ms step_avg:46.65ms
+step:1029/1490 train_time:48039ms step_avg:46.69ms
+step:1030/1490 train_time:48127ms step_avg:46.73ms
+step:1031/1490 train_time:48207ms step_avg:46.76ms
+step:1032/1490 train_time:48293ms step_avg:46.80ms
+step:1033/1490 train_time:48372ms step_avg:46.83ms
+step:1034/1490 train_time:48457ms step_avg:46.86ms
+step:1035/1490 train_time:48539ms step_avg:46.90ms
+step:1036/1490 train_time:48626ms step_avg:46.94ms
+step:1037/1490 train_time:48707ms step_avg:46.97ms
+step:1038/1490 train_time:48796ms step_avg:47.01ms
+step:1039/1490 train_time:48877ms step_avg:47.04ms
+step:1040/1490 train_time:48963ms step_avg:47.08ms
+step:1041/1490 train_time:49046ms step_avg:47.11ms
+step:1042/1490 train_time:49134ms step_avg:47.15ms
+step:1043/1490 train_time:49214ms step_avg:47.19ms
+step:1044/1490 train_time:49299ms step_avg:47.22ms
+step:1045/1490 train_time:49381ms step_avg:47.25ms
+step:1046/1490 train_time:49467ms step_avg:47.29ms
+step:1047/1490 train_time:49547ms step_avg:47.32ms
+step:1048/1490 train_time:49634ms step_avg:47.36ms
+step:1049/1490 train_time:49714ms step_avg:47.39ms
+step:1050/1490 train_time:49800ms step_avg:47.43ms
+step:1051/1490 train_time:49883ms step_avg:47.46ms
+step:1052/1490 train_time:49971ms step_avg:47.50ms
+step:1053/1490 train_time:50053ms step_avg:47.53ms
+step:1054/1490 train_time:50140ms step_avg:47.57ms
+step:1055/1490 train_time:50220ms step_avg:47.60ms
+step:1056/1490 train_time:50305ms step_avg:47.64ms
+step:1057/1490 train_time:50386ms step_avg:47.67ms
+step:1058/1490 train_time:50472ms step_avg:47.71ms
+step:1059/1490 train_time:50552ms step_avg:47.74ms
+step:1060/1490 train_time:50639ms step_avg:47.77ms
+step:1061/1490 train_time:50719ms step_avg:47.80ms
+step:1062/1490 train_time:50807ms step_avg:47.84ms
+step:1063/1490 train_time:50889ms step_avg:47.87ms
+step:1064/1490 train_time:50975ms step_avg:47.91ms
+step:1065/1490 train_time:51056ms step_avg:47.94ms
+step:1066/1490 train_time:51144ms step_avg:47.98ms
+step:1067/1490 train_time:51224ms step_avg:48.01ms
+step:1068/1490 train_time:51311ms step_avg:48.04ms
+step:1069/1490 train_time:51391ms step_avg:48.07ms
+step:1070/1490 train_time:51477ms step_avg:48.11ms
+step:1071/1490 train_time:51557ms step_avg:48.14ms
+step:1072/1490 train_time:51643ms step_avg:48.17ms
+step:1073/1490 train_time:51723ms step_avg:48.20ms
+step:1074/1490 train_time:51810ms step_avg:48.24ms
+step:1075/1490 train_time:51891ms step_avg:48.27ms
+step:1076/1490 train_time:51979ms step_avg:48.31ms
+step:1077/1490 train_time:52060ms step_avg:48.34ms
+step:1078/1490 train_time:52146ms step_avg:48.37ms
+step:1079/1490 train_time:52227ms step_avg:48.40ms
+step:1080/1490 train_time:52312ms step_avg:48.44ms
+step:1081/1490 train_time:52394ms step_avg:48.47ms
+step:1082/1490 train_time:52480ms step_avg:48.50ms
+step:1083/1490 train_time:52560ms step_avg:48.53ms
+step:1084/1490 train_time:52647ms step_avg:48.57ms
+step:1085/1490 train_time:52729ms step_avg:48.60ms
+step:1086/1490 train_time:52815ms step_avg:48.63ms
+step:1087/1490 train_time:52896ms step_avg:48.66ms
+step:1088/1490 train_time:52983ms step_avg:48.70ms
+step:1089/1490 train_time:53065ms step_avg:48.73ms
+step:1090/1490 train_time:53152ms step_avg:48.76ms
+step:1091/1490 train_time:53234ms step_avg:48.79ms
+step:1092/1490 train_time:53321ms step_avg:48.83ms
+step:1093/1490 train_time:53402ms step_avg:48.86ms
+step:1094/1490 train_time:53488ms step_avg:48.89ms
+step:1095/1490 train_time:53570ms step_avg:48.92ms
+step:1096/1490 train_time:53656ms step_avg:48.96ms
+step:1097/1490 train_time:53737ms step_avg:48.99ms
+step:1098/1490 train_time:53822ms step_avg:49.02ms
+step:1099/1490 train_time:53904ms step_avg:49.05ms
+step:1100/1490 train_time:53990ms step_avg:49.08ms
+step:1101/1490 train_time:54071ms step_avg:49.11ms
+step:1102/1490 train_time:54159ms step_avg:49.15ms
+step:1103/1490 train_time:54240ms step_avg:49.17ms
+step:1104/1490 train_time:54327ms step_avg:49.21ms
+step:1105/1490 train_time:54407ms step_avg:49.24ms
+step:1106/1490 train_time:54492ms step_avg:49.27ms
+step:1107/1490 train_time:54572ms step_avg:49.30ms
+step:1108/1490 train_time:54660ms step_avg:49.33ms
+step:1109/1490 train_time:54741ms step_avg:49.36ms
+step:1110/1490 train_time:54827ms step_avg:49.39ms
+step:1111/1490 train_time:54908ms step_avg:49.42ms
+step:1112/1490 train_time:54993ms step_avg:49.45ms
+step:1113/1490 train_time:55074ms step_avg:49.48ms
+step:1114/1490 train_time:55162ms step_avg:49.52ms
+step:1115/1490 train_time:55244ms step_avg:49.55ms
+step:1116/1490 train_time:55330ms step_avg:49.58ms
+step:1117/1490 train_time:55411ms step_avg:49.61ms
+step:1118/1490 train_time:55499ms step_avg:49.64ms
+step:1119/1490 train_time:55580ms step_avg:49.67ms
+step:1120/1490 train_time:55667ms step_avg:49.70ms
+step:1121/1490 train_time:55749ms step_avg:49.73ms
+step:1122/1490 train_time:55835ms step_avg:49.76ms
+step:1123/1490 train_time:55916ms step_avg:49.79ms
+step:1124/1490 train_time:56002ms step_avg:49.82ms
+step:1125/1490 train_time:56083ms step_avg:49.85ms
+step:1126/1490 train_time:56170ms step_avg:49.88ms
+step:1127/1490 train_time:56251ms step_avg:49.91ms
+step:1128/1490 train_time:56337ms step_avg:49.94ms
+step:1129/1490 train_time:56418ms step_avg:49.97ms
+step:1130/1490 train_time:56502ms step_avg:50.00ms
+step:1131/1490 train_time:56584ms step_avg:50.03ms
+step:1132/1490 train_time:56672ms step_avg:50.06ms
+step:1133/1490 train_time:56752ms step_avg:50.09ms
+step:1134/1490 train_time:56839ms step_avg:50.12ms
+step:1135/1490 train_time:56919ms step_avg:50.15ms
+step:1136/1490 train_time:57004ms step_avg:50.18ms
+step:1137/1490 train_time:57085ms step_avg:50.21ms
+step:1138/1490 train_time:57171ms step_avg:50.24ms
+step:1139/1490 train_time:57253ms step_avg:50.27ms
+step:1140/1490 train_time:57340ms step_avg:50.30ms
+step:1141/1490 train_time:57421ms step_avg:50.32ms
+step:1142/1490 train_time:57507ms step_avg:50.36ms
+step:1143/1490 train_time:57587ms step_avg:50.38ms
+step:1144/1490 train_time:57673ms step_avg:50.41ms
+step:1145/1490 train_time:57755ms step_avg:50.44ms
+step:1146/1490 train_time:57840ms step_avg:50.47ms
+step:1147/1490 train_time:57922ms step_avg:50.50ms
+step:1148/1490 train_time:58009ms step_avg:50.53ms
+step:1149/1490 train_time:58089ms step_avg:50.56ms
+step:1150/1490 train_time:58177ms step_avg:50.59ms
+step:1151/1490 train_time:58257ms step_avg:50.61ms
+step:1152/1490 train_time:58343ms step_avg:50.65ms
+step:1153/1490 train_time:58425ms step_avg:50.67ms
+step:1154/1490 train_time:58511ms step_avg:50.70ms
+step:1155/1490 train_time:58592ms step_avg:50.73ms
+step:1156/1490 train_time:58680ms step_avg:50.76ms
+step:1157/1490 train_time:58762ms step_avg:50.79ms
+step:1158/1490 train_time:58847ms step_avg:50.82ms
+step:1159/1490 train_time:58928ms step_avg:50.84ms
+step:1160/1490 train_time:59013ms step_avg:50.87ms
+step:1161/1490 train_time:59095ms step_avg:50.90ms
+step:1162/1490 train_time:59182ms step_avg:50.93ms
+step:1163/1490 train_time:59263ms step_avg:50.96ms
+step:1164/1490 train_time:59350ms step_avg:50.99ms
+step:1165/1490 train_time:59431ms step_avg:51.01ms
+step:1166/1490 train_time:59517ms step_avg:51.04ms
+step:1167/1490 train_time:59597ms step_avg:51.07ms
+step:1168/1490 train_time:59683ms step_avg:51.10ms
+step:1169/1490 train_time:59765ms step_avg:51.12ms
+step:1170/1490 train_time:59852ms step_avg:51.16ms
+step:1171/1490 train_time:59933ms step_avg:51.18ms
+step:1172/1490 train_time:60020ms step_avg:51.21ms
+step:1173/1490 train_time:60100ms step_avg:51.24ms
+step:1174/1490 train_time:60187ms step_avg:51.27ms
+step:1175/1490 train_time:60267ms step_avg:51.29ms
+step:1176/1490 train_time:60354ms step_avg:51.32ms
+step:1177/1490 train_time:60436ms step_avg:51.35ms
+step:1178/1490 train_time:60522ms step_avg:51.38ms
+step:1179/1490 train_time:60603ms step_avg:51.40ms
+step:1180/1490 train_time:60689ms step_avg:51.43ms
+step:1181/1490 train_time:60770ms step_avg:51.46ms
+step:1182/1490 train_time:60856ms step_avg:51.49ms
+step:1183/1490 train_time:60937ms step_avg:51.51ms
+step:1184/1490 train_time:61024ms step_avg:51.54ms
+step:1185/1490 train_time:61105ms step_avg:51.57ms
+step:1186/1490 train_time:61192ms step_avg:51.59ms
+step:1187/1490 train_time:61273ms step_avg:51.62ms
+step:1188/1490 train_time:61360ms step_avg:51.65ms
+step:1189/1490 train_time:61441ms step_avg:51.67ms
+step:1190/1490 train_time:61528ms step_avg:51.70ms
+step:1191/1490 train_time:61608ms step_avg:51.73ms
+step:1192/1490 train_time:61694ms step_avg:51.76ms
+step:1193/1490 train_time:61776ms step_avg:51.78ms
+step:1194/1490 train_time:61861ms step_avg:51.81ms
+step:1195/1490 train_time:61943ms step_avg:51.84ms
+step:1196/1490 train_time:62029ms step_avg:51.86ms
+step:1197/1490 train_time:62110ms step_avg:51.89ms
+step:1198/1490 train_time:62197ms step_avg:51.92ms
+step:1199/1490 train_time:62276ms step_avg:51.94ms
+step:1200/1490 train_time:62364ms step_avg:51.97ms
+step:1201/1490 train_time:62445ms step_avg:51.99ms
+step:1202/1490 train_time:62533ms step_avg:52.02ms
+step:1203/1490 train_time:62613ms step_avg:52.05ms
+step:1204/1490 train_time:62699ms step_avg:52.08ms
+step:1205/1490 train_time:62780ms step_avg:52.10ms
+step:1206/1490 train_time:62867ms step_avg:52.13ms
+step:1207/1490 train_time:62948ms step_avg:52.15ms
+step:1208/1490 train_time:63036ms step_avg:52.18ms
+step:1209/1490 train_time:63116ms step_avg:52.20ms
+step:1210/1490 train_time:63202ms step_avg:52.23ms
+step:1211/1490 train_time:63284ms step_avg:52.26ms
+step:1212/1490 train_time:63369ms step_avg:52.28ms
+step:1213/1490 train_time:63450ms step_avg:52.31ms
+step:1214/1490 train_time:63538ms step_avg:52.34ms
+step:1215/1490 train_time:63618ms step_avg:52.36ms
+step:1216/1490 train_time:63704ms step_avg:52.39ms
+step:1217/1490 train_time:63784ms step_avg:52.41ms
+step:1218/1490 train_time:63871ms step_avg:52.44ms
+step:1219/1490 train_time:63954ms step_avg:52.46ms
+step:1220/1490 train_time:64040ms step_avg:52.49ms
+step:1221/1490 train_time:64121ms step_avg:52.52ms
+step:1222/1490 train_time:64206ms step_avg:52.54ms
+step:1223/1490 train_time:64288ms step_avg:52.57ms
+step:1224/1490 train_time:64376ms step_avg:52.59ms
+step:1225/1490 train_time:64456ms step_avg:52.62ms
+step:1226/1490 train_time:64542ms step_avg:52.64ms
+step:1227/1490 train_time:64624ms step_avg:52.67ms
+step:1228/1490 train_time:64709ms step_avg:52.69ms
+step:1229/1490 train_time:64790ms step_avg:52.72ms
+step:1230/1490 train_time:64876ms step_avg:52.74ms
+step:1231/1490 train_time:64958ms step_avg:52.77ms
+step:1232/1490 train_time:65045ms step_avg:52.80ms
+step:1233/1490 train_time:65126ms step_avg:52.82ms
+step:1234/1490 train_time:65212ms step_avg:52.85ms
+step:1235/1490 train_time:65293ms step_avg:52.87ms
+step:1236/1490 train_time:65380ms step_avg:52.90ms
+step:1237/1490 train_time:65462ms step_avg:52.92ms
+step:1238/1490 train_time:65547ms step_avg:52.95ms
+step:1239/1490 train_time:65628ms step_avg:52.97ms
+step:1240/1490 train_time:65716ms step_avg:53.00ms
+step:1241/1490 train_time:65797ms step_avg:53.02ms
+step:1242/1490 train_time:65884ms step_avg:53.05ms
+step:1243/1490 train_time:65965ms step_avg:53.07ms
+step:1244/1490 train_time:66052ms step_avg:53.10ms
+step:1245/1490 train_time:66132ms step_avg:53.12ms
+step:1246/1490 train_time:66218ms step_avg:53.14ms
+step:1247/1490 train_time:66299ms step_avg:53.17ms
+step:1248/1490 train_time:66385ms step_avg:53.19ms
+step:1249/1490 train_time:66467ms step_avg:53.22ms
+step:1250/1490 train_time:66555ms step_avg:53.24ms
+step:1250/1490 val_loss:3.3715 train_time:66657ms step_avg:53.33ms
+step:1251/1490 train_time:66675ms step_avg:53.30ms
+step:1252/1490 train_time:66723ms step_avg:53.29ms
+step:1253/1490 train_time:66809ms step_avg:53.32ms
+step:1254/1490 train_time:66896ms step_avg:53.35ms
+step:1255/1490 train_time:66976ms step_avg:53.37ms
+step:1256/1490 train_time:67062ms step_avg:53.39ms
+step:1257/1490 train_time:67142ms step_avg:53.41ms
+step:1258/1490 train_time:67228ms step_avg:53.44ms
+step:1259/1490 train_time:67308ms step_avg:53.46ms
+step:1260/1490 train_time:67393ms step_avg:53.49ms
+step:1261/1490 train_time:67472ms step_avg:53.51ms
+step:1262/1490 train_time:67559ms step_avg:53.53ms
+step:1263/1490 train_time:67642ms step_avg:53.56ms
+step:1264/1490 train_time:67729ms step_avg:53.58ms
+step:1265/1490 train_time:67813ms step_avg:53.61ms
+step:1266/1490 train_time:67903ms step_avg:53.64ms
+step:1267/1490 train_time:67983ms step_avg:53.66ms
+step:1268/1490 train_time:68069ms step_avg:53.68ms
+step:1269/1490 train_time:68149ms step_avg:53.70ms
+step:1270/1490 train_time:68235ms step_avg:53.73ms
+step:1271/1490 train_time:68315ms step_avg:53.75ms
+step:1272/1490 train_time:68400ms step_avg:53.77ms
+step:1273/1490 train_time:68480ms step_avg:53.79ms
+step:1274/1490 train_time:68568ms step_avg:53.82ms
+step:1275/1490 train_time:68649ms step_avg:53.84ms
+step:1276/1490 train_time:68737ms step_avg:53.87ms
+step:1277/1490 train_time:68819ms step_avg:53.89ms
+step:1278/1490 train_time:68907ms step_avg:53.92ms
+step:1279/1490 train_time:68989ms step_avg:53.94ms
+step:1280/1490 train_time:69075ms step_avg:53.96ms
+step:1281/1490 train_time:69155ms step_avg:53.99ms
+step:1282/1490 train_time:69241ms step_avg:54.01ms
+step:1283/1490 train_time:69321ms step_avg:54.03ms
+step:1284/1490 train_time:69406ms step_avg:54.05ms
+step:1285/1490 train_time:69487ms step_avg:54.08ms
+step:1286/1490 train_time:69573ms step_avg:54.10ms
+step:1287/1490 train_time:69655ms step_avg:54.12ms
+step:1288/1490 train_time:69742ms step_avg:54.15ms
+step:1289/1490 train_time:69824ms step_avg:54.17ms
+step:1290/1490 train_time:69910ms step_avg:54.19ms
+step:1291/1490 train_time:69992ms step_avg:54.21ms
+step:1292/1490 train_time:70078ms step_avg:54.24ms
+step:1293/1490 train_time:70161ms step_avg:54.26ms
+step:1294/1490 train_time:70246ms step_avg:54.29ms
+step:1295/1490 train_time:70325ms step_avg:54.31ms
+step:1296/1490 train_time:70410ms step_avg:54.33ms
+step:1297/1490 train_time:70490ms step_avg:54.35ms
+step:1298/1490 train_time:70576ms step_avg:54.37ms
+step:1299/1490 train_time:70659ms step_avg:54.39ms
+step:1300/1490 train_time:70746ms step_avg:54.42ms
+step:1301/1490 train_time:70829ms step_avg:54.44ms
+step:1302/1490 train_time:70914ms step_avg:54.47ms
+step:1303/1490 train_time:70996ms step_avg:54.49ms
+step:1304/1490 train_time:71082ms step_avg:54.51ms
+step:1305/1490 train_time:71162ms step_avg:54.53ms
+step:1306/1490 train_time:71249ms step_avg:54.55ms
+step:1307/1490 train_time:71329ms step_avg:54.57ms
+step:1308/1490 train_time:71414ms step_avg:54.60ms
+step:1309/1490 train_time:71496ms step_avg:54.62ms
+step:1310/1490 train_time:71581ms step_avg:54.64ms
+step:1311/1490 train_time:71663ms step_avg:54.66ms
+step:1312/1490 train_time:71750ms step_avg:54.69ms
+step:1313/1490 train_time:71833ms step_avg:54.71ms
+step:1314/1490 train_time:71919ms step_avg:54.73ms
+step:1315/1490 train_time:71999ms step_avg:54.75ms
+step:1316/1490 train_time:72087ms step_avg:54.78ms
+step:1317/1490 train_time:72168ms step_avg:54.80ms
+step:1318/1490 train_time:72253ms step_avg:54.82ms
+step:1319/1490 train_time:72334ms step_avg:54.84ms
+step:1320/1490 train_time:72419ms step_avg:54.86ms
+step:1321/1490 train_time:72500ms step_avg:54.88ms
+step:1322/1490 train_time:72588ms step_avg:54.91ms
+step:1323/1490 train_time:72669ms step_avg:54.93ms
+step:1324/1490 train_time:72756ms step_avg:54.95ms
+step:1325/1490 train_time:72837ms step_avg:54.97ms
+step:1326/1490 train_time:72923ms step_avg:55.00ms
+step:1327/1490 train_time:73006ms step_avg:55.02ms
+step:1328/1490 train_time:73092ms step_avg:55.04ms
+step:1329/1490 train_time:73172ms step_avg:55.06ms
+step:1330/1490 train_time:73258ms step_avg:55.08ms
+step:1331/1490 train_time:73338ms step_avg:55.10ms
+step:1332/1490 train_time:73423ms step_avg:55.12ms
+step:1333/1490 train_time:73504ms step_avg:55.14ms
+step:1334/1490 train_time:73590ms step_avg:55.17ms
+step:1335/1490 train_time:73670ms step_avg:55.18ms
+step:1336/1490 train_time:73758ms step_avg:55.21ms
+step:1337/1490 train_time:73840ms step_avg:55.23ms
+step:1338/1490 train_time:73927ms step_avg:55.25ms
+step:1339/1490 train_time:74009ms step_avg:55.27ms
+step:1340/1490 train_time:74095ms step_avg:55.29ms
+step:1341/1490 train_time:74176ms step_avg:55.31ms
+step:1342/1490 train_time:74262ms step_avg:55.34ms
+step:1343/1490 train_time:74342ms step_avg:55.36ms
+step:1344/1490 train_time:74429ms step_avg:55.38ms
+step:1345/1490 train_time:74510ms step_avg:55.40ms
+step:1346/1490 train_time:74597ms step_avg:55.42ms
+step:1347/1490 train_time:74678ms step_avg:55.44ms
+step:1348/1490 train_time:74766ms step_avg:55.46ms
+step:1349/1490 train_time:74848ms step_avg:55.48ms
+step:1350/1490 train_time:74934ms step_avg:55.51ms
+step:1351/1490 train_time:75014ms step_avg:55.52ms
+step:1352/1490 train_time:75099ms step_avg:55.55ms
+step:1353/1490 train_time:75181ms step_avg:55.57ms
+step:1354/1490 train_time:75268ms step_avg:55.59ms
+step:1355/1490 train_time:75350ms step_avg:55.61ms
+step:1356/1490 train_time:75435ms step_avg:55.63ms
+step:1357/1490 train_time:75516ms step_avg:55.65ms
+step:1358/1490 train_time:75603ms step_avg:55.67ms
+step:1359/1490 train_time:75683ms step_avg:55.69ms
+step:1360/1490 train_time:75771ms step_avg:55.71ms
+step:1361/1490 train_time:75852ms step_avg:55.73ms
+step:1362/1490 train_time:75938ms step_avg:55.75ms
+step:1363/1490 train_time:76019ms step_avg:55.77ms
+step:1364/1490 train_time:76105ms step_avg:55.80ms
+step:1365/1490 train_time:76186ms step_avg:55.81ms
+step:1366/1490 train_time:76272ms step_avg:55.84ms
+step:1367/1490 train_time:76354ms step_avg:55.85ms
+step:1368/1490 train_time:76440ms step_avg:55.88ms
+step:1369/1490 train_time:76521ms step_avg:55.90ms
+step:1370/1490 train_time:76608ms step_avg:55.92ms
+step:1371/1490 train_time:76689ms step_avg:55.94ms
+step:1372/1490 train_time:76776ms step_avg:55.96ms
+step:1373/1490 train_time:76857ms step_avg:55.98ms
+step:1374/1490 train_time:76943ms step_avg:56.00ms
+step:1375/1490 train_time:77024ms step_avg:56.02ms
+step:1376/1490 train_time:77109ms step_avg:56.04ms
+step:1377/1490 train_time:77190ms step_avg:56.06ms
+step:1378/1490 train_time:77277ms step_avg:56.08ms
+step:1379/1490 train_time:77359ms step_avg:56.10ms
+step:1380/1490 train_time:77446ms step_avg:56.12ms
+step:1381/1490 train_time:77526ms step_avg:56.14ms
+step:1382/1490 train_time:77612ms step_avg:56.16ms
+step:1383/1490 train_time:77694ms step_avg:56.18ms
+step:1384/1490 train_time:77780ms step_avg:56.20ms
+step:1385/1490 train_time:77860ms step_avg:56.22ms
+step:1386/1490 train_time:77948ms step_avg:56.24ms
+step:1387/1490 train_time:78028ms step_avg:56.26ms
+step:1388/1490 train_time:78114ms step_avg:56.28ms
+step:1389/1490 train_time:78195ms step_avg:56.30ms
+step:1390/1490 train_time:78281ms step_avg:56.32ms
+step:1391/1490 train_time:78364ms step_avg:56.34ms
+step:1392/1490 train_time:78451ms step_avg:56.36ms
+step:1393/1490 train_time:78531ms step_avg:56.38ms
+step:1394/1490 train_time:78617ms step_avg:56.40ms
+step:1395/1490 train_time:78698ms step_avg:56.41ms
+step:1396/1490 train_time:78784ms step_avg:56.44ms
+step:1397/1490 train_time:78866ms step_avg:56.45ms
+step:1398/1490 train_time:78954ms step_avg:56.48ms
+step:1399/1490 train_time:79036ms step_avg:56.49ms
+step:1400/1490 train_time:79122ms step_avg:56.52ms
+step:1401/1490 train_time:79202ms step_avg:56.53ms
+step:1402/1490 train_time:79289ms step_avg:56.55ms
+step:1403/1490 train_time:79370ms step_avg:56.57ms
+step:1404/1490 train_time:79457ms step_avg:56.59ms
+step:1405/1490 train_time:79537ms step_avg:56.61ms
+step:1406/1490 train_time:79624ms step_avg:56.63ms
+step:1407/1490 train_time:79704ms step_avg:56.65ms
+step:1408/1490 train_time:79789ms step_avg:56.67ms
+step:1409/1490 train_time:79870ms step_avg:56.69ms
+step:1410/1490 train_time:79958ms step_avg:56.71ms
+step:1411/1490 train_time:80039ms step_avg:56.73ms
+step:1412/1490 train_time:80126ms step_avg:56.75ms
+step:1413/1490 train_time:80206ms step_avg:56.76ms
+step:1414/1490 train_time:80292ms step_avg:56.78ms
+step:1415/1490 train_time:80373ms step_avg:56.80ms
+step:1416/1490 train_time:80459ms step_avg:56.82ms
+step:1417/1490 train_time:80540ms step_avg:56.84ms
+step:1418/1490 train_time:80626ms step_avg:56.86ms
+step:1419/1490 train_time:80707ms step_avg:56.88ms
+step:1420/1490 train_time:80793ms step_avg:56.90ms
+step:1421/1490 train_time:80874ms step_avg:56.91ms
+step:1422/1490 train_time:80961ms step_avg:56.93ms
+step:1423/1490 train_time:81043ms step_avg:56.95ms
+step:1424/1490 train_time:81128ms step_avg:56.97ms
+step:1425/1490 train_time:81209ms step_avg:56.99ms
+step:1426/1490 train_time:81294ms step_avg:57.01ms
+step:1427/1490 train_time:81375ms step_avg:57.03ms
+step:1428/1490 train_time:81461ms step_avg:57.05ms
+step:1429/1490 train_time:81542ms step_avg:57.06ms
+step:1430/1490 train_time:81630ms step_avg:57.08ms
+step:1431/1490 train_time:81710ms step_avg:57.10ms
+step:1432/1490 train_time:81796ms step_avg:57.12ms
+step:1433/1490 train_time:81878ms step_avg:57.14ms
+step:1434/1490 train_time:81967ms step_avg:57.16ms
+step:1435/1490 train_time:82048ms step_avg:57.18ms
+step:1436/1490 train_time:82134ms step_avg:57.20ms
+step:1437/1490 train_time:82215ms step_avg:57.21ms
+step:1438/1490 train_time:82301ms step_avg:57.23ms
+step:1439/1490 train_time:82381ms step_avg:57.25ms
+step:1440/1490 train_time:82467ms step_avg:57.27ms
+step:1441/1490 train_time:82548ms step_avg:57.29ms
+step:1442/1490 train_time:82634ms step_avg:57.31ms
+step:1443/1490 train_time:82715ms step_avg:57.32ms
+step:1444/1490 train_time:82801ms step_avg:57.34ms
+step:1445/1490 train_time:82883ms step_avg:57.36ms
+step:1446/1490 train_time:82969ms step_avg:57.38ms
+step:1447/1490 train_time:83051ms step_avg:57.40ms
+step:1448/1490 train_time:83138ms step_avg:57.42ms
+step:1449/1490 train_time:83218ms step_avg:57.43ms
+step:1450/1490 train_time:83304ms step_avg:57.45ms
+step:1451/1490 train_time:83388ms step_avg:57.47ms
+step:1452/1490 train_time:83476ms step_avg:57.49ms
+step:1453/1490 train_time:83557ms step_avg:57.51ms
+step:1454/1490 train_time:83644ms step_avg:57.53ms
+step:1455/1490 train_time:83725ms step_avg:57.54ms
+step:1456/1490 train_time:83812ms step_avg:57.56ms
+step:1457/1490 train_time:83893ms step_avg:57.58ms
+step:1458/1490 train_time:83982ms step_avg:57.60ms
+step:1459/1490 train_time:84063ms step_avg:57.62ms
+step:1460/1490 train_time:84150ms step_avg:57.64ms
+step:1461/1490 train_time:84230ms step_avg:57.65ms
+step:1462/1490 train_time:84317ms step_avg:57.67ms
+step:1463/1490 train_time:84399ms step_avg:57.69ms
+step:1464/1490 train_time:84485ms step_avg:57.71ms
+step:1465/1490 train_time:84568ms step_avg:57.73ms
+step:1466/1490 train_time:84653ms step_avg:57.74ms
+step:1467/1490 train_time:84734ms step_avg:57.76ms
+step:1468/1490 train_time:84821ms step_avg:57.78ms
+step:1469/1490 train_time:84901ms step_avg:57.80ms
+step:1470/1490 train_time:84989ms step_avg:57.82ms
+step:1471/1490 train_time:85070ms step_avg:57.83ms
+step:1472/1490 train_time:85157ms step_avg:57.85ms
+step:1473/1490 train_time:85239ms step_avg:57.87ms
+step:1474/1490 train_time:85324ms step_avg:57.89ms
+step:1475/1490 train_time:85404ms step_avg:57.90ms
+step:1476/1490 train_time:85493ms step_avg:57.92ms
+step:1477/1490 train_time:85574ms step_avg:57.94ms
+step:1478/1490 train_time:85661ms step_avg:57.96ms
+step:1479/1490 train_time:85741ms step_avg:57.97ms
+step:1480/1490 train_time:85828ms step_avg:57.99ms
+step:1481/1490 train_time:85909ms step_avg:58.01ms
+step:1482/1490 train_time:85996ms step_avg:58.03ms
+step:1483/1490 train_time:86079ms step_avg:58.04ms
+step:1484/1490 train_time:86166ms step_avg:58.06ms
+step:1485/1490 train_time:86247ms step_avg:58.08ms
+step:1486/1490 train_time:86333ms step_avg:58.10ms
+step:1487/1490 train_time:86414ms step_avg:58.11ms
+step:1488/1490 train_time:86502ms step_avg:58.13ms
+step:1489/1490 train_time:86584ms step_avg:58.15ms
+step:1490/1490 train_time:86669ms step_avg:58.17ms
+step:1490/1490 val_loss:3.2784 train_time:86774ms step_avg:58.24ms
+peak memory allocated: 31277 MiB reserved: 47162 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/muon-beta2/2026-03-22_19-27-02_time-187_secs_04-muon-beta2_a2572a.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/muon-beta2/2026-03-22_19-27-02_time-187_secs_04-muon-beta2_a2572a.txt
@@ -1,0 +1,4456 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,  # from nanochat autoresearch (was 0.95)
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 19:27:17 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   36C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            132W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   41C    P0            124W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1657845      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1657846      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1657847      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1657848      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1657849      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1657850      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1657851      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1657852      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8275 train_time:0ms step_avg:0.04ms
+step:1/1490 train_time:84ms step_avg:84.38ms
+step:2/1490 train_time:109ms step_avg:54.44ms
+step:3/1490 train_time:126ms step_avg:41.88ms
+step:4/1490 train_time:153ms step_avg:38.16ms
+step:5/1490 train_time:180ms step_avg:35.98ms
+step:6/1490 train_time:215ms step_avg:35.81ms
+step:7/1490 train_time:243ms step_avg:34.66ms
+step:8/1490 train_time:277ms step_avg:34.65ms
+step:9/1490 train_time:305ms step_avg:33.89ms
+step:10/1490 train_time:340ms step_avg:33.95ms
+step:11/1490 train_time:367ms step_avg:33.40ms
+step:12/1490 train_time:402ms step_avg:33.48ms
+step:13/1490 train_time:430ms step_avg:33.07ms
+step:14/1490 train_time:464ms step_avg:33.17ms
+step:15/1490 train_time:493ms step_avg:32.85ms
+step:16/1490 train_time:527ms step_avg:32.95ms
+step:17/1490 train_time:555ms step_avg:32.67ms
+step:18/1490 train_time:589ms step_avg:32.74ms
+step:19/1490 train_time:618ms step_avg:32.53ms
+step:20/1490 train_time:653ms step_avg:32.63ms
+step:21/1490 train_time:681ms step_avg:32.42ms
+step:22/1490 train_time:715ms step_avg:32.50ms
+step:23/1490 train_time:744ms step_avg:32.34ms
+step:24/1490 train_time:778ms step_avg:32.41ms
+step:25/1490 train_time:806ms step_avg:32.25ms
+step:26/1490 train_time:840ms step_avg:32.33ms
+step:27/1490 train_time:869ms step_avg:32.19ms
+step:28/1490 train_time:904ms step_avg:32.28ms
+step:29/1490 train_time:932ms step_avg:32.13ms
+step:30/1490 train_time:966ms step_avg:32.21ms
+step:31/1490 train_time:995ms step_avg:32.10ms
+step:32/1490 train_time:1030ms step_avg:32.20ms
+step:33/1490 train_time:1060ms step_avg:32.11ms
+step:34/1490 train_time:1095ms step_avg:32.20ms
+step:35/1490 train_time:1124ms step_avg:32.12ms
+step:36/1490 train_time:1159ms step_avg:32.20ms
+step:37/1490 train_time:1188ms step_avg:32.10ms
+step:38/1490 train_time:1222ms step_avg:32.16ms
+step:39/1490 train_time:1251ms step_avg:32.07ms
+step:40/1490 train_time:1286ms step_avg:32.14ms
+step:41/1490 train_time:1314ms step_avg:32.06ms
+step:42/1490 train_time:1349ms step_avg:32.11ms
+step:43/1490 train_time:1377ms step_avg:32.02ms
+step:44/1490 train_time:1411ms step_avg:32.08ms
+step:45/1490 train_time:1440ms step_avg:32.00ms
+step:46/1490 train_time:1475ms step_avg:32.05ms
+step:47/1490 train_time:1503ms step_avg:31.99ms
+step:48/1490 train_time:1538ms step_avg:32.04ms
+step:49/1490 train_time:1566ms step_avg:31.96ms
+step:50/1490 train_time:1600ms step_avg:32.01ms
+step:51/1490 train_time:1629ms step_avg:31.95ms
+step:52/1490 train_time:1664ms step_avg:32.00ms
+step:53/1490 train_time:1692ms step_avg:31.93ms
+step:54/1490 train_time:1727ms step_avg:31.98ms
+step:55/1490 train_time:1755ms step_avg:31.91ms
+step:56/1490 train_time:1790ms step_avg:31.96ms
+step:57/1490 train_time:1818ms step_avg:31.90ms
+step:58/1490 train_time:1853ms step_avg:31.95ms
+step:59/1490 train_time:1881ms step_avg:31.88ms
+step:60/1490 train_time:1915ms step_avg:31.92ms
+step:61/1490 train_time:1943ms step_avg:31.86ms
+step:62/1490 train_time:1978ms step_avg:31.90ms
+step:63/1490 train_time:2006ms step_avg:31.85ms
+step:64/1490 train_time:2041ms step_avg:31.90ms
+step:65/1490 train_time:2070ms step_avg:31.85ms
+step:66/1490 train_time:2105ms step_avg:31.90ms
+step:67/1490 train_time:2134ms step_avg:31.84ms
+step:68/1490 train_time:2168ms step_avg:31.89ms
+step:69/1490 train_time:2197ms step_avg:31.84ms
+step:70/1490 train_time:2232ms step_avg:31.89ms
+step:71/1490 train_time:2261ms step_avg:31.84ms
+step:72/1490 train_time:2295ms step_avg:31.88ms
+step:73/1490 train_time:2324ms step_avg:31.84ms
+step:74/1490 train_time:2358ms step_avg:31.87ms
+step:75/1490 train_time:2387ms step_avg:31.83ms
+step:76/1490 train_time:2421ms step_avg:31.86ms
+step:77/1490 train_time:2450ms step_avg:31.82ms
+step:78/1490 train_time:2484ms step_avg:31.85ms
+step:79/1490 train_time:2512ms step_avg:31.80ms
+step:80/1490 train_time:2547ms step_avg:31.84ms
+step:81/1490 train_time:2575ms step_avg:31.80ms
+step:82/1490 train_time:2610ms step_avg:31.83ms
+step:83/1490 train_time:2638ms step_avg:31.78ms
+step:84/1490 train_time:2672ms step_avg:31.81ms
+step:85/1490 train_time:2701ms step_avg:31.78ms
+step:86/1490 train_time:2736ms step_avg:31.81ms
+step:87/1490 train_time:2764ms step_avg:31.77ms
+step:88/1490 train_time:2798ms step_avg:31.80ms
+step:89/1490 train_time:2827ms step_avg:31.76ms
+step:90/1490 train_time:2861ms step_avg:31.79ms
+step:91/1490 train_time:2889ms step_avg:31.75ms
+step:92/1490 train_time:2924ms step_avg:31.78ms
+step:93/1490 train_time:2952ms step_avg:31.75ms
+step:94/1490 train_time:2987ms step_avg:31.77ms
+step:95/1490 train_time:3015ms step_avg:31.74ms
+step:96/1490 train_time:3050ms step_avg:31.77ms
+step:97/1490 train_time:3079ms step_avg:31.74ms
+step:98/1490 train_time:3113ms step_avg:31.77ms
+step:99/1490 train_time:3142ms step_avg:31.73ms
+step:100/1490 train_time:3176ms step_avg:31.76ms
+step:101/1490 train_time:3204ms step_avg:31.73ms
+step:102/1490 train_time:3238ms step_avg:31.75ms
+step:103/1490 train_time:3267ms step_avg:31.72ms
+step:104/1490 train_time:3301ms step_avg:31.74ms
+step:105/1490 train_time:3330ms step_avg:31.71ms
+step:106/1490 train_time:3364ms step_avg:31.74ms
+step:107/1490 train_time:3393ms step_avg:31.71ms
+step:108/1490 train_time:3427ms step_avg:31.73ms
+step:109/1490 train_time:3455ms step_avg:31.70ms
+step:110/1490 train_time:3490ms step_avg:31.73ms
+step:111/1490 train_time:3519ms step_avg:31.71ms
+step:112/1490 train_time:3554ms step_avg:31.73ms
+step:113/1490 train_time:3583ms step_avg:31.71ms
+step:114/1490 train_time:3617ms step_avg:31.73ms
+step:115/1490 train_time:3645ms step_avg:31.70ms
+step:116/1490 train_time:3680ms step_avg:31.72ms
+step:117/1490 train_time:3708ms step_avg:31.69ms
+step:118/1490 train_time:3743ms step_avg:31.72ms
+step:119/1490 train_time:3771ms step_avg:31.69ms
+step:120/1490 train_time:3805ms step_avg:31.71ms
+step:121/1490 train_time:3834ms step_avg:31.68ms
+step:122/1490 train_time:3868ms step_avg:31.71ms
+step:123/1490 train_time:3897ms step_avg:31.69ms
+step:124/1490 train_time:3932ms step_avg:31.71ms
+step:125/1490 train_time:3960ms step_avg:31.68ms
+step:126/1490 train_time:3995ms step_avg:31.71ms
+step:127/1490 train_time:4024ms step_avg:31.68ms
+step:128/1490 train_time:4058ms step_avg:31.70ms
+step:129/1490 train_time:4087ms step_avg:31.68ms
+step:130/1490 train_time:4121ms step_avg:31.70ms
+step:131/1490 train_time:4149ms step_avg:31.67ms
+step:132/1490 train_time:4184ms step_avg:31.70ms
+step:133/1490 train_time:4213ms step_avg:31.67ms
+step:134/1490 train_time:4247ms step_avg:31.70ms
+step:135/1490 train_time:4276ms step_avg:31.67ms
+step:136/1490 train_time:4311ms step_avg:31.70ms
+step:137/1490 train_time:4339ms step_avg:31.67ms
+step:138/1490 train_time:4374ms step_avg:31.69ms
+step:139/1490 train_time:4402ms step_avg:31.67ms
+step:140/1490 train_time:4437ms step_avg:31.69ms
+step:141/1490 train_time:4465ms step_avg:31.67ms
+step:142/1490 train_time:4500ms step_avg:31.69ms
+step:143/1490 train_time:4529ms step_avg:31.67ms
+step:144/1490 train_time:4563ms step_avg:31.69ms
+step:145/1490 train_time:4592ms step_avg:31.67ms
+step:146/1490 train_time:4626ms step_avg:31.69ms
+step:147/1490 train_time:4655ms step_avg:31.67ms
+step:148/1490 train_time:4689ms step_avg:31.68ms
+step:149/1490 train_time:4718ms step_avg:31.66ms
+step:150/1490 train_time:4752ms step_avg:31.68ms
+step:151/1490 train_time:4781ms step_avg:31.66ms
+step:152/1490 train_time:4815ms step_avg:31.68ms
+step:153/1490 train_time:4844ms step_avg:31.66ms
+step:154/1490 train_time:4878ms step_avg:31.67ms
+step:155/1490 train_time:4907ms step_avg:31.66ms
+step:156/1490 train_time:4942ms step_avg:31.68ms
+step:157/1490 train_time:4970ms step_avg:31.66ms
+step:158/1490 train_time:5005ms step_avg:31.68ms
+step:159/1490 train_time:5033ms step_avg:31.65ms
+step:160/1490 train_time:5068ms step_avg:31.67ms
+step:161/1490 train_time:5096ms step_avg:31.65ms
+step:162/1490 train_time:5131ms step_avg:31.67ms
+step:163/1490 train_time:5159ms step_avg:31.65ms
+step:164/1490 train_time:5194ms step_avg:31.67ms
+step:165/1490 train_time:5222ms step_avg:31.65ms
+step:166/1490 train_time:5257ms step_avg:31.67ms
+step:167/1490 train_time:5285ms step_avg:31.65ms
+step:168/1490 train_time:5319ms step_avg:31.66ms
+step:169/1490 train_time:5348ms step_avg:31.65ms
+step:170/1490 train_time:5383ms step_avg:31.66ms
+step:171/1490 train_time:5411ms step_avg:31.64ms
+step:172/1490 train_time:5446ms step_avg:31.66ms
+step:173/1490 train_time:5474ms step_avg:31.64ms
+step:174/1490 train_time:5509ms step_avg:31.66ms
+step:175/1490 train_time:5538ms step_avg:31.64ms
+step:176/1490 train_time:5572ms step_avg:31.66ms
+step:177/1490 train_time:5601ms step_avg:31.64ms
+step:178/1490 train_time:5635ms step_avg:31.66ms
+step:179/1490 train_time:5663ms step_avg:31.64ms
+step:180/1490 train_time:5697ms step_avg:31.65ms
+step:181/1490 train_time:5726ms step_avg:31.64ms
+step:182/1490 train_time:5760ms step_avg:31.65ms
+step:183/1490 train_time:5789ms step_avg:31.63ms
+step:184/1490 train_time:5823ms step_avg:31.65ms
+step:185/1490 train_time:5851ms step_avg:31.63ms
+step:186/1490 train_time:5886ms step_avg:31.64ms
+step:187/1490 train_time:5914ms step_avg:31.63ms
+step:188/1490 train_time:5949ms step_avg:31.64ms
+step:189/1490 train_time:5977ms step_avg:31.63ms
+step:190/1490 train_time:6012ms step_avg:31.64ms
+step:191/1490 train_time:6040ms step_avg:31.62ms
+step:192/1490 train_time:6074ms step_avg:31.64ms
+step:193/1490 train_time:6103ms step_avg:31.62ms
+step:194/1490 train_time:6137ms step_avg:31.64ms
+step:195/1490 train_time:6166ms step_avg:31.62ms
+step:196/1490 train_time:6200ms step_avg:31.63ms
+step:197/1490 train_time:6229ms step_avg:31.62ms
+step:198/1490 train_time:6263ms step_avg:31.63ms
+step:199/1490 train_time:6291ms step_avg:31.61ms
+step:200/1490 train_time:6326ms step_avg:31.63ms
+step:201/1490 train_time:6354ms step_avg:31.61ms
+step:202/1490 train_time:6389ms step_avg:31.63ms
+step:203/1490 train_time:6417ms step_avg:31.61ms
+step:204/1490 train_time:6452ms step_avg:31.63ms
+step:205/1490 train_time:6480ms step_avg:31.61ms
+step:206/1490 train_time:6515ms step_avg:31.62ms
+step:207/1490 train_time:6543ms step_avg:31.61ms
+step:208/1490 train_time:6577ms step_avg:31.62ms
+step:209/1490 train_time:6606ms step_avg:31.61ms
+step:210/1490 train_time:6640ms step_avg:31.62ms
+step:211/1490 train_time:6669ms step_avg:31.61ms
+step:212/1490 train_time:6704ms step_avg:31.62ms
+step:213/1490 train_time:6732ms step_avg:31.61ms
+step:214/1490 train_time:6767ms step_avg:31.62ms
+step:215/1490 train_time:6795ms step_avg:31.61ms
+step:216/1490 train_time:6830ms step_avg:31.62ms
+step:217/1490 train_time:6858ms step_avg:31.60ms
+step:218/1490 train_time:6893ms step_avg:31.62ms
+step:219/1490 train_time:6921ms step_avg:31.60ms
+step:220/1490 train_time:6956ms step_avg:31.62ms
+step:221/1490 train_time:6984ms step_avg:31.60ms
+step:222/1490 train_time:7018ms step_avg:31.61ms
+step:223/1490 train_time:7047ms step_avg:31.60ms
+step:224/1490 train_time:7081ms step_avg:31.61ms
+step:225/1490 train_time:7110ms step_avg:31.60ms
+step:226/1490 train_time:7144ms step_avg:31.61ms
+step:227/1490 train_time:7173ms step_avg:31.60ms
+step:228/1490 train_time:7207ms step_avg:31.61ms
+step:229/1490 train_time:7235ms step_avg:31.59ms
+step:230/1490 train_time:7270ms step_avg:31.61ms
+step:231/1490 train_time:7298ms step_avg:31.60ms
+step:232/1490 train_time:7333ms step_avg:31.61ms
+step:233/1490 train_time:7361ms step_avg:31.59ms
+step:234/1490 train_time:7395ms step_avg:31.60ms
+step:235/1490 train_time:7424ms step_avg:31.59ms
+step:236/1490 train_time:7458ms step_avg:31.60ms
+step:237/1490 train_time:7486ms step_avg:31.59ms
+step:238/1490 train_time:7521ms step_avg:31.60ms
+step:239/1490 train_time:7549ms step_avg:31.59ms
+step:240/1490 train_time:7583ms step_avg:31.60ms
+step:241/1490 train_time:7612ms step_avg:31.58ms
+step:242/1490 train_time:7646ms step_avg:31.60ms
+step:243/1490 train_time:7675ms step_avg:31.58ms
+step:244/1490 train_time:7710ms step_avg:31.60ms
+step:245/1490 train_time:7738ms step_avg:31.58ms
+step:246/1490 train_time:7773ms step_avg:31.60ms
+step:247/1490 train_time:7801ms step_avg:31.58ms
+step:248/1490 train_time:7836ms step_avg:31.59ms
+step:249/1490 train_time:7864ms step_avg:31.58ms
+step:250/1490 train_time:7898ms step_avg:31.59ms
+step:250/1490 val_loss:4.5105 train_time:7942ms step_avg:31.77ms
+step:251/1490 train_time:7957ms step_avg:31.70ms
+step:252/1490 train_time:7975ms step_avg:31.65ms
+step:253/1490 train_time:7993ms step_avg:31.59ms
+step:254/1490 train_time:8027ms step_avg:31.60ms
+step:255/1490 train_time:8057ms step_avg:31.60ms
+step:256/1490 train_time:8094ms step_avg:31.62ms
+step:257/1490 train_time:8123ms step_avg:31.61ms
+step:258/1490 train_time:8158ms step_avg:31.62ms
+step:259/1490 train_time:8187ms step_avg:31.61ms
+step:260/1490 train_time:8222ms step_avg:31.62ms
+step:261/1490 train_time:8250ms step_avg:31.61ms
+step:262/1490 train_time:8285ms step_avg:31.62ms
+step:263/1490 train_time:8313ms step_avg:31.61ms
+step:264/1490 train_time:8347ms step_avg:31.62ms
+step:265/1490 train_time:8375ms step_avg:31.60ms
+step:266/1490 train_time:8410ms step_avg:31.61ms
+step:267/1490 train_time:8438ms step_avg:31.60ms
+step:268/1490 train_time:8472ms step_avg:31.61ms
+step:269/1490 train_time:8500ms step_avg:31.60ms
+step:270/1490 train_time:8534ms step_avg:31.61ms
+step:271/1490 train_time:8562ms step_avg:31.59ms
+step:272/1490 train_time:8596ms step_avg:31.60ms
+step:273/1490 train_time:8624ms step_avg:31.59ms
+step:274/1490 train_time:8658ms step_avg:31.60ms
+step:275/1490 train_time:8686ms step_avg:31.59ms
+step:276/1490 train_time:8720ms step_avg:31.60ms
+step:277/1490 train_time:8749ms step_avg:31.58ms
+step:278/1490 train_time:8783ms step_avg:31.59ms
+step:279/1490 train_time:8811ms step_avg:31.58ms
+step:280/1490 train_time:8845ms step_avg:31.59ms
+step:281/1490 train_time:8874ms step_avg:31.58ms
+step:282/1490 train_time:8908ms step_avg:31.59ms
+step:283/1490 train_time:8936ms step_avg:31.58ms
+step:284/1490 train_time:8971ms step_avg:31.59ms
+step:285/1490 train_time:9000ms step_avg:31.58ms
+step:286/1490 train_time:9035ms step_avg:31.59ms
+step:287/1490 train_time:9064ms step_avg:31.58ms
+step:288/1490 train_time:9099ms step_avg:31.59ms
+step:289/1490 train_time:9128ms step_avg:31.58ms
+step:290/1490 train_time:9162ms step_avg:31.59ms
+step:291/1490 train_time:9190ms step_avg:31.58ms
+step:292/1490 train_time:9225ms step_avg:31.59ms
+step:293/1490 train_time:9254ms step_avg:31.58ms
+step:294/1490 train_time:9288ms step_avg:31.59ms
+step:295/1490 train_time:9317ms step_avg:31.58ms
+step:296/1490 train_time:9351ms step_avg:31.59ms
+step:297/1490 train_time:9380ms step_avg:31.58ms
+step:298/1490 train_time:9414ms step_avg:31.59ms
+step:299/1490 train_time:9442ms step_avg:31.58ms
+step:300/1490 train_time:9477ms step_avg:31.59ms
+step:301/1490 train_time:9505ms step_avg:31.58ms
+step:302/1490 train_time:9540ms step_avg:31.59ms
+step:303/1490 train_time:9568ms step_avg:31.58ms
+step:304/1490 train_time:9602ms step_avg:31.59ms
+step:305/1490 train_time:9631ms step_avg:31.58ms
+step:306/1490 train_time:9665ms step_avg:31.58ms
+step:307/1490 train_time:9693ms step_avg:31.57ms
+step:308/1490 train_time:9727ms step_avg:31.58ms
+step:309/1490 train_time:9755ms step_avg:31.57ms
+step:310/1490 train_time:9790ms step_avg:31.58ms
+step:311/1490 train_time:9818ms step_avg:31.57ms
+step:312/1490 train_time:9852ms step_avg:31.58ms
+step:313/1490 train_time:9880ms step_avg:31.57ms
+step:314/1490 train_time:9915ms step_avg:31.58ms
+step:315/1490 train_time:9944ms step_avg:31.57ms
+step:316/1490 train_time:9979ms step_avg:31.58ms
+step:317/1490 train_time:10007ms step_avg:31.57ms
+step:318/1490 train_time:10042ms step_avg:31.58ms
+step:319/1490 train_time:10070ms step_avg:31.57ms
+step:320/1490 train_time:10104ms step_avg:31.58ms
+step:321/1490 train_time:10133ms step_avg:31.57ms
+step:322/1490 train_time:10167ms step_avg:31.58ms
+step:323/1490 train_time:10196ms step_avg:31.57ms
+step:324/1490 train_time:10230ms step_avg:31.57ms
+step:325/1490 train_time:10259ms step_avg:31.57ms
+step:326/1490 train_time:10294ms step_avg:31.58ms
+step:327/1490 train_time:10322ms step_avg:31.57ms
+step:328/1490 train_time:10357ms step_avg:31.57ms
+step:329/1490 train_time:10385ms step_avg:31.57ms
+step:330/1490 train_time:10420ms step_avg:31.57ms
+step:331/1490 train_time:10448ms step_avg:31.56ms
+step:332/1490 train_time:10482ms step_avg:31.57ms
+step:333/1490 train_time:10510ms step_avg:31.56ms
+step:334/1490 train_time:10545ms step_avg:31.57ms
+step:335/1490 train_time:10573ms step_avg:31.56ms
+step:336/1490 train_time:10607ms step_avg:31.57ms
+step:337/1490 train_time:10635ms step_avg:31.56ms
+step:338/1490 train_time:10670ms step_avg:31.57ms
+step:339/1490 train_time:10698ms step_avg:31.56ms
+step:340/1490 train_time:10733ms step_avg:31.57ms
+step:341/1490 train_time:10760ms step_avg:31.56ms
+step:342/1490 train_time:10795ms step_avg:31.56ms
+step:343/1490 train_time:10823ms step_avg:31.55ms
+step:344/1490 train_time:10858ms step_avg:31.56ms
+step:345/1490 train_time:10886ms step_avg:31.55ms
+step:346/1490 train_time:10921ms step_avg:31.56ms
+step:347/1490 train_time:10949ms step_avg:31.55ms
+step:348/1490 train_time:10983ms step_avg:31.56ms
+step:349/1490 train_time:11012ms step_avg:31.55ms
+step:350/1490 train_time:11046ms step_avg:31.56ms
+step:351/1490 train_time:11074ms step_avg:31.55ms
+step:352/1490 train_time:11109ms step_avg:31.56ms
+step:353/1490 train_time:11138ms step_avg:31.55ms
+step:354/1490 train_time:11172ms step_avg:31.56ms
+step:355/1490 train_time:11201ms step_avg:31.55ms
+step:356/1490 train_time:11235ms step_avg:31.56ms
+step:357/1490 train_time:11264ms step_avg:31.55ms
+step:358/1490 train_time:11299ms step_avg:31.56ms
+step:359/1490 train_time:11327ms step_avg:31.55ms
+step:360/1490 train_time:11362ms step_avg:31.56ms
+step:361/1490 train_time:11390ms step_avg:31.55ms
+step:362/1490 train_time:11424ms step_avg:31.56ms
+step:363/1490 train_time:11453ms step_avg:31.55ms
+step:364/1490 train_time:11487ms step_avg:31.56ms
+step:365/1490 train_time:11516ms step_avg:31.55ms
+step:366/1490 train_time:11550ms step_avg:31.56ms
+step:367/1490 train_time:11579ms step_avg:31.55ms
+step:368/1490 train_time:11613ms step_avg:31.56ms
+step:369/1490 train_time:11641ms step_avg:31.55ms
+step:370/1490 train_time:11676ms step_avg:31.56ms
+step:371/1490 train_time:11705ms step_avg:31.55ms
+step:372/1490 train_time:11739ms step_avg:31.56ms
+step:373/1490 train_time:11767ms step_avg:31.55ms
+step:374/1490 train_time:11802ms step_avg:31.55ms
+step:375/1490 train_time:11830ms step_avg:31.55ms
+step:376/1490 train_time:11864ms step_avg:31.55ms
+step:377/1490 train_time:11892ms step_avg:31.54ms
+step:378/1490 train_time:11927ms step_avg:31.55ms
+step:379/1490 train_time:11955ms step_avg:31.54ms
+step:380/1490 train_time:11990ms step_avg:31.55ms
+step:381/1490 train_time:12018ms step_avg:31.54ms
+step:382/1490 train_time:12052ms step_avg:31.55ms
+step:383/1490 train_time:12081ms step_avg:31.54ms
+step:384/1490 train_time:12115ms step_avg:31.55ms
+step:385/1490 train_time:12144ms step_avg:31.54ms
+step:386/1490 train_time:12179ms step_avg:31.55ms
+step:387/1490 train_time:12207ms step_avg:31.54ms
+step:388/1490 train_time:12241ms step_avg:31.55ms
+step:389/1490 train_time:12270ms step_avg:31.54ms
+step:390/1490 train_time:12304ms step_avg:31.55ms
+step:391/1490 train_time:12333ms step_avg:31.54ms
+step:392/1490 train_time:12367ms step_avg:31.55ms
+step:393/1490 train_time:12395ms step_avg:31.54ms
+step:394/1490 train_time:12430ms step_avg:31.55ms
+step:395/1490 train_time:12459ms step_avg:31.54ms
+step:396/1490 train_time:12494ms step_avg:31.55ms
+step:397/1490 train_time:12521ms step_avg:31.54ms
+step:398/1490 train_time:12557ms step_avg:31.55ms
+step:399/1490 train_time:12585ms step_avg:31.54ms
+step:400/1490 train_time:12619ms step_avg:31.55ms
+step:401/1490 train_time:12648ms step_avg:31.54ms
+step:402/1490 train_time:12682ms step_avg:31.55ms
+step:403/1490 train_time:12710ms step_avg:31.54ms
+step:404/1490 train_time:12744ms step_avg:31.55ms
+step:405/1490 train_time:12773ms step_avg:31.54ms
+step:406/1490 train_time:12808ms step_avg:31.55ms
+step:407/1490 train_time:12836ms step_avg:31.54ms
+step:408/1490 train_time:12871ms step_avg:31.55ms
+step:409/1490 train_time:12899ms step_avg:31.54ms
+step:410/1490 train_time:12933ms step_avg:31.54ms
+step:411/1490 train_time:12961ms step_avg:31.54ms
+step:412/1490 train_time:12996ms step_avg:31.54ms
+step:413/1490 train_time:13024ms step_avg:31.54ms
+step:414/1490 train_time:13059ms step_avg:31.54ms
+step:415/1490 train_time:13087ms step_avg:31.53ms
+step:416/1490 train_time:13121ms step_avg:31.54ms
+step:417/1490 train_time:13150ms step_avg:31.53ms
+step:418/1490 train_time:13184ms step_avg:31.54ms
+step:419/1490 train_time:13212ms step_avg:31.53ms
+step:420/1490 train_time:13246ms step_avg:31.54ms
+step:421/1490 train_time:13275ms step_avg:31.53ms
+step:422/1490 train_time:13309ms step_avg:31.54ms
+step:423/1490 train_time:13338ms step_avg:31.53ms
+step:424/1490 train_time:13372ms step_avg:31.54ms
+step:425/1490 train_time:13401ms step_avg:31.53ms
+step:426/1490 train_time:13436ms step_avg:31.54ms
+step:427/1490 train_time:13464ms step_avg:31.53ms
+step:428/1490 train_time:13499ms step_avg:31.54ms
+step:429/1490 train_time:13527ms step_avg:31.53ms
+step:430/1490 train_time:13562ms step_avg:31.54ms
+step:431/1490 train_time:13590ms step_avg:31.53ms
+step:432/1490 train_time:13624ms step_avg:31.54ms
+step:433/1490 train_time:13653ms step_avg:31.53ms
+step:434/1490 train_time:13687ms step_avg:31.54ms
+step:435/1490 train_time:13716ms step_avg:31.53ms
+step:436/1490 train_time:13750ms step_avg:31.54ms
+step:437/1490 train_time:13779ms step_avg:31.53ms
+step:438/1490 train_time:13813ms step_avg:31.54ms
+step:439/1490 train_time:13841ms step_avg:31.53ms
+step:440/1490 train_time:13876ms step_avg:31.54ms
+step:441/1490 train_time:13905ms step_avg:31.53ms
+step:442/1490 train_time:13939ms step_avg:31.54ms
+step:443/1490 train_time:13968ms step_avg:31.53ms
+step:444/1490 train_time:14002ms step_avg:31.54ms
+step:445/1490 train_time:14031ms step_avg:31.53ms
+step:446/1490 train_time:14065ms step_avg:31.54ms
+step:447/1490 train_time:14094ms step_avg:31.53ms
+step:448/1490 train_time:14128ms step_avg:31.54ms
+step:449/1490 train_time:14156ms step_avg:31.53ms
+step:450/1490 train_time:14191ms step_avg:31.53ms
+step:451/1490 train_time:14219ms step_avg:31.53ms
+step:452/1490 train_time:14254ms step_avg:31.53ms
+step:453/1490 train_time:14282ms step_avg:31.53ms
+step:454/1490 train_time:14317ms step_avg:31.53ms
+step:455/1490 train_time:14345ms step_avg:31.53ms
+step:456/1490 train_time:14380ms step_avg:31.54ms
+step:457/1490 train_time:14408ms step_avg:31.53ms
+step:458/1490 train_time:14442ms step_avg:31.53ms
+step:459/1490 train_time:14471ms step_avg:31.53ms
+step:460/1490 train_time:14505ms step_avg:31.53ms
+step:461/1490 train_time:14533ms step_avg:31.53ms
+step:462/1490 train_time:14568ms step_avg:31.53ms
+step:463/1490 train_time:14596ms step_avg:31.53ms
+step:464/1490 train_time:14631ms step_avg:31.53ms
+step:465/1490 train_time:14659ms step_avg:31.52ms
+step:466/1490 train_time:14694ms step_avg:31.53ms
+step:467/1490 train_time:14722ms step_avg:31.52ms
+step:468/1490 train_time:14756ms step_avg:31.53ms
+step:469/1490 train_time:14785ms step_avg:31.52ms
+step:470/1490 train_time:14820ms step_avg:31.53ms
+step:471/1490 train_time:14848ms step_avg:31.52ms
+step:472/1490 train_time:14883ms step_avg:31.53ms
+step:473/1490 train_time:14911ms step_avg:31.52ms
+step:474/1490 train_time:14946ms step_avg:31.53ms
+step:475/1490 train_time:14974ms step_avg:31.52ms
+step:476/1490 train_time:15008ms step_avg:31.53ms
+step:477/1490 train_time:15037ms step_avg:31.52ms
+step:478/1490 train_time:15071ms step_avg:31.53ms
+step:479/1490 train_time:15099ms step_avg:31.52ms
+step:480/1490 train_time:15134ms step_avg:31.53ms
+step:481/1490 train_time:15162ms step_avg:31.52ms
+step:482/1490 train_time:15197ms step_avg:31.53ms
+step:483/1490 train_time:15225ms step_avg:31.52ms
+step:484/1490 train_time:15262ms step_avg:31.53ms
+step:485/1490 train_time:15314ms step_avg:31.58ms
+step:486/1490 train_time:15374ms step_avg:31.63ms
+step:487/1490 train_time:15427ms step_avg:31.68ms
+step:488/1490 train_time:15487ms step_avg:31.74ms
+step:489/1490 train_time:15541ms step_avg:31.78ms
+step:490/1490 train_time:15603ms step_avg:31.84ms
+step:491/1490 train_time:15656ms step_avg:31.89ms
+step:492/1490 train_time:15717ms step_avg:31.94ms
+step:493/1490 train_time:15770ms step_avg:31.99ms
+step:494/1490 train_time:15830ms step_avg:32.04ms
+step:495/1490 train_time:15885ms step_avg:32.09ms
+step:496/1490 train_time:15945ms step_avg:32.15ms
+step:497/1490 train_time:16000ms step_avg:32.19ms
+step:498/1490 train_time:16059ms step_avg:32.25ms
+step:499/1490 train_time:16113ms step_avg:32.29ms
+step:500/1490 train_time:16176ms step_avg:32.35ms
+step:500/1490 val_loss:4.2376 train_time:16247ms step_avg:32.49ms
+step:501/1490 train_time:16263ms step_avg:32.46ms
+step:502/1490 train_time:16290ms step_avg:32.45ms
+step:503/1490 train_time:16348ms step_avg:32.50ms
+step:504/1490 train_time:16411ms step_avg:32.56ms
+step:505/1490 train_time:16467ms step_avg:32.61ms
+step:506/1490 train_time:16527ms step_avg:32.66ms
+step:507/1490 train_time:16581ms step_avg:32.70ms
+step:508/1490 train_time:16641ms step_avg:32.76ms
+step:509/1490 train_time:16694ms step_avg:32.80ms
+step:510/1490 train_time:16753ms step_avg:32.85ms
+step:511/1490 train_time:16807ms step_avg:32.89ms
+step:512/1490 train_time:16866ms step_avg:32.94ms
+step:513/1490 train_time:16918ms step_avg:32.98ms
+step:514/1490 train_time:16977ms step_avg:33.03ms
+step:515/1490 train_time:17030ms step_avg:33.07ms
+step:516/1490 train_time:17090ms step_avg:33.12ms
+step:517/1490 train_time:17143ms step_avg:33.16ms
+step:518/1490 train_time:17203ms step_avg:33.21ms
+step:519/1490 train_time:17258ms step_avg:33.25ms
+step:520/1490 train_time:17319ms step_avg:33.31ms
+step:521/1490 train_time:17375ms step_avg:33.35ms
+step:522/1490 train_time:17436ms step_avg:33.40ms
+step:523/1490 train_time:17492ms step_avg:33.44ms
+step:524/1490 train_time:17551ms step_avg:33.49ms
+step:525/1490 train_time:17606ms step_avg:33.53ms
+step:526/1490 train_time:17665ms step_avg:33.58ms
+step:527/1490 train_time:17719ms step_avg:33.62ms
+step:528/1490 train_time:17779ms step_avg:33.67ms
+step:529/1490 train_time:17832ms step_avg:33.71ms
+step:530/1490 train_time:17891ms step_avg:33.76ms
+step:531/1490 train_time:17944ms step_avg:33.79ms
+step:532/1490 train_time:18004ms step_avg:33.84ms
+step:533/1490 train_time:18058ms step_avg:33.88ms
+step:534/1490 train_time:18117ms step_avg:33.93ms
+step:535/1490 train_time:18172ms step_avg:33.97ms
+step:536/1490 train_time:18232ms step_avg:34.01ms
+step:537/1490 train_time:18286ms step_avg:34.05ms
+step:538/1490 train_time:18347ms step_avg:34.10ms
+step:539/1490 train_time:18403ms step_avg:34.14ms
+step:540/1490 train_time:18463ms step_avg:34.19ms
+step:541/1490 train_time:18518ms step_avg:34.23ms
+step:542/1490 train_time:18577ms step_avg:34.27ms
+step:543/1490 train_time:18632ms step_avg:34.31ms
+step:544/1490 train_time:18691ms step_avg:34.36ms
+step:545/1490 train_time:18745ms step_avg:34.39ms
+step:546/1490 train_time:18805ms step_avg:34.44ms
+step:547/1490 train_time:18859ms step_avg:34.48ms
+step:548/1490 train_time:18919ms step_avg:34.52ms
+step:549/1490 train_time:18972ms step_avg:34.56ms
+step:550/1490 train_time:19031ms step_avg:34.60ms
+step:551/1490 train_time:19085ms step_avg:34.64ms
+step:552/1490 train_time:19144ms step_avg:34.68ms
+step:553/1490 train_time:19199ms step_avg:34.72ms
+step:554/1490 train_time:19258ms step_avg:34.76ms
+step:555/1490 train_time:19314ms step_avg:34.80ms
+step:556/1490 train_time:19373ms step_avg:34.84ms
+step:557/1490 train_time:19427ms step_avg:34.88ms
+step:558/1490 train_time:19487ms step_avg:34.92ms
+step:559/1490 train_time:19542ms step_avg:34.96ms
+step:560/1490 train_time:19603ms step_avg:35.01ms
+step:561/1490 train_time:19657ms step_avg:35.04ms
+step:562/1490 train_time:19717ms step_avg:35.08ms
+step:563/1490 train_time:19771ms step_avg:35.12ms
+step:564/1490 train_time:19831ms step_avg:35.16ms
+step:565/1490 train_time:19885ms step_avg:35.19ms
+step:566/1490 train_time:19944ms step_avg:35.24ms
+step:567/1490 train_time:19998ms step_avg:35.27ms
+step:568/1490 train_time:20057ms step_avg:35.31ms
+step:569/1490 train_time:20111ms step_avg:35.34ms
+step:570/1490 train_time:20170ms step_avg:35.39ms
+step:571/1490 train_time:20225ms step_avg:35.42ms
+step:572/1490 train_time:20286ms step_avg:35.46ms
+step:573/1490 train_time:20340ms step_avg:35.50ms
+step:574/1490 train_time:20400ms step_avg:35.54ms
+step:575/1490 train_time:20455ms step_avg:35.57ms
+step:576/1490 train_time:20516ms step_avg:35.62ms
+step:577/1490 train_time:20570ms step_avg:35.65ms
+step:578/1490 train_time:20630ms step_avg:35.69ms
+step:579/1490 train_time:20684ms step_avg:35.72ms
+step:580/1490 train_time:20743ms step_avg:35.76ms
+step:581/1490 train_time:20797ms step_avg:35.80ms
+step:582/1490 train_time:20856ms step_avg:35.84ms
+step:583/1490 train_time:20911ms step_avg:35.87ms
+step:584/1490 train_time:20970ms step_avg:35.91ms
+step:585/1490 train_time:21024ms step_avg:35.94ms
+step:586/1490 train_time:21083ms step_avg:35.98ms
+step:587/1490 train_time:21137ms step_avg:36.01ms
+step:588/1490 train_time:21197ms step_avg:36.05ms
+step:589/1490 train_time:21251ms step_avg:36.08ms
+step:590/1490 train_time:21311ms step_avg:36.12ms
+step:591/1490 train_time:21366ms step_avg:36.15ms
+step:592/1490 train_time:21427ms step_avg:36.19ms
+step:593/1490 train_time:21481ms step_avg:36.22ms
+step:594/1490 train_time:21542ms step_avg:36.27ms
+step:595/1490 train_time:21596ms step_avg:36.30ms
+step:596/1490 train_time:21656ms step_avg:36.34ms
+step:597/1490 train_time:21710ms step_avg:36.37ms
+step:598/1490 train_time:21770ms step_avg:36.40ms
+step:599/1490 train_time:21824ms step_avg:36.43ms
+step:600/1490 train_time:21883ms step_avg:36.47ms
+step:601/1490 train_time:21937ms step_avg:36.50ms
+step:602/1490 train_time:21996ms step_avg:36.54ms
+step:603/1490 train_time:22050ms step_avg:36.57ms
+step:604/1490 train_time:22110ms step_avg:36.61ms
+step:605/1490 train_time:22164ms step_avg:36.64ms
+step:606/1490 train_time:22224ms step_avg:36.67ms
+step:607/1490 train_time:22279ms step_avg:36.70ms
+step:608/1490 train_time:22338ms step_avg:36.74ms
+step:609/1490 train_time:22392ms step_avg:36.77ms
+step:610/1490 train_time:22454ms step_avg:36.81ms
+step:611/1490 train_time:22508ms step_avg:36.84ms
+step:612/1490 train_time:22569ms step_avg:36.88ms
+step:613/1490 train_time:22623ms step_avg:36.91ms
+step:614/1490 train_time:22683ms step_avg:36.94ms
+step:615/1490 train_time:22737ms step_avg:36.97ms
+step:616/1490 train_time:22796ms step_avg:37.01ms
+step:617/1490 train_time:22851ms step_avg:37.04ms
+step:618/1490 train_time:22911ms step_avg:37.07ms
+step:619/1490 train_time:22965ms step_avg:37.10ms
+step:620/1490 train_time:23025ms step_avg:37.14ms
+step:621/1490 train_time:23080ms step_avg:37.17ms
+step:622/1490 train_time:23138ms step_avg:37.20ms
+step:623/1490 train_time:23192ms step_avg:37.23ms
+step:624/1490 train_time:23252ms step_avg:37.26ms
+step:625/1490 train_time:23306ms step_avg:37.29ms
+step:626/1490 train_time:23367ms step_avg:37.33ms
+step:627/1490 train_time:23422ms step_avg:37.36ms
+step:628/1490 train_time:23481ms step_avg:37.39ms
+step:629/1490 train_time:23536ms step_avg:37.42ms
+step:630/1490 train_time:23595ms step_avg:37.45ms
+step:631/1490 train_time:23650ms step_avg:37.48ms
+step:632/1490 train_time:23710ms step_avg:37.52ms
+step:633/1490 train_time:23764ms step_avg:37.54ms
+step:634/1490 train_time:23823ms step_avg:37.58ms
+step:635/1490 train_time:23878ms step_avg:37.60ms
+step:636/1490 train_time:23937ms step_avg:37.64ms
+step:637/1490 train_time:23991ms step_avg:37.66ms
+step:638/1490 train_time:24051ms step_avg:37.70ms
+step:639/1490 train_time:24105ms step_avg:37.72ms
+step:640/1490 train_time:24166ms step_avg:37.76ms
+step:641/1490 train_time:24220ms step_avg:37.78ms
+step:642/1490 train_time:24279ms step_avg:37.82ms
+step:643/1490 train_time:24333ms step_avg:37.84ms
+step:644/1490 train_time:24393ms step_avg:37.88ms
+step:645/1490 train_time:24447ms step_avg:37.90ms
+step:646/1490 train_time:24507ms step_avg:37.94ms
+step:647/1490 train_time:24563ms step_avg:37.96ms
+step:648/1490 train_time:24623ms step_avg:38.00ms
+step:649/1490 train_time:24677ms step_avg:38.02ms
+step:650/1490 train_time:24736ms step_avg:38.06ms
+step:651/1490 train_time:24791ms step_avg:38.08ms
+step:652/1490 train_time:24851ms step_avg:38.11ms
+step:653/1490 train_time:24904ms step_avg:38.14ms
+step:654/1490 train_time:24965ms step_avg:38.17ms
+step:655/1490 train_time:25019ms step_avg:38.20ms
+step:656/1490 train_time:25079ms step_avg:38.23ms
+step:657/1490 train_time:25132ms step_avg:38.25ms
+step:658/1490 train_time:25191ms step_avg:38.28ms
+step:659/1490 train_time:25245ms step_avg:38.31ms
+step:660/1490 train_time:25306ms step_avg:38.34ms
+step:661/1490 train_time:25361ms step_avg:38.37ms
+step:662/1490 train_time:25420ms step_avg:38.40ms
+step:663/1490 train_time:25475ms step_avg:38.42ms
+step:664/1490 train_time:25534ms step_avg:38.45ms
+step:665/1490 train_time:25588ms step_avg:38.48ms
+step:666/1490 train_time:25649ms step_avg:38.51ms
+step:667/1490 train_time:25704ms step_avg:38.54ms
+step:668/1490 train_time:25763ms step_avg:38.57ms
+step:669/1490 train_time:25817ms step_avg:38.59ms
+step:670/1490 train_time:25877ms step_avg:38.62ms
+step:671/1490 train_time:25931ms step_avg:38.65ms
+step:672/1490 train_time:25990ms step_avg:38.68ms
+step:673/1490 train_time:26045ms step_avg:38.70ms
+step:674/1490 train_time:26104ms step_avg:38.73ms
+step:675/1490 train_time:26159ms step_avg:38.75ms
+step:676/1490 train_time:26219ms step_avg:38.79ms
+step:677/1490 train_time:26274ms step_avg:38.81ms
+step:678/1490 train_time:26334ms step_avg:38.84ms
+step:679/1490 train_time:26388ms step_avg:38.86ms
+step:680/1490 train_time:26448ms step_avg:38.89ms
+step:681/1490 train_time:26503ms step_avg:38.92ms
+step:682/1490 train_time:26563ms step_avg:38.95ms
+step:683/1490 train_time:26617ms step_avg:38.97ms
+step:684/1490 train_time:26677ms step_avg:39.00ms
+step:685/1490 train_time:26731ms step_avg:39.02ms
+step:686/1490 train_time:26790ms step_avg:39.05ms
+step:687/1490 train_time:26845ms step_avg:39.08ms
+step:688/1490 train_time:26905ms step_avg:39.11ms
+step:689/1490 train_time:26959ms step_avg:39.13ms
+step:690/1490 train_time:27019ms step_avg:39.16ms
+step:691/1490 train_time:27073ms step_avg:39.18ms
+step:692/1490 train_time:27132ms step_avg:39.21ms
+step:693/1490 train_time:27187ms step_avg:39.23ms
+step:694/1490 train_time:27247ms step_avg:39.26ms
+step:695/1490 train_time:27302ms step_avg:39.28ms
+step:696/1490 train_time:27362ms step_avg:39.31ms
+step:697/1490 train_time:27415ms step_avg:39.33ms
+step:698/1490 train_time:27474ms step_avg:39.36ms
+step:699/1490 train_time:27529ms step_avg:39.38ms
+step:700/1490 train_time:27588ms step_avg:39.41ms
+step:701/1490 train_time:27642ms step_avg:39.43ms
+step:702/1490 train_time:27702ms step_avg:39.46ms
+step:703/1490 train_time:27756ms step_avg:39.48ms
+step:704/1490 train_time:27816ms step_avg:39.51ms
+step:705/1490 train_time:27871ms step_avg:39.53ms
+step:706/1490 train_time:27930ms step_avg:39.56ms
+step:707/1490 train_time:27984ms step_avg:39.58ms
+step:708/1490 train_time:28044ms step_avg:39.61ms
+step:709/1490 train_time:28098ms step_avg:39.63ms
+step:710/1490 train_time:28158ms step_avg:39.66ms
+step:711/1490 train_time:28213ms step_avg:39.68ms
+step:712/1490 train_time:28273ms step_avg:39.71ms
+step:713/1490 train_time:28327ms step_avg:39.73ms
+step:714/1490 train_time:28387ms step_avg:39.76ms
+step:715/1490 train_time:28441ms step_avg:39.78ms
+step:716/1490 train_time:28502ms step_avg:39.81ms
+step:717/1490 train_time:28556ms step_avg:39.83ms
+step:718/1490 train_time:28616ms step_avg:39.86ms
+step:719/1490 train_time:28669ms step_avg:39.87ms
+step:720/1490 train_time:28729ms step_avg:39.90ms
+step:721/1490 train_time:28783ms step_avg:39.92ms
+step:722/1490 train_time:28844ms step_avg:39.95ms
+step:723/1490 train_time:28898ms step_avg:39.97ms
+step:724/1490 train_time:28958ms step_avg:40.00ms
+step:725/1490 train_time:29012ms step_avg:40.02ms
+step:726/1490 train_time:29072ms step_avg:40.04ms
+step:727/1490 train_time:29126ms step_avg:40.06ms
+step:728/1490 train_time:29187ms step_avg:40.09ms
+step:729/1490 train_time:29240ms step_avg:40.11ms
+step:730/1490 train_time:29300ms step_avg:40.14ms
+step:731/1490 train_time:29354ms step_avg:40.16ms
+step:732/1490 train_time:29415ms step_avg:40.18ms
+step:733/1490 train_time:29468ms step_avg:40.20ms
+step:734/1490 train_time:29529ms step_avg:40.23ms
+step:735/1490 train_time:29583ms step_avg:40.25ms
+step:736/1490 train_time:29643ms step_avg:40.28ms
+step:737/1490 train_time:29697ms step_avg:40.29ms
+step:738/1490 train_time:29757ms step_avg:40.32ms
+step:739/1490 train_time:29811ms step_avg:40.34ms
+step:740/1490 train_time:29871ms step_avg:40.37ms
+step:741/1490 train_time:29925ms step_avg:40.38ms
+step:742/1490 train_time:29985ms step_avg:40.41ms
+step:743/1490 train_time:30039ms step_avg:40.43ms
+step:744/1490 train_time:30099ms step_avg:40.46ms
+step:745/1490 train_time:30154ms step_avg:40.48ms
+step:746/1490 train_time:30213ms step_avg:40.50ms
+step:747/1490 train_time:30267ms step_avg:40.52ms
+step:748/1490 train_time:30328ms step_avg:40.55ms
+step:749/1490 train_time:30382ms step_avg:40.56ms
+step:750/1490 train_time:30441ms step_avg:40.59ms
+step:750/1490 val_loss:3.8038 train_time:30514ms step_avg:40.68ms
+step:751/1490 train_time:30530ms step_avg:40.65ms
+step:752/1490 train_time:30557ms step_avg:40.63ms
+step:753/1490 train_time:30616ms step_avg:40.66ms
+step:754/1490 train_time:30678ms step_avg:40.69ms
+step:755/1490 train_time:30733ms step_avg:40.71ms
+step:756/1490 train_time:30794ms step_avg:40.73ms
+step:757/1490 train_time:30848ms step_avg:40.75ms
+step:758/1490 train_time:30908ms step_avg:40.78ms
+step:759/1490 train_time:30962ms step_avg:40.79ms
+step:760/1490 train_time:31021ms step_avg:40.82ms
+step:761/1490 train_time:31075ms step_avg:40.83ms
+step:762/1490 train_time:31134ms step_avg:40.86ms
+step:763/1490 train_time:31187ms step_avg:40.87ms
+step:764/1490 train_time:31246ms step_avg:40.90ms
+step:765/1490 train_time:31300ms step_avg:40.92ms
+step:766/1490 train_time:31360ms step_avg:40.94ms
+step:767/1490 train_time:31413ms step_avg:40.96ms
+step:768/1490 train_time:31473ms step_avg:40.98ms
+step:769/1490 train_time:31527ms step_avg:41.00ms
+step:770/1490 train_time:31588ms step_avg:41.02ms
+step:771/1490 train_time:31644ms step_avg:41.04ms
+step:772/1490 train_time:31705ms step_avg:41.07ms
+step:773/1490 train_time:31761ms step_avg:41.09ms
+step:774/1490 train_time:31822ms step_avg:41.11ms
+step:775/1490 train_time:31876ms step_avg:41.13ms
+step:776/1490 train_time:31936ms step_avg:41.15ms
+step:777/1490 train_time:31990ms step_avg:41.17ms
+step:778/1490 train_time:32050ms step_avg:41.19ms
+step:779/1490 train_time:32104ms step_avg:41.21ms
+step:780/1490 train_time:32163ms step_avg:41.23ms
+step:781/1490 train_time:32216ms step_avg:41.25ms
+step:782/1490 train_time:32276ms step_avg:41.27ms
+step:783/1490 train_time:32330ms step_avg:41.29ms
+step:784/1490 train_time:32389ms step_avg:41.31ms
+step:785/1490 train_time:32443ms step_avg:41.33ms
+step:786/1490 train_time:32503ms step_avg:41.35ms
+step:787/1490 train_time:32558ms step_avg:41.37ms
+step:788/1490 train_time:32619ms step_avg:41.39ms
+step:789/1490 train_time:32673ms step_avg:41.41ms
+step:790/1490 train_time:32734ms step_avg:41.44ms
+step:791/1490 train_time:32789ms step_avg:41.45ms
+step:792/1490 train_time:32849ms step_avg:41.48ms
+step:793/1490 train_time:32904ms step_avg:41.49ms
+step:794/1490 train_time:32964ms step_avg:41.52ms
+step:795/1490 train_time:33019ms step_avg:41.53ms
+step:796/1490 train_time:33079ms step_avg:41.56ms
+step:797/1490 train_time:33133ms step_avg:41.57ms
+step:798/1490 train_time:33192ms step_avg:41.59ms
+step:799/1490 train_time:33245ms step_avg:41.61ms
+step:800/1490 train_time:33305ms step_avg:41.63ms
+step:801/1490 train_time:33359ms step_avg:41.65ms
+step:802/1490 train_time:33419ms step_avg:41.67ms
+step:803/1490 train_time:33473ms step_avg:41.68ms
+step:804/1490 train_time:33533ms step_avg:41.71ms
+step:805/1490 train_time:33587ms step_avg:41.72ms
+step:806/1490 train_time:33649ms step_avg:41.75ms
+step:807/1490 train_time:33704ms step_avg:41.76ms
+step:808/1490 train_time:33763ms step_avg:41.79ms
+step:809/1490 train_time:33818ms step_avg:41.80ms
+step:810/1490 train_time:33879ms step_avg:41.83ms
+step:811/1490 train_time:33932ms step_avg:41.84ms
+step:812/1490 train_time:33992ms step_avg:41.86ms
+step:813/1490 train_time:34047ms step_avg:41.88ms
+step:814/1490 train_time:34107ms step_avg:41.90ms
+step:815/1490 train_time:34161ms step_avg:41.92ms
+step:816/1490 train_time:34221ms step_avg:41.94ms
+step:817/1490 train_time:34274ms step_avg:41.95ms
+step:818/1490 train_time:34334ms step_avg:41.97ms
+step:819/1490 train_time:34388ms step_avg:41.99ms
+step:820/1490 train_time:34447ms step_avg:42.01ms
+step:821/1490 train_time:34502ms step_avg:42.02ms
+step:822/1490 train_time:34562ms step_avg:42.05ms
+step:823/1490 train_time:34617ms step_avg:42.06ms
+step:824/1490 train_time:34678ms step_avg:42.09ms
+step:825/1490 train_time:34732ms step_avg:42.10ms
+step:826/1490 train_time:34792ms step_avg:42.12ms
+step:827/1490 train_time:34846ms step_avg:42.14ms
+step:828/1490 train_time:34906ms step_avg:42.16ms
+step:829/1490 train_time:34961ms step_avg:42.17ms
+step:830/1490 train_time:35022ms step_avg:42.19ms
+step:831/1490 train_time:35075ms step_avg:42.21ms
+step:832/1490 train_time:35135ms step_avg:42.23ms
+step:833/1490 train_time:35189ms step_avg:42.24ms
+step:834/1490 train_time:35248ms step_avg:42.26ms
+step:835/1490 train_time:35302ms step_avg:42.28ms
+step:836/1490 train_time:35362ms step_avg:42.30ms
+step:837/1490 train_time:35416ms step_avg:42.31ms
+step:838/1490 train_time:35475ms step_avg:42.33ms
+step:839/1490 train_time:35529ms step_avg:42.35ms
+step:840/1490 train_time:35590ms step_avg:42.37ms
+step:841/1490 train_time:35644ms step_avg:42.38ms
+step:842/1490 train_time:35704ms step_avg:42.40ms
+step:843/1490 train_time:35758ms step_avg:42.42ms
+step:844/1490 train_time:35820ms step_avg:42.44ms
+step:845/1490 train_time:35874ms step_avg:42.45ms
+step:846/1490 train_time:35935ms step_avg:42.48ms
+step:847/1490 train_time:35989ms step_avg:42.49ms
+step:848/1490 train_time:36049ms step_avg:42.51ms
+step:849/1490 train_time:36104ms step_avg:42.53ms
+step:850/1490 train_time:36163ms step_avg:42.54ms
+step:851/1490 train_time:36217ms step_avg:42.56ms
+step:852/1490 train_time:36277ms step_avg:42.58ms
+step:853/1490 train_time:36331ms step_avg:42.59ms
+step:854/1490 train_time:36391ms step_avg:42.61ms
+step:855/1490 train_time:36445ms step_avg:42.63ms
+step:856/1490 train_time:36504ms step_avg:42.64ms
+step:857/1490 train_time:36560ms step_avg:42.66ms
+step:858/1490 train_time:36621ms step_avg:42.68ms
+step:859/1490 train_time:36675ms step_avg:42.70ms
+step:860/1490 train_time:36735ms step_avg:42.72ms
+step:861/1490 train_time:36789ms step_avg:42.73ms
+step:862/1490 train_time:36850ms step_avg:42.75ms
+step:863/1490 train_time:36904ms step_avg:42.76ms
+step:864/1490 train_time:36964ms step_avg:42.78ms
+step:865/1490 train_time:37018ms step_avg:42.80ms
+step:866/1490 train_time:37079ms step_avg:42.82ms
+step:867/1490 train_time:37132ms step_avg:42.83ms
+step:868/1490 train_time:37192ms step_avg:42.85ms
+step:869/1490 train_time:37246ms step_avg:42.86ms
+step:870/1490 train_time:37306ms step_avg:42.88ms
+step:871/1490 train_time:37360ms step_avg:42.89ms
+step:872/1490 train_time:37420ms step_avg:42.91ms
+step:873/1490 train_time:37474ms step_avg:42.93ms
+step:874/1490 train_time:37534ms step_avg:42.95ms
+step:875/1490 train_time:37589ms step_avg:42.96ms
+step:876/1490 train_time:37648ms step_avg:42.98ms
+step:877/1490 train_time:37703ms step_avg:42.99ms
+step:878/1490 train_time:37763ms step_avg:43.01ms
+step:879/1490 train_time:37817ms step_avg:43.02ms
+step:880/1490 train_time:37877ms step_avg:43.04ms
+step:881/1490 train_time:37932ms step_avg:43.06ms
+step:882/1490 train_time:37992ms step_avg:43.07ms
+step:883/1490 train_time:38046ms step_avg:43.09ms
+step:884/1490 train_time:38106ms step_avg:43.11ms
+step:885/1490 train_time:38160ms step_avg:43.12ms
+step:886/1490 train_time:38220ms step_avg:43.14ms
+step:887/1490 train_time:38274ms step_avg:43.15ms
+step:888/1490 train_time:38333ms step_avg:43.17ms
+step:889/1490 train_time:38387ms step_avg:43.18ms
+step:890/1490 train_time:38447ms step_avg:43.20ms
+step:891/1490 train_time:38501ms step_avg:43.21ms
+step:892/1490 train_time:38561ms step_avg:43.23ms
+step:893/1490 train_time:38615ms step_avg:43.24ms
+step:894/1490 train_time:38675ms step_avg:43.26ms
+step:895/1490 train_time:38729ms step_avg:43.27ms
+step:896/1490 train_time:38789ms step_avg:43.29ms
+step:897/1490 train_time:38844ms step_avg:43.30ms
+step:898/1490 train_time:38903ms step_avg:43.32ms
+step:899/1490 train_time:38957ms step_avg:43.33ms
+step:900/1490 train_time:39018ms step_avg:43.35ms
+step:901/1490 train_time:39073ms step_avg:43.37ms
+step:902/1490 train_time:39132ms step_avg:43.38ms
+step:903/1490 train_time:39185ms step_avg:43.39ms
+step:904/1490 train_time:39245ms step_avg:43.41ms
+step:905/1490 train_time:39299ms step_avg:43.42ms
+step:906/1490 train_time:39359ms step_avg:43.44ms
+step:907/1490 train_time:39413ms step_avg:43.45ms
+step:908/1490 train_time:39472ms step_avg:43.47ms
+step:909/1490 train_time:39526ms step_avg:43.48ms
+step:910/1490 train_time:39587ms step_avg:43.50ms
+step:911/1490 train_time:39641ms step_avg:43.51ms
+step:912/1490 train_time:39701ms step_avg:43.53ms
+step:913/1490 train_time:39755ms step_avg:43.54ms
+step:914/1490 train_time:39815ms step_avg:43.56ms
+step:915/1490 train_time:39870ms step_avg:43.57ms
+step:916/1490 train_time:39930ms step_avg:43.59ms
+step:917/1490 train_time:39984ms step_avg:43.60ms
+step:918/1490 train_time:40044ms step_avg:43.62ms
+step:919/1490 train_time:40098ms step_avg:43.63ms
+step:920/1490 train_time:40158ms step_avg:43.65ms
+step:921/1490 train_time:40212ms step_avg:43.66ms
+step:922/1490 train_time:40272ms step_avg:43.68ms
+step:923/1490 train_time:40327ms step_avg:43.69ms
+step:924/1490 train_time:40386ms step_avg:43.71ms
+step:925/1490 train_time:40440ms step_avg:43.72ms
+step:926/1490 train_time:40501ms step_avg:43.74ms
+step:927/1490 train_time:40554ms step_avg:43.75ms
+step:928/1490 train_time:40615ms step_avg:43.77ms
+step:929/1490 train_time:40668ms step_avg:43.78ms
+step:930/1490 train_time:40729ms step_avg:43.79ms
+step:931/1490 train_time:40783ms step_avg:43.81ms
+step:932/1490 train_time:40843ms step_avg:43.82ms
+step:933/1490 train_time:40897ms step_avg:43.83ms
+step:934/1490 train_time:40958ms step_avg:43.85ms
+step:935/1490 train_time:41012ms step_avg:43.86ms
+step:936/1490 train_time:41071ms step_avg:43.88ms
+step:937/1490 train_time:41126ms step_avg:43.89ms
+step:938/1490 train_time:41186ms step_avg:43.91ms
+step:939/1490 train_time:41240ms step_avg:43.92ms
+step:940/1490 train_time:41300ms step_avg:43.94ms
+step:941/1490 train_time:41355ms step_avg:43.95ms
+step:942/1490 train_time:41414ms step_avg:43.96ms
+step:943/1490 train_time:41468ms step_avg:43.97ms
+step:944/1490 train_time:41529ms step_avg:43.99ms
+step:945/1490 train_time:41583ms step_avg:44.00ms
+step:946/1490 train_time:41643ms step_avg:44.02ms
+step:947/1490 train_time:41696ms step_avg:44.03ms
+step:948/1490 train_time:41756ms step_avg:44.05ms
+step:949/1490 train_time:41810ms step_avg:44.06ms
+step:950/1490 train_time:41870ms step_avg:44.07ms
+step:951/1490 train_time:41924ms step_avg:44.08ms
+step:952/1490 train_time:41985ms step_avg:44.10ms
+step:953/1490 train_time:42040ms step_avg:44.11ms
+step:954/1490 train_time:42099ms step_avg:44.13ms
+step:955/1490 train_time:42153ms step_avg:44.14ms
+step:956/1490 train_time:42213ms step_avg:44.16ms
+step:957/1490 train_time:42267ms step_avg:44.17ms
+step:958/1490 train_time:42327ms step_avg:44.18ms
+step:959/1490 train_time:42381ms step_avg:44.19ms
+step:960/1490 train_time:42441ms step_avg:44.21ms
+step:961/1490 train_time:42495ms step_avg:44.22ms
+step:962/1490 train_time:42555ms step_avg:44.24ms
+step:963/1490 train_time:42609ms step_avg:44.25ms
+step:964/1490 train_time:42669ms step_avg:44.26ms
+step:965/1490 train_time:42723ms step_avg:44.27ms
+step:966/1490 train_time:42783ms step_avg:44.29ms
+step:967/1490 train_time:42837ms step_avg:44.30ms
+step:968/1490 train_time:42900ms step_avg:44.32ms
+step:969/1490 train_time:42979ms step_avg:44.35ms
+step:970/1490 train_time:43067ms step_avg:44.40ms
+step:971/1490 train_time:43148ms step_avg:44.44ms
+step:972/1490 train_time:43234ms step_avg:44.48ms
+step:973/1490 train_time:43315ms step_avg:44.52ms
+step:974/1490 train_time:43401ms step_avg:44.56ms
+step:975/1490 train_time:43481ms step_avg:44.60ms
+step:976/1490 train_time:43568ms step_avg:44.64ms
+step:977/1490 train_time:43648ms step_avg:44.68ms
+step:978/1490 train_time:43735ms step_avg:44.72ms
+step:979/1490 train_time:43815ms step_avg:44.75ms
+step:980/1490 train_time:43901ms step_avg:44.80ms
+step:981/1490 train_time:43984ms step_avg:44.84ms
+step:982/1490 train_time:44070ms step_avg:44.88ms
+step:983/1490 train_time:44151ms step_avg:44.91ms
+step:984/1490 train_time:44237ms step_avg:44.96ms
+step:985/1490 train_time:44318ms step_avg:44.99ms
+step:986/1490 train_time:44405ms step_avg:45.04ms
+step:987/1490 train_time:44486ms step_avg:45.07ms
+step:988/1490 train_time:44571ms step_avg:45.11ms
+step:989/1490 train_time:44653ms step_avg:45.15ms
+step:990/1490 train_time:44739ms step_avg:45.19ms
+step:991/1490 train_time:44821ms step_avg:45.23ms
+step:992/1490 train_time:44907ms step_avg:45.27ms
+step:993/1490 train_time:44988ms step_avg:45.31ms
+step:994/1490 train_time:45075ms step_avg:45.35ms
+step:995/1490 train_time:45157ms step_avg:45.38ms
+step:996/1490 train_time:45243ms step_avg:45.42ms
+step:997/1490 train_time:45323ms step_avg:45.46ms
+step:998/1490 train_time:45408ms step_avg:45.50ms
+step:999/1490 train_time:45488ms step_avg:45.53ms
+step:1000/1490 train_time:45574ms step_avg:45.57ms
+step:1000/1490 val_loss:3.5137 train_time:45677ms step_avg:45.68ms
+step:1001/1490 train_time:45695ms step_avg:45.65ms
+step:1002/1490 train_time:45746ms step_avg:45.65ms
+step:1003/1490 train_time:45832ms step_avg:45.69ms
+step:1004/1490 train_time:45921ms step_avg:45.74ms
+step:1005/1490 train_time:46001ms step_avg:45.77ms
+step:1006/1490 train_time:46087ms step_avg:45.81ms
+step:1007/1490 train_time:46168ms step_avg:45.85ms
+step:1008/1490 train_time:46254ms step_avg:45.89ms
+step:1009/1490 train_time:46333ms step_avg:45.92ms
+step:1010/1490 train_time:46418ms step_avg:45.96ms
+step:1011/1490 train_time:46497ms step_avg:45.99ms
+step:1012/1490 train_time:46583ms step_avg:46.03ms
+step:1013/1490 train_time:46666ms step_avg:46.07ms
+step:1014/1490 train_time:46754ms step_avg:46.11ms
+step:1015/1490 train_time:46838ms step_avg:46.15ms
+step:1016/1490 train_time:46925ms step_avg:46.19ms
+step:1017/1490 train_time:47006ms step_avg:46.22ms
+step:1018/1490 train_time:47093ms step_avg:46.26ms
+step:1019/1490 train_time:47173ms step_avg:46.29ms
+step:1020/1490 train_time:47259ms step_avg:46.33ms
+step:1021/1490 train_time:47339ms step_avg:46.37ms
+step:1022/1490 train_time:47424ms step_avg:46.40ms
+step:1023/1490 train_time:47504ms step_avg:46.44ms
+step:1024/1490 train_time:47590ms step_avg:46.47ms
+step:1025/1490 train_time:47671ms step_avg:46.51ms
+step:1026/1490 train_time:47758ms step_avg:46.55ms
+step:1027/1490 train_time:47840ms step_avg:46.58ms
+step:1028/1490 train_time:47929ms step_avg:46.62ms
+step:1029/1490 train_time:48009ms step_avg:46.66ms
+step:1030/1490 train_time:48095ms step_avg:46.69ms
+step:1031/1490 train_time:48176ms step_avg:46.73ms
+step:1032/1490 train_time:48262ms step_avg:46.77ms
+step:1033/1490 train_time:48342ms step_avg:46.80ms
+step:1034/1490 train_time:48427ms step_avg:46.83ms
+step:1035/1490 train_time:48507ms step_avg:46.87ms
+step:1036/1490 train_time:48593ms step_avg:46.90ms
+step:1037/1490 train_time:48674ms step_avg:46.94ms
+step:1038/1490 train_time:48762ms step_avg:46.98ms
+step:1039/1490 train_time:48844ms step_avg:47.01ms
+step:1040/1490 train_time:48930ms step_avg:47.05ms
+step:1041/1490 train_time:49011ms step_avg:47.08ms
+step:1042/1490 train_time:49098ms step_avg:47.12ms
+step:1043/1490 train_time:49180ms step_avg:47.15ms
+step:1044/1490 train_time:49267ms step_avg:47.19ms
+step:1045/1490 train_time:49346ms step_avg:47.22ms
+step:1046/1490 train_time:49432ms step_avg:47.26ms
+step:1047/1490 train_time:49512ms step_avg:47.29ms
+step:1048/1490 train_time:49599ms step_avg:47.33ms
+step:1049/1490 train_time:49681ms step_avg:47.36ms
+step:1050/1490 train_time:49768ms step_avg:47.40ms
+step:1051/1490 train_time:49851ms step_avg:47.43ms
+step:1052/1490 train_time:49937ms step_avg:47.47ms
+step:1053/1490 train_time:50018ms step_avg:47.50ms
+step:1054/1490 train_time:50104ms step_avg:47.54ms
+step:1055/1490 train_time:50186ms step_avg:47.57ms
+step:1056/1490 train_time:50272ms step_avg:47.61ms
+step:1057/1490 train_time:50353ms step_avg:47.64ms
+step:1058/1490 train_time:50439ms step_avg:47.67ms
+step:1059/1490 train_time:50520ms step_avg:47.70ms
+step:1060/1490 train_time:50606ms step_avg:47.74ms
+step:1061/1490 train_time:50687ms step_avg:47.77ms
+step:1062/1490 train_time:50774ms step_avg:47.81ms
+step:1063/1490 train_time:50856ms step_avg:47.84ms
+step:1064/1490 train_time:50942ms step_avg:47.88ms
+step:1065/1490 train_time:51023ms step_avg:47.91ms
+step:1066/1490 train_time:51108ms step_avg:47.94ms
+step:1067/1490 train_time:51189ms step_avg:47.97ms
+step:1068/1490 train_time:51276ms step_avg:48.01ms
+step:1069/1490 train_time:51358ms step_avg:48.04ms
+step:1070/1490 train_time:51444ms step_avg:48.08ms
+step:1071/1490 train_time:51524ms step_avg:48.11ms
+step:1072/1490 train_time:51610ms step_avg:48.14ms
+step:1073/1490 train_time:51690ms step_avg:48.17ms
+step:1074/1490 train_time:51777ms step_avg:48.21ms
+step:1075/1490 train_time:51859ms step_avg:48.24ms
+step:1076/1490 train_time:51947ms step_avg:48.28ms
+step:1077/1490 train_time:52027ms step_avg:48.31ms
+step:1078/1490 train_time:52112ms step_avg:48.34ms
+step:1079/1490 train_time:52194ms step_avg:48.37ms
+step:1080/1490 train_time:52281ms step_avg:48.41ms
+step:1081/1490 train_time:52362ms step_avg:48.44ms
+step:1082/1490 train_time:52450ms step_avg:48.47ms
+step:1083/1490 train_time:52530ms step_avg:48.50ms
+step:1084/1490 train_time:52617ms step_avg:48.54ms
+step:1085/1490 train_time:52699ms step_avg:48.57ms
+step:1086/1490 train_time:52786ms step_avg:48.61ms
+step:1087/1490 train_time:52868ms step_avg:48.64ms
+step:1088/1490 train_time:52954ms step_avg:48.67ms
+step:1089/1490 train_time:53035ms step_avg:48.70ms
+step:1090/1490 train_time:53121ms step_avg:48.73ms
+step:1091/1490 train_time:53203ms step_avg:48.77ms
+step:1092/1490 train_time:53288ms step_avg:48.80ms
+step:1093/1490 train_time:53369ms step_avg:48.83ms
+step:1094/1490 train_time:53455ms step_avg:48.86ms
+step:1095/1490 train_time:53536ms step_avg:48.89ms
+step:1096/1490 train_time:53621ms step_avg:48.92ms
+step:1097/1490 train_time:53702ms step_avg:48.95ms
+step:1098/1490 train_time:53791ms step_avg:48.99ms
+step:1099/1490 train_time:53873ms step_avg:49.02ms
+step:1100/1490 train_time:53959ms step_avg:49.05ms
+step:1101/1490 train_time:54039ms step_avg:49.08ms
+step:1102/1490 train_time:54125ms step_avg:49.12ms
+step:1103/1490 train_time:54207ms step_avg:49.14ms
+step:1104/1490 train_time:54293ms step_avg:49.18ms
+step:1105/1490 train_time:54374ms step_avg:49.21ms
+step:1106/1490 train_time:54460ms step_avg:49.24ms
+step:1107/1490 train_time:54542ms step_avg:49.27ms
+step:1108/1490 train_time:54627ms step_avg:49.30ms
+step:1109/1490 train_time:54709ms step_avg:49.33ms
+step:1110/1490 train_time:54796ms step_avg:49.37ms
+step:1111/1490 train_time:54878ms step_avg:49.40ms
+step:1112/1490 train_time:54963ms step_avg:49.43ms
+step:1113/1490 train_time:55045ms step_avg:49.46ms
+step:1114/1490 train_time:55130ms step_avg:49.49ms
+step:1115/1490 train_time:55211ms step_avg:49.52ms
+step:1116/1490 train_time:55299ms step_avg:49.55ms
+step:1117/1490 train_time:55380ms step_avg:49.58ms
+step:1118/1490 train_time:55467ms step_avg:49.61ms
+step:1119/1490 train_time:55548ms step_avg:49.64ms
+step:1120/1490 train_time:55633ms step_avg:49.67ms
+step:1121/1490 train_time:55715ms step_avg:49.70ms
+step:1122/1490 train_time:55801ms step_avg:49.73ms
+step:1123/1490 train_time:55884ms step_avg:49.76ms
+step:1124/1490 train_time:55970ms step_avg:49.80ms
+step:1125/1490 train_time:56051ms step_avg:49.82ms
+step:1126/1490 train_time:56136ms step_avg:49.85ms
+step:1127/1490 train_time:56217ms step_avg:49.88ms
+step:1128/1490 train_time:56304ms step_avg:49.91ms
+step:1129/1490 train_time:56385ms step_avg:49.94ms
+step:1130/1490 train_time:56471ms step_avg:49.97ms
+step:1131/1490 train_time:56552ms step_avg:50.00ms
+step:1132/1490 train_time:56639ms step_avg:50.03ms
+step:1133/1490 train_time:56719ms step_avg:50.06ms
+step:1134/1490 train_time:56805ms step_avg:50.09ms
+step:1135/1490 train_time:56887ms step_avg:50.12ms
+step:1136/1490 train_time:56973ms step_avg:50.15ms
+step:1137/1490 train_time:57055ms step_avg:50.18ms
+step:1138/1490 train_time:57141ms step_avg:50.21ms
+step:1139/1490 train_time:57221ms step_avg:50.24ms
+step:1140/1490 train_time:57307ms step_avg:50.27ms
+step:1141/1490 train_time:57388ms step_avg:50.30ms
+step:1142/1490 train_time:57474ms step_avg:50.33ms
+step:1143/1490 train_time:57555ms step_avg:50.35ms
+step:1144/1490 train_time:57642ms step_avg:50.39ms
+step:1145/1490 train_time:57723ms step_avg:50.41ms
+step:1146/1490 train_time:57808ms step_avg:50.44ms
+step:1147/1490 train_time:57888ms step_avg:50.47ms
+step:1148/1490 train_time:57976ms step_avg:50.50ms
+step:1149/1490 train_time:58058ms step_avg:50.53ms
+step:1150/1490 train_time:58144ms step_avg:50.56ms
+step:1151/1490 train_time:58224ms step_avg:50.59ms
+step:1152/1490 train_time:58310ms step_avg:50.62ms
+step:1153/1490 train_time:58392ms step_avg:50.64ms
+step:1154/1490 train_time:58478ms step_avg:50.67ms
+step:1155/1490 train_time:58559ms step_avg:50.70ms
+step:1156/1490 train_time:58646ms step_avg:50.73ms
+step:1157/1490 train_time:58727ms step_avg:50.76ms
+step:1158/1490 train_time:58813ms step_avg:50.79ms
+step:1159/1490 train_time:58894ms step_avg:50.81ms
+step:1160/1490 train_time:58980ms step_avg:50.84ms
+step:1161/1490 train_time:59063ms step_avg:50.87ms
+step:1162/1490 train_time:59150ms step_avg:50.90ms
+step:1163/1490 train_time:59230ms step_avg:50.93ms
+step:1164/1490 train_time:59316ms step_avg:50.96ms
+step:1165/1490 train_time:59396ms step_avg:50.98ms
+step:1166/1490 train_time:59483ms step_avg:51.01ms
+step:1167/1490 train_time:59564ms step_avg:51.04ms
+step:1168/1490 train_time:59652ms step_avg:51.07ms
+step:1169/1490 train_time:59733ms step_avg:51.10ms
+step:1170/1490 train_time:59819ms step_avg:51.13ms
+step:1171/1490 train_time:59899ms step_avg:51.15ms
+step:1172/1490 train_time:59985ms step_avg:51.18ms
+step:1173/1490 train_time:60067ms step_avg:51.21ms
+step:1174/1490 train_time:60153ms step_avg:51.24ms
+step:1175/1490 train_time:60234ms step_avg:51.26ms
+step:1176/1490 train_time:60320ms step_avg:51.29ms
+step:1177/1490 train_time:60401ms step_avg:51.32ms
+step:1178/1490 train_time:60487ms step_avg:51.35ms
+step:1179/1490 train_time:60567ms step_avg:51.37ms
+step:1180/1490 train_time:60654ms step_avg:51.40ms
+step:1181/1490 train_time:60736ms step_avg:51.43ms
+step:1182/1490 train_time:60822ms step_avg:51.46ms
+step:1183/1490 train_time:60903ms step_avg:51.48ms
+step:1184/1490 train_time:60988ms step_avg:51.51ms
+step:1185/1490 train_time:61069ms step_avg:51.53ms
+step:1186/1490 train_time:61157ms step_avg:51.57ms
+step:1187/1490 train_time:61238ms step_avg:51.59ms
+step:1188/1490 train_time:61325ms step_avg:51.62ms
+step:1189/1490 train_time:61407ms step_avg:51.65ms
+step:1190/1490 train_time:61493ms step_avg:51.67ms
+step:1191/1490 train_time:61574ms step_avg:51.70ms
+step:1192/1490 train_time:61660ms step_avg:51.73ms
+step:1193/1490 train_time:61742ms step_avg:51.75ms
+step:1194/1490 train_time:61829ms step_avg:51.78ms
+step:1195/1490 train_time:61909ms step_avg:51.81ms
+step:1196/1490 train_time:61997ms step_avg:51.84ms
+step:1197/1490 train_time:62079ms step_avg:51.86ms
+step:1198/1490 train_time:62166ms step_avg:51.89ms
+step:1199/1490 train_time:62247ms step_avg:51.92ms
+step:1200/1490 train_time:62333ms step_avg:51.94ms
+step:1201/1490 train_time:62415ms step_avg:51.97ms
+step:1202/1490 train_time:62500ms step_avg:52.00ms
+step:1203/1490 train_time:62582ms step_avg:52.02ms
+step:1204/1490 train_time:62668ms step_avg:52.05ms
+step:1205/1490 train_time:62749ms step_avg:52.07ms
+step:1206/1490 train_time:62835ms step_avg:52.10ms
+step:1207/1490 train_time:62916ms step_avg:52.13ms
+step:1208/1490 train_time:63003ms step_avg:52.15ms
+step:1209/1490 train_time:63084ms step_avg:52.18ms
+step:1210/1490 train_time:63170ms step_avg:52.21ms
+step:1211/1490 train_time:63251ms step_avg:52.23ms
+step:1212/1490 train_time:63336ms step_avg:52.26ms
+step:1213/1490 train_time:63417ms step_avg:52.28ms
+step:1214/1490 train_time:63503ms step_avg:52.31ms
+step:1215/1490 train_time:63585ms step_avg:52.33ms
+step:1216/1490 train_time:63672ms step_avg:52.36ms
+step:1217/1490 train_time:63752ms step_avg:52.38ms
+step:1218/1490 train_time:63839ms step_avg:52.41ms
+step:1219/1490 train_time:63920ms step_avg:52.44ms
+step:1220/1490 train_time:64006ms step_avg:52.46ms
+step:1221/1490 train_time:64087ms step_avg:52.49ms
+step:1222/1490 train_time:64174ms step_avg:52.52ms
+step:1223/1490 train_time:64256ms step_avg:52.54ms
+step:1224/1490 train_time:64343ms step_avg:52.57ms
+step:1225/1490 train_time:64422ms step_avg:52.59ms
+step:1226/1490 train_time:64509ms step_avg:52.62ms
+step:1227/1490 train_time:64589ms step_avg:52.64ms
+step:1228/1490 train_time:64676ms step_avg:52.67ms
+step:1229/1490 train_time:64757ms step_avg:52.69ms
+step:1230/1490 train_time:64846ms step_avg:52.72ms
+step:1231/1490 train_time:64928ms step_avg:52.74ms
+step:1232/1490 train_time:65014ms step_avg:52.77ms
+step:1233/1490 train_time:65094ms step_avg:52.79ms
+step:1234/1490 train_time:65181ms step_avg:52.82ms
+step:1235/1490 train_time:65261ms step_avg:52.84ms
+step:1236/1490 train_time:65349ms step_avg:52.87ms
+step:1237/1490 train_time:65429ms step_avg:52.89ms
+step:1238/1490 train_time:65515ms step_avg:52.92ms
+step:1239/1490 train_time:65598ms step_avg:52.94ms
+step:1240/1490 train_time:65684ms step_avg:52.97ms
+step:1241/1490 train_time:65764ms step_avg:52.99ms
+step:1242/1490 train_time:65851ms step_avg:53.02ms
+step:1243/1490 train_time:65932ms step_avg:53.04ms
+step:1244/1490 train_time:66017ms step_avg:53.07ms
+step:1245/1490 train_time:66098ms step_avg:53.09ms
+step:1246/1490 train_time:66184ms step_avg:53.12ms
+step:1247/1490 train_time:66267ms step_avg:53.14ms
+step:1248/1490 train_time:66354ms step_avg:53.17ms
+step:1249/1490 train_time:66434ms step_avg:53.19ms
+step:1250/1490 train_time:66521ms step_avg:53.22ms
+step:1250/1490 val_loss:3.3706 train_time:66625ms step_avg:53.30ms
+step:1251/1490 train_time:66642ms step_avg:53.27ms
+step:1252/1490 train_time:66693ms step_avg:53.27ms
+step:1253/1490 train_time:66779ms step_avg:53.30ms
+step:1254/1490 train_time:66868ms step_avg:53.32ms
+step:1255/1490 train_time:66949ms step_avg:53.35ms
+step:1256/1490 train_time:67035ms step_avg:53.37ms
+step:1257/1490 train_time:67114ms step_avg:53.39ms
+step:1258/1490 train_time:67199ms step_avg:53.42ms
+step:1259/1490 train_time:67279ms step_avg:53.44ms
+step:1260/1490 train_time:67364ms step_avg:53.46ms
+step:1261/1490 train_time:67444ms step_avg:53.48ms
+step:1262/1490 train_time:67528ms step_avg:53.51ms
+step:1263/1490 train_time:67610ms step_avg:53.53ms
+step:1264/1490 train_time:67698ms step_avg:53.56ms
+step:1265/1490 train_time:67783ms step_avg:53.58ms
+step:1266/1490 train_time:67872ms step_avg:53.61ms
+step:1267/1490 train_time:67954ms step_avg:53.63ms
+step:1268/1490 train_time:68040ms step_avg:53.66ms
+step:1269/1490 train_time:68119ms step_avg:53.68ms
+step:1270/1490 train_time:68204ms step_avg:53.70ms
+step:1271/1490 train_time:68284ms step_avg:53.72ms
+step:1272/1490 train_time:68370ms step_avg:53.75ms
+step:1273/1490 train_time:68450ms step_avg:53.77ms
+step:1274/1490 train_time:68536ms step_avg:53.80ms
+step:1275/1490 train_time:68616ms step_avg:53.82ms
+step:1276/1490 train_time:68704ms step_avg:53.84ms
+step:1277/1490 train_time:68786ms step_avg:53.87ms
+step:1278/1490 train_time:68876ms step_avg:53.89ms
+step:1279/1490 train_time:68958ms step_avg:53.92ms
+step:1280/1490 train_time:69044ms step_avg:53.94ms
+step:1281/1490 train_time:69124ms step_avg:53.96ms
+step:1282/1490 train_time:69210ms step_avg:53.99ms
+step:1283/1490 train_time:69291ms step_avg:54.01ms
+step:1284/1490 train_time:69376ms step_avg:54.03ms
+step:1285/1490 train_time:69456ms step_avg:54.05ms
+step:1286/1490 train_time:69542ms step_avg:54.08ms
+step:1287/1490 train_time:69623ms step_avg:54.10ms
+step:1288/1490 train_time:69712ms step_avg:54.12ms
+step:1289/1490 train_time:69794ms step_avg:54.15ms
+step:1290/1490 train_time:69881ms step_avg:54.17ms
+step:1291/1490 train_time:69964ms step_avg:54.19ms
+step:1292/1490 train_time:70051ms step_avg:54.22ms
+step:1293/1490 train_time:70131ms step_avg:54.24ms
+step:1294/1490 train_time:70216ms step_avg:54.26ms
+step:1295/1490 train_time:70297ms step_avg:54.28ms
+step:1296/1490 train_time:70382ms step_avg:54.31ms
+step:1297/1490 train_time:70464ms step_avg:54.33ms
+step:1298/1490 train_time:70551ms step_avg:54.35ms
+step:1299/1490 train_time:70631ms step_avg:54.37ms
+step:1300/1490 train_time:70718ms step_avg:54.40ms
+step:1301/1490 train_time:70800ms step_avg:54.42ms
+step:1302/1490 train_time:70888ms step_avg:54.45ms
+step:1303/1490 train_time:70970ms step_avg:54.47ms
+step:1304/1490 train_time:71056ms step_avg:54.49ms
+step:1305/1490 train_time:71136ms step_avg:54.51ms
+step:1306/1490 train_time:71223ms step_avg:54.53ms
+step:1307/1490 train_time:71303ms step_avg:54.55ms
+step:1308/1490 train_time:71389ms step_avg:54.58ms
+step:1309/1490 train_time:71470ms step_avg:54.60ms
+step:1310/1490 train_time:71556ms step_avg:54.62ms
+step:1311/1490 train_time:71637ms step_avg:54.64ms
+step:1312/1490 train_time:71724ms step_avg:54.67ms
+step:1313/1490 train_time:71805ms step_avg:54.69ms
+step:1314/1490 train_time:71892ms step_avg:54.71ms
+step:1315/1490 train_time:71973ms step_avg:54.73ms
+step:1316/1490 train_time:72062ms step_avg:54.76ms
+step:1317/1490 train_time:72144ms step_avg:54.78ms
+step:1318/1490 train_time:72229ms step_avg:54.80ms
+step:1319/1490 train_time:72310ms step_avg:54.82ms
+step:1320/1490 train_time:72397ms step_avg:54.85ms
+step:1321/1490 train_time:72478ms step_avg:54.87ms
+step:1322/1490 train_time:72564ms step_avg:54.89ms
+step:1323/1490 train_time:72645ms step_avg:54.91ms
+step:1324/1490 train_time:72732ms step_avg:54.93ms
+step:1325/1490 train_time:72813ms step_avg:54.95ms
+step:1326/1490 train_time:72900ms step_avg:54.98ms
+step:1327/1490 train_time:72982ms step_avg:55.00ms
+step:1328/1490 train_time:73069ms step_avg:55.02ms
+step:1329/1490 train_time:73153ms step_avg:55.04ms
+step:1330/1490 train_time:73238ms step_avg:55.07ms
+step:1331/1490 train_time:73319ms step_avg:55.09ms
+step:1332/1490 train_time:73404ms step_avg:55.11ms
+step:1333/1490 train_time:73485ms step_avg:55.13ms
+step:1334/1490 train_time:73572ms step_avg:55.15ms
+step:1335/1490 train_time:73653ms step_avg:55.17ms
+step:1336/1490 train_time:73739ms step_avg:55.19ms
+step:1337/1490 train_time:73820ms step_avg:55.21ms
+step:1338/1490 train_time:73906ms step_avg:55.24ms
+step:1339/1490 train_time:73988ms step_avg:55.26ms
+step:1340/1490 train_time:74075ms step_avg:55.28ms
+step:1341/1490 train_time:74157ms step_avg:55.30ms
+step:1342/1490 train_time:74244ms step_avg:55.32ms
+step:1343/1490 train_time:74326ms step_avg:55.34ms
+step:1344/1490 train_time:74412ms step_avg:55.37ms
+step:1345/1490 train_time:74492ms step_avg:55.38ms
+step:1346/1490 train_time:74579ms step_avg:55.41ms
+step:1347/1490 train_time:74660ms step_avg:55.43ms
+step:1348/1490 train_time:74746ms step_avg:55.45ms
+step:1349/1490 train_time:74827ms step_avg:55.47ms
+step:1350/1490 train_time:74915ms step_avg:55.49ms
+step:1351/1490 train_time:74996ms step_avg:55.51ms
+step:1352/1490 train_time:75081ms step_avg:55.53ms
+step:1353/1490 train_time:75163ms step_avg:55.55ms
+step:1354/1490 train_time:75252ms step_avg:55.58ms
+step:1355/1490 train_time:75332ms step_avg:55.60ms
+step:1356/1490 train_time:75418ms step_avg:55.62ms
+step:1357/1490 train_time:75499ms step_avg:55.64ms
+step:1358/1490 train_time:75585ms step_avg:55.66ms
+step:1359/1490 train_time:75666ms step_avg:55.68ms
+step:1360/1490 train_time:75754ms step_avg:55.70ms
+step:1361/1490 train_time:75834ms step_avg:55.72ms
+step:1362/1490 train_time:75921ms step_avg:55.74ms
+step:1363/1490 train_time:76003ms step_avg:55.76ms
+step:1364/1490 train_time:76089ms step_avg:55.78ms
+step:1365/1490 train_time:76171ms step_avg:55.80ms
+step:1366/1490 train_time:76256ms step_avg:55.82ms
+step:1367/1490 train_time:76337ms step_avg:55.84ms
+step:1368/1490 train_time:76423ms step_avg:55.87ms
+step:1369/1490 train_time:76505ms step_avg:55.88ms
+step:1370/1490 train_time:76593ms step_avg:55.91ms
+step:1371/1490 train_time:76674ms step_avg:55.93ms
+step:1372/1490 train_time:76760ms step_avg:55.95ms
+step:1373/1490 train_time:76840ms step_avg:55.97ms
+step:1374/1490 train_time:76926ms step_avg:55.99ms
+step:1375/1490 train_time:77007ms step_avg:56.01ms
+step:1376/1490 train_time:77096ms step_avg:56.03ms
+step:1377/1490 train_time:77178ms step_avg:56.05ms
+step:1378/1490 train_time:77264ms step_avg:56.07ms
+step:1379/1490 train_time:77344ms step_avg:56.09ms
+step:1380/1490 train_time:77431ms step_avg:56.11ms
+step:1381/1490 train_time:77512ms step_avg:56.13ms
+step:1382/1490 train_time:77599ms step_avg:56.15ms
+step:1383/1490 train_time:77681ms step_avg:56.17ms
+step:1384/1490 train_time:77766ms step_avg:56.19ms
+step:1385/1490 train_time:77848ms step_avg:56.21ms
+step:1386/1490 train_time:77933ms step_avg:56.23ms
+step:1387/1490 train_time:78013ms step_avg:56.25ms
+step:1388/1490 train_time:78102ms step_avg:56.27ms
+step:1389/1490 train_time:78183ms step_avg:56.29ms
+step:1390/1490 train_time:78269ms step_avg:56.31ms
+step:1391/1490 train_time:78349ms step_avg:56.33ms
+step:1392/1490 train_time:78435ms step_avg:56.35ms
+step:1393/1490 train_time:78517ms step_avg:56.37ms
+step:1394/1490 train_time:78603ms step_avg:56.39ms
+step:1395/1490 train_time:78684ms step_avg:56.40ms
+step:1396/1490 train_time:78771ms step_avg:56.43ms
+step:1397/1490 train_time:78852ms step_avg:56.44ms
+step:1398/1490 train_time:78938ms step_avg:56.47ms
+step:1399/1490 train_time:79020ms step_avg:56.48ms
+step:1400/1490 train_time:79105ms step_avg:56.50ms
+step:1401/1490 train_time:79187ms step_avg:56.52ms
+step:1402/1490 train_time:79274ms step_avg:56.54ms
+step:1403/1490 train_time:79354ms step_avg:56.56ms
+step:1404/1490 train_time:79439ms step_avg:56.58ms
+step:1405/1490 train_time:79521ms step_avg:56.60ms
+step:1406/1490 train_time:79608ms step_avg:56.62ms
+step:1407/1490 train_time:79688ms step_avg:56.64ms
+step:1408/1490 train_time:79776ms step_avg:56.66ms
+step:1409/1490 train_time:79857ms step_avg:56.68ms
+step:1410/1490 train_time:79943ms step_avg:56.70ms
+step:1411/1490 train_time:80024ms step_avg:56.71ms
+step:1412/1490 train_time:80109ms step_avg:56.73ms
+step:1413/1490 train_time:80191ms step_avg:56.75ms
+step:1414/1490 train_time:80277ms step_avg:56.77ms
+step:1415/1490 train_time:80358ms step_avg:56.79ms
+step:1416/1490 train_time:80444ms step_avg:56.81ms
+step:1417/1490 train_time:80524ms step_avg:56.83ms
+step:1418/1490 train_time:80610ms step_avg:56.85ms
+step:1419/1490 train_time:80693ms step_avg:56.87ms
+step:1420/1490 train_time:80779ms step_avg:56.89ms
+step:1421/1490 train_time:80861ms step_avg:56.90ms
+step:1422/1490 train_time:80948ms step_avg:56.93ms
+step:1423/1490 train_time:81029ms step_avg:56.94ms
+step:1424/1490 train_time:81116ms step_avg:56.96ms
+step:1425/1490 train_time:81196ms step_avg:56.98ms
+step:1426/1490 train_time:81283ms step_avg:57.00ms
+step:1427/1490 train_time:81364ms step_avg:57.02ms
+step:1428/1490 train_time:81450ms step_avg:57.04ms
+step:1429/1490 train_time:81530ms step_avg:57.05ms
+step:1430/1490 train_time:81617ms step_avg:57.07ms
+step:1431/1490 train_time:81698ms step_avg:57.09ms
+step:1432/1490 train_time:81785ms step_avg:57.11ms
+step:1433/1490 train_time:81866ms step_avg:57.13ms
+step:1434/1490 train_time:81952ms step_avg:57.15ms
+step:1435/1490 train_time:82032ms step_avg:57.16ms
+step:1436/1490 train_time:82118ms step_avg:57.18ms
+step:1437/1490 train_time:82199ms step_avg:57.20ms
+step:1438/1490 train_time:82286ms step_avg:57.22ms
+step:1439/1490 train_time:82368ms step_avg:57.24ms
+step:1440/1490 train_time:82454ms step_avg:57.26ms
+step:1441/1490 train_time:82535ms step_avg:57.28ms
+step:1442/1490 train_time:82620ms step_avg:57.30ms
+step:1443/1490 train_time:82702ms step_avg:57.31ms
+step:1444/1490 train_time:82789ms step_avg:57.33ms
+step:1445/1490 train_time:82870ms step_avg:57.35ms
+step:1446/1490 train_time:82956ms step_avg:57.37ms
+step:1447/1490 train_time:83036ms step_avg:57.38ms
+step:1448/1490 train_time:83121ms step_avg:57.40ms
+step:1449/1490 train_time:83203ms step_avg:57.42ms
+step:1450/1490 train_time:83289ms step_avg:57.44ms
+step:1451/1490 train_time:83374ms step_avg:57.46ms
+step:1452/1490 train_time:83462ms step_avg:57.48ms
+step:1453/1490 train_time:83542ms step_avg:57.50ms
+step:1454/1490 train_time:83629ms step_avg:57.52ms
+step:1455/1490 train_time:83709ms step_avg:57.53ms
+step:1456/1490 train_time:83797ms step_avg:57.55ms
+step:1457/1490 train_time:83878ms step_avg:57.57ms
+step:1458/1490 train_time:83964ms step_avg:57.59ms
+step:1459/1490 train_time:84045ms step_avg:57.60ms
+step:1460/1490 train_time:84132ms step_avg:57.62ms
+step:1461/1490 train_time:84213ms step_avg:57.64ms
+step:1462/1490 train_time:84301ms step_avg:57.66ms
+step:1463/1490 train_time:84384ms step_avg:57.68ms
+step:1464/1490 train_time:84471ms step_avg:57.70ms
+step:1465/1490 train_time:84552ms step_avg:57.71ms
+step:1466/1490 train_time:84639ms step_avg:57.73ms
+step:1467/1490 train_time:84720ms step_avg:57.75ms
+step:1468/1490 train_time:84807ms step_avg:57.77ms
+step:1469/1490 train_time:84889ms step_avg:57.79ms
+step:1470/1490 train_time:84975ms step_avg:57.81ms
+step:1471/1490 train_time:85056ms step_avg:57.82ms
+step:1472/1490 train_time:85143ms step_avg:57.84ms
+step:1473/1490 train_time:85224ms step_avg:57.86ms
+step:1474/1490 train_time:85311ms step_avg:57.88ms
+step:1475/1490 train_time:85392ms step_avg:57.89ms
+step:1476/1490 train_time:85480ms step_avg:57.91ms
+step:1477/1490 train_time:85561ms step_avg:57.93ms
+step:1478/1490 train_time:85647ms step_avg:57.95ms
+step:1479/1490 train_time:85727ms step_avg:57.96ms
+step:1480/1490 train_time:85814ms step_avg:57.98ms
+step:1481/1490 train_time:85897ms step_avg:58.00ms
+step:1482/1490 train_time:85983ms step_avg:58.02ms
+step:1483/1490 train_time:86064ms step_avg:58.03ms
+step:1484/1490 train_time:86150ms step_avg:58.05ms
+step:1485/1490 train_time:86232ms step_avg:58.07ms
+step:1486/1490 train_time:86318ms step_avg:58.09ms
+step:1487/1490 train_time:86399ms step_avg:58.10ms
+step:1488/1490 train_time:86486ms step_avg:58.12ms
+step:1489/1490 train_time:86569ms step_avg:58.14ms
+step:1490/1490 train_time:86655ms step_avg:58.16ms
+step:1490/1490 val_loss:3.2776 train_time:86759ms step_avg:58.23ms
+peak memory allocated: 31296 MiB reserved: 47162 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/muon-beta2/2026-03-22_19-30-10_time-186_secs_04-muon-beta2_ef782f.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/muon-beta2/2026-03-22_19-30-10_time-186_secs_04-muon-beta2_ef782f.txt
@@ -1,0 +1,4456 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,  # from nanochat autoresearch (was 0.95)
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 19:30:25 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            122W /  700W |    1520MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            131W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   40C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1675169      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1675170      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1675171      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1675172      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1675173      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1675174      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1675175      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1675176      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8315 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:84ms step_avg:84.02ms
+step:2/1490 train_time:109ms step_avg:54.66ms
+step:3/1490 train_time:125ms step_avg:41.72ms
+step:4/1490 train_time:152ms step_avg:38.06ms
+step:5/1490 train_time:180ms step_avg:35.95ms
+step:6/1490 train_time:214ms step_avg:35.74ms
+step:7/1490 train_time:242ms step_avg:34.57ms
+step:8/1490 train_time:276ms step_avg:34.55ms
+step:9/1490 train_time:304ms step_avg:33.78ms
+step:10/1490 train_time:339ms step_avg:33.86ms
+step:11/1490 train_time:367ms step_avg:33.36ms
+step:12/1490 train_time:401ms step_avg:33.45ms
+step:13/1490 train_time:430ms step_avg:33.04ms
+step:14/1490 train_time:464ms step_avg:33.16ms
+step:15/1490 train_time:492ms step_avg:32.82ms
+step:16/1490 train_time:527ms step_avg:32.91ms
+step:17/1490 train_time:555ms step_avg:32.65ms
+step:18/1490 train_time:589ms step_avg:32.74ms
+step:19/1490 train_time:618ms step_avg:32.52ms
+step:20/1490 train_time:652ms step_avg:32.62ms
+step:21/1490 train_time:681ms step_avg:32.42ms
+step:22/1490 train_time:715ms step_avg:32.50ms
+step:23/1490 train_time:744ms step_avg:32.33ms
+step:24/1490 train_time:778ms step_avg:32.41ms
+step:25/1490 train_time:807ms step_avg:32.26ms
+step:26/1490 train_time:841ms step_avg:32.33ms
+step:27/1490 train_time:869ms step_avg:32.19ms
+step:28/1490 train_time:904ms step_avg:32.27ms
+step:29/1490 train_time:932ms step_avg:32.13ms
+step:30/1490 train_time:967ms step_avg:32.24ms
+step:31/1490 train_time:998ms step_avg:32.18ms
+step:32/1490 train_time:1034ms step_avg:32.31ms
+step:33/1490 train_time:1064ms step_avg:32.24ms
+step:34/1490 train_time:1099ms step_avg:32.32ms
+step:35/1490 train_time:1128ms step_avg:32.22ms
+step:36/1490 train_time:1163ms step_avg:32.30ms
+step:37/1490 train_time:1191ms step_avg:32.20ms
+step:38/1490 train_time:1226ms step_avg:32.25ms
+step:39/1490 train_time:1254ms step_avg:32.16ms
+step:40/1490 train_time:1289ms step_avg:32.21ms
+step:41/1490 train_time:1317ms step_avg:32.12ms
+step:42/1490 train_time:1352ms step_avg:32.18ms
+step:43/1490 train_time:1380ms step_avg:32.09ms
+step:44/1490 train_time:1414ms step_avg:32.14ms
+step:45/1490 train_time:1442ms step_avg:32.05ms
+step:46/1490 train_time:1476ms step_avg:32.10ms
+step:47/1490 train_time:1505ms step_avg:32.03ms
+step:48/1490 train_time:1540ms step_avg:32.08ms
+step:49/1490 train_time:1568ms step_avg:32.01ms
+step:50/1490 train_time:1603ms step_avg:32.06ms
+step:51/1490 train_time:1631ms step_avg:31.99ms
+step:52/1490 train_time:1666ms step_avg:32.03ms
+step:53/1490 train_time:1694ms step_avg:31.96ms
+step:54/1490 train_time:1728ms step_avg:32.00ms
+step:55/1490 train_time:1757ms step_avg:31.94ms
+step:56/1490 train_time:1791ms step_avg:31.98ms
+step:57/1490 train_time:1820ms step_avg:31.93ms
+step:58/1490 train_time:1854ms step_avg:31.97ms
+step:59/1490 train_time:1882ms step_avg:31.90ms
+step:60/1490 train_time:1916ms step_avg:31.94ms
+step:61/1490 train_time:1946ms step_avg:31.91ms
+step:62/1490 train_time:1981ms step_avg:31.95ms
+step:63/1490 train_time:2010ms step_avg:31.90ms
+step:64/1490 train_time:2045ms step_avg:31.95ms
+step:65/1490 train_time:2073ms step_avg:31.90ms
+step:66/1490 train_time:2108ms step_avg:31.95ms
+step:67/1490 train_time:2137ms step_avg:31.90ms
+step:68/1490 train_time:2171ms step_avg:31.93ms
+step:69/1490 train_time:2200ms step_avg:31.89ms
+step:70/1490 train_time:2235ms step_avg:31.92ms
+step:71/1490 train_time:2263ms step_avg:31.88ms
+step:72/1490 train_time:2297ms step_avg:31.91ms
+step:73/1490 train_time:2326ms step_avg:31.86ms
+step:74/1490 train_time:2360ms step_avg:31.90ms
+step:75/1490 train_time:2389ms step_avg:31.85ms
+step:76/1490 train_time:2423ms step_avg:31.89ms
+step:77/1490 train_time:2452ms step_avg:31.84ms
+step:78/1490 train_time:2486ms step_avg:31.88ms
+step:79/1490 train_time:2515ms step_avg:31.83ms
+step:80/1490 train_time:2549ms step_avg:31.86ms
+step:81/1490 train_time:2578ms step_avg:31.82ms
+step:82/1490 train_time:2612ms step_avg:31.85ms
+step:83/1490 train_time:2641ms step_avg:31.82ms
+step:84/1490 train_time:2675ms step_avg:31.84ms
+step:85/1490 train_time:2703ms step_avg:31.80ms
+step:86/1490 train_time:2737ms step_avg:31.83ms
+step:87/1490 train_time:2766ms step_avg:31.80ms
+step:88/1490 train_time:2801ms step_avg:31.82ms
+step:89/1490 train_time:2829ms step_avg:31.79ms
+step:90/1490 train_time:2864ms step_avg:31.82ms
+step:91/1490 train_time:2892ms step_avg:31.78ms
+step:92/1490 train_time:2927ms step_avg:31.81ms
+step:93/1490 train_time:2956ms step_avg:31.78ms
+step:94/1490 train_time:2990ms step_avg:31.81ms
+step:95/1490 train_time:3019ms step_avg:31.78ms
+step:96/1490 train_time:3053ms step_avg:31.80ms
+step:97/1490 train_time:3082ms step_avg:31.77ms
+step:98/1490 train_time:3116ms step_avg:31.79ms
+step:99/1490 train_time:3145ms step_avg:31.76ms
+step:100/1490 train_time:3179ms step_avg:31.79ms
+step:101/1490 train_time:3207ms step_avg:31.76ms
+step:102/1490 train_time:3242ms step_avg:31.78ms
+step:103/1490 train_time:3270ms step_avg:31.75ms
+step:104/1490 train_time:3305ms step_avg:31.78ms
+step:105/1490 train_time:3333ms step_avg:31.74ms
+step:106/1490 train_time:3368ms step_avg:31.77ms
+step:107/1490 train_time:3396ms step_avg:31.74ms
+step:108/1490 train_time:3431ms step_avg:31.77ms
+step:109/1490 train_time:3460ms step_avg:31.74ms
+step:110/1490 train_time:3494ms step_avg:31.76ms
+step:111/1490 train_time:3523ms step_avg:31.74ms
+step:112/1490 train_time:3557ms step_avg:31.76ms
+step:113/1490 train_time:3585ms step_avg:31.73ms
+step:114/1490 train_time:3620ms step_avg:31.75ms
+step:115/1490 train_time:3648ms step_avg:31.72ms
+step:116/1490 train_time:3683ms step_avg:31.75ms
+step:117/1490 train_time:3711ms step_avg:31.72ms
+step:118/1490 train_time:3746ms step_avg:31.75ms
+step:119/1490 train_time:3775ms step_avg:31.72ms
+step:120/1490 train_time:3809ms step_avg:31.74ms
+step:121/1490 train_time:3838ms step_avg:31.72ms
+step:122/1490 train_time:3873ms step_avg:31.74ms
+step:123/1490 train_time:3901ms step_avg:31.71ms
+step:124/1490 train_time:3935ms step_avg:31.73ms
+step:125/1490 train_time:3964ms step_avg:31.71ms
+step:126/1490 train_time:3998ms step_avg:31.73ms
+step:127/1490 train_time:4027ms step_avg:31.71ms
+step:128/1490 train_time:4062ms step_avg:31.73ms
+step:129/1490 train_time:4090ms step_avg:31.71ms
+step:130/1490 train_time:4124ms step_avg:31.73ms
+step:131/1490 train_time:4153ms step_avg:31.70ms
+step:132/1490 train_time:4187ms step_avg:31.72ms
+step:133/1490 train_time:4216ms step_avg:31.70ms
+step:134/1490 train_time:4251ms step_avg:31.72ms
+step:135/1490 train_time:4279ms step_avg:31.70ms
+step:136/1490 train_time:4314ms step_avg:31.72ms
+step:137/1490 train_time:4342ms step_avg:31.70ms
+step:138/1490 train_time:4377ms step_avg:31.72ms
+step:139/1490 train_time:4405ms step_avg:31.69ms
+step:140/1490 train_time:4440ms step_avg:31.71ms
+step:141/1490 train_time:4469ms step_avg:31.69ms
+step:142/1490 train_time:4504ms step_avg:31.71ms
+step:143/1490 train_time:4532ms step_avg:31.69ms
+step:144/1490 train_time:4567ms step_avg:31.71ms
+step:145/1490 train_time:4595ms step_avg:31.69ms
+step:146/1490 train_time:4630ms step_avg:31.71ms
+step:147/1490 train_time:4658ms step_avg:31.69ms
+step:148/1490 train_time:4693ms step_avg:31.71ms
+step:149/1490 train_time:4721ms step_avg:31.69ms
+step:150/1490 train_time:4755ms step_avg:31.70ms
+step:151/1490 train_time:4784ms step_avg:31.68ms
+step:152/1490 train_time:4818ms step_avg:31.70ms
+step:153/1490 train_time:4847ms step_avg:31.68ms
+step:154/1490 train_time:4882ms step_avg:31.70ms
+step:155/1490 train_time:4910ms step_avg:31.68ms
+step:156/1490 train_time:4945ms step_avg:31.70ms
+step:157/1490 train_time:4974ms step_avg:31.68ms
+step:158/1490 train_time:5008ms step_avg:31.70ms
+step:159/1490 train_time:5037ms step_avg:31.68ms
+step:160/1490 train_time:5071ms step_avg:31.70ms
+step:161/1490 train_time:5100ms step_avg:31.68ms
+step:162/1490 train_time:5134ms step_avg:31.69ms
+step:163/1490 train_time:5163ms step_avg:31.67ms
+step:164/1490 train_time:5197ms step_avg:31.69ms
+step:165/1490 train_time:5226ms step_avg:31.67ms
+step:166/1490 train_time:5260ms step_avg:31.69ms
+step:167/1490 train_time:5289ms step_avg:31.67ms
+step:168/1490 train_time:5324ms step_avg:31.69ms
+step:169/1490 train_time:5352ms step_avg:31.67ms
+step:170/1490 train_time:5386ms step_avg:31.69ms
+step:171/1490 train_time:5415ms step_avg:31.67ms
+step:172/1490 train_time:5450ms step_avg:31.69ms
+step:173/1490 train_time:5479ms step_avg:31.67ms
+step:174/1490 train_time:5513ms step_avg:31.69ms
+step:175/1490 train_time:5542ms step_avg:31.67ms
+step:176/1490 train_time:5576ms step_avg:31.68ms
+step:177/1490 train_time:5605ms step_avg:31.67ms
+step:178/1490 train_time:5639ms step_avg:31.68ms
+step:179/1490 train_time:5668ms step_avg:31.67ms
+step:180/1490 train_time:5703ms step_avg:31.68ms
+step:181/1490 train_time:5731ms step_avg:31.66ms
+step:182/1490 train_time:5766ms step_avg:31.68ms
+step:183/1490 train_time:5794ms step_avg:31.66ms
+step:184/1490 train_time:5829ms step_avg:31.68ms
+step:185/1490 train_time:5857ms step_avg:31.66ms
+step:186/1490 train_time:5891ms step_avg:31.67ms
+step:187/1490 train_time:5920ms step_avg:31.66ms
+step:188/1490 train_time:5954ms step_avg:31.67ms
+step:189/1490 train_time:5982ms step_avg:31.65ms
+step:190/1490 train_time:6016ms step_avg:31.67ms
+step:191/1490 train_time:6045ms step_avg:31.65ms
+step:192/1490 train_time:6079ms step_avg:31.66ms
+step:193/1490 train_time:6108ms step_avg:31.65ms
+step:194/1490 train_time:6142ms step_avg:31.66ms
+step:195/1490 train_time:6171ms step_avg:31.65ms
+step:196/1490 train_time:6205ms step_avg:31.66ms
+step:197/1490 train_time:6234ms step_avg:31.64ms
+step:198/1490 train_time:6268ms step_avg:31.66ms
+step:199/1490 train_time:6297ms step_avg:31.64ms
+step:200/1490 train_time:6332ms step_avg:31.66ms
+step:201/1490 train_time:6360ms step_avg:31.64ms
+step:202/1490 train_time:6394ms step_avg:31.66ms
+step:203/1490 train_time:6423ms step_avg:31.64ms
+step:204/1490 train_time:6457ms step_avg:31.65ms
+step:205/1490 train_time:6486ms step_avg:31.64ms
+step:206/1490 train_time:6520ms step_avg:31.65ms
+step:207/1490 train_time:6549ms step_avg:31.64ms
+step:208/1490 train_time:6583ms step_avg:31.65ms
+step:209/1490 train_time:6612ms step_avg:31.64ms
+step:210/1490 train_time:6647ms step_avg:31.65ms
+step:211/1490 train_time:6676ms step_avg:31.64ms
+step:212/1490 train_time:6710ms step_avg:31.65ms
+step:213/1490 train_time:6739ms step_avg:31.64ms
+step:214/1490 train_time:6773ms step_avg:31.65ms
+step:215/1490 train_time:6801ms step_avg:31.63ms
+step:216/1490 train_time:6836ms step_avg:31.65ms
+step:217/1490 train_time:6864ms step_avg:31.63ms
+step:218/1490 train_time:6899ms step_avg:31.64ms
+step:219/1490 train_time:6928ms step_avg:31.63ms
+step:220/1490 train_time:6962ms step_avg:31.65ms
+step:221/1490 train_time:6990ms step_avg:31.63ms
+step:222/1490 train_time:7026ms step_avg:31.65ms
+step:223/1490 train_time:7054ms step_avg:31.63ms
+step:224/1490 train_time:7089ms step_avg:31.65ms
+step:225/1490 train_time:7117ms step_avg:31.63ms
+step:226/1490 train_time:7151ms step_avg:31.64ms
+step:227/1490 train_time:7180ms step_avg:31.63ms
+step:228/1490 train_time:7214ms step_avg:31.64ms
+step:229/1490 train_time:7242ms step_avg:31.63ms
+step:230/1490 train_time:7277ms step_avg:31.64ms
+step:231/1490 train_time:7305ms step_avg:31.62ms
+step:232/1490 train_time:7339ms step_avg:31.63ms
+step:233/1490 train_time:7368ms step_avg:31.62ms
+step:234/1490 train_time:7402ms step_avg:31.63ms
+step:235/1490 train_time:7431ms step_avg:31.62ms
+step:236/1490 train_time:7466ms step_avg:31.63ms
+step:237/1490 train_time:7494ms step_avg:31.62ms
+step:238/1490 train_time:7528ms step_avg:31.63ms
+step:239/1490 train_time:7557ms step_avg:31.62ms
+step:240/1490 train_time:7591ms step_avg:31.63ms
+step:241/1490 train_time:7620ms step_avg:31.62ms
+step:242/1490 train_time:7654ms step_avg:31.63ms
+step:243/1490 train_time:7683ms step_avg:31.62ms
+step:244/1490 train_time:7717ms step_avg:31.63ms
+step:245/1490 train_time:7746ms step_avg:31.62ms
+step:246/1490 train_time:7781ms step_avg:31.63ms
+step:247/1490 train_time:7810ms step_avg:31.62ms
+step:248/1490 train_time:7844ms step_avg:31.63ms
+step:249/1490 train_time:7872ms step_avg:31.61ms
+step:250/1490 train_time:7907ms step_avg:31.63ms
+step:250/1490 val_loss:4.5182 train_time:7950ms step_avg:31.80ms
+step:251/1490 train_time:7965ms step_avg:31.73ms
+step:252/1490 train_time:7982ms step_avg:31.67ms
+step:253/1490 train_time:8001ms step_avg:31.62ms
+step:254/1490 train_time:8037ms step_avg:31.64ms
+step:255/1490 train_time:8067ms step_avg:31.63ms
+step:256/1490 train_time:8103ms step_avg:31.65ms
+step:257/1490 train_time:8133ms step_avg:31.64ms
+step:258/1490 train_time:8168ms step_avg:31.66ms
+step:259/1490 train_time:8197ms step_avg:31.65ms
+step:260/1490 train_time:8231ms step_avg:31.66ms
+step:261/1490 train_time:8260ms step_avg:31.65ms
+step:262/1490 train_time:8294ms step_avg:31.66ms
+step:263/1490 train_time:8322ms step_avg:31.64ms
+step:264/1490 train_time:8357ms step_avg:31.65ms
+step:265/1490 train_time:8385ms step_avg:31.64ms
+step:266/1490 train_time:8419ms step_avg:31.65ms
+step:267/1490 train_time:8448ms step_avg:31.64ms
+step:268/1490 train_time:8482ms step_avg:31.65ms
+step:269/1490 train_time:8510ms step_avg:31.64ms
+step:270/1490 train_time:8544ms step_avg:31.65ms
+step:271/1490 train_time:8573ms step_avg:31.63ms
+step:272/1490 train_time:8607ms step_avg:31.64ms
+step:273/1490 train_time:8635ms step_avg:31.63ms
+step:274/1490 train_time:8669ms step_avg:31.64ms
+step:275/1490 train_time:8697ms step_avg:31.63ms
+step:276/1490 train_time:8731ms step_avg:31.63ms
+step:277/1490 train_time:8759ms step_avg:31.62ms
+step:278/1490 train_time:8793ms step_avg:31.63ms
+step:279/1490 train_time:8821ms step_avg:31.62ms
+step:280/1490 train_time:8855ms step_avg:31.63ms
+step:281/1490 train_time:8884ms step_avg:31.62ms
+step:282/1490 train_time:8919ms step_avg:31.63ms
+step:283/1490 train_time:8947ms step_avg:31.62ms
+step:284/1490 train_time:8982ms step_avg:31.63ms
+step:285/1490 train_time:9011ms step_avg:31.62ms
+step:286/1490 train_time:9046ms step_avg:31.63ms
+step:287/1490 train_time:9075ms step_avg:31.62ms
+step:288/1490 train_time:9110ms step_avg:31.63ms
+step:289/1490 train_time:9139ms step_avg:31.62ms
+step:290/1490 train_time:9173ms step_avg:31.63ms
+step:291/1490 train_time:9202ms step_avg:31.62ms
+step:292/1490 train_time:9237ms step_avg:31.63ms
+step:293/1490 train_time:9265ms step_avg:31.62ms
+step:294/1490 train_time:9299ms step_avg:31.63ms
+step:295/1490 train_time:9328ms step_avg:31.62ms
+step:296/1490 train_time:9363ms step_avg:31.63ms
+step:297/1490 train_time:9392ms step_avg:31.62ms
+step:298/1490 train_time:9426ms step_avg:31.63ms
+step:299/1490 train_time:9455ms step_avg:31.62ms
+step:300/1490 train_time:9489ms step_avg:31.63ms
+step:301/1490 train_time:9517ms step_avg:31.62ms
+step:302/1490 train_time:9551ms step_avg:31.63ms
+step:303/1490 train_time:9580ms step_avg:31.62ms
+step:304/1490 train_time:9614ms step_avg:31.62ms
+step:305/1490 train_time:9642ms step_avg:31.61ms
+step:306/1490 train_time:9676ms step_avg:31.62ms
+step:307/1490 train_time:9705ms step_avg:31.61ms
+step:308/1490 train_time:9739ms step_avg:31.62ms
+step:309/1490 train_time:9767ms step_avg:31.61ms
+step:310/1490 train_time:9801ms step_avg:31.62ms
+step:311/1490 train_time:9830ms step_avg:31.61ms
+step:312/1490 train_time:9864ms step_avg:31.62ms
+step:313/1490 train_time:9893ms step_avg:31.61ms
+step:314/1490 train_time:9928ms step_avg:31.62ms
+step:315/1490 train_time:9957ms step_avg:31.61ms
+step:316/1490 train_time:9991ms step_avg:31.62ms
+step:317/1490 train_time:10020ms step_avg:31.61ms
+step:318/1490 train_time:10054ms step_avg:31.62ms
+step:319/1490 train_time:10083ms step_avg:31.61ms
+step:320/1490 train_time:10118ms step_avg:31.62ms
+step:321/1490 train_time:10146ms step_avg:31.61ms
+step:322/1490 train_time:10181ms step_avg:31.62ms
+step:323/1490 train_time:10210ms step_avg:31.61ms
+step:324/1490 train_time:10245ms step_avg:31.62ms
+step:325/1490 train_time:10274ms step_avg:31.61ms
+step:326/1490 train_time:10308ms step_avg:31.62ms
+step:327/1490 train_time:10336ms step_avg:31.61ms
+step:328/1490 train_time:10371ms step_avg:31.62ms
+step:329/1490 train_time:10400ms step_avg:31.61ms
+step:330/1490 train_time:10434ms step_avg:31.62ms
+step:331/1490 train_time:10463ms step_avg:31.61ms
+step:332/1490 train_time:10497ms step_avg:31.62ms
+step:333/1490 train_time:10525ms step_avg:31.61ms
+step:334/1490 train_time:10560ms step_avg:31.62ms
+step:335/1490 train_time:10588ms step_avg:31.61ms
+step:336/1490 train_time:10623ms step_avg:31.61ms
+step:337/1490 train_time:10651ms step_avg:31.60ms
+step:338/1490 train_time:10685ms step_avg:31.61ms
+step:339/1490 train_time:10714ms step_avg:31.61ms
+step:340/1490 train_time:10748ms step_avg:31.61ms
+step:341/1490 train_time:10776ms step_avg:31.60ms
+step:342/1490 train_time:10810ms step_avg:31.61ms
+step:343/1490 train_time:10839ms step_avg:31.60ms
+step:344/1490 train_time:10873ms step_avg:31.61ms
+step:345/1490 train_time:10901ms step_avg:31.60ms
+step:346/1490 train_time:10935ms step_avg:31.60ms
+step:347/1490 train_time:10963ms step_avg:31.59ms
+step:348/1490 train_time:10998ms step_avg:31.60ms
+step:349/1490 train_time:11026ms step_avg:31.59ms
+step:350/1490 train_time:11061ms step_avg:31.60ms
+step:351/1490 train_time:11089ms step_avg:31.59ms
+step:352/1490 train_time:11125ms step_avg:31.60ms
+step:353/1490 train_time:11153ms step_avg:31.60ms
+step:354/1490 train_time:11188ms step_avg:31.60ms
+step:355/1490 train_time:11217ms step_avg:31.60ms
+step:356/1490 train_time:11251ms step_avg:31.60ms
+step:357/1490 train_time:11280ms step_avg:31.60ms
+step:358/1490 train_time:11314ms step_avg:31.60ms
+step:359/1490 train_time:11343ms step_avg:31.60ms
+step:360/1490 train_time:11377ms step_avg:31.60ms
+step:361/1490 train_time:11406ms step_avg:31.59ms
+step:362/1490 train_time:11441ms step_avg:31.60ms
+step:363/1490 train_time:11469ms step_avg:31.59ms
+step:364/1490 train_time:11503ms step_avg:31.60ms
+step:365/1490 train_time:11532ms step_avg:31.59ms
+step:366/1490 train_time:11567ms step_avg:31.60ms
+step:367/1490 train_time:11595ms step_avg:31.59ms
+step:368/1490 train_time:11629ms step_avg:31.60ms
+step:369/1490 train_time:11657ms step_avg:31.59ms
+step:370/1490 train_time:11691ms step_avg:31.60ms
+step:371/1490 train_time:11720ms step_avg:31.59ms
+step:372/1490 train_time:11754ms step_avg:31.60ms
+step:373/1490 train_time:11782ms step_avg:31.59ms
+step:374/1490 train_time:11816ms step_avg:31.59ms
+step:375/1490 train_time:11845ms step_avg:31.59ms
+step:376/1490 train_time:11879ms step_avg:31.59ms
+step:377/1490 train_time:11908ms step_avg:31.59ms
+step:378/1490 train_time:11942ms step_avg:31.59ms
+step:379/1490 train_time:11970ms step_avg:31.58ms
+step:380/1490 train_time:12005ms step_avg:31.59ms
+step:381/1490 train_time:12033ms step_avg:31.58ms
+step:382/1490 train_time:12068ms step_avg:31.59ms
+step:383/1490 train_time:12096ms step_avg:31.58ms
+step:384/1490 train_time:12130ms step_avg:31.59ms
+step:385/1490 train_time:12159ms step_avg:31.58ms
+step:386/1490 train_time:12193ms step_avg:31.59ms
+step:387/1490 train_time:12222ms step_avg:31.58ms
+step:388/1490 train_time:12256ms step_avg:31.59ms
+step:389/1490 train_time:12284ms step_avg:31.58ms
+step:390/1490 train_time:12319ms step_avg:31.59ms
+step:391/1490 train_time:12347ms step_avg:31.58ms
+step:392/1490 train_time:12382ms step_avg:31.59ms
+step:393/1490 train_time:12410ms step_avg:31.58ms
+step:394/1490 train_time:12445ms step_avg:31.59ms
+step:395/1490 train_time:12473ms step_avg:31.58ms
+step:396/1490 train_time:12507ms step_avg:31.58ms
+step:397/1490 train_time:12536ms step_avg:31.58ms
+step:398/1490 train_time:12570ms step_avg:31.58ms
+step:399/1490 train_time:12598ms step_avg:31.58ms
+step:400/1490 train_time:12633ms step_avg:31.58ms
+step:401/1490 train_time:12661ms step_avg:31.57ms
+step:402/1490 train_time:12696ms step_avg:31.58ms
+step:403/1490 train_time:12724ms step_avg:31.57ms
+step:404/1490 train_time:12759ms step_avg:31.58ms
+step:405/1490 train_time:12787ms step_avg:31.57ms
+step:406/1490 train_time:12822ms step_avg:31.58ms
+step:407/1490 train_time:12851ms step_avg:31.57ms
+step:408/1490 train_time:12885ms step_avg:31.58ms
+step:409/1490 train_time:12913ms step_avg:31.57ms
+step:410/1490 train_time:12947ms step_avg:31.58ms
+step:411/1490 train_time:12976ms step_avg:31.57ms
+step:412/1490 train_time:13010ms step_avg:31.58ms
+step:413/1490 train_time:13038ms step_avg:31.57ms
+step:414/1490 train_time:13072ms step_avg:31.58ms
+step:415/1490 train_time:13101ms step_avg:31.57ms
+step:416/1490 train_time:13135ms step_avg:31.58ms
+step:417/1490 train_time:13164ms step_avg:31.57ms
+step:418/1490 train_time:13198ms step_avg:31.57ms
+step:419/1490 train_time:13227ms step_avg:31.57ms
+step:420/1490 train_time:13261ms step_avg:31.57ms
+step:421/1490 train_time:13290ms step_avg:31.57ms
+step:422/1490 train_time:13324ms step_avg:31.57ms
+step:423/1490 train_time:13353ms step_avg:31.57ms
+step:424/1490 train_time:13387ms step_avg:31.57ms
+step:425/1490 train_time:13416ms step_avg:31.57ms
+step:426/1490 train_time:13449ms step_avg:31.57ms
+step:427/1490 train_time:13478ms step_avg:31.56ms
+step:428/1490 train_time:13512ms step_avg:31.57ms
+step:429/1490 train_time:13540ms step_avg:31.56ms
+step:430/1490 train_time:13574ms step_avg:31.57ms
+step:431/1490 train_time:13603ms step_avg:31.56ms
+step:432/1490 train_time:13639ms step_avg:31.57ms
+step:433/1490 train_time:13666ms step_avg:31.56ms
+step:434/1490 train_time:13700ms step_avg:31.57ms
+step:435/1490 train_time:13729ms step_avg:31.56ms
+step:436/1490 train_time:13764ms step_avg:31.57ms
+step:437/1490 train_time:13793ms step_avg:31.56ms
+step:438/1490 train_time:13827ms step_avg:31.57ms
+step:439/1490 train_time:13855ms step_avg:31.56ms
+step:440/1490 train_time:13890ms step_avg:31.57ms
+step:441/1490 train_time:13918ms step_avg:31.56ms
+step:442/1490 train_time:13952ms step_avg:31.57ms
+step:443/1490 train_time:13981ms step_avg:31.56ms
+step:444/1490 train_time:14015ms step_avg:31.57ms
+step:445/1490 train_time:14044ms step_avg:31.56ms
+step:446/1490 train_time:14078ms step_avg:31.56ms
+step:447/1490 train_time:14106ms step_avg:31.56ms
+step:448/1490 train_time:14141ms step_avg:31.56ms
+step:449/1490 train_time:14169ms step_avg:31.56ms
+step:450/1490 train_time:14203ms step_avg:31.56ms
+step:451/1490 train_time:14232ms step_avg:31.56ms
+step:452/1490 train_time:14267ms step_avg:31.56ms
+step:453/1490 train_time:14295ms step_avg:31.56ms
+step:454/1490 train_time:14329ms step_avg:31.56ms
+step:455/1490 train_time:14358ms step_avg:31.56ms
+step:456/1490 train_time:14392ms step_avg:31.56ms
+step:457/1490 train_time:14421ms step_avg:31.55ms
+step:458/1490 train_time:14455ms step_avg:31.56ms
+step:459/1490 train_time:14483ms step_avg:31.55ms
+step:460/1490 train_time:14518ms step_avg:31.56ms
+step:461/1490 train_time:14546ms step_avg:31.55ms
+step:462/1490 train_time:14581ms step_avg:31.56ms
+step:463/1490 train_time:14609ms step_avg:31.55ms
+step:464/1490 train_time:14644ms step_avg:31.56ms
+step:465/1490 train_time:14672ms step_avg:31.55ms
+step:466/1490 train_time:14707ms step_avg:31.56ms
+step:467/1490 train_time:14735ms step_avg:31.55ms
+step:468/1490 train_time:14769ms step_avg:31.56ms
+step:469/1490 train_time:14798ms step_avg:31.55ms
+step:470/1490 train_time:14832ms step_avg:31.56ms
+step:471/1490 train_time:14861ms step_avg:31.55ms
+step:472/1490 train_time:14895ms step_avg:31.56ms
+step:473/1490 train_time:14924ms step_avg:31.55ms
+step:474/1490 train_time:14958ms step_avg:31.56ms
+step:475/1490 train_time:14987ms step_avg:31.55ms
+step:476/1490 train_time:15021ms step_avg:31.56ms
+step:477/1490 train_time:15050ms step_avg:31.55ms
+step:478/1490 train_time:15084ms step_avg:31.56ms
+step:479/1490 train_time:15112ms step_avg:31.55ms
+step:480/1490 train_time:15146ms step_avg:31.55ms
+step:481/1490 train_time:15175ms step_avg:31.55ms
+step:482/1490 train_time:15209ms step_avg:31.55ms
+step:483/1490 train_time:15238ms step_avg:31.55ms
+step:484/1490 train_time:15275ms step_avg:31.56ms
+step:485/1490 train_time:15327ms step_avg:31.60ms
+step:486/1490 train_time:15386ms step_avg:31.66ms
+step:487/1490 train_time:15440ms step_avg:31.70ms
+step:488/1490 train_time:15501ms step_avg:31.76ms
+step:489/1490 train_time:15555ms step_avg:31.81ms
+step:490/1490 train_time:15614ms step_avg:31.87ms
+step:491/1490 train_time:15669ms step_avg:31.91ms
+step:492/1490 train_time:15728ms step_avg:31.97ms
+step:493/1490 train_time:15784ms step_avg:32.02ms
+step:494/1490 train_time:15843ms step_avg:32.07ms
+step:495/1490 train_time:15897ms step_avg:32.12ms
+step:496/1490 train_time:15957ms step_avg:32.17ms
+step:497/1490 train_time:16011ms step_avg:32.22ms
+step:498/1490 train_time:16072ms step_avg:32.27ms
+step:499/1490 train_time:16127ms step_avg:32.32ms
+step:500/1490 train_time:16187ms step_avg:32.37ms
+step:500/1490 val_loss:4.2126 train_time:16258ms step_avg:32.52ms
+step:501/1490 train_time:16273ms step_avg:32.48ms
+step:502/1490 train_time:16301ms step_avg:32.47ms
+step:503/1490 train_time:16357ms step_avg:32.52ms
+step:504/1490 train_time:16419ms step_avg:32.58ms
+step:505/1490 train_time:16475ms step_avg:32.62ms
+step:506/1490 train_time:16536ms step_avg:32.68ms
+step:507/1490 train_time:16590ms step_avg:32.72ms
+step:508/1490 train_time:16648ms step_avg:32.77ms
+step:509/1490 train_time:16704ms step_avg:32.82ms
+step:510/1490 train_time:16763ms step_avg:32.87ms
+step:511/1490 train_time:16816ms step_avg:32.91ms
+step:512/1490 train_time:16874ms step_avg:32.96ms
+step:513/1490 train_time:16927ms step_avg:33.00ms
+step:514/1490 train_time:16986ms step_avg:33.05ms
+step:515/1490 train_time:17040ms step_avg:33.09ms
+step:516/1490 train_time:17100ms step_avg:33.14ms
+step:517/1490 train_time:17155ms step_avg:33.18ms
+step:518/1490 train_time:17216ms step_avg:33.24ms
+step:519/1490 train_time:17271ms step_avg:33.28ms
+step:520/1490 train_time:17332ms step_avg:33.33ms
+step:521/1490 train_time:17387ms step_avg:33.37ms
+step:522/1490 train_time:17447ms step_avg:33.42ms
+step:523/1490 train_time:17502ms step_avg:33.47ms
+step:524/1490 train_time:17562ms step_avg:33.52ms
+step:525/1490 train_time:17616ms step_avg:33.55ms
+step:526/1490 train_time:17676ms step_avg:33.60ms
+step:527/1490 train_time:17730ms step_avg:33.64ms
+step:528/1490 train_time:17790ms step_avg:33.69ms
+step:529/1490 train_time:17844ms step_avg:33.73ms
+step:530/1490 train_time:17903ms step_avg:33.78ms
+step:531/1490 train_time:17957ms step_avg:33.82ms
+step:532/1490 train_time:18016ms step_avg:33.86ms
+step:533/1490 train_time:18070ms step_avg:33.90ms
+step:534/1490 train_time:18129ms step_avg:33.95ms
+step:535/1490 train_time:18183ms step_avg:33.99ms
+step:536/1490 train_time:18244ms step_avg:34.04ms
+step:537/1490 train_time:18298ms step_avg:34.07ms
+step:538/1490 train_time:18360ms step_avg:34.13ms
+step:539/1490 train_time:18415ms step_avg:34.17ms
+step:540/1490 train_time:18475ms step_avg:34.21ms
+step:541/1490 train_time:18529ms step_avg:34.25ms
+step:542/1490 train_time:18588ms step_avg:34.30ms
+step:543/1490 train_time:18643ms step_avg:34.33ms
+step:544/1490 train_time:18703ms step_avg:34.38ms
+step:545/1490 train_time:18756ms step_avg:34.41ms
+step:546/1490 train_time:18816ms step_avg:34.46ms
+step:547/1490 train_time:18870ms step_avg:34.50ms
+step:548/1490 train_time:18929ms step_avg:34.54ms
+step:549/1490 train_time:18983ms step_avg:34.58ms
+step:550/1490 train_time:19042ms step_avg:34.62ms
+step:551/1490 train_time:19096ms step_avg:34.66ms
+step:552/1490 train_time:19156ms step_avg:34.70ms
+step:553/1490 train_time:19210ms step_avg:34.74ms
+step:554/1490 train_time:19271ms step_avg:34.79ms
+step:555/1490 train_time:19326ms step_avg:34.82ms
+step:556/1490 train_time:19386ms step_avg:34.87ms
+step:557/1490 train_time:19442ms step_avg:34.90ms
+step:558/1490 train_time:19502ms step_avg:34.95ms
+step:559/1490 train_time:19556ms step_avg:34.98ms
+step:560/1490 train_time:19616ms step_avg:35.03ms
+step:561/1490 train_time:19670ms step_avg:35.06ms
+step:562/1490 train_time:19730ms step_avg:35.11ms
+step:563/1490 train_time:19784ms step_avg:35.14ms
+step:564/1490 train_time:19844ms step_avg:35.18ms
+step:565/1490 train_time:19898ms step_avg:35.22ms
+step:566/1490 train_time:19958ms step_avg:35.26ms
+step:567/1490 train_time:20012ms step_avg:35.29ms
+step:568/1490 train_time:20072ms step_avg:35.34ms
+step:569/1490 train_time:20126ms step_avg:35.37ms
+step:570/1490 train_time:20186ms step_avg:35.41ms
+step:571/1490 train_time:20240ms step_avg:35.45ms
+step:572/1490 train_time:20300ms step_avg:35.49ms
+step:573/1490 train_time:20354ms step_avg:35.52ms
+step:574/1490 train_time:20415ms step_avg:35.57ms
+step:575/1490 train_time:20470ms step_avg:35.60ms
+step:576/1490 train_time:20529ms step_avg:35.64ms
+step:577/1490 train_time:20584ms step_avg:35.67ms
+step:578/1490 train_time:20643ms step_avg:35.72ms
+step:579/1490 train_time:20697ms step_avg:35.75ms
+step:580/1490 train_time:20757ms step_avg:35.79ms
+step:581/1490 train_time:20811ms step_avg:35.82ms
+step:582/1490 train_time:20870ms step_avg:35.86ms
+step:583/1490 train_time:20924ms step_avg:35.89ms
+step:584/1490 train_time:20983ms step_avg:35.93ms
+step:585/1490 train_time:21038ms step_avg:35.96ms
+step:586/1490 train_time:21099ms step_avg:36.00ms
+step:587/1490 train_time:21152ms step_avg:36.03ms
+step:588/1490 train_time:21213ms step_avg:36.08ms
+step:589/1490 train_time:21267ms step_avg:36.11ms
+step:590/1490 train_time:21327ms step_avg:36.15ms
+step:591/1490 train_time:21381ms step_avg:36.18ms
+step:592/1490 train_time:21441ms step_avg:36.22ms
+step:593/1490 train_time:21496ms step_avg:36.25ms
+step:594/1490 train_time:21556ms step_avg:36.29ms
+step:595/1490 train_time:21610ms step_avg:36.32ms
+step:596/1490 train_time:21670ms step_avg:36.36ms
+step:597/1490 train_time:21725ms step_avg:36.39ms
+step:598/1490 train_time:21784ms step_avg:36.43ms
+step:599/1490 train_time:21838ms step_avg:36.46ms
+step:600/1490 train_time:21898ms step_avg:36.50ms
+step:601/1490 train_time:21952ms step_avg:36.53ms
+step:602/1490 train_time:22011ms step_avg:36.56ms
+step:603/1490 train_time:22065ms step_avg:36.59ms
+step:604/1490 train_time:22124ms step_avg:36.63ms
+step:605/1490 train_time:22179ms step_avg:36.66ms
+step:606/1490 train_time:22239ms step_avg:36.70ms
+step:607/1490 train_time:22293ms step_avg:36.73ms
+step:608/1490 train_time:22353ms step_avg:36.76ms
+step:609/1490 train_time:22408ms step_avg:36.80ms
+step:610/1490 train_time:22468ms step_avg:36.83ms
+step:611/1490 train_time:22523ms step_avg:36.86ms
+step:612/1490 train_time:22583ms step_avg:36.90ms
+step:613/1490 train_time:22637ms step_avg:36.93ms
+step:614/1490 train_time:22697ms step_avg:36.97ms
+step:615/1490 train_time:22751ms step_avg:36.99ms
+step:616/1490 train_time:22811ms step_avg:37.03ms
+step:617/1490 train_time:22865ms step_avg:37.06ms
+step:618/1490 train_time:22925ms step_avg:37.09ms
+step:619/1490 train_time:22978ms step_avg:37.12ms
+step:620/1490 train_time:23038ms step_avg:37.16ms
+step:621/1490 train_time:23093ms step_avg:37.19ms
+step:622/1490 train_time:23152ms step_avg:37.22ms
+step:623/1490 train_time:23206ms step_avg:37.25ms
+step:624/1490 train_time:23265ms step_avg:37.28ms
+step:625/1490 train_time:23320ms step_avg:37.31ms
+step:626/1490 train_time:23381ms step_avg:37.35ms
+step:627/1490 train_time:23435ms step_avg:37.38ms
+step:628/1490 train_time:23495ms step_avg:37.41ms
+step:629/1490 train_time:23550ms step_avg:37.44ms
+step:630/1490 train_time:23610ms step_avg:37.48ms
+step:631/1490 train_time:23664ms step_avg:37.50ms
+step:632/1490 train_time:23723ms step_avg:37.54ms
+step:633/1490 train_time:23777ms step_avg:37.56ms
+step:634/1490 train_time:23837ms step_avg:37.60ms
+step:635/1490 train_time:23891ms step_avg:37.62ms
+step:636/1490 train_time:23950ms step_avg:37.66ms
+step:637/1490 train_time:24004ms step_avg:37.68ms
+step:638/1490 train_time:24064ms step_avg:37.72ms
+step:639/1490 train_time:24118ms step_avg:37.74ms
+step:640/1490 train_time:24179ms step_avg:37.78ms
+step:641/1490 train_time:24234ms step_avg:37.81ms
+step:642/1490 train_time:24294ms step_avg:37.84ms
+step:643/1490 train_time:24348ms step_avg:37.87ms
+step:644/1490 train_time:24407ms step_avg:37.90ms
+step:645/1490 train_time:24461ms step_avg:37.92ms
+step:646/1490 train_time:24521ms step_avg:37.96ms
+step:647/1490 train_time:24576ms step_avg:37.98ms
+step:648/1490 train_time:24636ms step_avg:38.02ms
+step:649/1490 train_time:24690ms step_avg:38.04ms
+step:650/1490 train_time:24750ms step_avg:38.08ms
+step:651/1490 train_time:24804ms step_avg:38.10ms
+step:652/1490 train_time:24863ms step_avg:38.13ms
+step:653/1490 train_time:24917ms step_avg:38.16ms
+step:654/1490 train_time:24978ms step_avg:38.19ms
+step:655/1490 train_time:25032ms step_avg:38.22ms
+step:656/1490 train_time:25091ms step_avg:38.25ms
+step:657/1490 train_time:25145ms step_avg:38.27ms
+step:658/1490 train_time:25206ms step_avg:38.31ms
+step:659/1490 train_time:25261ms step_avg:38.33ms
+step:660/1490 train_time:25321ms step_avg:38.37ms
+step:661/1490 train_time:25376ms step_avg:38.39ms
+step:662/1490 train_time:25436ms step_avg:38.42ms
+step:663/1490 train_time:25490ms step_avg:38.45ms
+step:664/1490 train_time:25550ms step_avg:38.48ms
+step:665/1490 train_time:25605ms step_avg:38.50ms
+step:666/1490 train_time:25665ms step_avg:38.54ms
+step:667/1490 train_time:25719ms step_avg:38.56ms
+step:668/1490 train_time:25779ms step_avg:38.59ms
+step:669/1490 train_time:25833ms step_avg:38.61ms
+step:670/1490 train_time:25893ms step_avg:38.65ms
+step:671/1490 train_time:25948ms step_avg:38.67ms
+step:672/1490 train_time:26008ms step_avg:38.70ms
+step:673/1490 train_time:26062ms step_avg:38.73ms
+step:674/1490 train_time:26122ms step_avg:38.76ms
+step:675/1490 train_time:26176ms step_avg:38.78ms
+step:676/1490 train_time:26237ms step_avg:38.81ms
+step:677/1490 train_time:26292ms step_avg:38.84ms
+step:678/1490 train_time:26351ms step_avg:38.87ms
+step:679/1490 train_time:26405ms step_avg:38.89ms
+step:680/1490 train_time:26464ms step_avg:38.92ms
+step:681/1490 train_time:26520ms step_avg:38.94ms
+step:682/1490 train_time:26580ms step_avg:38.97ms
+step:683/1490 train_time:26634ms step_avg:39.00ms
+step:684/1490 train_time:26694ms step_avg:39.03ms
+step:685/1490 train_time:26748ms step_avg:39.05ms
+step:686/1490 train_time:26809ms step_avg:39.08ms
+step:687/1490 train_time:26863ms step_avg:39.10ms
+step:688/1490 train_time:26922ms step_avg:39.13ms
+step:689/1490 train_time:26976ms step_avg:39.15ms
+step:690/1490 train_time:27036ms step_avg:39.18ms
+step:691/1490 train_time:27091ms step_avg:39.20ms
+step:692/1490 train_time:27150ms step_avg:39.23ms
+step:693/1490 train_time:27205ms step_avg:39.26ms
+step:694/1490 train_time:27264ms step_avg:39.29ms
+step:695/1490 train_time:27319ms step_avg:39.31ms
+step:696/1490 train_time:27379ms step_avg:39.34ms
+step:697/1490 train_time:27433ms step_avg:39.36ms
+step:698/1490 train_time:27493ms step_avg:39.39ms
+step:699/1490 train_time:27547ms step_avg:39.41ms
+step:700/1490 train_time:27607ms step_avg:39.44ms
+step:701/1490 train_time:27661ms step_avg:39.46ms
+step:702/1490 train_time:27722ms step_avg:39.49ms
+step:703/1490 train_time:27776ms step_avg:39.51ms
+step:704/1490 train_time:27836ms step_avg:39.54ms
+step:705/1490 train_time:27890ms step_avg:39.56ms
+step:706/1490 train_time:27950ms step_avg:39.59ms
+step:707/1490 train_time:28005ms step_avg:39.61ms
+step:708/1490 train_time:28065ms step_avg:39.64ms
+step:709/1490 train_time:28119ms step_avg:39.66ms
+step:710/1490 train_time:28180ms step_avg:39.69ms
+step:711/1490 train_time:28233ms step_avg:39.71ms
+step:712/1490 train_time:28293ms step_avg:39.74ms
+step:713/1490 train_time:28348ms step_avg:39.76ms
+step:714/1490 train_time:28408ms step_avg:39.79ms
+step:715/1490 train_time:28463ms step_avg:39.81ms
+step:716/1490 train_time:28523ms step_avg:39.84ms
+step:717/1490 train_time:28577ms step_avg:39.86ms
+step:718/1490 train_time:28636ms step_avg:39.88ms
+step:719/1490 train_time:28690ms step_avg:39.90ms
+step:720/1490 train_time:28751ms step_avg:39.93ms
+step:721/1490 train_time:28804ms step_avg:39.95ms
+step:722/1490 train_time:28864ms step_avg:39.98ms
+step:723/1490 train_time:28918ms step_avg:40.00ms
+step:724/1490 train_time:28979ms step_avg:40.03ms
+step:725/1490 train_time:29033ms step_avg:40.05ms
+step:726/1490 train_time:29093ms step_avg:40.07ms
+step:727/1490 train_time:29147ms step_avg:40.09ms
+step:728/1490 train_time:29207ms step_avg:40.12ms
+step:729/1490 train_time:29261ms step_avg:40.14ms
+step:730/1490 train_time:29321ms step_avg:40.17ms
+step:731/1490 train_time:29375ms step_avg:40.18ms
+step:732/1490 train_time:29435ms step_avg:40.21ms
+step:733/1490 train_time:29490ms step_avg:40.23ms
+step:734/1490 train_time:29549ms step_avg:40.26ms
+step:735/1490 train_time:29605ms step_avg:40.28ms
+step:736/1490 train_time:29664ms step_avg:40.30ms
+step:737/1490 train_time:29719ms step_avg:40.32ms
+step:738/1490 train_time:29779ms step_avg:40.35ms
+step:739/1490 train_time:29834ms step_avg:40.37ms
+step:740/1490 train_time:29893ms step_avg:40.40ms
+step:741/1490 train_time:29947ms step_avg:40.41ms
+step:742/1490 train_time:30008ms step_avg:40.44ms
+step:743/1490 train_time:30063ms step_avg:40.46ms
+step:744/1490 train_time:30123ms step_avg:40.49ms
+step:745/1490 train_time:30176ms step_avg:40.51ms
+step:746/1490 train_time:30236ms step_avg:40.53ms
+step:747/1490 train_time:30290ms step_avg:40.55ms
+step:748/1490 train_time:30350ms step_avg:40.57ms
+step:749/1490 train_time:30404ms step_avg:40.59ms
+step:750/1490 train_time:30464ms step_avg:40.62ms
+step:750/1490 val_loss:3.8052 train_time:30537ms step_avg:40.72ms
+step:751/1490 train_time:30553ms step_avg:40.68ms
+step:752/1490 train_time:30580ms step_avg:40.66ms
+step:753/1490 train_time:30634ms step_avg:40.68ms
+step:754/1490 train_time:30699ms step_avg:40.71ms
+step:755/1490 train_time:30756ms step_avg:40.74ms
+step:756/1490 train_time:30816ms step_avg:40.76ms
+step:757/1490 train_time:30870ms step_avg:40.78ms
+step:758/1490 train_time:30930ms step_avg:40.80ms
+step:759/1490 train_time:30984ms step_avg:40.82ms
+step:760/1490 train_time:31043ms step_avg:40.85ms
+step:761/1490 train_time:31097ms step_avg:40.86ms
+step:762/1490 train_time:31157ms step_avg:40.89ms
+step:763/1490 train_time:31210ms step_avg:40.90ms
+step:764/1490 train_time:31269ms step_avg:40.93ms
+step:765/1490 train_time:31323ms step_avg:40.95ms
+step:766/1490 train_time:31382ms step_avg:40.97ms
+step:767/1490 train_time:31436ms step_avg:40.99ms
+step:768/1490 train_time:31498ms step_avg:41.01ms
+step:769/1490 train_time:31553ms step_avg:41.03ms
+step:770/1490 train_time:31615ms step_avg:41.06ms
+step:771/1490 train_time:31669ms step_avg:41.08ms
+step:772/1490 train_time:31730ms step_avg:41.10ms
+step:773/1490 train_time:31786ms step_avg:41.12ms
+step:774/1490 train_time:31846ms step_avg:41.14ms
+step:775/1490 train_time:31901ms step_avg:41.16ms
+step:776/1490 train_time:31962ms step_avg:41.19ms
+step:777/1490 train_time:32017ms step_avg:41.21ms
+step:778/1490 train_time:32076ms step_avg:41.23ms
+step:779/1490 train_time:32129ms step_avg:41.24ms
+step:780/1490 train_time:32188ms step_avg:41.27ms
+step:781/1490 train_time:32242ms step_avg:41.28ms
+step:782/1490 train_time:32302ms step_avg:41.31ms
+step:783/1490 train_time:32356ms step_avg:41.32ms
+step:784/1490 train_time:32416ms step_avg:41.35ms
+step:785/1490 train_time:32471ms step_avg:41.36ms
+step:786/1490 train_time:32532ms step_avg:41.39ms
+step:787/1490 train_time:32588ms step_avg:41.41ms
+step:788/1490 train_time:32648ms step_avg:41.43ms
+step:789/1490 train_time:32703ms step_avg:41.45ms
+step:790/1490 train_time:32764ms step_avg:41.47ms
+step:791/1490 train_time:32819ms step_avg:41.49ms
+step:792/1490 train_time:32879ms step_avg:41.51ms
+step:793/1490 train_time:32934ms step_avg:41.53ms
+step:794/1490 train_time:32994ms step_avg:41.55ms
+step:795/1490 train_time:33048ms step_avg:41.57ms
+step:796/1490 train_time:33107ms step_avg:41.59ms
+step:797/1490 train_time:33162ms step_avg:41.61ms
+step:798/1490 train_time:33222ms step_avg:41.63ms
+step:799/1490 train_time:33276ms step_avg:41.65ms
+step:800/1490 train_time:33335ms step_avg:41.67ms
+step:801/1490 train_time:33389ms step_avg:41.68ms
+step:802/1490 train_time:33449ms step_avg:41.71ms
+step:803/1490 train_time:33503ms step_avg:41.72ms
+step:804/1490 train_time:33563ms step_avg:41.74ms
+step:805/1490 train_time:33618ms step_avg:41.76ms
+step:806/1490 train_time:33679ms step_avg:41.78ms
+step:807/1490 train_time:33732ms step_avg:41.80ms
+step:808/1490 train_time:33792ms step_avg:41.82ms
+step:809/1490 train_time:33847ms step_avg:41.84ms
+step:810/1490 train_time:33907ms step_avg:41.86ms
+step:811/1490 train_time:33962ms step_avg:41.88ms
+step:812/1490 train_time:34022ms step_avg:41.90ms
+step:813/1490 train_time:34076ms step_avg:41.91ms
+step:814/1490 train_time:34136ms step_avg:41.94ms
+step:815/1490 train_time:34190ms step_avg:41.95ms
+step:816/1490 train_time:34250ms step_avg:41.97ms
+step:817/1490 train_time:34304ms step_avg:41.99ms
+step:818/1490 train_time:34363ms step_avg:42.01ms
+step:819/1490 train_time:34418ms step_avg:42.02ms
+step:820/1490 train_time:34478ms step_avg:42.05ms
+step:821/1490 train_time:34532ms step_avg:42.06ms
+step:822/1490 train_time:34592ms step_avg:42.08ms
+step:823/1490 train_time:34648ms step_avg:42.10ms
+step:824/1490 train_time:34708ms step_avg:42.12ms
+step:825/1490 train_time:34762ms step_avg:42.14ms
+step:826/1490 train_time:34822ms step_avg:42.16ms
+step:827/1490 train_time:34876ms step_avg:42.17ms
+step:828/1490 train_time:34936ms step_avg:42.19ms
+step:829/1490 train_time:34990ms step_avg:42.21ms
+step:830/1490 train_time:35050ms step_avg:42.23ms
+step:831/1490 train_time:35104ms step_avg:42.24ms
+step:832/1490 train_time:35164ms step_avg:42.26ms
+step:833/1490 train_time:35219ms step_avg:42.28ms
+step:834/1490 train_time:35278ms step_avg:42.30ms
+step:835/1490 train_time:35332ms step_avg:42.31ms
+step:836/1490 train_time:35391ms step_avg:42.33ms
+step:837/1490 train_time:35446ms step_avg:42.35ms
+step:838/1490 train_time:35505ms step_avg:42.37ms
+step:839/1490 train_time:35559ms step_avg:42.38ms
+step:840/1490 train_time:35621ms step_avg:42.41ms
+step:841/1490 train_time:35676ms step_avg:42.42ms
+step:842/1490 train_time:35736ms step_avg:42.44ms
+step:843/1490 train_time:35790ms step_avg:42.45ms
+step:844/1490 train_time:35849ms step_avg:42.48ms
+step:845/1490 train_time:35904ms step_avg:42.49ms
+step:846/1490 train_time:35963ms step_avg:42.51ms
+step:847/1490 train_time:36019ms step_avg:42.53ms
+step:848/1490 train_time:36078ms step_avg:42.55ms
+step:849/1490 train_time:36133ms step_avg:42.56ms
+step:850/1490 train_time:36192ms step_avg:42.58ms
+step:851/1490 train_time:36246ms step_avg:42.59ms
+step:852/1490 train_time:36306ms step_avg:42.61ms
+step:853/1490 train_time:36361ms step_avg:42.63ms
+step:854/1490 train_time:36423ms step_avg:42.65ms
+step:855/1490 train_time:36477ms step_avg:42.66ms
+step:856/1490 train_time:36537ms step_avg:42.68ms
+step:857/1490 train_time:36591ms step_avg:42.70ms
+step:858/1490 train_time:36651ms step_avg:42.72ms
+step:859/1490 train_time:36705ms step_avg:42.73ms
+step:860/1490 train_time:36765ms step_avg:42.75ms
+step:861/1490 train_time:36820ms step_avg:42.76ms
+step:862/1490 train_time:36879ms step_avg:42.78ms
+step:863/1490 train_time:36934ms step_avg:42.80ms
+step:864/1490 train_time:36994ms step_avg:42.82ms
+step:865/1490 train_time:37049ms step_avg:42.83ms
+step:866/1490 train_time:37109ms step_avg:42.85ms
+step:867/1490 train_time:37163ms step_avg:42.86ms
+step:868/1490 train_time:37223ms step_avg:42.88ms
+step:869/1490 train_time:37278ms step_avg:42.90ms
+step:870/1490 train_time:37337ms step_avg:42.92ms
+step:871/1490 train_time:37391ms step_avg:42.93ms
+step:872/1490 train_time:37450ms step_avg:42.95ms
+step:873/1490 train_time:37505ms step_avg:42.96ms
+step:874/1490 train_time:37565ms step_avg:42.98ms
+step:875/1490 train_time:37620ms step_avg:42.99ms
+step:876/1490 train_time:37680ms step_avg:43.01ms
+step:877/1490 train_time:37735ms step_avg:43.03ms
+step:878/1490 train_time:37795ms step_avg:43.05ms
+step:879/1490 train_time:37849ms step_avg:43.06ms
+step:880/1490 train_time:37910ms step_avg:43.08ms
+step:881/1490 train_time:37964ms step_avg:43.09ms
+step:882/1490 train_time:38025ms step_avg:43.11ms
+step:883/1490 train_time:38079ms step_avg:43.12ms
+step:884/1490 train_time:38139ms step_avg:43.14ms
+step:885/1490 train_time:38192ms step_avg:43.16ms
+step:886/1490 train_time:38253ms step_avg:43.17ms
+step:887/1490 train_time:38307ms step_avg:43.19ms
+step:888/1490 train_time:38367ms step_avg:43.21ms
+step:889/1490 train_time:38422ms step_avg:43.22ms
+step:890/1490 train_time:38481ms step_avg:43.24ms
+step:891/1490 train_time:38536ms step_avg:43.25ms
+step:892/1490 train_time:38597ms step_avg:43.27ms
+step:893/1490 train_time:38651ms step_avg:43.28ms
+step:894/1490 train_time:38712ms step_avg:43.30ms
+step:895/1490 train_time:38766ms step_avg:43.31ms
+step:896/1490 train_time:38826ms step_avg:43.33ms
+step:897/1490 train_time:38880ms step_avg:43.34ms
+step:898/1490 train_time:38940ms step_avg:43.36ms
+step:899/1490 train_time:38994ms step_avg:43.37ms
+step:900/1490 train_time:39054ms step_avg:43.39ms
+step:901/1490 train_time:39109ms step_avg:43.41ms
+step:902/1490 train_time:39168ms step_avg:43.42ms
+step:903/1490 train_time:39222ms step_avg:43.44ms
+step:904/1490 train_time:39281ms step_avg:43.45ms
+step:905/1490 train_time:39335ms step_avg:43.46ms
+step:906/1490 train_time:39395ms step_avg:43.48ms
+step:907/1490 train_time:39449ms step_avg:43.49ms
+step:908/1490 train_time:39509ms step_avg:43.51ms
+step:909/1490 train_time:39564ms step_avg:43.52ms
+step:910/1490 train_time:39624ms step_avg:43.54ms
+step:911/1490 train_time:39679ms step_avg:43.56ms
+step:912/1490 train_time:39739ms step_avg:43.57ms
+step:913/1490 train_time:39793ms step_avg:43.58ms
+step:914/1490 train_time:39852ms step_avg:43.60ms
+step:915/1490 train_time:39907ms step_avg:43.61ms
+step:916/1490 train_time:39966ms step_avg:43.63ms
+step:917/1490 train_time:40021ms step_avg:43.64ms
+step:918/1490 train_time:40081ms step_avg:43.66ms
+step:919/1490 train_time:40136ms step_avg:43.67ms
+step:920/1490 train_time:40197ms step_avg:43.69ms
+step:921/1490 train_time:40251ms step_avg:43.70ms
+step:922/1490 train_time:40310ms step_avg:43.72ms
+step:923/1490 train_time:40364ms step_avg:43.73ms
+step:924/1490 train_time:40424ms step_avg:43.75ms
+step:925/1490 train_time:40478ms step_avg:43.76ms
+step:926/1490 train_time:40537ms step_avg:43.78ms
+step:927/1490 train_time:40592ms step_avg:43.79ms
+step:928/1490 train_time:40652ms step_avg:43.81ms
+step:929/1490 train_time:40706ms step_avg:43.82ms
+step:930/1490 train_time:40766ms step_avg:43.83ms
+step:931/1490 train_time:40821ms step_avg:43.85ms
+step:932/1490 train_time:40881ms step_avg:43.86ms
+step:933/1490 train_time:40935ms step_avg:43.87ms
+step:934/1490 train_time:40995ms step_avg:43.89ms
+step:935/1490 train_time:41050ms step_avg:43.90ms
+step:936/1490 train_time:41109ms step_avg:43.92ms
+step:937/1490 train_time:41164ms step_avg:43.93ms
+step:938/1490 train_time:41224ms step_avg:43.95ms
+step:939/1490 train_time:41278ms step_avg:43.96ms
+step:940/1490 train_time:41338ms step_avg:43.98ms
+step:941/1490 train_time:41392ms step_avg:43.99ms
+step:942/1490 train_time:41452ms step_avg:44.00ms
+step:943/1490 train_time:41506ms step_avg:44.02ms
+step:944/1490 train_time:41566ms step_avg:44.03ms
+step:945/1490 train_time:41620ms step_avg:44.04ms
+step:946/1490 train_time:41679ms step_avg:44.06ms
+step:947/1490 train_time:41734ms step_avg:44.07ms
+step:948/1490 train_time:41794ms step_avg:44.09ms
+step:949/1490 train_time:41848ms step_avg:44.10ms
+step:950/1490 train_time:41908ms step_avg:44.11ms
+step:951/1490 train_time:41962ms step_avg:44.12ms
+step:952/1490 train_time:42021ms step_avg:44.14ms
+step:953/1490 train_time:42076ms step_avg:44.15ms
+step:954/1490 train_time:42136ms step_avg:44.17ms
+step:955/1490 train_time:42191ms step_avg:44.18ms
+step:956/1490 train_time:42250ms step_avg:44.19ms
+step:957/1490 train_time:42304ms step_avg:44.21ms
+step:958/1490 train_time:42364ms step_avg:44.22ms
+step:959/1490 train_time:42418ms step_avg:44.23ms
+step:960/1490 train_time:42478ms step_avg:44.25ms
+step:961/1490 train_time:42532ms step_avg:44.26ms
+step:962/1490 train_time:42592ms step_avg:44.27ms
+step:963/1490 train_time:42646ms step_avg:44.28ms
+step:964/1490 train_time:42705ms step_avg:44.30ms
+step:965/1490 train_time:42760ms step_avg:44.31ms
+step:966/1490 train_time:42821ms step_avg:44.33ms
+step:967/1490 train_time:42875ms step_avg:44.34ms
+step:968/1490 train_time:42938ms step_avg:44.36ms
+step:969/1490 train_time:43017ms step_avg:44.39ms
+step:970/1490 train_time:43104ms step_avg:44.44ms
+step:971/1490 train_time:43184ms step_avg:44.47ms
+step:972/1490 train_time:43270ms step_avg:44.52ms
+step:973/1490 train_time:43352ms step_avg:44.56ms
+step:974/1490 train_time:43439ms step_avg:44.60ms
+step:975/1490 train_time:43521ms step_avg:44.64ms
+step:976/1490 train_time:43606ms step_avg:44.68ms
+step:977/1490 train_time:43688ms step_avg:44.72ms
+step:978/1490 train_time:43775ms step_avg:44.76ms
+step:979/1490 train_time:43856ms step_avg:44.80ms
+step:980/1490 train_time:43942ms step_avg:44.84ms
+step:981/1490 train_time:44023ms step_avg:44.88ms
+step:982/1490 train_time:44108ms step_avg:44.92ms
+step:983/1490 train_time:44190ms step_avg:44.95ms
+step:984/1490 train_time:44276ms step_avg:45.00ms
+step:985/1490 train_time:44356ms step_avg:45.03ms
+step:986/1490 train_time:44444ms step_avg:45.07ms
+step:987/1490 train_time:44525ms step_avg:45.11ms
+step:988/1490 train_time:44610ms step_avg:45.15ms
+step:989/1490 train_time:44692ms step_avg:45.19ms
+step:990/1490 train_time:44779ms step_avg:45.23ms
+step:991/1490 train_time:44861ms step_avg:45.27ms
+step:992/1490 train_time:44947ms step_avg:45.31ms
+step:993/1490 train_time:45028ms step_avg:45.35ms
+step:994/1490 train_time:45113ms step_avg:45.39ms
+step:995/1490 train_time:45195ms step_avg:45.42ms
+step:996/1490 train_time:45284ms step_avg:45.47ms
+step:997/1490 train_time:45365ms step_avg:45.50ms
+step:998/1490 train_time:45451ms step_avg:45.54ms
+step:999/1490 train_time:45532ms step_avg:45.58ms
+step:1000/1490 train_time:45619ms step_avg:45.62ms
+step:1000/1490 val_loss:3.5174 train_time:45722ms step_avg:45.72ms
+step:1001/1490 train_time:45739ms step_avg:45.69ms
+step:1002/1490 train_time:45789ms step_avg:45.70ms
+step:1003/1490 train_time:45873ms step_avg:45.74ms
+step:1004/1490 train_time:45963ms step_avg:45.78ms
+step:1005/1490 train_time:46045ms step_avg:45.82ms
+step:1006/1490 train_time:46130ms step_avg:45.86ms
+step:1007/1490 train_time:46211ms step_avg:45.89ms
+step:1008/1490 train_time:46295ms step_avg:45.93ms
+step:1009/1490 train_time:46375ms step_avg:45.96ms
+step:1010/1490 train_time:46461ms step_avg:46.00ms
+step:1011/1490 train_time:46542ms step_avg:46.04ms
+step:1012/1490 train_time:46629ms step_avg:46.08ms
+step:1013/1490 train_time:46712ms step_avg:46.11ms
+step:1014/1490 train_time:46800ms step_avg:46.15ms
+step:1015/1490 train_time:46883ms step_avg:46.19ms
+step:1016/1490 train_time:46970ms step_avg:46.23ms
+step:1017/1490 train_time:47051ms step_avg:46.26ms
+step:1018/1490 train_time:47139ms step_avg:46.31ms
+step:1019/1490 train_time:47219ms step_avg:46.34ms
+step:1020/1490 train_time:47305ms step_avg:46.38ms
+step:1021/1490 train_time:47385ms step_avg:46.41ms
+step:1022/1490 train_time:47470ms step_avg:46.45ms
+step:1023/1490 train_time:47551ms step_avg:46.48ms
+step:1024/1490 train_time:47638ms step_avg:46.52ms
+step:1025/1490 train_time:47720ms step_avg:46.56ms
+step:1026/1490 train_time:47807ms step_avg:46.60ms
+step:1027/1490 train_time:47890ms step_avg:46.63ms
+step:1028/1490 train_time:47977ms step_avg:46.67ms
+step:1029/1490 train_time:48059ms step_avg:46.70ms
+step:1030/1490 train_time:48146ms step_avg:46.74ms
+step:1031/1490 train_time:48226ms step_avg:46.78ms
+step:1032/1490 train_time:48311ms step_avg:46.81ms
+step:1033/1490 train_time:48391ms step_avg:46.85ms
+step:1034/1490 train_time:48477ms step_avg:46.88ms
+step:1035/1490 train_time:48557ms step_avg:46.91ms
+step:1036/1490 train_time:48644ms step_avg:46.95ms
+step:1037/1490 train_time:48726ms step_avg:46.99ms
+step:1038/1490 train_time:48812ms step_avg:47.03ms
+step:1039/1490 train_time:48893ms step_avg:47.06ms
+step:1040/1490 train_time:48980ms step_avg:47.10ms
+step:1041/1490 train_time:49062ms step_avg:47.13ms
+step:1042/1490 train_time:49149ms step_avg:47.17ms
+step:1043/1490 train_time:49229ms step_avg:47.20ms
+step:1044/1490 train_time:49315ms step_avg:47.24ms
+step:1045/1490 train_time:49394ms step_avg:47.27ms
+step:1046/1490 train_time:49480ms step_avg:47.30ms
+step:1047/1490 train_time:49562ms step_avg:47.34ms
+step:1048/1490 train_time:49650ms step_avg:47.38ms
+step:1049/1490 train_time:49730ms step_avg:47.41ms
+step:1050/1490 train_time:49816ms step_avg:47.44ms
+step:1051/1490 train_time:49900ms step_avg:47.48ms
+step:1052/1490 train_time:49987ms step_avg:47.52ms
+step:1053/1490 train_time:50067ms step_avg:47.55ms
+step:1054/1490 train_time:50154ms step_avg:47.58ms
+step:1055/1490 train_time:50233ms step_avg:47.61ms
+step:1056/1490 train_time:50319ms step_avg:47.65ms
+step:1057/1490 train_time:50401ms step_avg:47.68ms
+step:1058/1490 train_time:50486ms step_avg:47.72ms
+step:1059/1490 train_time:50569ms step_avg:47.75ms
+step:1060/1490 train_time:50656ms step_avg:47.79ms
+step:1061/1490 train_time:50737ms step_avg:47.82ms
+step:1062/1490 train_time:50824ms step_avg:47.86ms
+step:1063/1490 train_time:50904ms step_avg:47.89ms
+step:1064/1490 train_time:50992ms step_avg:47.92ms
+step:1065/1490 train_time:51073ms step_avg:47.96ms
+step:1066/1490 train_time:51159ms step_avg:47.99ms
+step:1067/1490 train_time:51240ms step_avg:48.02ms
+step:1068/1490 train_time:51326ms step_avg:48.06ms
+step:1069/1490 train_time:51406ms step_avg:48.09ms
+step:1070/1490 train_time:51494ms step_avg:48.13ms
+step:1071/1490 train_time:51575ms step_avg:48.16ms
+step:1072/1490 train_time:51660ms step_avg:48.19ms
+step:1073/1490 train_time:51742ms step_avg:48.22ms
+step:1074/1490 train_time:51828ms step_avg:48.26ms
+step:1075/1490 train_time:51909ms step_avg:48.29ms
+step:1076/1490 train_time:51997ms step_avg:48.32ms
+step:1077/1490 train_time:52078ms step_avg:48.36ms
+step:1078/1490 train_time:52165ms step_avg:48.39ms
+step:1079/1490 train_time:52245ms step_avg:48.42ms
+step:1080/1490 train_time:52330ms step_avg:48.45ms
+step:1081/1490 train_time:52411ms step_avg:48.48ms
+step:1082/1490 train_time:52497ms step_avg:48.52ms
+step:1083/1490 train_time:52578ms step_avg:48.55ms
+step:1084/1490 train_time:52664ms step_avg:48.58ms
+step:1085/1490 train_time:52746ms step_avg:48.61ms
+step:1086/1490 train_time:52833ms step_avg:48.65ms
+step:1087/1490 train_time:52914ms step_avg:48.68ms
+step:1088/1490 train_time:53002ms step_avg:48.72ms
+step:1089/1490 train_time:53083ms step_avg:48.75ms
+step:1090/1490 train_time:53171ms step_avg:48.78ms
+step:1091/1490 train_time:53251ms step_avg:48.81ms
+step:1092/1490 train_time:53337ms step_avg:48.84ms
+step:1093/1490 train_time:53419ms step_avg:48.87ms
+step:1094/1490 train_time:53506ms step_avg:48.91ms
+step:1095/1490 train_time:53586ms step_avg:48.94ms
+step:1096/1490 train_time:53673ms step_avg:48.97ms
+step:1097/1490 train_time:53753ms step_avg:49.00ms
+step:1098/1490 train_time:53840ms step_avg:49.03ms
+step:1099/1490 train_time:53922ms step_avg:49.06ms
+step:1100/1490 train_time:54009ms step_avg:49.10ms
+step:1101/1490 train_time:54091ms step_avg:49.13ms
+step:1102/1490 train_time:54177ms step_avg:49.16ms
+step:1103/1490 train_time:54258ms step_avg:49.19ms
+step:1104/1490 train_time:54345ms step_avg:49.23ms
+step:1105/1490 train_time:54427ms step_avg:49.25ms
+step:1106/1490 train_time:54512ms step_avg:49.29ms
+step:1107/1490 train_time:54594ms step_avg:49.32ms
+step:1108/1490 train_time:54680ms step_avg:49.35ms
+step:1109/1490 train_time:54763ms step_avg:49.38ms
+step:1110/1490 train_time:54850ms step_avg:49.41ms
+step:1111/1490 train_time:54930ms step_avg:49.44ms
+step:1112/1490 train_time:55016ms step_avg:49.47ms
+step:1113/1490 train_time:55099ms step_avg:49.50ms
+step:1114/1490 train_time:55185ms step_avg:49.54ms
+step:1115/1490 train_time:55265ms step_avg:49.57ms
+step:1116/1490 train_time:55352ms step_avg:49.60ms
+step:1117/1490 train_time:55433ms step_avg:49.63ms
+step:1118/1490 train_time:55518ms step_avg:49.66ms
+step:1119/1490 train_time:55599ms step_avg:49.69ms
+step:1120/1490 train_time:55685ms step_avg:49.72ms
+step:1121/1490 train_time:55765ms step_avg:49.75ms
+step:1122/1490 train_time:55852ms step_avg:49.78ms
+step:1123/1490 train_time:55933ms step_avg:49.81ms
+step:1124/1490 train_time:56019ms step_avg:49.84ms
+step:1125/1490 train_time:56100ms step_avg:49.87ms
+step:1126/1490 train_time:56187ms step_avg:49.90ms
+step:1127/1490 train_time:56269ms step_avg:49.93ms
+step:1128/1490 train_time:56354ms step_avg:49.96ms
+step:1129/1490 train_time:56435ms step_avg:49.99ms
+step:1130/1490 train_time:56520ms step_avg:50.02ms
+step:1131/1490 train_time:56601ms step_avg:50.05ms
+step:1132/1490 train_time:56687ms step_avg:50.08ms
+step:1133/1490 train_time:56769ms step_avg:50.11ms
+step:1134/1490 train_time:56855ms step_avg:50.14ms
+step:1135/1490 train_time:56936ms step_avg:50.16ms
+step:1136/1490 train_time:57022ms step_avg:50.20ms
+step:1137/1490 train_time:57103ms step_avg:50.22ms
+step:1138/1490 train_time:57192ms step_avg:50.26ms
+step:1139/1490 train_time:57273ms step_avg:50.28ms
+step:1140/1490 train_time:57360ms step_avg:50.32ms
+step:1141/1490 train_time:57440ms step_avg:50.34ms
+step:1142/1490 train_time:57526ms step_avg:50.37ms
+step:1143/1490 train_time:57605ms step_avg:50.40ms
+step:1144/1490 train_time:57694ms step_avg:50.43ms
+step:1145/1490 train_time:57776ms step_avg:50.46ms
+step:1146/1490 train_time:57862ms step_avg:50.49ms
+step:1147/1490 train_time:57943ms step_avg:50.52ms
+step:1148/1490 train_time:58030ms step_avg:50.55ms
+step:1149/1490 train_time:58111ms step_avg:50.58ms
+step:1150/1490 train_time:58198ms step_avg:50.61ms
+step:1151/1490 train_time:58278ms step_avg:50.63ms
+step:1152/1490 train_time:58364ms step_avg:50.66ms
+step:1153/1490 train_time:58445ms step_avg:50.69ms
+step:1154/1490 train_time:58531ms step_avg:50.72ms
+step:1155/1490 train_time:58612ms step_avg:50.75ms
+step:1156/1490 train_time:58699ms step_avg:50.78ms
+step:1157/1490 train_time:58780ms step_avg:50.80ms
+step:1158/1490 train_time:58866ms step_avg:50.83ms
+step:1159/1490 train_time:58946ms step_avg:50.86ms
+step:1160/1490 train_time:59033ms step_avg:50.89ms
+step:1161/1490 train_time:59114ms step_avg:50.92ms
+step:1162/1490 train_time:59200ms step_avg:50.95ms
+step:1163/1490 train_time:59281ms step_avg:50.97ms
+step:1164/1490 train_time:59368ms step_avg:51.00ms
+step:1165/1490 train_time:59450ms step_avg:51.03ms
+step:1166/1490 train_time:59535ms step_avg:51.06ms
+step:1167/1490 train_time:59616ms step_avg:51.08ms
+step:1168/1490 train_time:59703ms step_avg:51.12ms
+step:1169/1490 train_time:59784ms step_avg:51.14ms
+step:1170/1490 train_time:59872ms step_avg:51.17ms
+step:1171/1490 train_time:59953ms step_avg:51.20ms
+step:1172/1490 train_time:60039ms step_avg:51.23ms
+step:1173/1490 train_time:60120ms step_avg:51.25ms
+step:1174/1490 train_time:60206ms step_avg:51.28ms
+step:1175/1490 train_time:60288ms step_avg:51.31ms
+step:1176/1490 train_time:60375ms step_avg:51.34ms
+step:1177/1490 train_time:60456ms step_avg:51.36ms
+step:1178/1490 train_time:60542ms step_avg:51.39ms
+step:1179/1490 train_time:60622ms step_avg:51.42ms
+step:1180/1490 train_time:60709ms step_avg:51.45ms
+step:1181/1490 train_time:60789ms step_avg:51.47ms
+step:1182/1490 train_time:60876ms step_avg:51.50ms
+step:1183/1490 train_time:60958ms step_avg:51.53ms
+step:1184/1490 train_time:61043ms step_avg:51.56ms
+step:1185/1490 train_time:61124ms step_avg:51.58ms
+step:1186/1490 train_time:61212ms step_avg:51.61ms
+step:1187/1490 train_time:61293ms step_avg:51.64ms
+step:1188/1490 train_time:61379ms step_avg:51.67ms
+step:1189/1490 train_time:61460ms step_avg:51.69ms
+step:1190/1490 train_time:61548ms step_avg:51.72ms
+step:1191/1490 train_time:61630ms step_avg:51.75ms
+step:1192/1490 train_time:61716ms step_avg:51.78ms
+step:1193/1490 train_time:61796ms step_avg:51.80ms
+step:1194/1490 train_time:61882ms step_avg:51.83ms
+step:1195/1490 train_time:61964ms step_avg:51.85ms
+step:1196/1490 train_time:62051ms step_avg:51.88ms
+step:1197/1490 train_time:62131ms step_avg:51.91ms
+step:1198/1490 train_time:62218ms step_avg:51.93ms
+step:1199/1490 train_time:62299ms step_avg:51.96ms
+step:1200/1490 train_time:62386ms step_avg:51.99ms
+step:1201/1490 train_time:62467ms step_avg:52.01ms
+step:1202/1490 train_time:62556ms step_avg:52.04ms
+step:1203/1490 train_time:62636ms step_avg:52.07ms
+step:1204/1490 train_time:62722ms step_avg:52.09ms
+step:1205/1490 train_time:62803ms step_avg:52.12ms
+step:1206/1490 train_time:62888ms step_avg:52.15ms
+step:1207/1490 train_time:62970ms step_avg:52.17ms
+step:1208/1490 train_time:63057ms step_avg:52.20ms
+step:1209/1490 train_time:63137ms step_avg:52.22ms
+step:1210/1490 train_time:63224ms step_avg:52.25ms
+step:1211/1490 train_time:63305ms step_avg:52.27ms
+step:1212/1490 train_time:63391ms step_avg:52.30ms
+step:1213/1490 train_time:63472ms step_avg:52.33ms
+step:1214/1490 train_time:63559ms step_avg:52.36ms
+step:1215/1490 train_time:63640ms step_avg:52.38ms
+step:1216/1490 train_time:63726ms step_avg:52.41ms
+step:1217/1490 train_time:63806ms step_avg:52.43ms
+step:1218/1490 train_time:63893ms step_avg:52.46ms
+step:1219/1490 train_time:63974ms step_avg:52.48ms
+step:1220/1490 train_time:64060ms step_avg:52.51ms
+step:1221/1490 train_time:64142ms step_avg:52.53ms
+step:1222/1490 train_time:64229ms step_avg:52.56ms
+step:1223/1490 train_time:64309ms step_avg:52.58ms
+step:1224/1490 train_time:64394ms step_avg:52.61ms
+step:1225/1490 train_time:64475ms step_avg:52.63ms
+step:1226/1490 train_time:64561ms step_avg:52.66ms
+step:1227/1490 train_time:64643ms step_avg:52.68ms
+step:1228/1490 train_time:64728ms step_avg:52.71ms
+step:1229/1490 train_time:64809ms step_avg:52.73ms
+step:1230/1490 train_time:64894ms step_avg:52.76ms
+step:1231/1490 train_time:64975ms step_avg:52.78ms
+step:1232/1490 train_time:65061ms step_avg:52.81ms
+step:1233/1490 train_time:65143ms step_avg:52.83ms
+step:1234/1490 train_time:65230ms step_avg:52.86ms
+step:1235/1490 train_time:65311ms step_avg:52.88ms
+step:1236/1490 train_time:65397ms step_avg:52.91ms
+step:1237/1490 train_time:65478ms step_avg:52.93ms
+step:1238/1490 train_time:65565ms step_avg:52.96ms
+step:1239/1490 train_time:65648ms step_avg:52.98ms
+step:1240/1490 train_time:65734ms step_avg:53.01ms
+step:1241/1490 train_time:65814ms step_avg:53.03ms
+step:1242/1490 train_time:65900ms step_avg:53.06ms
+step:1243/1490 train_time:65981ms step_avg:53.08ms
+step:1244/1490 train_time:66068ms step_avg:53.11ms
+step:1245/1490 train_time:66149ms step_avg:53.13ms
+step:1246/1490 train_time:66236ms step_avg:53.16ms
+step:1247/1490 train_time:66317ms step_avg:53.18ms
+step:1248/1490 train_time:66403ms step_avg:53.21ms
+step:1249/1490 train_time:66484ms step_avg:53.23ms
+step:1250/1490 train_time:66571ms step_avg:53.26ms
+step:1250/1490 val_loss:3.3722 train_time:66675ms step_avg:53.34ms
+step:1251/1490 train_time:66691ms step_avg:53.31ms
+step:1252/1490 train_time:66740ms step_avg:53.31ms
+step:1253/1490 train_time:66824ms step_avg:53.33ms
+step:1254/1490 train_time:66917ms step_avg:53.36ms
+step:1255/1490 train_time:66997ms step_avg:53.38ms
+step:1256/1490 train_time:67083ms step_avg:53.41ms
+step:1257/1490 train_time:67164ms step_avg:53.43ms
+step:1258/1490 train_time:67249ms step_avg:53.46ms
+step:1259/1490 train_time:67329ms step_avg:53.48ms
+step:1260/1490 train_time:67414ms step_avg:53.50ms
+step:1261/1490 train_time:67493ms step_avg:53.52ms
+step:1262/1490 train_time:67580ms step_avg:53.55ms
+step:1263/1490 train_time:67663ms step_avg:53.57ms
+step:1264/1490 train_time:67751ms step_avg:53.60ms
+step:1265/1490 train_time:67834ms step_avg:53.62ms
+step:1266/1490 train_time:67921ms step_avg:53.65ms
+step:1267/1490 train_time:68003ms step_avg:53.67ms
+step:1268/1490 train_time:68089ms step_avg:53.70ms
+step:1269/1490 train_time:68170ms step_avg:53.72ms
+step:1270/1490 train_time:68256ms step_avg:53.74ms
+step:1271/1490 train_time:68335ms step_avg:53.76ms
+step:1272/1490 train_time:68421ms step_avg:53.79ms
+step:1273/1490 train_time:68501ms step_avg:53.81ms
+step:1274/1490 train_time:68589ms step_avg:53.84ms
+step:1275/1490 train_time:68670ms step_avg:53.86ms
+step:1276/1490 train_time:68760ms step_avg:53.89ms
+step:1277/1490 train_time:68841ms step_avg:53.91ms
+step:1278/1490 train_time:68928ms step_avg:53.93ms
+step:1279/1490 train_time:69009ms step_avg:53.96ms
+step:1280/1490 train_time:69095ms step_avg:53.98ms
+step:1281/1490 train_time:69176ms step_avg:54.00ms
+step:1282/1490 train_time:69262ms step_avg:54.03ms
+step:1283/1490 train_time:69341ms step_avg:54.05ms
+step:1284/1490 train_time:69428ms step_avg:54.07ms
+step:1285/1490 train_time:69509ms step_avg:54.09ms
+step:1286/1490 train_time:69595ms step_avg:54.12ms
+step:1287/1490 train_time:69678ms step_avg:54.14ms
+step:1288/1490 train_time:69765ms step_avg:54.17ms
+step:1289/1490 train_time:69848ms step_avg:54.19ms
+step:1290/1490 train_time:69935ms step_avg:54.21ms
+step:1291/1490 train_time:70015ms step_avg:54.23ms
+step:1292/1490 train_time:70101ms step_avg:54.26ms
+step:1293/1490 train_time:70182ms step_avg:54.28ms
+step:1294/1490 train_time:70268ms step_avg:54.30ms
+step:1295/1490 train_time:70348ms step_avg:54.32ms
+step:1296/1490 train_time:70433ms step_avg:54.35ms
+step:1297/1490 train_time:70514ms step_avg:54.37ms
+step:1298/1490 train_time:70601ms step_avg:54.39ms
+step:1299/1490 train_time:70682ms step_avg:54.41ms
+step:1300/1490 train_time:70769ms step_avg:54.44ms
+step:1301/1490 train_time:70853ms step_avg:54.46ms
+step:1302/1490 train_time:70939ms step_avg:54.48ms
+step:1303/1490 train_time:71021ms step_avg:54.51ms
+step:1304/1490 train_time:71107ms step_avg:54.53ms
+step:1305/1490 train_time:71186ms step_avg:54.55ms
+step:1306/1490 train_time:71273ms step_avg:54.57ms
+step:1307/1490 train_time:71353ms step_avg:54.59ms
+step:1308/1490 train_time:71438ms step_avg:54.62ms
+step:1309/1490 train_time:71518ms step_avg:54.64ms
+step:1310/1490 train_time:71604ms step_avg:54.66ms
+step:1311/1490 train_time:71687ms step_avg:54.68ms
+step:1312/1490 train_time:71775ms step_avg:54.71ms
+step:1313/1490 train_time:71857ms step_avg:54.73ms
+step:1314/1490 train_time:71943ms step_avg:54.75ms
+step:1315/1490 train_time:72024ms step_avg:54.77ms
+step:1316/1490 train_time:72111ms step_avg:54.80ms
+step:1317/1490 train_time:72192ms step_avg:54.82ms
+step:1318/1490 train_time:72278ms step_avg:54.84ms
+step:1319/1490 train_time:72359ms step_avg:54.86ms
+step:1320/1490 train_time:72446ms step_avg:54.88ms
+step:1321/1490 train_time:72527ms step_avg:54.90ms
+step:1322/1490 train_time:72613ms step_avg:54.93ms
+step:1323/1490 train_time:72694ms step_avg:54.95ms
+step:1324/1490 train_time:72781ms step_avg:54.97ms
+step:1325/1490 train_time:72863ms step_avg:54.99ms
+step:1326/1490 train_time:72950ms step_avg:55.01ms
+step:1327/1490 train_time:73030ms step_avg:55.03ms
+step:1328/1490 train_time:73117ms step_avg:55.06ms
+step:1329/1490 train_time:73198ms step_avg:55.08ms
+step:1330/1490 train_time:73284ms step_avg:55.10ms
+step:1331/1490 train_time:73364ms step_avg:55.12ms
+step:1332/1490 train_time:73451ms step_avg:55.14ms
+step:1333/1490 train_time:73530ms step_avg:55.16ms
+step:1334/1490 train_time:73616ms step_avg:55.18ms
+step:1335/1490 train_time:73697ms step_avg:55.20ms
+step:1336/1490 train_time:73784ms step_avg:55.23ms
+step:1337/1490 train_time:73866ms step_avg:55.25ms
+step:1338/1490 train_time:73953ms step_avg:55.27ms
+step:1339/1490 train_time:74035ms step_avg:55.29ms
+step:1340/1490 train_time:74121ms step_avg:55.31ms
+step:1341/1490 train_time:74204ms step_avg:55.33ms
+step:1342/1490 train_time:74289ms step_avg:55.36ms
+step:1343/1490 train_time:74371ms step_avg:55.38ms
+step:1344/1490 train_time:74458ms step_avg:55.40ms
+step:1345/1490 train_time:74538ms step_avg:55.42ms
+step:1346/1490 train_time:74624ms step_avg:55.44ms
+step:1347/1490 train_time:74705ms step_avg:55.46ms
+step:1348/1490 train_time:74793ms step_avg:55.48ms
+step:1349/1490 train_time:74873ms step_avg:55.50ms
+step:1350/1490 train_time:74961ms step_avg:55.53ms
+step:1351/1490 train_time:75042ms step_avg:55.55ms
+step:1352/1490 train_time:75128ms step_avg:55.57ms
+step:1353/1490 train_time:75209ms step_avg:55.59ms
+step:1354/1490 train_time:75296ms step_avg:55.61ms
+step:1355/1490 train_time:75378ms step_avg:55.63ms
+step:1356/1490 train_time:75464ms step_avg:55.65ms
+step:1357/1490 train_time:75546ms step_avg:55.67ms
+step:1358/1490 train_time:75632ms step_avg:55.69ms
+step:1359/1490 train_time:75713ms step_avg:55.71ms
+step:1360/1490 train_time:75800ms step_avg:55.74ms
+step:1361/1490 train_time:75882ms step_avg:55.75ms
+step:1362/1490 train_time:75968ms step_avg:55.78ms
+step:1363/1490 train_time:76048ms step_avg:55.79ms
+step:1364/1490 train_time:76134ms step_avg:55.82ms
+step:1365/1490 train_time:76216ms step_avg:55.84ms
+step:1366/1490 train_time:76302ms step_avg:55.86ms
+step:1367/1490 train_time:76383ms step_avg:55.88ms
+step:1368/1490 train_time:76470ms step_avg:55.90ms
+step:1369/1490 train_time:76551ms step_avg:55.92ms
+step:1370/1490 train_time:76637ms step_avg:55.94ms
+step:1371/1490 train_time:76717ms step_avg:55.96ms
+step:1372/1490 train_time:76804ms step_avg:55.98ms
+step:1373/1490 train_time:76887ms step_avg:56.00ms
+step:1374/1490 train_time:76973ms step_avg:56.02ms
+step:1375/1490 train_time:77055ms step_avg:56.04ms
+step:1376/1490 train_time:77141ms step_avg:56.06ms
+step:1377/1490 train_time:77222ms step_avg:56.08ms
+step:1378/1490 train_time:77309ms step_avg:56.10ms
+step:1379/1490 train_time:77390ms step_avg:56.12ms
+step:1380/1490 train_time:77476ms step_avg:56.14ms
+step:1381/1490 train_time:77558ms step_avg:56.16ms
+step:1382/1490 train_time:77644ms step_avg:56.18ms
+step:1383/1490 train_time:77725ms step_avg:56.20ms
+step:1384/1490 train_time:77811ms step_avg:56.22ms
+step:1385/1490 train_time:77893ms step_avg:56.24ms
+step:1386/1490 train_time:77981ms step_avg:56.26ms
+step:1387/1490 train_time:78062ms step_avg:56.28ms
+step:1388/1490 train_time:78150ms step_avg:56.30ms
+step:1389/1490 train_time:78231ms step_avg:56.32ms
+step:1390/1490 train_time:78317ms step_avg:56.34ms
+step:1391/1490 train_time:78398ms step_avg:56.36ms
+step:1392/1490 train_time:78484ms step_avg:56.38ms
+step:1393/1490 train_time:78564ms step_avg:56.40ms
+step:1394/1490 train_time:78651ms step_avg:56.42ms
+step:1395/1490 train_time:78730ms step_avg:56.44ms
+step:1396/1490 train_time:78818ms step_avg:56.46ms
+step:1397/1490 train_time:78898ms step_avg:56.48ms
+step:1398/1490 train_time:78984ms step_avg:56.50ms
+step:1399/1490 train_time:79066ms step_avg:56.52ms
+step:1400/1490 train_time:79152ms step_avg:56.54ms
+step:1401/1490 train_time:79233ms step_avg:56.55ms
+step:1402/1490 train_time:79320ms step_avg:56.58ms
+step:1403/1490 train_time:79402ms step_avg:56.59ms
+step:1404/1490 train_time:79488ms step_avg:56.62ms
+step:1405/1490 train_time:79569ms step_avg:56.63ms
+step:1406/1490 train_time:79656ms step_avg:56.65ms
+step:1407/1490 train_time:79737ms step_avg:56.67ms
+step:1408/1490 train_time:79824ms step_avg:56.69ms
+step:1409/1490 train_time:79905ms step_avg:56.71ms
+step:1410/1490 train_time:79992ms step_avg:56.73ms
+step:1411/1490 train_time:80074ms step_avg:56.75ms
+step:1412/1490 train_time:80160ms step_avg:56.77ms
+step:1413/1490 train_time:80241ms step_avg:56.79ms
+step:1414/1490 train_time:80327ms step_avg:56.81ms
+step:1415/1490 train_time:80407ms step_avg:56.83ms
+step:1416/1490 train_time:80494ms step_avg:56.85ms
+step:1417/1490 train_time:80575ms step_avg:56.86ms
+step:1418/1490 train_time:80661ms step_avg:56.88ms
+step:1419/1490 train_time:80742ms step_avg:56.90ms
+step:1420/1490 train_time:80829ms step_avg:56.92ms
+step:1421/1490 train_time:80909ms step_avg:56.94ms
+step:1422/1490 train_time:80997ms step_avg:56.96ms
+step:1423/1490 train_time:81078ms step_avg:56.98ms
+step:1424/1490 train_time:81165ms step_avg:57.00ms
+step:1425/1490 train_time:81246ms step_avg:57.01ms
+step:1426/1490 train_time:81331ms step_avg:57.03ms
+step:1427/1490 train_time:81412ms step_avg:57.05ms
+step:1428/1490 train_time:81499ms step_avg:57.07ms
+step:1429/1490 train_time:81580ms step_avg:57.09ms
+step:1430/1490 train_time:81667ms step_avg:57.11ms
+step:1431/1490 train_time:81749ms step_avg:57.13ms
+step:1432/1490 train_time:81834ms step_avg:57.15ms
+step:1433/1490 train_time:81916ms step_avg:57.16ms
+step:1434/1490 train_time:82003ms step_avg:57.18ms
+step:1435/1490 train_time:82084ms step_avg:57.20ms
+step:1436/1490 train_time:82169ms step_avg:57.22ms
+step:1437/1490 train_time:82249ms step_avg:57.24ms
+step:1438/1490 train_time:82337ms step_avg:57.26ms
+step:1439/1490 train_time:82418ms step_avg:57.27ms
+step:1440/1490 train_time:82505ms step_avg:57.29ms
+step:1441/1490 train_time:82585ms step_avg:57.31ms
+step:1442/1490 train_time:82672ms step_avg:57.33ms
+step:1443/1490 train_time:82754ms step_avg:57.35ms
+step:1444/1490 train_time:82840ms step_avg:57.37ms
+step:1445/1490 train_time:82921ms step_avg:57.39ms
+step:1446/1490 train_time:83009ms step_avg:57.41ms
+step:1447/1490 train_time:83090ms step_avg:57.42ms
+step:1448/1490 train_time:83177ms step_avg:57.44ms
+step:1449/1490 train_time:83257ms step_avg:57.46ms
+step:1450/1490 train_time:83343ms step_avg:57.48ms
+step:1451/1490 train_time:83428ms step_avg:57.50ms
+step:1452/1490 train_time:83517ms step_avg:57.52ms
+step:1453/1490 train_time:83598ms step_avg:57.53ms
+step:1454/1490 train_time:83685ms step_avg:57.55ms
+step:1455/1490 train_time:83767ms step_avg:57.57ms
+step:1456/1490 train_time:83854ms step_avg:57.59ms
+step:1457/1490 train_time:83935ms step_avg:57.61ms
+step:1458/1490 train_time:84021ms step_avg:57.63ms
+step:1459/1490 train_time:84102ms step_avg:57.64ms
+step:1460/1490 train_time:84189ms step_avg:57.66ms
+step:1461/1490 train_time:84269ms step_avg:57.68ms
+step:1462/1490 train_time:84357ms step_avg:57.70ms
+step:1463/1490 train_time:84437ms step_avg:57.71ms
+step:1464/1490 train_time:84523ms step_avg:57.73ms
+step:1465/1490 train_time:84606ms step_avg:57.75ms
+step:1466/1490 train_time:84693ms step_avg:57.77ms
+step:1467/1490 train_time:84774ms step_avg:57.79ms
+step:1468/1490 train_time:84860ms step_avg:57.81ms
+step:1469/1490 train_time:84941ms step_avg:57.82ms
+step:1470/1490 train_time:85029ms step_avg:57.84ms
+step:1471/1490 train_time:85112ms step_avg:57.86ms
+step:1472/1490 train_time:85197ms step_avg:57.88ms
+step:1473/1490 train_time:85278ms step_avg:57.89ms
+step:1474/1490 train_time:85364ms step_avg:57.91ms
+step:1475/1490 train_time:85445ms step_avg:57.93ms
+step:1476/1490 train_time:85532ms step_avg:57.95ms
+step:1477/1490 train_time:85616ms step_avg:57.97ms
+step:1478/1490 train_time:85704ms step_avg:57.99ms
+step:1479/1490 train_time:85785ms step_avg:58.00ms
+step:1480/1490 train_time:85872ms step_avg:58.02ms
+step:1481/1490 train_time:85952ms step_avg:58.04ms
+step:1482/1490 train_time:86039ms step_avg:58.06ms
+step:1483/1490 train_time:86121ms step_avg:58.07ms
+step:1484/1490 train_time:86208ms step_avg:58.09ms
+step:1485/1490 train_time:86288ms step_avg:58.11ms
+step:1486/1490 train_time:86375ms step_avg:58.13ms
+step:1487/1490 train_time:86455ms step_avg:58.14ms
+step:1488/1490 train_time:86543ms step_avg:58.16ms
+step:1489/1490 train_time:86624ms step_avg:58.18ms
+step:1490/1490 train_time:86710ms step_avg:58.19ms
+step:1490/1490 val_loss:3.2789 train_time:86815ms step_avg:58.27ms
+peak memory allocated: 31296 MiB reserved: 47002 MiB

--- a/records/track_1_short/2026-03-22_VarlenMaxDocs/muon-beta2/2026-03-22_19-33-17_time-185_secs_04-muon-beta2_65d0d0.txt
+++ b/records/track_1_short/2026-03-22_VarlenMaxDocs/muon-beta2/2026-03-22_19-33-17_time-185_secs_04-muon-beta2_65d0d0.txt
@@ -1,0 +1,4456 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,  # from nanochat autoresearch (was 0.95)
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sun Mar 22 19:33:32 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            131W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   42C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   40C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   31C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   1690854      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A   1690855      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A   1690856      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A   1690857      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A   1690858      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A   1690859      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A   1690860      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A   1690861      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8303 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:81ms step_avg:80.91ms
+step:2/1490 train_time:103ms step_avg:51.38ms
+step:3/1490 train_time:120ms step_avg:40.10ms
+step:4/1490 train_time:150ms step_avg:37.42ms
+step:5/1490 train_time:177ms step_avg:35.34ms
+step:6/1490 train_time:211ms step_avg:35.24ms
+step:7/1490 train_time:239ms step_avg:34.12ms
+step:8/1490 train_time:274ms step_avg:34.21ms
+step:9/1490 train_time:301ms step_avg:33.49ms
+step:10/1490 train_time:336ms step_avg:33.65ms
+step:11/1490 train_time:364ms step_avg:33.13ms
+step:12/1490 train_time:399ms step_avg:33.25ms
+step:13/1490 train_time:427ms step_avg:32.85ms
+step:14/1490 train_time:462ms step_avg:32.97ms
+step:15/1490 train_time:490ms step_avg:32.66ms
+step:16/1490 train_time:524ms step_avg:32.77ms
+step:17/1490 train_time:552ms step_avg:32.50ms
+step:18/1490 train_time:587ms step_avg:32.60ms
+step:19/1490 train_time:615ms step_avg:32.39ms
+step:20/1490 train_time:650ms step_avg:32.48ms
+step:21/1490 train_time:678ms step_avg:32.29ms
+step:22/1490 train_time:712ms step_avg:32.38ms
+step:23/1490 train_time:741ms step_avg:32.22ms
+step:24/1490 train_time:776ms step_avg:32.31ms
+step:25/1490 train_time:804ms step_avg:32.15ms
+step:26/1490 train_time:838ms step_avg:32.25ms
+step:27/1490 train_time:867ms step_avg:32.10ms
+step:28/1490 train_time:902ms step_avg:32.20ms
+step:29/1490 train_time:930ms step_avg:32.07ms
+step:30/1490 train_time:965ms step_avg:32.16ms
+step:31/1490 train_time:995ms step_avg:32.10ms
+step:32/1490 train_time:1030ms step_avg:32.20ms
+step:33/1490 train_time:1060ms step_avg:32.11ms
+step:34/1490 train_time:1094ms step_avg:32.19ms
+step:35/1490 train_time:1123ms step_avg:32.09ms
+step:36/1490 train_time:1158ms step_avg:32.17ms
+step:37/1490 train_time:1187ms step_avg:32.07ms
+step:38/1490 train_time:1221ms step_avg:32.14ms
+step:39/1490 train_time:1250ms step_avg:32.05ms
+step:40/1490 train_time:1284ms step_avg:32.11ms
+step:41/1490 train_time:1313ms step_avg:32.02ms
+step:42/1490 train_time:1347ms step_avg:32.08ms
+step:43/1490 train_time:1376ms step_avg:32.01ms
+step:44/1490 train_time:1410ms step_avg:32.05ms
+step:45/1490 train_time:1439ms step_avg:31.97ms
+step:46/1490 train_time:1473ms step_avg:32.01ms
+step:47/1490 train_time:1501ms step_avg:31.94ms
+step:48/1490 train_time:1535ms step_avg:31.99ms
+step:49/1490 train_time:1564ms step_avg:31.92ms
+step:50/1490 train_time:1599ms step_avg:31.97ms
+step:51/1490 train_time:1627ms step_avg:31.90ms
+step:52/1490 train_time:1661ms step_avg:31.95ms
+step:53/1490 train_time:1690ms step_avg:31.88ms
+step:54/1490 train_time:1724ms step_avg:31.93ms
+step:55/1490 train_time:1753ms step_avg:31.87ms
+step:56/1490 train_time:1787ms step_avg:31.91ms
+step:57/1490 train_time:1816ms step_avg:31.85ms
+step:58/1490 train_time:1850ms step_avg:31.89ms
+step:59/1490 train_time:1879ms step_avg:31.84ms
+step:60/1490 train_time:1913ms step_avg:31.89ms
+step:61/1490 train_time:1942ms step_avg:31.84ms
+step:62/1490 train_time:1978ms step_avg:31.90ms
+step:63/1490 train_time:2006ms step_avg:31.85ms
+step:64/1490 train_time:2041ms step_avg:31.89ms
+step:65/1490 train_time:2070ms step_avg:31.84ms
+step:66/1490 train_time:2105ms step_avg:31.90ms
+step:67/1490 train_time:2134ms step_avg:31.85ms
+step:68/1490 train_time:2168ms step_avg:31.89ms
+step:69/1490 train_time:2197ms step_avg:31.85ms
+step:70/1490 train_time:2232ms step_avg:31.88ms
+step:71/1490 train_time:2261ms step_avg:31.84ms
+step:72/1490 train_time:2295ms step_avg:31.87ms
+step:73/1490 train_time:2324ms step_avg:31.83ms
+step:74/1490 train_time:2358ms step_avg:31.87ms
+step:75/1490 train_time:2387ms step_avg:31.82ms
+step:76/1490 train_time:2421ms step_avg:31.86ms
+step:77/1490 train_time:2450ms step_avg:31.81ms
+step:78/1490 train_time:2484ms step_avg:31.85ms
+step:79/1490 train_time:2513ms step_avg:31.80ms
+step:80/1490 train_time:2547ms step_avg:31.84ms
+step:81/1490 train_time:2576ms step_avg:31.80ms
+step:82/1490 train_time:2610ms step_avg:31.83ms
+step:83/1490 train_time:2639ms step_avg:31.79ms
+step:84/1490 train_time:2673ms step_avg:31.82ms
+step:85/1490 train_time:2702ms step_avg:31.79ms
+step:86/1490 train_time:2736ms step_avg:31.81ms
+step:87/1490 train_time:2764ms step_avg:31.77ms
+step:88/1490 train_time:2799ms step_avg:31.81ms
+step:89/1490 train_time:2828ms step_avg:31.77ms
+step:90/1490 train_time:2862ms step_avg:31.80ms
+step:91/1490 train_time:2891ms step_avg:31.77ms
+step:92/1490 train_time:2926ms step_avg:31.80ms
+step:93/1490 train_time:2954ms step_avg:31.76ms
+step:94/1490 train_time:2988ms step_avg:31.79ms
+step:95/1490 train_time:3017ms step_avg:31.76ms
+step:96/1490 train_time:3051ms step_avg:31.78ms
+step:97/1490 train_time:3080ms step_avg:31.75ms
+step:98/1490 train_time:3114ms step_avg:31.78ms
+step:99/1490 train_time:3143ms step_avg:31.75ms
+step:100/1490 train_time:3177ms step_avg:31.77ms
+step:101/1490 train_time:3206ms step_avg:31.74ms
+step:102/1490 train_time:3241ms step_avg:31.77ms
+step:103/1490 train_time:3269ms step_avg:31.74ms
+step:104/1490 train_time:3304ms step_avg:31.77ms
+step:105/1490 train_time:3333ms step_avg:31.74ms
+step:106/1490 train_time:3367ms step_avg:31.77ms
+step:107/1490 train_time:3395ms step_avg:31.73ms
+step:108/1490 train_time:3430ms step_avg:31.75ms
+step:109/1490 train_time:3458ms step_avg:31.72ms
+step:110/1490 train_time:3492ms step_avg:31.75ms
+step:111/1490 train_time:3521ms step_avg:31.72ms
+step:112/1490 train_time:3555ms step_avg:31.74ms
+step:113/1490 train_time:3583ms step_avg:31.71ms
+step:114/1490 train_time:3618ms step_avg:31.74ms
+step:115/1490 train_time:3647ms step_avg:31.71ms
+step:116/1490 train_time:3681ms step_avg:31.74ms
+step:117/1490 train_time:3710ms step_avg:31.71ms
+step:118/1490 train_time:3745ms step_avg:31.74ms
+step:119/1490 train_time:3773ms step_avg:31.71ms
+step:120/1490 train_time:3807ms step_avg:31.73ms
+step:121/1490 train_time:3836ms step_avg:31.70ms
+step:122/1490 train_time:3870ms step_avg:31.73ms
+step:123/1490 train_time:3899ms step_avg:31.70ms
+step:124/1490 train_time:3934ms step_avg:31.72ms
+step:125/1490 train_time:3962ms step_avg:31.70ms
+step:126/1490 train_time:3996ms step_avg:31.72ms
+step:127/1490 train_time:4026ms step_avg:31.70ms
+step:128/1490 train_time:4060ms step_avg:31.72ms
+step:129/1490 train_time:4088ms step_avg:31.69ms
+step:130/1490 train_time:4123ms step_avg:31.72ms
+step:131/1490 train_time:4152ms step_avg:31.70ms
+step:132/1490 train_time:4187ms step_avg:31.72ms
+step:133/1490 train_time:4215ms step_avg:31.69ms
+step:134/1490 train_time:4249ms step_avg:31.71ms
+step:135/1490 train_time:4278ms step_avg:31.69ms
+step:136/1490 train_time:4312ms step_avg:31.71ms
+step:137/1490 train_time:4341ms step_avg:31.68ms
+step:138/1490 train_time:4375ms step_avg:31.70ms
+step:139/1490 train_time:4404ms step_avg:31.68ms
+step:140/1490 train_time:4438ms step_avg:31.70ms
+step:141/1490 train_time:4466ms step_avg:31.68ms
+step:142/1490 train_time:4501ms step_avg:31.70ms
+step:143/1490 train_time:4529ms step_avg:31.67ms
+step:144/1490 train_time:4564ms step_avg:31.70ms
+step:145/1490 train_time:4593ms step_avg:31.67ms
+step:146/1490 train_time:4627ms step_avg:31.69ms
+step:147/1490 train_time:4656ms step_avg:31.67ms
+step:148/1490 train_time:4690ms step_avg:31.69ms
+step:149/1490 train_time:4719ms step_avg:31.67ms
+step:150/1490 train_time:4753ms step_avg:31.69ms
+step:151/1490 train_time:4782ms step_avg:31.67ms
+step:152/1490 train_time:4817ms step_avg:31.69ms
+step:153/1490 train_time:4845ms step_avg:31.67ms
+step:154/1490 train_time:4879ms step_avg:31.68ms
+step:155/1490 train_time:4908ms step_avg:31.66ms
+step:156/1490 train_time:4942ms step_avg:31.68ms
+step:157/1490 train_time:4971ms step_avg:31.66ms
+step:158/1490 train_time:5005ms step_avg:31.68ms
+step:159/1490 train_time:5033ms step_avg:31.66ms
+step:160/1490 train_time:5068ms step_avg:31.67ms
+step:161/1490 train_time:5096ms step_avg:31.65ms
+step:162/1490 train_time:5131ms step_avg:31.67ms
+step:163/1490 train_time:5159ms step_avg:31.65ms
+step:164/1490 train_time:5194ms step_avg:31.67ms
+step:165/1490 train_time:5222ms step_avg:31.65ms
+step:166/1490 train_time:5257ms step_avg:31.67ms
+step:167/1490 train_time:5286ms step_avg:31.65ms
+step:168/1490 train_time:5320ms step_avg:31.67ms
+step:169/1490 train_time:5349ms step_avg:31.65ms
+step:170/1490 train_time:5384ms step_avg:31.67ms
+step:171/1490 train_time:5412ms step_avg:31.65ms
+step:172/1490 train_time:5447ms step_avg:31.67ms
+step:173/1490 train_time:5475ms step_avg:31.65ms
+step:174/1490 train_time:5509ms step_avg:31.66ms
+step:175/1490 train_time:5538ms step_avg:31.65ms
+step:176/1490 train_time:5572ms step_avg:31.66ms
+step:177/1490 train_time:5600ms step_avg:31.64ms
+step:178/1490 train_time:5635ms step_avg:31.65ms
+step:179/1490 train_time:5663ms step_avg:31.64ms
+step:180/1490 train_time:5697ms step_avg:31.65ms
+step:181/1490 train_time:5726ms step_avg:31.63ms
+step:182/1490 train_time:5760ms step_avg:31.65ms
+step:183/1490 train_time:5788ms step_avg:31.63ms
+step:184/1490 train_time:5823ms step_avg:31.65ms
+step:185/1490 train_time:5852ms step_avg:31.63ms
+step:186/1490 train_time:5886ms step_avg:31.64ms
+step:187/1490 train_time:5915ms step_avg:31.63ms
+step:188/1490 train_time:5949ms step_avg:31.64ms
+step:189/1490 train_time:5978ms step_avg:31.63ms
+step:190/1490 train_time:6012ms step_avg:31.64ms
+step:191/1490 train_time:6041ms step_avg:31.63ms
+step:192/1490 train_time:6075ms step_avg:31.64ms
+step:193/1490 train_time:6103ms step_avg:31.62ms
+step:194/1490 train_time:6138ms step_avg:31.64ms
+step:195/1490 train_time:6167ms step_avg:31.62ms
+step:196/1490 train_time:6203ms step_avg:31.65ms
+step:197/1490 train_time:6230ms step_avg:31.62ms
+step:198/1490 train_time:6264ms step_avg:31.64ms
+step:199/1490 train_time:6293ms step_avg:31.62ms
+step:200/1490 train_time:6328ms step_avg:31.64ms
+step:201/1490 train_time:6356ms step_avg:31.62ms
+step:202/1490 train_time:6390ms step_avg:31.64ms
+step:203/1490 train_time:6419ms step_avg:31.62ms
+step:204/1490 train_time:6453ms step_avg:31.63ms
+step:205/1490 train_time:6481ms step_avg:31.62ms
+step:206/1490 train_time:6515ms step_avg:31.63ms
+step:207/1490 train_time:6544ms step_avg:31.61ms
+step:208/1490 train_time:6579ms step_avg:31.63ms
+step:209/1490 train_time:6607ms step_avg:31.61ms
+step:210/1490 train_time:6642ms step_avg:31.63ms
+step:211/1490 train_time:6671ms step_avg:31.61ms
+step:212/1490 train_time:6705ms step_avg:31.63ms
+step:213/1490 train_time:6733ms step_avg:31.61ms
+step:214/1490 train_time:6767ms step_avg:31.62ms
+step:215/1490 train_time:6796ms step_avg:31.61ms
+step:216/1490 train_time:6830ms step_avg:31.62ms
+step:217/1490 train_time:6859ms step_avg:31.61ms
+step:218/1490 train_time:6893ms step_avg:31.62ms
+step:219/1490 train_time:6922ms step_avg:31.61ms
+step:220/1490 train_time:6956ms step_avg:31.62ms
+step:221/1490 train_time:6985ms step_avg:31.61ms
+step:222/1490 train_time:7019ms step_avg:31.62ms
+step:223/1490 train_time:7048ms step_avg:31.60ms
+step:224/1490 train_time:7082ms step_avg:31.62ms
+step:225/1490 train_time:7111ms step_avg:31.60ms
+step:226/1490 train_time:7145ms step_avg:31.62ms
+step:227/1490 train_time:7174ms step_avg:31.60ms
+step:228/1490 train_time:7208ms step_avg:31.61ms
+step:229/1490 train_time:7237ms step_avg:31.60ms
+step:230/1490 train_time:7271ms step_avg:31.61ms
+step:231/1490 train_time:7300ms step_avg:31.60ms
+step:232/1490 train_time:7334ms step_avg:31.61ms
+step:233/1490 train_time:7363ms step_avg:31.60ms
+step:234/1490 train_time:7397ms step_avg:31.61ms
+step:235/1490 train_time:7425ms step_avg:31.60ms
+step:236/1490 train_time:7460ms step_avg:31.61ms
+step:237/1490 train_time:7488ms step_avg:31.59ms
+step:238/1490 train_time:7522ms step_avg:31.61ms
+step:239/1490 train_time:7551ms step_avg:31.59ms
+step:240/1490 train_time:7585ms step_avg:31.61ms
+step:241/1490 train_time:7614ms step_avg:31.59ms
+step:242/1490 train_time:7648ms step_avg:31.61ms
+step:243/1490 train_time:7677ms step_avg:31.59ms
+step:244/1490 train_time:7711ms step_avg:31.60ms
+step:245/1490 train_time:7740ms step_avg:31.59ms
+step:246/1490 train_time:7774ms step_avg:31.60ms
+step:247/1490 train_time:7802ms step_avg:31.59ms
+step:248/1490 train_time:7837ms step_avg:31.60ms
+step:249/1490 train_time:7865ms step_avg:31.59ms
+step:250/1490 train_time:7900ms step_avg:31.60ms
+step:250/1490 val_loss:4.4875 train_time:7943ms step_avg:31.77ms
+step:251/1490 train_time:7958ms step_avg:31.71ms
+step:252/1490 train_time:7976ms step_avg:31.65ms
+step:253/1490 train_time:7994ms step_avg:31.60ms
+step:254/1490 train_time:8029ms step_avg:31.61ms
+step:255/1490 train_time:8059ms step_avg:31.60ms
+step:256/1490 train_time:8094ms step_avg:31.62ms
+step:257/1490 train_time:8123ms step_avg:31.61ms
+step:258/1490 train_time:8158ms step_avg:31.62ms
+step:259/1490 train_time:8186ms step_avg:31.61ms
+step:260/1490 train_time:8222ms step_avg:31.62ms
+step:261/1490 train_time:8250ms step_avg:31.61ms
+step:262/1490 train_time:8285ms step_avg:31.62ms
+step:263/1490 train_time:8313ms step_avg:31.61ms
+step:264/1490 train_time:8348ms step_avg:31.62ms
+step:265/1490 train_time:8376ms step_avg:31.61ms
+step:266/1490 train_time:8410ms step_avg:31.62ms
+step:267/1490 train_time:8438ms step_avg:31.60ms
+step:268/1490 train_time:8472ms step_avg:31.61ms
+step:269/1490 train_time:8501ms step_avg:31.60ms
+step:270/1490 train_time:8535ms step_avg:31.61ms
+step:271/1490 train_time:8563ms step_avg:31.60ms
+step:272/1490 train_time:8598ms step_avg:31.61ms
+step:273/1490 train_time:8626ms step_avg:31.60ms
+step:274/1490 train_time:8660ms step_avg:31.61ms
+step:275/1490 train_time:8688ms step_avg:31.59ms
+step:276/1490 train_time:8723ms step_avg:31.60ms
+step:277/1490 train_time:8751ms step_avg:31.59ms
+step:278/1490 train_time:8785ms step_avg:31.60ms
+step:279/1490 train_time:8814ms step_avg:31.59ms
+step:280/1490 train_time:8848ms step_avg:31.60ms
+step:281/1490 train_time:8876ms step_avg:31.59ms
+step:282/1490 train_time:8911ms step_avg:31.60ms
+step:283/1490 train_time:8940ms step_avg:31.59ms
+step:284/1490 train_time:8975ms step_avg:31.60ms
+step:285/1490 train_time:9004ms step_avg:31.59ms
+step:286/1490 train_time:9039ms step_avg:31.60ms
+step:287/1490 train_time:9067ms step_avg:31.59ms
+step:288/1490 train_time:9102ms step_avg:31.60ms
+step:289/1490 train_time:9131ms step_avg:31.59ms
+step:290/1490 train_time:9166ms step_avg:31.61ms
+step:291/1490 train_time:9195ms step_avg:31.60ms
+step:292/1490 train_time:9229ms step_avg:31.61ms
+step:293/1490 train_time:9258ms step_avg:31.60ms
+step:294/1490 train_time:9292ms step_avg:31.61ms
+step:295/1490 train_time:9321ms step_avg:31.60ms
+step:296/1490 train_time:9355ms step_avg:31.60ms
+step:297/1490 train_time:9383ms step_avg:31.59ms
+step:298/1490 train_time:9417ms step_avg:31.60ms
+step:299/1490 train_time:9445ms step_avg:31.59ms
+step:300/1490 train_time:9480ms step_avg:31.60ms
+step:301/1490 train_time:9508ms step_avg:31.59ms
+step:302/1490 train_time:9542ms step_avg:31.60ms
+step:303/1490 train_time:9571ms step_avg:31.59ms
+step:304/1490 train_time:9605ms step_avg:31.60ms
+step:305/1490 train_time:9634ms step_avg:31.59ms
+step:306/1490 train_time:9668ms step_avg:31.60ms
+step:307/1490 train_time:9696ms step_avg:31.58ms
+step:308/1490 train_time:9730ms step_avg:31.59ms
+step:309/1490 train_time:9759ms step_avg:31.58ms
+step:310/1490 train_time:9793ms step_avg:31.59ms
+step:311/1490 train_time:9822ms step_avg:31.58ms
+step:312/1490 train_time:9856ms step_avg:31.59ms
+step:313/1490 train_time:9885ms step_avg:31.58ms
+step:314/1490 train_time:9920ms step_avg:31.59ms
+step:315/1490 train_time:9948ms step_avg:31.58ms
+step:316/1490 train_time:9983ms step_avg:31.59ms
+step:317/1490 train_time:10012ms step_avg:31.58ms
+step:318/1490 train_time:10047ms step_avg:31.59ms
+step:319/1490 train_time:10076ms step_avg:31.58ms
+step:320/1490 train_time:10110ms step_avg:31.59ms
+step:321/1490 train_time:10139ms step_avg:31.58ms
+step:322/1490 train_time:10173ms step_avg:31.59ms
+step:323/1490 train_time:10201ms step_avg:31.58ms
+step:324/1490 train_time:10236ms step_avg:31.59ms
+step:325/1490 train_time:10265ms step_avg:31.58ms
+step:326/1490 train_time:10300ms step_avg:31.59ms
+step:327/1490 train_time:10328ms step_avg:31.58ms
+step:328/1490 train_time:10363ms step_avg:31.59ms
+step:329/1490 train_time:10391ms step_avg:31.58ms
+step:330/1490 train_time:10426ms step_avg:31.59ms
+step:331/1490 train_time:10454ms step_avg:31.58ms
+step:332/1490 train_time:10489ms step_avg:31.59ms
+step:333/1490 train_time:10517ms step_avg:31.58ms
+step:334/1490 train_time:10551ms step_avg:31.59ms
+step:335/1490 train_time:10580ms step_avg:31.58ms
+step:336/1490 train_time:10614ms step_avg:31.59ms
+step:337/1490 train_time:10642ms step_avg:31.58ms
+step:338/1490 train_time:10676ms step_avg:31.59ms
+step:339/1490 train_time:10705ms step_avg:31.58ms
+step:340/1490 train_time:10740ms step_avg:31.59ms
+step:341/1490 train_time:10768ms step_avg:31.58ms
+step:342/1490 train_time:10802ms step_avg:31.59ms
+step:343/1490 train_time:10830ms step_avg:31.58ms
+step:344/1490 train_time:10865ms step_avg:31.58ms
+step:345/1490 train_time:10893ms step_avg:31.57ms
+step:346/1490 train_time:10928ms step_avg:31.58ms
+step:347/1490 train_time:10956ms step_avg:31.57ms
+step:348/1490 train_time:10991ms step_avg:31.58ms
+step:349/1490 train_time:11019ms step_avg:31.57ms
+step:350/1490 train_time:11054ms step_avg:31.58ms
+step:351/1490 train_time:11082ms step_avg:31.57ms
+step:352/1490 train_time:11117ms step_avg:31.58ms
+step:353/1490 train_time:11145ms step_avg:31.57ms
+step:354/1490 train_time:11180ms step_avg:31.58ms
+step:355/1490 train_time:11208ms step_avg:31.57ms
+step:356/1490 train_time:11243ms step_avg:31.58ms
+step:357/1490 train_time:11272ms step_avg:31.57ms
+step:358/1490 train_time:11307ms step_avg:31.58ms
+step:359/1490 train_time:11335ms step_avg:31.57ms
+step:360/1490 train_time:11369ms step_avg:31.58ms
+step:361/1490 train_time:11398ms step_avg:31.57ms
+step:362/1490 train_time:11432ms step_avg:31.58ms
+step:363/1490 train_time:11461ms step_avg:31.57ms
+step:364/1490 train_time:11495ms step_avg:31.58ms
+step:365/1490 train_time:11524ms step_avg:31.57ms
+step:366/1490 train_time:11558ms step_avg:31.58ms
+step:367/1490 train_time:11587ms step_avg:31.57ms
+step:368/1490 train_time:11622ms step_avg:31.58ms
+step:369/1490 train_time:11650ms step_avg:31.57ms
+step:370/1490 train_time:11685ms step_avg:31.58ms
+step:371/1490 train_time:11713ms step_avg:31.57ms
+step:372/1490 train_time:11747ms step_avg:31.58ms
+step:373/1490 train_time:11776ms step_avg:31.57ms
+step:374/1490 train_time:11810ms step_avg:31.58ms
+step:375/1490 train_time:11838ms step_avg:31.57ms
+step:376/1490 train_time:11872ms step_avg:31.58ms
+step:377/1490 train_time:11901ms step_avg:31.57ms
+step:378/1490 train_time:11935ms step_avg:31.57ms
+step:379/1490 train_time:11964ms step_avg:31.57ms
+step:380/1490 train_time:11999ms step_avg:31.58ms
+step:381/1490 train_time:12027ms step_avg:31.57ms
+step:382/1490 train_time:12062ms step_avg:31.58ms
+step:383/1490 train_time:12090ms step_avg:31.57ms
+step:384/1490 train_time:12125ms step_avg:31.58ms
+step:385/1490 train_time:12153ms step_avg:31.57ms
+step:386/1490 train_time:12188ms step_avg:31.57ms
+step:387/1490 train_time:12216ms step_avg:31.57ms
+step:388/1490 train_time:12250ms step_avg:31.57ms
+step:389/1490 train_time:12279ms step_avg:31.57ms
+step:390/1490 train_time:12313ms step_avg:31.57ms
+step:391/1490 train_time:12341ms step_avg:31.56ms
+step:392/1490 train_time:12376ms step_avg:31.57ms
+step:393/1490 train_time:12405ms step_avg:31.56ms
+step:394/1490 train_time:12439ms step_avg:31.57ms
+step:395/1490 train_time:12468ms step_avg:31.56ms
+step:396/1490 train_time:12502ms step_avg:31.57ms
+step:397/1490 train_time:12530ms step_avg:31.56ms
+step:398/1490 train_time:12565ms step_avg:31.57ms
+step:399/1490 train_time:12594ms step_avg:31.56ms
+step:400/1490 train_time:12628ms step_avg:31.57ms
+step:401/1490 train_time:12656ms step_avg:31.56ms
+step:402/1490 train_time:12691ms step_avg:31.57ms
+step:403/1490 train_time:12719ms step_avg:31.56ms
+step:404/1490 train_time:12753ms step_avg:31.57ms
+step:405/1490 train_time:12782ms step_avg:31.56ms
+step:406/1490 train_time:12817ms step_avg:31.57ms
+step:407/1490 train_time:12845ms step_avg:31.56ms
+step:408/1490 train_time:12880ms step_avg:31.57ms
+step:409/1490 train_time:12908ms step_avg:31.56ms
+step:410/1490 train_time:12943ms step_avg:31.57ms
+step:411/1490 train_time:12971ms step_avg:31.56ms
+step:412/1490 train_time:13006ms step_avg:31.57ms
+step:413/1490 train_time:13034ms step_avg:31.56ms
+step:414/1490 train_time:13069ms step_avg:31.57ms
+step:415/1490 train_time:13097ms step_avg:31.56ms
+step:416/1490 train_time:13131ms step_avg:31.57ms
+step:417/1490 train_time:13160ms step_avg:31.56ms
+step:418/1490 train_time:13194ms step_avg:31.56ms
+step:419/1490 train_time:13222ms step_avg:31.56ms
+step:420/1490 train_time:13257ms step_avg:31.56ms
+step:421/1490 train_time:13285ms step_avg:31.56ms
+step:422/1490 train_time:13320ms step_avg:31.56ms
+step:423/1490 train_time:13348ms step_avg:31.56ms
+step:424/1490 train_time:13383ms step_avg:31.56ms
+step:425/1490 train_time:13411ms step_avg:31.56ms
+step:426/1490 train_time:13446ms step_avg:31.56ms
+step:427/1490 train_time:13474ms step_avg:31.56ms
+step:428/1490 train_time:13509ms step_avg:31.56ms
+step:429/1490 train_time:13537ms step_avg:31.55ms
+step:430/1490 train_time:13571ms step_avg:31.56ms
+step:431/1490 train_time:13599ms step_avg:31.55ms
+step:432/1490 train_time:13633ms step_avg:31.56ms
+step:433/1490 train_time:13662ms step_avg:31.55ms
+step:434/1490 train_time:13696ms step_avg:31.56ms
+step:435/1490 train_time:13724ms step_avg:31.55ms
+step:436/1490 train_time:13759ms step_avg:31.56ms
+step:437/1490 train_time:13787ms step_avg:31.55ms
+step:438/1490 train_time:13822ms step_avg:31.56ms
+step:439/1490 train_time:13850ms step_avg:31.55ms
+step:440/1490 train_time:13885ms step_avg:31.56ms
+step:441/1490 train_time:13913ms step_avg:31.55ms
+step:442/1490 train_time:13948ms step_avg:31.56ms
+step:443/1490 train_time:13977ms step_avg:31.55ms
+step:444/1490 train_time:14011ms step_avg:31.56ms
+step:445/1490 train_time:14039ms step_avg:31.55ms
+step:446/1490 train_time:14074ms step_avg:31.56ms
+step:447/1490 train_time:14102ms step_avg:31.55ms
+step:448/1490 train_time:14137ms step_avg:31.56ms
+step:449/1490 train_time:14165ms step_avg:31.55ms
+step:450/1490 train_time:14200ms step_avg:31.56ms
+step:451/1490 train_time:14229ms step_avg:31.55ms
+step:452/1490 train_time:14263ms step_avg:31.56ms
+step:453/1490 train_time:14292ms step_avg:31.55ms
+step:454/1490 train_time:14327ms step_avg:31.56ms
+step:455/1490 train_time:14355ms step_avg:31.55ms
+step:456/1490 train_time:14389ms step_avg:31.56ms
+step:457/1490 train_time:14418ms step_avg:31.55ms
+step:458/1490 train_time:14452ms step_avg:31.55ms
+step:459/1490 train_time:14481ms step_avg:31.55ms
+step:460/1490 train_time:14515ms step_avg:31.56ms
+step:461/1490 train_time:14544ms step_avg:31.55ms
+step:462/1490 train_time:14578ms step_avg:31.55ms
+step:463/1490 train_time:14606ms step_avg:31.55ms
+step:464/1490 train_time:14641ms step_avg:31.55ms
+step:465/1490 train_time:14669ms step_avg:31.55ms
+step:466/1490 train_time:14704ms step_avg:31.55ms
+step:467/1490 train_time:14732ms step_avg:31.55ms
+step:468/1490 train_time:14766ms step_avg:31.55ms
+step:469/1490 train_time:14795ms step_avg:31.55ms
+step:470/1490 train_time:14829ms step_avg:31.55ms
+step:471/1490 train_time:14858ms step_avg:31.55ms
+step:472/1490 train_time:14892ms step_avg:31.55ms
+step:473/1490 train_time:14920ms step_avg:31.54ms
+step:474/1490 train_time:14954ms step_avg:31.55ms
+step:475/1490 train_time:14983ms step_avg:31.54ms
+step:476/1490 train_time:15017ms step_avg:31.55ms
+step:477/1490 train_time:15045ms step_avg:31.54ms
+step:478/1490 train_time:15080ms step_avg:31.55ms
+step:479/1490 train_time:15108ms step_avg:31.54ms
+step:480/1490 train_time:15142ms step_avg:31.55ms
+step:481/1490 train_time:15171ms step_avg:31.54ms
+step:482/1490 train_time:15206ms step_avg:31.55ms
+step:483/1490 train_time:15234ms step_avg:31.54ms
+step:484/1490 train_time:15271ms step_avg:31.55ms
+step:485/1490 train_time:15323ms step_avg:31.59ms
+step:486/1490 train_time:15382ms step_avg:31.65ms
+step:487/1490 train_time:15436ms step_avg:31.70ms
+step:488/1490 train_time:15495ms step_avg:31.75ms
+step:489/1490 train_time:15549ms step_avg:31.80ms
+step:490/1490 train_time:15609ms step_avg:31.85ms
+step:491/1490 train_time:15663ms step_avg:31.90ms
+step:492/1490 train_time:15723ms step_avg:31.96ms
+step:493/1490 train_time:15777ms step_avg:32.00ms
+step:494/1490 train_time:15837ms step_avg:32.06ms
+step:495/1490 train_time:15892ms step_avg:32.11ms
+step:496/1490 train_time:15952ms step_avg:32.16ms
+step:497/1490 train_time:16006ms step_avg:32.20ms
+step:498/1490 train_time:16065ms step_avg:32.26ms
+step:499/1490 train_time:16120ms step_avg:32.30ms
+step:500/1490 train_time:16180ms step_avg:32.36ms
+step:500/1490 val_loss:4.2475 train_time:16253ms step_avg:32.51ms
+step:501/1490 train_time:16269ms step_avg:32.47ms
+step:502/1490 train_time:16295ms step_avg:32.46ms
+step:503/1490 train_time:16353ms step_avg:32.51ms
+step:504/1490 train_time:16414ms step_avg:32.57ms
+step:505/1490 train_time:16471ms step_avg:32.62ms
+step:506/1490 train_time:16532ms step_avg:32.67ms
+step:507/1490 train_time:16586ms step_avg:32.71ms
+step:508/1490 train_time:16645ms step_avg:32.77ms
+step:509/1490 train_time:16699ms step_avg:32.81ms
+step:510/1490 train_time:16758ms step_avg:32.86ms
+step:511/1490 train_time:16811ms step_avg:32.90ms
+step:512/1490 train_time:16870ms step_avg:32.95ms
+step:513/1490 train_time:16923ms step_avg:32.99ms
+step:514/1490 train_time:16982ms step_avg:33.04ms
+step:515/1490 train_time:17036ms step_avg:33.08ms
+step:516/1490 train_time:17095ms step_avg:33.13ms
+step:517/1490 train_time:17148ms step_avg:33.17ms
+step:518/1490 train_time:17210ms step_avg:33.22ms
+step:519/1490 train_time:17265ms step_avg:33.27ms
+step:520/1490 train_time:17327ms step_avg:33.32ms
+step:521/1490 train_time:17383ms step_avg:33.36ms
+step:522/1490 train_time:17444ms step_avg:33.42ms
+step:523/1490 train_time:17499ms step_avg:33.46ms
+step:524/1490 train_time:17558ms step_avg:33.51ms
+step:525/1490 train_time:17613ms step_avg:33.55ms
+step:526/1490 train_time:17672ms step_avg:33.60ms
+step:527/1490 train_time:17726ms step_avg:33.64ms
+step:528/1490 train_time:17786ms step_avg:33.69ms
+step:529/1490 train_time:17840ms step_avg:33.72ms
+step:530/1490 train_time:17898ms step_avg:33.77ms
+step:531/1490 train_time:17952ms step_avg:33.81ms
+step:532/1490 train_time:18012ms step_avg:33.86ms
+step:533/1490 train_time:18065ms step_avg:33.89ms
+step:534/1490 train_time:18125ms step_avg:33.94ms
+step:535/1490 train_time:18180ms step_avg:33.98ms
+step:536/1490 train_time:18240ms step_avg:34.03ms
+step:537/1490 train_time:18295ms step_avg:34.07ms
+step:538/1490 train_time:18356ms step_avg:34.12ms
+step:539/1490 train_time:18412ms step_avg:34.16ms
+step:540/1490 train_time:18472ms step_avg:34.21ms
+step:541/1490 train_time:18527ms step_avg:34.24ms
+step:542/1490 train_time:18586ms step_avg:34.29ms
+step:543/1490 train_time:18640ms step_avg:34.33ms
+step:544/1490 train_time:18700ms step_avg:34.37ms
+step:545/1490 train_time:18755ms step_avg:34.41ms
+step:546/1490 train_time:18815ms step_avg:34.46ms
+step:547/1490 train_time:18868ms step_avg:34.49ms
+step:548/1490 train_time:18927ms step_avg:34.54ms
+step:549/1490 train_time:18981ms step_avg:34.57ms
+step:550/1490 train_time:19040ms step_avg:34.62ms
+step:551/1490 train_time:19094ms step_avg:34.65ms
+step:552/1490 train_time:19155ms step_avg:34.70ms
+step:553/1490 train_time:19210ms step_avg:34.74ms
+step:554/1490 train_time:19270ms step_avg:34.78ms
+step:555/1490 train_time:19324ms step_avg:34.82ms
+step:556/1490 train_time:19385ms step_avg:34.87ms
+step:557/1490 train_time:19440ms step_avg:34.90ms
+step:558/1490 train_time:19499ms step_avg:34.95ms
+step:559/1490 train_time:19554ms step_avg:34.98ms
+step:560/1490 train_time:19614ms step_avg:35.03ms
+step:561/1490 train_time:19668ms step_avg:35.06ms
+step:562/1490 train_time:19729ms step_avg:35.10ms
+step:563/1490 train_time:19783ms step_avg:35.14ms
+step:564/1490 train_time:19843ms step_avg:35.18ms
+step:565/1490 train_time:19897ms step_avg:35.22ms
+step:566/1490 train_time:19956ms step_avg:35.26ms
+step:567/1490 train_time:20010ms step_avg:35.29ms
+step:568/1490 train_time:20070ms step_avg:35.33ms
+step:569/1490 train_time:20124ms step_avg:35.37ms
+step:570/1490 train_time:20184ms step_avg:35.41ms
+step:571/1490 train_time:20238ms step_avg:35.44ms
+step:572/1490 train_time:20298ms step_avg:35.49ms
+step:573/1490 train_time:20353ms step_avg:35.52ms
+step:574/1490 train_time:20414ms step_avg:35.56ms
+step:575/1490 train_time:20468ms step_avg:35.60ms
+step:576/1490 train_time:20529ms step_avg:35.64ms
+step:577/1490 train_time:20583ms step_avg:35.67ms
+step:578/1490 train_time:20643ms step_avg:35.71ms
+step:579/1490 train_time:20697ms step_avg:35.75ms
+step:580/1490 train_time:20757ms step_avg:35.79ms
+step:581/1490 train_time:20812ms step_avg:35.82ms
+step:582/1490 train_time:20871ms step_avg:35.86ms
+step:583/1490 train_time:20925ms step_avg:35.89ms
+step:584/1490 train_time:20985ms step_avg:35.93ms
+step:585/1490 train_time:21039ms step_avg:35.96ms
+step:586/1490 train_time:21099ms step_avg:36.01ms
+step:587/1490 train_time:21153ms step_avg:36.04ms
+step:588/1490 train_time:21213ms step_avg:36.08ms
+step:589/1490 train_time:21267ms step_avg:36.11ms
+step:590/1490 train_time:21327ms step_avg:36.15ms
+step:591/1490 train_time:21381ms step_avg:36.18ms
+step:592/1490 train_time:21442ms step_avg:36.22ms
+step:593/1490 train_time:21496ms step_avg:36.25ms
+step:594/1490 train_time:21556ms step_avg:36.29ms
+step:595/1490 train_time:21611ms step_avg:36.32ms
+step:596/1490 train_time:21670ms step_avg:36.36ms
+step:597/1490 train_time:21725ms step_avg:36.39ms
+step:598/1490 train_time:21784ms step_avg:36.43ms
+step:599/1490 train_time:21838ms step_avg:36.46ms
+step:600/1490 train_time:21897ms step_avg:36.50ms
+step:601/1490 train_time:21951ms step_avg:36.52ms
+step:602/1490 train_time:22012ms step_avg:36.56ms
+step:603/1490 train_time:22067ms step_avg:36.59ms
+step:604/1490 train_time:22127ms step_avg:36.63ms
+step:605/1490 train_time:22182ms step_avg:36.66ms
+step:606/1490 train_time:22241ms step_avg:36.70ms
+step:607/1490 train_time:22294ms step_avg:36.73ms
+step:608/1490 train_time:22355ms step_avg:36.77ms
+step:609/1490 train_time:22409ms step_avg:36.80ms
+step:610/1490 train_time:22469ms step_avg:36.83ms
+step:611/1490 train_time:22523ms step_avg:36.86ms
+step:612/1490 train_time:22582ms step_avg:36.90ms
+step:613/1490 train_time:22636ms step_avg:36.93ms
+step:614/1490 train_time:22696ms step_avg:36.96ms
+step:615/1490 train_time:22750ms step_avg:36.99ms
+step:616/1490 train_time:22810ms step_avg:37.03ms
+step:617/1490 train_time:22863ms step_avg:37.06ms
+step:618/1490 train_time:22924ms step_avg:37.09ms
+step:619/1490 train_time:22978ms step_avg:37.12ms
+step:620/1490 train_time:23037ms step_avg:37.16ms
+step:621/1490 train_time:23091ms step_avg:37.18ms
+step:622/1490 train_time:23151ms step_avg:37.22ms
+step:623/1490 train_time:23205ms step_avg:37.25ms
+step:624/1490 train_time:23266ms step_avg:37.28ms
+step:625/1490 train_time:23320ms step_avg:37.31ms
+step:626/1490 train_time:23379ms step_avg:37.35ms
+step:627/1490 train_time:23434ms step_avg:37.37ms
+step:628/1490 train_time:23494ms step_avg:37.41ms
+step:629/1490 train_time:23548ms step_avg:37.44ms
+step:630/1490 train_time:23608ms step_avg:37.47ms
+step:631/1490 train_time:23662ms step_avg:37.50ms
+step:632/1490 train_time:23721ms step_avg:37.53ms
+step:633/1490 train_time:23775ms step_avg:37.56ms
+step:634/1490 train_time:23834ms step_avg:37.59ms
+step:635/1490 train_time:23888ms step_avg:37.62ms
+step:636/1490 train_time:23949ms step_avg:37.65ms
+step:637/1490 train_time:24002ms step_avg:37.68ms
+step:638/1490 train_time:24062ms step_avg:37.71ms
+step:639/1490 train_time:24116ms step_avg:37.74ms
+step:640/1490 train_time:24176ms step_avg:37.78ms
+step:641/1490 train_time:24231ms step_avg:37.80ms
+step:642/1490 train_time:24291ms step_avg:37.84ms
+step:643/1490 train_time:24346ms step_avg:37.86ms
+step:644/1490 train_time:24407ms step_avg:37.90ms
+step:645/1490 train_time:24461ms step_avg:37.92ms
+step:646/1490 train_time:24521ms step_avg:37.96ms
+step:647/1490 train_time:24575ms step_avg:37.98ms
+step:648/1490 train_time:24635ms step_avg:38.02ms
+step:649/1490 train_time:24690ms step_avg:38.04ms
+step:650/1490 train_time:24749ms step_avg:38.08ms
+step:651/1490 train_time:24803ms step_avg:38.10ms
+step:652/1490 train_time:24863ms step_avg:38.13ms
+step:653/1490 train_time:24917ms step_avg:38.16ms
+step:654/1490 train_time:24977ms step_avg:38.19ms
+step:655/1490 train_time:25031ms step_avg:38.21ms
+step:656/1490 train_time:25090ms step_avg:38.25ms
+step:657/1490 train_time:25145ms step_avg:38.27ms
+step:658/1490 train_time:25206ms step_avg:38.31ms
+step:659/1490 train_time:25260ms step_avg:38.33ms
+step:660/1490 train_time:25320ms step_avg:38.36ms
+step:661/1490 train_time:25374ms step_avg:38.39ms
+step:662/1490 train_time:25433ms step_avg:38.42ms
+step:663/1490 train_time:25488ms step_avg:38.44ms
+step:664/1490 train_time:25548ms step_avg:38.48ms
+step:665/1490 train_time:25602ms step_avg:38.50ms
+step:666/1490 train_time:25662ms step_avg:38.53ms
+step:667/1490 train_time:25716ms step_avg:38.55ms
+step:668/1490 train_time:25777ms step_avg:38.59ms
+step:669/1490 train_time:25830ms step_avg:38.61ms
+step:670/1490 train_time:25889ms step_avg:38.64ms
+step:671/1490 train_time:25944ms step_avg:38.67ms
+step:672/1490 train_time:26005ms step_avg:38.70ms
+step:673/1490 train_time:26059ms step_avg:38.72ms
+step:674/1490 train_time:26118ms step_avg:38.75ms
+step:675/1490 train_time:26172ms step_avg:38.77ms
+step:676/1490 train_time:26232ms step_avg:38.80ms
+step:677/1490 train_time:26286ms step_avg:38.83ms
+step:678/1490 train_time:26347ms step_avg:38.86ms
+step:679/1490 train_time:26401ms step_avg:38.88ms
+step:680/1490 train_time:26462ms step_avg:38.91ms
+step:681/1490 train_time:26516ms step_avg:38.94ms
+step:682/1490 train_time:26576ms step_avg:38.97ms
+step:683/1490 train_time:26630ms step_avg:38.99ms
+step:684/1490 train_time:26690ms step_avg:39.02ms
+step:685/1490 train_time:26744ms step_avg:39.04ms
+step:686/1490 train_time:26803ms step_avg:39.07ms
+step:687/1490 train_time:26857ms step_avg:39.09ms
+step:688/1490 train_time:26917ms step_avg:39.12ms
+step:689/1490 train_time:26971ms step_avg:39.15ms
+step:690/1490 train_time:27031ms step_avg:39.17ms
+step:691/1490 train_time:27084ms step_avg:39.20ms
+step:692/1490 train_time:27145ms step_avg:39.23ms
+step:693/1490 train_time:27199ms step_avg:39.25ms
+step:694/1490 train_time:27259ms step_avg:39.28ms
+step:695/1490 train_time:27314ms step_avg:39.30ms
+step:696/1490 train_time:27374ms step_avg:39.33ms
+step:697/1490 train_time:27429ms step_avg:39.35ms
+step:698/1490 train_time:27488ms step_avg:39.38ms
+step:699/1490 train_time:27542ms step_avg:39.40ms
+step:700/1490 train_time:27603ms step_avg:39.43ms
+step:701/1490 train_time:27658ms step_avg:39.46ms
+step:702/1490 train_time:27717ms step_avg:39.48ms
+step:703/1490 train_time:27771ms step_avg:39.50ms
+step:704/1490 train_time:27831ms step_avg:39.53ms
+step:705/1490 train_time:27885ms step_avg:39.55ms
+step:706/1490 train_time:27945ms step_avg:39.58ms
+step:707/1490 train_time:27999ms step_avg:39.60ms
+step:708/1490 train_time:28059ms step_avg:39.63ms
+step:709/1490 train_time:28113ms step_avg:39.65ms
+step:710/1490 train_time:28172ms step_avg:39.68ms
+step:711/1490 train_time:28227ms step_avg:39.70ms
+step:712/1490 train_time:28287ms step_avg:39.73ms
+step:713/1490 train_time:28342ms step_avg:39.75ms
+step:714/1490 train_time:28402ms step_avg:39.78ms
+step:715/1490 train_time:28456ms step_avg:39.80ms
+step:716/1490 train_time:28518ms step_avg:39.83ms
+step:717/1490 train_time:28572ms step_avg:39.85ms
+step:718/1490 train_time:28632ms step_avg:39.88ms
+step:719/1490 train_time:28686ms step_avg:39.90ms
+step:720/1490 train_time:28747ms step_avg:39.93ms
+step:721/1490 train_time:28802ms step_avg:39.95ms
+step:722/1490 train_time:28861ms step_avg:39.97ms
+step:723/1490 train_time:28915ms step_avg:39.99ms
+step:724/1490 train_time:28974ms step_avg:40.02ms
+step:725/1490 train_time:29027ms step_avg:40.04ms
+step:726/1490 train_time:29089ms step_avg:40.07ms
+step:727/1490 train_time:29143ms step_avg:40.09ms
+step:728/1490 train_time:29203ms step_avg:40.11ms
+step:729/1490 train_time:29257ms step_avg:40.13ms
+step:730/1490 train_time:29317ms step_avg:40.16ms
+step:731/1490 train_time:29371ms step_avg:40.18ms
+step:732/1490 train_time:29431ms step_avg:40.21ms
+step:733/1490 train_time:29485ms step_avg:40.23ms
+step:734/1490 train_time:29545ms step_avg:40.25ms
+step:735/1490 train_time:29600ms step_avg:40.27ms
+step:736/1490 train_time:29659ms step_avg:40.30ms
+step:737/1490 train_time:29714ms step_avg:40.32ms
+step:738/1490 train_time:29774ms step_avg:40.34ms
+step:739/1490 train_time:29828ms step_avg:40.36ms
+step:740/1490 train_time:29888ms step_avg:40.39ms
+step:741/1490 train_time:29941ms step_avg:40.41ms
+step:742/1490 train_time:30001ms step_avg:40.43ms
+step:743/1490 train_time:30056ms step_avg:40.45ms
+step:744/1490 train_time:30116ms step_avg:40.48ms
+step:745/1490 train_time:30170ms step_avg:40.50ms
+step:746/1490 train_time:30230ms step_avg:40.52ms
+step:747/1490 train_time:30285ms step_avg:40.54ms
+step:748/1490 train_time:30345ms step_avg:40.57ms
+step:749/1490 train_time:30400ms step_avg:40.59ms
+step:750/1490 train_time:30460ms step_avg:40.61ms
+step:750/1490 val_loss:3.8091 train_time:30533ms step_avg:40.71ms
+step:751/1490 train_time:30549ms step_avg:40.68ms
+step:752/1490 train_time:30576ms step_avg:40.66ms
+step:753/1490 train_time:30630ms step_avg:40.68ms
+step:754/1490 train_time:30696ms step_avg:40.71ms
+step:755/1490 train_time:30754ms step_avg:40.73ms
+step:756/1490 train_time:30814ms step_avg:40.76ms
+step:757/1490 train_time:30868ms step_avg:40.78ms
+step:758/1490 train_time:30928ms step_avg:40.80ms
+step:759/1490 train_time:30982ms step_avg:40.82ms
+step:760/1490 train_time:31042ms step_avg:40.84ms
+step:761/1490 train_time:31095ms step_avg:40.86ms
+step:762/1490 train_time:31154ms step_avg:40.88ms
+step:763/1490 train_time:31208ms step_avg:40.90ms
+step:764/1490 train_time:31267ms step_avg:40.93ms
+step:765/1490 train_time:31321ms step_avg:40.94ms
+step:766/1490 train_time:31381ms step_avg:40.97ms
+step:767/1490 train_time:31435ms step_avg:40.98ms
+step:768/1490 train_time:31495ms step_avg:41.01ms
+step:769/1490 train_time:31550ms step_avg:41.03ms
+step:770/1490 train_time:31610ms step_avg:41.05ms
+step:771/1490 train_time:31666ms step_avg:41.07ms
+step:772/1490 train_time:31728ms step_avg:41.10ms
+step:773/1490 train_time:31784ms step_avg:41.12ms
+step:774/1490 train_time:31844ms step_avg:41.14ms
+step:775/1490 train_time:31898ms step_avg:41.16ms
+step:776/1490 train_time:31958ms step_avg:41.18ms
+step:777/1490 train_time:32011ms step_avg:41.20ms
+step:778/1490 train_time:32071ms step_avg:41.22ms
+step:779/1490 train_time:32125ms step_avg:41.24ms
+step:780/1490 train_time:32183ms step_avg:41.26ms
+step:781/1490 train_time:32237ms step_avg:41.28ms
+step:782/1490 train_time:32296ms step_avg:41.30ms
+step:783/1490 train_time:32349ms step_avg:41.31ms
+step:784/1490 train_time:32408ms step_avg:41.34ms
+step:785/1490 train_time:32462ms step_avg:41.35ms
+step:786/1490 train_time:32522ms step_avg:41.38ms
+step:787/1490 train_time:32578ms step_avg:41.39ms
+step:788/1490 train_time:32639ms step_avg:41.42ms
+step:789/1490 train_time:32694ms step_avg:41.44ms
+step:790/1490 train_time:32755ms step_avg:41.46ms
+step:791/1490 train_time:32810ms step_avg:41.48ms
+step:792/1490 train_time:32869ms step_avg:41.50ms
+step:793/1490 train_time:32923ms step_avg:41.52ms
+step:794/1490 train_time:32983ms step_avg:41.54ms
+step:795/1490 train_time:33038ms step_avg:41.56ms
+step:796/1490 train_time:33098ms step_avg:41.58ms
+step:797/1490 train_time:33152ms step_avg:41.60ms
+step:798/1490 train_time:33211ms step_avg:41.62ms
+step:799/1490 train_time:33264ms step_avg:41.63ms
+step:800/1490 train_time:33324ms step_avg:41.65ms
+step:801/1490 train_time:33378ms step_avg:41.67ms
+step:802/1490 train_time:33437ms step_avg:41.69ms
+step:803/1490 train_time:33492ms step_avg:41.71ms
+step:804/1490 train_time:33552ms step_avg:41.73ms
+step:805/1490 train_time:33607ms step_avg:41.75ms
+step:806/1490 train_time:33666ms step_avg:41.77ms
+step:807/1490 train_time:33721ms step_avg:41.79ms
+step:808/1490 train_time:33781ms step_avg:41.81ms
+step:809/1490 train_time:33836ms step_avg:41.82ms
+step:810/1490 train_time:33897ms step_avg:41.85ms
+step:811/1490 train_time:33951ms step_avg:41.86ms
+step:812/1490 train_time:34011ms step_avg:41.89ms
+step:813/1490 train_time:34065ms step_avg:41.90ms
+step:814/1490 train_time:34124ms step_avg:41.92ms
+step:815/1490 train_time:34179ms step_avg:41.94ms
+step:816/1490 train_time:34238ms step_avg:41.96ms
+step:817/1490 train_time:34292ms step_avg:41.97ms
+step:818/1490 train_time:34352ms step_avg:41.99ms
+step:819/1490 train_time:34405ms step_avg:42.01ms
+step:820/1490 train_time:34464ms step_avg:42.03ms
+step:821/1490 train_time:34519ms step_avg:42.04ms
+step:822/1490 train_time:34579ms step_avg:42.07ms
+step:823/1490 train_time:34633ms step_avg:42.08ms
+step:824/1490 train_time:34694ms step_avg:42.10ms
+step:825/1490 train_time:34748ms step_avg:42.12ms
+step:826/1490 train_time:34808ms step_avg:42.14ms
+step:827/1490 train_time:34862ms step_avg:42.16ms
+step:828/1490 train_time:34923ms step_avg:42.18ms
+step:829/1490 train_time:34979ms step_avg:42.19ms
+step:830/1490 train_time:35039ms step_avg:42.22ms
+step:831/1490 train_time:35093ms step_avg:42.23ms
+step:832/1490 train_time:35153ms step_avg:42.25ms
+step:833/1490 train_time:35206ms step_avg:42.26ms
+step:834/1490 train_time:35265ms step_avg:42.28ms
+step:835/1490 train_time:35320ms step_avg:42.30ms
+step:836/1490 train_time:35379ms step_avg:42.32ms
+step:837/1490 train_time:35433ms step_avg:42.33ms
+step:838/1490 train_time:35493ms step_avg:42.35ms
+step:839/1490 train_time:35547ms step_avg:42.37ms
+step:840/1490 train_time:35607ms step_avg:42.39ms
+step:841/1490 train_time:35661ms step_avg:42.40ms
+step:842/1490 train_time:35721ms step_avg:42.42ms
+step:843/1490 train_time:35775ms step_avg:42.44ms
+step:844/1490 train_time:35837ms step_avg:42.46ms
+step:845/1490 train_time:35892ms step_avg:42.48ms
+step:846/1490 train_time:35952ms step_avg:42.50ms
+step:847/1490 train_time:36006ms step_avg:42.51ms
+step:848/1490 train_time:36066ms step_avg:42.53ms
+step:849/1490 train_time:36120ms step_avg:42.54ms
+step:850/1490 train_time:36179ms step_avg:42.56ms
+step:851/1490 train_time:36233ms step_avg:42.58ms
+step:852/1490 train_time:36294ms step_avg:42.60ms
+step:853/1490 train_time:36348ms step_avg:42.61ms
+step:854/1490 train_time:36408ms step_avg:42.63ms
+step:855/1490 train_time:36461ms step_avg:42.64ms
+step:856/1490 train_time:36521ms step_avg:42.67ms
+step:857/1490 train_time:36576ms step_avg:42.68ms
+step:858/1490 train_time:36637ms step_avg:42.70ms
+step:859/1490 train_time:36691ms step_avg:42.71ms
+step:860/1490 train_time:36751ms step_avg:42.73ms
+step:861/1490 train_time:36805ms step_avg:42.75ms
+step:862/1490 train_time:36865ms step_avg:42.77ms
+step:863/1490 train_time:36919ms step_avg:42.78ms
+step:864/1490 train_time:36979ms step_avg:42.80ms
+step:865/1490 train_time:37034ms step_avg:42.81ms
+step:866/1490 train_time:37094ms step_avg:42.83ms
+step:867/1490 train_time:37148ms step_avg:42.85ms
+step:868/1490 train_time:37207ms step_avg:42.87ms
+step:869/1490 train_time:37262ms step_avg:42.88ms
+step:870/1490 train_time:37321ms step_avg:42.90ms
+step:871/1490 train_time:37376ms step_avg:42.91ms
+step:872/1490 train_time:37436ms step_avg:42.93ms
+step:873/1490 train_time:37490ms step_avg:42.94ms
+step:874/1490 train_time:37550ms step_avg:42.96ms
+step:875/1490 train_time:37604ms step_avg:42.98ms
+step:876/1490 train_time:37663ms step_avg:42.99ms
+step:877/1490 train_time:37717ms step_avg:43.01ms
+step:878/1490 train_time:37777ms step_avg:43.03ms
+step:879/1490 train_time:37832ms step_avg:43.04ms
+step:880/1490 train_time:37891ms step_avg:43.06ms
+step:881/1490 train_time:37945ms step_avg:43.07ms
+step:882/1490 train_time:38005ms step_avg:43.09ms
+step:883/1490 train_time:38059ms step_avg:43.10ms
+step:884/1490 train_time:38119ms step_avg:43.12ms
+step:885/1490 train_time:38173ms step_avg:43.13ms
+step:886/1490 train_time:38233ms step_avg:43.15ms
+step:887/1490 train_time:38287ms step_avg:43.16ms
+step:888/1490 train_time:38347ms step_avg:43.18ms
+step:889/1490 train_time:38401ms step_avg:43.20ms
+step:890/1490 train_time:38461ms step_avg:43.21ms
+step:891/1490 train_time:38515ms step_avg:43.23ms
+step:892/1490 train_time:38575ms step_avg:43.25ms
+step:893/1490 train_time:38629ms step_avg:43.26ms
+step:894/1490 train_time:38688ms step_avg:43.28ms
+step:895/1490 train_time:38743ms step_avg:43.29ms
+step:896/1490 train_time:38803ms step_avg:43.31ms
+step:897/1490 train_time:38858ms step_avg:43.32ms
+step:898/1490 train_time:38917ms step_avg:43.34ms
+step:899/1490 train_time:38971ms step_avg:43.35ms
+step:900/1490 train_time:39031ms step_avg:43.37ms
+step:901/1490 train_time:39085ms step_avg:43.38ms
+step:902/1490 train_time:39145ms step_avg:43.40ms
+step:903/1490 train_time:39198ms step_avg:43.41ms
+step:904/1490 train_time:39258ms step_avg:43.43ms
+step:905/1490 train_time:39312ms step_avg:43.44ms
+step:906/1490 train_time:39373ms step_avg:43.46ms
+step:907/1490 train_time:39427ms step_avg:43.47ms
+step:908/1490 train_time:39486ms step_avg:43.49ms
+step:909/1490 train_time:39542ms step_avg:43.50ms
+step:910/1490 train_time:39601ms step_avg:43.52ms
+step:911/1490 train_time:39656ms step_avg:43.53ms
+step:912/1490 train_time:39716ms step_avg:43.55ms
+step:913/1490 train_time:39770ms step_avg:43.56ms
+step:914/1490 train_time:39830ms step_avg:43.58ms
+step:915/1490 train_time:39884ms step_avg:43.59ms
+step:916/1490 train_time:39944ms step_avg:43.61ms
+step:917/1490 train_time:39999ms step_avg:43.62ms
+step:918/1490 train_time:40059ms step_avg:43.64ms
+step:919/1490 train_time:40113ms step_avg:43.65ms
+step:920/1490 train_time:40173ms step_avg:43.67ms
+step:921/1490 train_time:40227ms step_avg:43.68ms
+step:922/1490 train_time:40286ms step_avg:43.69ms
+step:923/1490 train_time:40341ms step_avg:43.71ms
+step:924/1490 train_time:40400ms step_avg:43.72ms
+step:925/1490 train_time:40454ms step_avg:43.73ms
+step:926/1490 train_time:40515ms step_avg:43.75ms
+step:927/1490 train_time:40569ms step_avg:43.76ms
+step:928/1490 train_time:40629ms step_avg:43.78ms
+step:929/1490 train_time:40684ms step_avg:43.79ms
+step:930/1490 train_time:40745ms step_avg:43.81ms
+step:931/1490 train_time:40800ms step_avg:43.82ms
+step:932/1490 train_time:40860ms step_avg:43.84ms
+step:933/1490 train_time:40913ms step_avg:43.85ms
+step:934/1490 train_time:40974ms step_avg:43.87ms
+step:935/1490 train_time:41028ms step_avg:43.88ms
+step:936/1490 train_time:41088ms step_avg:43.90ms
+step:937/1490 train_time:41143ms step_avg:43.91ms
+step:938/1490 train_time:41202ms step_avg:43.93ms
+step:939/1490 train_time:41256ms step_avg:43.94ms
+step:940/1490 train_time:41316ms step_avg:43.95ms
+step:941/1490 train_time:41370ms step_avg:43.96ms
+step:942/1490 train_time:41430ms step_avg:43.98ms
+step:943/1490 train_time:41484ms step_avg:43.99ms
+step:944/1490 train_time:41545ms step_avg:44.01ms
+step:945/1490 train_time:41599ms step_avg:44.02ms
+step:946/1490 train_time:41658ms step_avg:44.04ms
+step:947/1490 train_time:41713ms step_avg:44.05ms
+step:948/1490 train_time:41772ms step_avg:44.06ms
+step:949/1490 train_time:41826ms step_avg:44.07ms
+step:950/1490 train_time:41886ms step_avg:44.09ms
+step:951/1490 train_time:41942ms step_avg:44.10ms
+step:952/1490 train_time:42002ms step_avg:44.12ms
+step:953/1490 train_time:42056ms step_avg:44.13ms
+step:954/1490 train_time:42116ms step_avg:44.15ms
+step:955/1490 train_time:42170ms step_avg:44.16ms
+step:956/1490 train_time:42229ms step_avg:44.17ms
+step:957/1490 train_time:42283ms step_avg:44.18ms
+step:958/1490 train_time:42343ms step_avg:44.20ms
+step:959/1490 train_time:42397ms step_avg:44.21ms
+step:960/1490 train_time:42458ms step_avg:44.23ms
+step:961/1490 train_time:42512ms step_avg:44.24ms
+step:962/1490 train_time:42572ms step_avg:44.25ms
+step:963/1490 train_time:42625ms step_avg:44.26ms
+step:964/1490 train_time:42685ms step_avg:44.28ms
+step:965/1490 train_time:42740ms step_avg:44.29ms
+step:966/1490 train_time:42800ms step_avg:44.31ms
+step:967/1490 train_time:42854ms step_avg:44.32ms
+step:968/1490 train_time:42918ms step_avg:44.34ms
+step:969/1490 train_time:42997ms step_avg:44.37ms
+step:970/1490 train_time:43085ms step_avg:44.42ms
+step:971/1490 train_time:43165ms step_avg:44.45ms
+step:972/1490 train_time:43252ms step_avg:44.50ms
+step:973/1490 train_time:43334ms step_avg:44.54ms
+step:974/1490 train_time:43420ms step_avg:44.58ms
+step:975/1490 train_time:43501ms step_avg:44.62ms
+step:976/1490 train_time:43588ms step_avg:44.66ms
+step:977/1490 train_time:43669ms step_avg:44.70ms
+step:978/1490 train_time:43758ms step_avg:44.74ms
+step:979/1490 train_time:43839ms step_avg:44.78ms
+step:980/1490 train_time:43925ms step_avg:44.82ms
+step:981/1490 train_time:44006ms step_avg:44.86ms
+step:982/1490 train_time:44092ms step_avg:44.90ms
+step:983/1490 train_time:44173ms step_avg:44.94ms
+step:984/1490 train_time:44260ms step_avg:44.98ms
+step:985/1490 train_time:44341ms step_avg:45.02ms
+step:986/1490 train_time:44428ms step_avg:45.06ms
+step:987/1490 train_time:44508ms step_avg:45.09ms
+step:988/1490 train_time:44595ms step_avg:45.14ms
+step:989/1490 train_time:44675ms step_avg:45.17ms
+step:990/1490 train_time:44763ms step_avg:45.22ms
+step:991/1490 train_time:44844ms step_avg:45.25ms
+step:992/1490 train_time:44929ms step_avg:45.29ms
+step:993/1490 train_time:45011ms step_avg:45.33ms
+step:994/1490 train_time:45097ms step_avg:45.37ms
+step:995/1490 train_time:45179ms step_avg:45.41ms
+step:996/1490 train_time:45265ms step_avg:45.45ms
+step:997/1490 train_time:45345ms step_avg:45.48ms
+step:998/1490 train_time:45431ms step_avg:45.52ms
+step:999/1490 train_time:45513ms step_avg:45.56ms
+step:1000/1490 train_time:45600ms step_avg:45.60ms
+step:1000/1490 val_loss:3.5177 train_time:45703ms step_avg:45.70ms
+step:1001/1490 train_time:45719ms step_avg:45.67ms
+step:1002/1490 train_time:45771ms step_avg:45.68ms
+step:1003/1490 train_time:45855ms step_avg:45.72ms
+step:1004/1490 train_time:45941ms step_avg:45.76ms
+step:1005/1490 train_time:46022ms step_avg:45.79ms
+step:1006/1490 train_time:46108ms step_avg:45.83ms
+step:1007/1490 train_time:46189ms step_avg:45.87ms
+step:1008/1490 train_time:46275ms step_avg:45.91ms
+step:1009/1490 train_time:46354ms step_avg:45.94ms
+step:1010/1490 train_time:46437ms step_avg:45.98ms
+step:1011/1490 train_time:46517ms step_avg:46.01ms
+step:1012/1490 train_time:46603ms step_avg:46.05ms
+step:1013/1490 train_time:46686ms step_avg:46.09ms
+step:1014/1490 train_time:46777ms step_avg:46.13ms
+step:1015/1490 train_time:46858ms step_avg:46.17ms
+step:1016/1490 train_time:46944ms step_avg:46.20ms
+step:1017/1490 train_time:47026ms step_avg:46.24ms
+step:1018/1490 train_time:47113ms step_avg:46.28ms
+step:1019/1490 train_time:47194ms step_avg:46.31ms
+step:1020/1490 train_time:47280ms step_avg:46.35ms
+step:1021/1490 train_time:47359ms step_avg:46.38ms
+step:1022/1490 train_time:47444ms step_avg:46.42ms
+step:1023/1490 train_time:47525ms step_avg:46.46ms
+step:1024/1490 train_time:47611ms step_avg:46.49ms
+step:1025/1490 train_time:47691ms step_avg:46.53ms
+step:1026/1490 train_time:47780ms step_avg:46.57ms
+step:1027/1490 train_time:47862ms step_avg:46.60ms
+step:1028/1490 train_time:47948ms step_avg:46.64ms
+step:1029/1490 train_time:48029ms step_avg:46.68ms
+step:1030/1490 train_time:48117ms step_avg:46.72ms
+step:1031/1490 train_time:48198ms step_avg:46.75ms
+step:1032/1490 train_time:48283ms step_avg:46.79ms
+step:1033/1490 train_time:48363ms step_avg:46.82ms
+step:1034/1490 train_time:48448ms step_avg:46.85ms
+step:1035/1490 train_time:48528ms step_avg:46.89ms
+step:1036/1490 train_time:48616ms step_avg:46.93ms
+step:1037/1490 train_time:48697ms step_avg:46.96ms
+step:1038/1490 train_time:48784ms step_avg:47.00ms
+step:1039/1490 train_time:48866ms step_avg:47.03ms
+step:1040/1490 train_time:48953ms step_avg:47.07ms
+step:1041/1490 train_time:49034ms step_avg:47.10ms
+step:1042/1490 train_time:49121ms step_avg:47.14ms
+step:1043/1490 train_time:49202ms step_avg:47.17ms
+step:1044/1490 train_time:49287ms step_avg:47.21ms
+step:1045/1490 train_time:49368ms step_avg:47.24ms
+step:1046/1490 train_time:49454ms step_avg:47.28ms
+step:1047/1490 train_time:49536ms step_avg:47.31ms
+step:1048/1490 train_time:49621ms step_avg:47.35ms
+step:1049/1490 train_time:49702ms step_avg:47.38ms
+step:1050/1490 train_time:49790ms step_avg:47.42ms
+step:1051/1490 train_time:49872ms step_avg:47.45ms
+step:1052/1490 train_time:49958ms step_avg:47.49ms
+step:1053/1490 train_time:50039ms step_avg:47.52ms
+step:1054/1490 train_time:50126ms step_avg:47.56ms
+step:1055/1490 train_time:50206ms step_avg:47.59ms
+step:1056/1490 train_time:50293ms step_avg:47.63ms
+step:1057/1490 train_time:50373ms step_avg:47.66ms
+step:1058/1490 train_time:50458ms step_avg:47.69ms
+step:1059/1490 train_time:50538ms step_avg:47.72ms
+step:1060/1490 train_time:50624ms step_avg:47.76ms
+step:1061/1490 train_time:50707ms step_avg:47.79ms
+step:1062/1490 train_time:50794ms step_avg:47.83ms
+step:1063/1490 train_time:50876ms step_avg:47.86ms
+step:1064/1490 train_time:50961ms step_avg:47.90ms
+step:1065/1490 train_time:51043ms step_avg:47.93ms
+step:1066/1490 train_time:51129ms step_avg:47.96ms
+step:1067/1490 train_time:51210ms step_avg:47.99ms
+step:1068/1490 train_time:51298ms step_avg:48.03ms
+step:1069/1490 train_time:51378ms step_avg:48.06ms
+step:1070/1490 train_time:51463ms step_avg:48.10ms
+step:1071/1490 train_time:51545ms step_avg:48.13ms
+step:1072/1490 train_time:51632ms step_avg:48.16ms
+step:1073/1490 train_time:51712ms step_avg:48.19ms
+step:1074/1490 train_time:51799ms step_avg:48.23ms
+step:1075/1490 train_time:51880ms step_avg:48.26ms
+step:1076/1490 train_time:51965ms step_avg:48.29ms
+step:1077/1490 train_time:52047ms step_avg:48.33ms
+step:1078/1490 train_time:52133ms step_avg:48.36ms
+step:1079/1490 train_time:52215ms step_avg:48.39ms
+step:1080/1490 train_time:52302ms step_avg:48.43ms
+step:1081/1490 train_time:52383ms step_avg:48.46ms
+step:1082/1490 train_time:52469ms step_avg:48.49ms
+step:1083/1490 train_time:52550ms step_avg:48.52ms
+step:1084/1490 train_time:52638ms step_avg:48.56ms
+step:1085/1490 train_time:52719ms step_avg:48.59ms
+step:1086/1490 train_time:52806ms step_avg:48.62ms
+step:1087/1490 train_time:52887ms step_avg:48.65ms
+step:1088/1490 train_time:52975ms step_avg:48.69ms
+step:1089/1490 train_time:53056ms step_avg:48.72ms
+step:1090/1490 train_time:53142ms step_avg:48.75ms
+step:1091/1490 train_time:53224ms step_avg:48.78ms
+step:1092/1490 train_time:53310ms step_avg:48.82ms
+step:1093/1490 train_time:53391ms step_avg:48.85ms
+step:1094/1490 train_time:53478ms step_avg:48.88ms
+step:1095/1490 train_time:53559ms step_avg:48.91ms
+step:1096/1490 train_time:53644ms step_avg:48.95ms
+step:1097/1490 train_time:53726ms step_avg:48.98ms
+step:1098/1490 train_time:53811ms step_avg:49.01ms
+step:1099/1490 train_time:53892ms step_avg:49.04ms
+step:1100/1490 train_time:53980ms step_avg:49.07ms
+step:1101/1490 train_time:54060ms step_avg:49.10ms
+step:1102/1490 train_time:54146ms step_avg:49.13ms
+step:1103/1490 train_time:54228ms step_avg:49.16ms
+step:1104/1490 train_time:54315ms step_avg:49.20ms
+step:1105/1490 train_time:54396ms step_avg:49.23ms
+step:1106/1490 train_time:54482ms step_avg:49.26ms
+step:1107/1490 train_time:54562ms step_avg:49.29ms
+step:1108/1490 train_time:54649ms step_avg:49.32ms
+step:1109/1490 train_time:54731ms step_avg:49.35ms
+step:1110/1490 train_time:54818ms step_avg:49.39ms
+step:1111/1490 train_time:54899ms step_avg:49.41ms
+step:1112/1490 train_time:54984ms step_avg:49.45ms
+step:1113/1490 train_time:55065ms step_avg:49.47ms
+step:1114/1490 train_time:55151ms step_avg:49.51ms
+step:1115/1490 train_time:55231ms step_avg:49.53ms
+step:1116/1490 train_time:55318ms step_avg:49.57ms
+step:1117/1490 train_time:55398ms step_avg:49.60ms
+step:1118/1490 train_time:55484ms step_avg:49.63ms
+step:1119/1490 train_time:55566ms step_avg:49.66ms
+step:1120/1490 train_time:55652ms step_avg:49.69ms
+step:1121/1490 train_time:55732ms step_avg:49.72ms
+step:1122/1490 train_time:55819ms step_avg:49.75ms
+step:1123/1490 train_time:55900ms step_avg:49.78ms
+step:1124/1490 train_time:55985ms step_avg:49.81ms
+step:1125/1490 train_time:56066ms step_avg:49.84ms
+step:1126/1490 train_time:56153ms step_avg:49.87ms
+step:1127/1490 train_time:56234ms step_avg:49.90ms
+step:1128/1490 train_time:56321ms step_avg:49.93ms
+step:1129/1490 train_time:56403ms step_avg:49.96ms
+step:1130/1490 train_time:56489ms step_avg:49.99ms
+step:1131/1490 train_time:56571ms step_avg:50.02ms
+step:1132/1490 train_time:56657ms step_avg:50.05ms
+step:1133/1490 train_time:56737ms step_avg:50.08ms
+step:1134/1490 train_time:56825ms step_avg:50.11ms
+step:1135/1490 train_time:56906ms step_avg:50.14ms
+step:1136/1490 train_time:56992ms step_avg:50.17ms
+step:1137/1490 train_time:57073ms step_avg:50.20ms
+step:1138/1490 train_time:57159ms step_avg:50.23ms
+step:1139/1490 train_time:57239ms step_avg:50.25ms
+step:1140/1490 train_time:57324ms step_avg:50.28ms
+step:1141/1490 train_time:57406ms step_avg:50.31ms
+step:1142/1490 train_time:57494ms step_avg:50.35ms
+step:1143/1490 train_time:57577ms step_avg:50.37ms
+step:1144/1490 train_time:57662ms step_avg:50.40ms
+step:1145/1490 train_time:57742ms step_avg:50.43ms
+step:1146/1490 train_time:57828ms step_avg:50.46ms
+step:1147/1490 train_time:57908ms step_avg:50.49ms
+step:1148/1490 train_time:57995ms step_avg:50.52ms
+step:1149/1490 train_time:58077ms step_avg:50.55ms
+step:1150/1490 train_time:58163ms step_avg:50.58ms
+step:1151/1490 train_time:58243ms step_avg:50.60ms
+step:1152/1490 train_time:58329ms step_avg:50.63ms
+step:1153/1490 train_time:58411ms step_avg:50.66ms
+step:1154/1490 train_time:58498ms step_avg:50.69ms
+step:1155/1490 train_time:58579ms step_avg:50.72ms
+step:1156/1490 train_time:58664ms step_avg:50.75ms
+step:1157/1490 train_time:58746ms step_avg:50.77ms
+step:1158/1490 train_time:58832ms step_avg:50.80ms
+step:1159/1490 train_time:58915ms step_avg:50.83ms
+step:1160/1490 train_time:59001ms step_avg:50.86ms
+step:1161/1490 train_time:59082ms step_avg:50.89ms
+step:1162/1490 train_time:59168ms step_avg:50.92ms
+step:1163/1490 train_time:59249ms step_avg:50.94ms
+step:1164/1490 train_time:59334ms step_avg:50.97ms
+step:1165/1490 train_time:59416ms step_avg:51.00ms
+step:1166/1490 train_time:59503ms step_avg:51.03ms
+step:1167/1490 train_time:59584ms step_avg:51.06ms
+step:1168/1490 train_time:59671ms step_avg:51.09ms
+step:1169/1490 train_time:59750ms step_avg:51.11ms
+step:1170/1490 train_time:59837ms step_avg:51.14ms
+step:1171/1490 train_time:59919ms step_avg:51.17ms
+step:1172/1490 train_time:60005ms step_avg:51.20ms
+step:1173/1490 train_time:60087ms step_avg:51.22ms
+step:1174/1490 train_time:60174ms step_avg:51.26ms
+step:1175/1490 train_time:60254ms step_avg:51.28ms
+step:1176/1490 train_time:60340ms step_avg:51.31ms
+step:1177/1490 train_time:60420ms step_avg:51.33ms
+step:1178/1490 train_time:60507ms step_avg:51.36ms
+step:1179/1490 train_time:60588ms step_avg:51.39ms
+step:1180/1490 train_time:60676ms step_avg:51.42ms
+step:1181/1490 train_time:60756ms step_avg:51.44ms
+step:1182/1490 train_time:60842ms step_avg:51.47ms
+step:1183/1490 train_time:60925ms step_avg:51.50ms
+step:1184/1490 train_time:61011ms step_avg:51.53ms
+step:1185/1490 train_time:61092ms step_avg:51.55ms
+step:1186/1490 train_time:61178ms step_avg:51.58ms
+step:1187/1490 train_time:61258ms step_avg:51.61ms
+step:1188/1490 train_time:61344ms step_avg:51.64ms
+step:1189/1490 train_time:61425ms step_avg:51.66ms
+step:1190/1490 train_time:61510ms step_avg:51.69ms
+step:1191/1490 train_time:61592ms step_avg:51.71ms
+step:1192/1490 train_time:61679ms step_avg:51.74ms
+step:1193/1490 train_time:61759ms step_avg:51.77ms
+step:1194/1490 train_time:61845ms step_avg:51.80ms
+step:1195/1490 train_time:61928ms step_avg:51.82ms
+step:1196/1490 train_time:62015ms step_avg:51.85ms
+step:1197/1490 train_time:62097ms step_avg:51.88ms
+step:1198/1490 train_time:62184ms step_avg:51.91ms
+step:1199/1490 train_time:62265ms step_avg:51.93ms
+step:1200/1490 train_time:62351ms step_avg:51.96ms
+step:1201/1490 train_time:62429ms step_avg:51.98ms
+step:1202/1490 train_time:62515ms step_avg:52.01ms
+step:1203/1490 train_time:62598ms step_avg:52.03ms
+step:1204/1490 train_time:62684ms step_avg:52.06ms
+step:1205/1490 train_time:62765ms step_avg:52.09ms
+step:1206/1490 train_time:62853ms step_avg:52.12ms
+step:1207/1490 train_time:62933ms step_avg:52.14ms
+step:1208/1490 train_time:63020ms step_avg:52.17ms
+step:1209/1490 train_time:63101ms step_avg:52.19ms
+step:1210/1490 train_time:63187ms step_avg:52.22ms
+step:1211/1490 train_time:63269ms step_avg:52.25ms
+step:1212/1490 train_time:63356ms step_avg:52.27ms
+step:1213/1490 train_time:63436ms step_avg:52.30ms
+step:1214/1490 train_time:63522ms step_avg:52.32ms
+step:1215/1490 train_time:63604ms step_avg:52.35ms
+step:1216/1490 train_time:63690ms step_avg:52.38ms
+step:1217/1490 train_time:63772ms step_avg:52.40ms
+step:1218/1490 train_time:63859ms step_avg:52.43ms
+step:1219/1490 train_time:63938ms step_avg:52.45ms
+step:1220/1490 train_time:64025ms step_avg:52.48ms
+step:1221/1490 train_time:64106ms step_avg:52.50ms
+step:1222/1490 train_time:64193ms step_avg:52.53ms
+step:1223/1490 train_time:64274ms step_avg:52.55ms
+step:1224/1490 train_time:64360ms step_avg:52.58ms
+step:1225/1490 train_time:64440ms step_avg:52.60ms
+step:1226/1490 train_time:64526ms step_avg:52.63ms
+step:1227/1490 train_time:64606ms step_avg:52.65ms
+step:1228/1490 train_time:64693ms step_avg:52.68ms
+step:1229/1490 train_time:64774ms step_avg:52.70ms
+step:1230/1490 train_time:64859ms step_avg:52.73ms
+step:1231/1490 train_time:64940ms step_avg:52.75ms
+step:1232/1490 train_time:65025ms step_avg:52.78ms
+step:1233/1490 train_time:65107ms step_avg:52.80ms
+step:1234/1490 train_time:65193ms step_avg:52.83ms
+step:1235/1490 train_time:65275ms step_avg:52.85ms
+step:1236/1490 train_time:65361ms step_avg:52.88ms
+step:1237/1490 train_time:65442ms step_avg:52.90ms
+step:1238/1490 train_time:65529ms step_avg:52.93ms
+step:1239/1490 train_time:65610ms step_avg:52.95ms
+step:1240/1490 train_time:65698ms step_avg:52.98ms
+step:1241/1490 train_time:65779ms step_avg:53.00ms
+step:1242/1490 train_time:65864ms step_avg:53.03ms
+step:1243/1490 train_time:65945ms step_avg:53.05ms
+step:1244/1490 train_time:66031ms step_avg:53.08ms
+step:1245/1490 train_time:66113ms step_avg:53.10ms
+step:1246/1490 train_time:66199ms step_avg:53.13ms
+step:1247/1490 train_time:66280ms step_avg:53.15ms
+step:1248/1490 train_time:66365ms step_avg:53.18ms
+step:1249/1490 train_time:66446ms step_avg:53.20ms
+step:1250/1490 train_time:66533ms step_avg:53.23ms
+step:1250/1490 val_loss:3.3721 train_time:66637ms step_avg:53.31ms
+step:1251/1490 train_time:66654ms step_avg:53.28ms
+step:1252/1490 train_time:66705ms step_avg:53.28ms
+step:1253/1490 train_time:66790ms step_avg:53.30ms
+step:1254/1490 train_time:66877ms step_avg:53.33ms
+step:1255/1490 train_time:66958ms step_avg:53.35ms
+step:1256/1490 train_time:67043ms step_avg:53.38ms
+step:1257/1490 train_time:67123ms step_avg:53.40ms
+step:1258/1490 train_time:67208ms step_avg:53.42ms
+step:1259/1490 train_time:67287ms step_avg:53.44ms
+step:1260/1490 train_time:67372ms step_avg:53.47ms
+step:1261/1490 train_time:67450ms step_avg:53.49ms
+step:1262/1490 train_time:67536ms step_avg:53.52ms
+step:1263/1490 train_time:67619ms step_avg:53.54ms
+step:1264/1490 train_time:67709ms step_avg:53.57ms
+step:1265/1490 train_time:67792ms step_avg:53.59ms
+step:1266/1490 train_time:67879ms step_avg:53.62ms
+step:1267/1490 train_time:67960ms step_avg:53.64ms
+step:1268/1490 train_time:68045ms step_avg:53.66ms
+step:1269/1490 train_time:68125ms step_avg:53.68ms
+step:1270/1490 train_time:68211ms step_avg:53.71ms
+step:1271/1490 train_time:68291ms step_avg:53.73ms
+step:1272/1490 train_time:68376ms step_avg:53.75ms
+step:1273/1490 train_time:68456ms step_avg:53.78ms
+step:1274/1490 train_time:68542ms step_avg:53.80ms
+step:1275/1490 train_time:68624ms step_avg:53.82ms
+step:1276/1490 train_time:68713ms step_avg:53.85ms
+step:1277/1490 train_time:68796ms step_avg:53.87ms
+step:1278/1490 train_time:68883ms step_avg:53.90ms
+step:1279/1490 train_time:68963ms step_avg:53.92ms
+step:1280/1490 train_time:69050ms step_avg:53.95ms
+step:1281/1490 train_time:69131ms step_avg:53.97ms
+step:1282/1490 train_time:69216ms step_avg:53.99ms
+step:1283/1490 train_time:69297ms step_avg:54.01ms
+step:1284/1490 train_time:69383ms step_avg:54.04ms
+step:1285/1490 train_time:69463ms step_avg:54.06ms
+step:1286/1490 train_time:69550ms step_avg:54.08ms
+step:1287/1490 train_time:69631ms step_avg:54.10ms
+step:1288/1490 train_time:69719ms step_avg:54.13ms
+step:1289/1490 train_time:69800ms step_avg:54.15ms
+step:1290/1490 train_time:69887ms step_avg:54.18ms
+step:1291/1490 train_time:69967ms step_avg:54.20ms
+step:1292/1490 train_time:70053ms step_avg:54.22ms
+step:1293/1490 train_time:70133ms step_avg:54.24ms
+step:1294/1490 train_time:70218ms step_avg:54.26ms
+step:1295/1490 train_time:70300ms step_avg:54.29ms
+step:1296/1490 train_time:70385ms step_avg:54.31ms
+step:1297/1490 train_time:70465ms step_avg:54.33ms
+step:1298/1490 train_time:70553ms step_avg:54.35ms
+step:1299/1490 train_time:70633ms step_avg:54.37ms
+step:1300/1490 train_time:70721ms step_avg:54.40ms
+step:1301/1490 train_time:70803ms step_avg:54.42ms
+step:1302/1490 train_time:70890ms step_avg:54.45ms
+step:1303/1490 train_time:70970ms step_avg:54.47ms
+step:1304/1490 train_time:71056ms step_avg:54.49ms
+step:1305/1490 train_time:71136ms step_avg:54.51ms
+step:1306/1490 train_time:71223ms step_avg:54.54ms
+step:1307/1490 train_time:71304ms step_avg:54.56ms
+step:1308/1490 train_time:71391ms step_avg:54.58ms
+step:1309/1490 train_time:71471ms step_avg:54.60ms
+step:1310/1490 train_time:71556ms step_avg:54.62ms
+step:1311/1490 train_time:71639ms step_avg:54.64ms
+step:1312/1490 train_time:71725ms step_avg:54.67ms
+step:1313/1490 train_time:71808ms step_avg:54.69ms
+step:1314/1490 train_time:71895ms step_avg:54.71ms
+step:1315/1490 train_time:71974ms step_avg:54.73ms
+step:1316/1490 train_time:72062ms step_avg:54.76ms
+step:1317/1490 train_time:72142ms step_avg:54.78ms
+step:1318/1490 train_time:72228ms step_avg:54.80ms
+step:1319/1490 train_time:72308ms step_avg:54.82ms
+step:1320/1490 train_time:72395ms step_avg:54.84ms
+step:1321/1490 train_time:72476ms step_avg:54.86ms
+step:1322/1490 train_time:72563ms step_avg:54.89ms
+step:1323/1490 train_time:72645ms step_avg:54.91ms
+step:1324/1490 train_time:72731ms step_avg:54.93ms
+step:1325/1490 train_time:72813ms step_avg:54.95ms
+step:1326/1490 train_time:72899ms step_avg:54.98ms
+step:1327/1490 train_time:72980ms step_avg:55.00ms
+step:1328/1490 train_time:73067ms step_avg:55.02ms
+step:1329/1490 train_time:73147ms step_avg:55.04ms
+step:1330/1490 train_time:73234ms step_avg:55.06ms
+step:1331/1490 train_time:73315ms step_avg:55.08ms
+step:1332/1490 train_time:73400ms step_avg:55.11ms
+step:1333/1490 train_time:73481ms step_avg:55.12ms
+step:1334/1490 train_time:73567ms step_avg:55.15ms
+step:1335/1490 train_time:73647ms step_avg:55.17ms
+step:1336/1490 train_time:73735ms step_avg:55.19ms
+step:1337/1490 train_time:73816ms step_avg:55.21ms
+step:1338/1490 train_time:73903ms step_avg:55.23ms
+step:1339/1490 train_time:73984ms step_avg:55.25ms
+step:1340/1490 train_time:74071ms step_avg:55.28ms
+step:1341/1490 train_time:74151ms step_avg:55.30ms
+step:1342/1490 train_time:74236ms step_avg:55.32ms
+step:1343/1490 train_time:74316ms step_avg:55.34ms
+step:1344/1490 train_time:74404ms step_avg:55.36ms
+step:1345/1490 train_time:74485ms step_avg:55.38ms
+step:1346/1490 train_time:74572ms step_avg:55.40ms
+step:1347/1490 train_time:74653ms step_avg:55.42ms
+step:1348/1490 train_time:74739ms step_avg:55.44ms
+step:1349/1490 train_time:74820ms step_avg:55.46ms
+step:1350/1490 train_time:74907ms step_avg:55.49ms
+step:1351/1490 train_time:74991ms step_avg:55.51ms
+step:1352/1490 train_time:75077ms step_avg:55.53ms
+step:1353/1490 train_time:75158ms step_avg:55.55ms
+step:1354/1490 train_time:75243ms step_avg:55.57ms
+step:1355/1490 train_time:75324ms step_avg:55.59ms
+step:1356/1490 train_time:75410ms step_avg:55.61ms
+step:1357/1490 train_time:75491ms step_avg:55.63ms
+step:1358/1490 train_time:75578ms step_avg:55.65ms
+step:1359/1490 train_time:75659ms step_avg:55.67ms
+step:1360/1490 train_time:75746ms step_avg:55.70ms
+step:1361/1490 train_time:75826ms step_avg:55.71ms
+step:1362/1490 train_time:75913ms step_avg:55.74ms
+step:1363/1490 train_time:75995ms step_avg:55.76ms
+step:1364/1490 train_time:76081ms step_avg:55.78ms
+step:1365/1490 train_time:76162ms step_avg:55.80ms
+step:1366/1490 train_time:76247ms step_avg:55.82ms
+step:1367/1490 train_time:76329ms step_avg:55.84ms
+step:1368/1490 train_time:76415ms step_avg:55.86ms
+step:1369/1490 train_time:76497ms step_avg:55.88ms
+step:1370/1490 train_time:76583ms step_avg:55.90ms
+step:1371/1490 train_time:76665ms step_avg:55.92ms
+step:1372/1490 train_time:76751ms step_avg:55.94ms
+step:1373/1490 train_time:76831ms step_avg:55.96ms
+step:1374/1490 train_time:76918ms step_avg:55.98ms
+step:1375/1490 train_time:77001ms step_avg:56.00ms
+step:1376/1490 train_time:77088ms step_avg:56.02ms
+step:1377/1490 train_time:77169ms step_avg:56.04ms
+step:1378/1490 train_time:77255ms step_avg:56.06ms
+step:1379/1490 train_time:77336ms step_avg:56.08ms
+step:1380/1490 train_time:77422ms step_avg:56.10ms
+step:1381/1490 train_time:77503ms step_avg:56.12ms
+step:1382/1490 train_time:77590ms step_avg:56.14ms
+step:1383/1490 train_time:77670ms step_avg:56.16ms
+step:1384/1490 train_time:77756ms step_avg:56.18ms
+step:1385/1490 train_time:77837ms step_avg:56.20ms
+step:1386/1490 train_time:77925ms step_avg:56.22ms
+step:1387/1490 train_time:78008ms step_avg:56.24ms
+step:1388/1490 train_time:78094ms step_avg:56.26ms
+step:1389/1490 train_time:78174ms step_avg:56.28ms
+step:1390/1490 train_time:78261ms step_avg:56.30ms
+step:1391/1490 train_time:78341ms step_avg:56.32ms
+step:1392/1490 train_time:78428ms step_avg:56.34ms
+step:1393/1490 train_time:78510ms step_avg:56.36ms
+step:1394/1490 train_time:78596ms step_avg:56.38ms
+step:1395/1490 train_time:78678ms step_avg:56.40ms
+step:1396/1490 train_time:78763ms step_avg:56.42ms
+step:1397/1490 train_time:78843ms step_avg:56.44ms
+step:1398/1490 train_time:78932ms step_avg:56.46ms
+step:1399/1490 train_time:79013ms step_avg:56.48ms
+step:1400/1490 train_time:79099ms step_avg:56.50ms
+step:1401/1490 train_time:79179ms step_avg:56.52ms
+step:1402/1490 train_time:79266ms step_avg:56.54ms
+step:1403/1490 train_time:79347ms step_avg:56.56ms
+step:1404/1490 train_time:79433ms step_avg:56.58ms
+step:1405/1490 train_time:79516ms step_avg:56.60ms
+step:1406/1490 train_time:79603ms step_avg:56.62ms
+step:1407/1490 train_time:79683ms step_avg:56.63ms
+step:1408/1490 train_time:79770ms step_avg:56.66ms
+step:1409/1490 train_time:79851ms step_avg:56.67ms
+step:1410/1490 train_time:79938ms step_avg:56.69ms
+step:1411/1490 train_time:80019ms step_avg:56.71ms
+step:1412/1490 train_time:80107ms step_avg:56.73ms
+step:1413/1490 train_time:80188ms step_avg:56.75ms
+step:1414/1490 train_time:80273ms step_avg:56.77ms
+step:1415/1490 train_time:80355ms step_avg:56.79ms
+step:1416/1490 train_time:80441ms step_avg:56.81ms
+step:1417/1490 train_time:80523ms step_avg:56.83ms
+step:1418/1490 train_time:80610ms step_avg:56.85ms
+step:1419/1490 train_time:80691ms step_avg:56.86ms
+step:1420/1490 train_time:80777ms step_avg:56.89ms
+step:1421/1490 train_time:80858ms step_avg:56.90ms
+step:1422/1490 train_time:80945ms step_avg:56.92ms
+step:1423/1490 train_time:81025ms step_avg:56.94ms
+step:1424/1490 train_time:81113ms step_avg:56.96ms
+step:1425/1490 train_time:81194ms step_avg:56.98ms
+step:1426/1490 train_time:81281ms step_avg:57.00ms
+step:1427/1490 train_time:81362ms step_avg:57.02ms
+step:1428/1490 train_time:81448ms step_avg:57.04ms
+step:1429/1490 train_time:81530ms step_avg:57.05ms
+step:1430/1490 train_time:81616ms step_avg:57.07ms
+step:1431/1490 train_time:81698ms step_avg:57.09ms
+step:1432/1490 train_time:81784ms step_avg:57.11ms
+step:1433/1490 train_time:81864ms step_avg:57.13ms
+step:1434/1490 train_time:81952ms step_avg:57.15ms
+step:1435/1490 train_time:82032ms step_avg:57.17ms
+step:1436/1490 train_time:82118ms step_avg:57.19ms
+step:1437/1490 train_time:82199ms step_avg:57.20ms
+step:1438/1490 train_time:82286ms step_avg:57.22ms
+step:1439/1490 train_time:82366ms step_avg:57.24ms
+step:1440/1490 train_time:82452ms step_avg:57.26ms
+step:1441/1490 train_time:82533ms step_avg:57.27ms
+step:1442/1490 train_time:82619ms step_avg:57.30ms
+step:1443/1490 train_time:82700ms step_avg:57.31ms
+step:1444/1490 train_time:82788ms step_avg:57.33ms
+step:1445/1490 train_time:82869ms step_avg:57.35ms
+step:1446/1490 train_time:82954ms step_avg:57.37ms
+step:1447/1490 train_time:83035ms step_avg:57.38ms
+step:1448/1490 train_time:83122ms step_avg:57.40ms
+step:1449/1490 train_time:83203ms step_avg:57.42ms
+step:1450/1490 train_time:83290ms step_avg:57.44ms
+step:1451/1490 train_time:83373ms step_avg:57.46ms
+step:1452/1490 train_time:83461ms step_avg:57.48ms
+step:1453/1490 train_time:83543ms step_avg:57.50ms
+step:1454/1490 train_time:83630ms step_avg:57.52ms
+step:1455/1490 train_time:83712ms step_avg:57.53ms
+step:1456/1490 train_time:83799ms step_avg:57.55ms
+step:1457/1490 train_time:83879ms step_avg:57.57ms
+step:1458/1490 train_time:83966ms step_avg:57.59ms
+step:1459/1490 train_time:84047ms step_avg:57.61ms
+step:1460/1490 train_time:84135ms step_avg:57.63ms
+step:1461/1490 train_time:84216ms step_avg:57.64ms
+step:1462/1490 train_time:84303ms step_avg:57.66ms
+step:1463/1490 train_time:84384ms step_avg:57.68ms
+step:1464/1490 train_time:84471ms step_avg:57.70ms
+step:1465/1490 train_time:84551ms step_avg:57.71ms
+step:1466/1490 train_time:84639ms step_avg:57.73ms
+step:1467/1490 train_time:84721ms step_avg:57.75ms
+step:1468/1490 train_time:84809ms step_avg:57.77ms
+step:1469/1490 train_time:84890ms step_avg:57.79ms
+step:1470/1490 train_time:84976ms step_avg:57.81ms
+step:1471/1490 train_time:85057ms step_avg:57.82ms
+step:1472/1490 train_time:85143ms step_avg:57.84ms
+step:1473/1490 train_time:85225ms step_avg:57.86ms
+step:1474/1490 train_time:85311ms step_avg:57.88ms
+step:1475/1490 train_time:85392ms step_avg:57.89ms
+step:1476/1490 train_time:85478ms step_avg:57.91ms
+step:1477/1490 train_time:85559ms step_avg:57.93ms
+step:1478/1490 train_time:85645ms step_avg:57.95ms
+step:1479/1490 train_time:85726ms step_avg:57.96ms
+step:1480/1490 train_time:85813ms step_avg:57.98ms
+step:1481/1490 train_time:85894ms step_avg:58.00ms
+step:1482/1490 train_time:85981ms step_avg:58.02ms
+step:1483/1490 train_time:86062ms step_avg:58.03ms
+step:1484/1490 train_time:86149ms step_avg:58.05ms
+step:1485/1490 train_time:86230ms step_avg:58.07ms
+step:1486/1490 train_time:86316ms step_avg:58.09ms
+step:1487/1490 train_time:86397ms step_avg:58.10ms
+step:1488/1490 train_time:86484ms step_avg:58.12ms
+step:1489/1490 train_time:86565ms step_avg:58.14ms
+step:1490/1490 train_time:86651ms step_avg:58.15ms
+step:1490/1490 val_loss:3.2792 train_time:86755ms step_avg:58.22ms
+peak memory allocated: 31296 MiB reserved: 47042 MiB

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -1371,6 +1371,7 @@ def _load_data_shard(file: Path):
     return tokens
 
 BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
 
 class Shard:
     def __init__(self, tokens: Tensor, world_size: int = 1):
@@ -1477,7 +1478,7 @@ def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_l
 
     while True:
         num_tokens_local = num_tokens // world_size
-        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
 
         if align_to_bos:
             try:
@@ -1711,7 +1712,7 @@ class TrainingManager():
         normuon_defaults = dict(
             lr=0.023,
             momentum=0.95,
-            beta2=0.95,
+            beta2=0.9,
             weight_decay=1.2,
         )
 


### PR DESCRIPTION
# Reduce Varlen max_num_docs

While working on refactoring `nanochat` for FlashAttention varlen ([here](https://github.com/karpathy/nanochat/pull/663)), I discovered that the size of the `cu_seqlens` tensor (which contains the document offsets in our 1D training batch) matters more than expected. 

Analyzing the fineweb dataset and better tailoring the size of `cu_seqlens` gave a ~500ms speed improvement.

Additionally, I tried some recent `nanochat` changes and found that the reduction of Muon's second beta from `0.95 --> 0.9` slightly improved loss, so I included that as well (no reduction in steps).

```
                    Runs  Steps   Time μ   Time σ  Time +/-   Time p   Loss μ   Loss σ  Loss +/-        p
baseline               8   1490  86.7400   0.0497    0.0000       NaN  3.2787   0.0015    0.0000   0.0218 
max_num_docs           4   1490  86.2422   0.0479   -0.4977   0.0000   3.2785   0.0012   -0.0002   0.0444 
muon-beta2             4   1490  86.7758   0.0274    0.0358   0.9296   3.2785   0.0007   -0.0002   0.0122 
combined (this PR)     8   1490  86.2246   0.0300   -0.5154   0.0000   3.2784   0.0013   -0.0003   0.0054 

baseline:
  losses = [3.2781, 3.2800, 3.2786, 3.2773, 3.2811, 3.2773, 3.2800, 3.2772]
  times  = [86.8210, 86.7020, 86.6940, 86.7430, 86.7960, 86.6970, 86.7010, 86.7660]

This PR:
  losses = [3.2788, 3.2785, 3.2792, 3.2762, 3.2792, 3.2795, 3.2794, 3.2766]
  times  = [86.2030, 86.2360, 86.2820, 86.2020, 86.1960, 86.2340, 86.2000, 86.2440]
```

### Choosing max_num_docs

We need `cu_seqlens` to be a fixed size for `torch.compile`. However, because we have a separate compute graph per batch size, we can safely choose a different `cu_seqlens` size for each batch size.

To determine appropriate sizes, I analyzed the first 10 shards (1.45M documents).

For token counts overall:
* median 403
* mean 690 
* min 32

I constructed the actual batches used and counted the number of documents in each, across our three batch sizes / stages:

| Stage | tokens/rank | current `max_num_docs` | observed max | proposed | savings |
|-------|-------------|----------------------|--------------|----------|---------|
| Stage 1 | 16,384 | 128 | 56 | **64** | -64 slots (50%) |
| Stage 2 | 32,768 | 128 | 90 | **96** | -32 slots (25%) |
| Stage 3 | 49,152 | 256 | 121 | **128** | -128 slots (50%) |

I've hardcoded those batch size --> num docs mappings, but with a fallback to the original method of rounding up conservatively if a different batch size is encountered.
