### PR TITLE
New record: Fuse CE fwd and bwd (-0.9s)

### DIFF
--- a/records/track_1_short/2026-04-4_FuseCEFwdAndBwd/baseline/01cf6f1d-31ac-4896-ad2f-d0f09a1fd8a5.txt
+++ b/records/track_1_short/2026-04-4_FuseCEFwdAndBwd/baseline/01cf6f1d-31ac-4896-ad2f-d0f09a1fd8a5.txt
@@ -1,0 +1,4457 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.12.3 (main, Mar  3 2026, 12:15:18) [GCC 13.3.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sat Apr  4 05:20:19 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:8D:00.0 Off |                    0 |
+| N/A   31C    P0            116W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:91:00.0 Off |                    0 |
+| N/A   30C    P0            115W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:95:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:99:00.0 Off |                    0 |
+| N/A   32C    P0            121W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   31C    P0            114W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AF:00.0 Off |                    0 |
+| N/A   31C    P0            116W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:B3:00.0 Off |                    0 |
+| N/A   32C    P0            118W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:B7:00.0 Off |                    0 |
+| N/A   29C    P0            116W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A            5204      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    1   N/A  N/A            5205      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    2   N/A  N/A            5206      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    3   N/A  N/A            5207      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    4   N/A  N/A            5208      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    5   N/A  N/A            5209      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    6   N/A  N/A            5210      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    7   N/A  N/A            5211      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8283 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:91ms step_avg:90.93ms
+step:2/1490 train_time:128ms step_avg:64.14ms
+step:3/1490 train_time:147ms step_avg:49.00ms
+step:4/1490 train_time:175ms step_avg:43.76ms
+step:5/1490 train_time:193ms step_avg:38.64ms
+step:6/1490 train_time:228ms step_avg:38.01ms
+step:7/1490 train_time:256ms step_avg:36.50ms
+step:8/1490 train_time:290ms step_avg:36.31ms
+step:9/1490 train_time:317ms step_avg:35.28ms
+step:10/1490 train_time:352ms step_avg:35.22ms
+step:11/1490 train_time:379ms step_avg:34.48ms
+step:12/1490 train_time:414ms step_avg:34.48ms
+step:13/1490 train_time:441ms step_avg:33.94ms
+step:14/1490 train_time:476ms step_avg:33.99ms
+step:15/1490 train_time:504ms step_avg:33.57ms
+step:16/1490 train_time:538ms step_avg:33.65ms
+step:17/1490 train_time:566ms step_avg:33.26ms
+step:18/1490 train_time:600ms step_avg:33.32ms
+step:19/1490 train_time:628ms step_avg:33.03ms
+step:20/1490 train_time:662ms step_avg:33.09ms
+step:21/1490 train_time:689ms step_avg:32.83ms
+step:22/1490 train_time:723ms step_avg:32.89ms
+step:23/1490 train_time:751ms step_avg:32.66ms
+step:24/1490 train_time:785ms step_avg:32.73ms
+step:25/1490 train_time:813ms step_avg:32.53ms
+step:26/1490 train_time:848ms step_avg:32.61ms
+step:27/1490 train_time:876ms step_avg:32.43ms
+step:28/1490 train_time:910ms step_avg:32.50ms
+step:29/1490 train_time:938ms step_avg:32.33ms
+step:30/1490 train_time:972ms step_avg:32.40ms
+step:31/1490 train_time:1000ms step_avg:32.24ms
+step:32/1490 train_time:1035ms step_avg:32.34ms
+step:33/1490 train_time:1064ms step_avg:32.24ms
+step:34/1490 train_time:1099ms step_avg:32.33ms
+step:35/1490 train_time:1128ms step_avg:32.22ms
+step:36/1490 train_time:1163ms step_avg:32.30ms
+step:37/1490 train_time:1191ms step_avg:32.19ms
+step:38/1490 train_time:1226ms step_avg:32.26ms
+step:39/1490 train_time:1254ms step_avg:32.16ms
+step:40/1490 train_time:1288ms step_avg:32.21ms
+step:41/1490 train_time:1316ms step_avg:32.11ms
+step:42/1490 train_time:1351ms step_avg:32.17ms
+step:43/1490 train_time:1379ms step_avg:32.07ms
+step:44/1490 train_time:1414ms step_avg:32.13ms
+step:45/1490 train_time:1441ms step_avg:32.03ms
+step:46/1490 train_time:1476ms step_avg:32.08ms
+step:47/1490 train_time:1503ms step_avg:31.98ms
+step:48/1490 train_time:1538ms step_avg:32.04ms
+step:49/1490 train_time:1566ms step_avg:31.95ms
+step:50/1490 train_time:1600ms step_avg:32.00ms
+step:51/1490 train_time:1628ms step_avg:31.92ms
+step:52/1490 train_time:1662ms step_avg:31.97ms
+step:53/1490 train_time:1690ms step_avg:31.88ms
+step:54/1490 train_time:1724ms step_avg:31.93ms
+step:55/1490 train_time:1751ms step_avg:31.84ms
+step:56/1490 train_time:1786ms step_avg:31.89ms
+step:57/1490 train_time:1814ms step_avg:31.82ms
+step:58/1490 train_time:1848ms step_avg:31.87ms
+step:59/1490 train_time:1876ms step_avg:31.79ms
+step:60/1490 train_time:1910ms step_avg:31.84ms
+step:61/1490 train_time:1938ms step_avg:31.76ms
+step:62/1490 train_time:1973ms step_avg:31.82ms
+step:63/1490 train_time:2000ms step_avg:31.75ms
+step:64/1490 train_time:2035ms step_avg:31.80ms
+step:65/1490 train_time:2063ms step_avg:31.74ms
+step:66/1490 train_time:2098ms step_avg:31.79ms
+step:67/1490 train_time:2127ms step_avg:31.75ms
+step:68/1490 train_time:2162ms step_avg:31.79ms
+step:69/1490 train_time:2190ms step_avg:31.74ms
+step:70/1490 train_time:2224ms step_avg:31.78ms
+step:71/1490 train_time:2253ms step_avg:31.73ms
+step:72/1490 train_time:2287ms step_avg:31.77ms
+step:73/1490 train_time:2316ms step_avg:31.73ms
+step:74/1490 train_time:2351ms step_avg:31.77ms
+step:75/1490 train_time:2378ms step_avg:31.71ms
+step:76/1490 train_time:2413ms step_avg:31.76ms
+step:77/1490 train_time:2441ms step_avg:31.70ms
+step:78/1490 train_time:2476ms step_avg:31.75ms
+step:79/1490 train_time:2504ms step_avg:31.69ms
+step:80/1490 train_time:2538ms step_avg:31.73ms
+step:81/1490 train_time:2566ms step_avg:31.68ms
+step:82/1490 train_time:2600ms step_avg:31.71ms
+step:83/1490 train_time:2628ms step_avg:31.66ms
+step:84/1490 train_time:2662ms step_avg:31.70ms
+step:85/1490 train_time:2690ms step_avg:31.65ms
+step:86/1490 train_time:2724ms step_avg:31.68ms
+step:87/1490 train_time:2752ms step_avg:31.63ms
+step:88/1490 train_time:2786ms step_avg:31.66ms
+step:89/1490 train_time:2814ms step_avg:31.62ms
+step:90/1490 train_time:2848ms step_avg:31.65ms
+step:91/1490 train_time:2876ms step_avg:31.61ms
+step:92/1490 train_time:2911ms step_avg:31.64ms
+step:93/1490 train_time:2938ms step_avg:31.59ms
+step:94/1490 train_time:2973ms step_avg:31.63ms
+step:95/1490 train_time:3001ms step_avg:31.59ms
+step:96/1490 train_time:3037ms step_avg:31.63ms
+step:97/1490 train_time:3064ms step_avg:31.59ms
+step:98/1490 train_time:3099ms step_avg:31.62ms
+step:99/1490 train_time:3128ms step_avg:31.59ms
+step:100/1490 train_time:3162ms step_avg:31.62ms
+step:101/1490 train_time:3190ms step_avg:31.58ms
+step:102/1490 train_time:3224ms step_avg:31.61ms
+step:103/1490 train_time:3252ms step_avg:31.58ms
+step:104/1490 train_time:3287ms step_avg:31.60ms
+step:105/1490 train_time:3316ms step_avg:31.58ms
+step:106/1490 train_time:3351ms step_avg:31.61ms
+step:107/1490 train_time:3379ms step_avg:31.58ms
+step:108/1490 train_time:3413ms step_avg:31.61ms
+step:109/1490 train_time:3441ms step_avg:31.57ms
+step:110/1490 train_time:3476ms step_avg:31.60ms
+step:111/1490 train_time:3504ms step_avg:31.56ms
+step:112/1490 train_time:3538ms step_avg:31.59ms
+step:113/1490 train_time:3566ms step_avg:31.56ms
+step:114/1490 train_time:3600ms step_avg:31.58ms
+step:115/1490 train_time:3628ms step_avg:31.55ms
+step:116/1490 train_time:3662ms step_avg:31.57ms
+step:117/1490 train_time:3690ms step_avg:31.54ms
+step:118/1490 train_time:3724ms step_avg:31.56ms
+step:119/1490 train_time:3752ms step_avg:31.53ms
+step:120/1490 train_time:3786ms step_avg:31.55ms
+step:121/1490 train_time:3814ms step_avg:31.52ms
+step:122/1490 train_time:3849ms step_avg:31.55ms
+step:123/1490 train_time:3876ms step_avg:31.52ms
+step:124/1490 train_time:3911ms step_avg:31.54ms
+step:125/1490 train_time:3939ms step_avg:31.51ms
+step:126/1490 train_time:3974ms step_avg:31.54ms
+step:127/1490 train_time:4001ms step_avg:31.51ms
+step:128/1490 train_time:4036ms step_avg:31.53ms
+step:129/1490 train_time:4064ms step_avg:31.50ms
+step:130/1490 train_time:4098ms step_avg:31.53ms
+step:131/1490 train_time:4127ms step_avg:31.50ms
+step:132/1490 train_time:4162ms step_avg:31.53ms
+step:133/1490 train_time:4190ms step_avg:31.50ms
+step:134/1490 train_time:4224ms step_avg:31.53ms
+step:135/1490 train_time:4252ms step_avg:31.50ms
+step:136/1490 train_time:4287ms step_avg:31.52ms
+step:137/1490 train_time:4315ms step_avg:31.50ms
+step:138/1490 train_time:4350ms step_avg:31.52ms
+step:139/1490 train_time:4378ms step_avg:31.50ms
+step:140/1490 train_time:4413ms step_avg:31.52ms
+step:141/1490 train_time:4441ms step_avg:31.50ms
+step:142/1490 train_time:4476ms step_avg:31.52ms
+step:143/1490 train_time:4503ms step_avg:31.49ms
+step:144/1490 train_time:4538ms step_avg:31.51ms
+step:145/1490 train_time:4565ms step_avg:31.48ms
+step:146/1490 train_time:4600ms step_avg:31.51ms
+step:147/1490 train_time:4627ms step_avg:31.48ms
+step:148/1490 train_time:4662ms step_avg:31.50ms
+step:149/1490 train_time:4690ms step_avg:31.48ms
+step:150/1490 train_time:4725ms step_avg:31.50ms
+step:151/1490 train_time:4753ms step_avg:31.47ms
+step:152/1490 train_time:4787ms step_avg:31.49ms
+step:153/1490 train_time:4815ms step_avg:31.47ms
+step:154/1490 train_time:4849ms step_avg:31.49ms
+step:155/1490 train_time:4877ms step_avg:31.46ms
+step:156/1490 train_time:4911ms step_avg:31.48ms
+step:157/1490 train_time:4939ms step_avg:31.46ms
+step:158/1490 train_time:4974ms step_avg:31.48ms
+step:159/1490 train_time:5001ms step_avg:31.45ms
+step:160/1490 train_time:5035ms step_avg:31.47ms
+step:161/1490 train_time:5063ms step_avg:31.45ms
+step:162/1490 train_time:5098ms step_avg:31.47ms
+step:163/1490 train_time:5126ms step_avg:31.45ms
+step:164/1490 train_time:5160ms step_avg:31.46ms
+step:165/1490 train_time:5188ms step_avg:31.44ms
+step:166/1490 train_time:5223ms step_avg:31.46ms
+step:167/1490 train_time:5251ms step_avg:31.44ms
+step:168/1490 train_time:5285ms step_avg:31.46ms
+step:169/1490 train_time:5313ms step_avg:31.44ms
+step:170/1490 train_time:5348ms step_avg:31.46ms
+step:171/1490 train_time:5376ms step_avg:31.44ms
+step:172/1490 train_time:5410ms step_avg:31.46ms
+step:173/1490 train_time:5438ms step_avg:31.43ms
+step:174/1490 train_time:5473ms step_avg:31.46ms
+step:175/1490 train_time:5501ms step_avg:31.43ms
+step:176/1490 train_time:5536ms step_avg:31.45ms
+step:177/1490 train_time:5563ms step_avg:31.43ms
+step:178/1490 train_time:5598ms step_avg:31.45ms
+step:179/1490 train_time:5626ms step_avg:31.43ms
+step:180/1490 train_time:5660ms step_avg:31.45ms
+step:181/1490 train_time:5688ms step_avg:31.43ms
+step:182/1490 train_time:5723ms step_avg:31.44ms
+step:183/1490 train_time:5751ms step_avg:31.42ms
+step:184/1490 train_time:5785ms step_avg:31.44ms
+step:185/1490 train_time:5813ms step_avg:31.42ms
+step:186/1490 train_time:5847ms step_avg:31.44ms
+step:187/1490 train_time:5875ms step_avg:31.42ms
+step:188/1490 train_time:5909ms step_avg:31.43ms
+step:189/1490 train_time:5937ms step_avg:31.41ms
+step:190/1490 train_time:5971ms step_avg:31.43ms
+step:191/1490 train_time:5999ms step_avg:31.41ms
+step:192/1490 train_time:6034ms step_avg:31.43ms
+step:193/1490 train_time:6061ms step_avg:31.41ms
+step:194/1490 train_time:6096ms step_avg:31.42ms
+step:195/1490 train_time:6124ms step_avg:31.40ms
+step:196/1490 train_time:6159ms step_avg:31.42ms
+step:197/1490 train_time:6186ms step_avg:31.40ms
+step:198/1490 train_time:6221ms step_avg:31.42ms
+step:199/1490 train_time:6249ms step_avg:31.40ms
+step:200/1490 train_time:6284ms step_avg:31.42ms
+step:201/1490 train_time:6311ms step_avg:31.40ms
+step:202/1490 train_time:6345ms step_avg:31.41ms
+step:203/1490 train_time:6374ms step_avg:31.40ms
+step:204/1490 train_time:6408ms step_avg:31.41ms
+step:205/1490 train_time:6436ms step_avg:31.40ms
+step:206/1490 train_time:6471ms step_avg:31.41ms
+step:207/1490 train_time:6499ms step_avg:31.39ms
+step:208/1490 train_time:6533ms step_avg:31.41ms
+step:209/1490 train_time:6561ms step_avg:31.39ms
+step:210/1490 train_time:6596ms step_avg:31.41ms
+step:211/1490 train_time:6624ms step_avg:31.39ms
+step:212/1490 train_time:6659ms step_avg:31.41ms
+step:213/1490 train_time:6686ms step_avg:31.39ms
+step:214/1490 train_time:6720ms step_avg:31.40ms
+step:215/1490 train_time:6749ms step_avg:31.39ms
+step:216/1490 train_time:6784ms step_avg:31.41ms
+step:217/1490 train_time:6811ms step_avg:31.39ms
+step:218/1490 train_time:6846ms step_avg:31.40ms
+step:219/1490 train_time:6874ms step_avg:31.39ms
+step:220/1490 train_time:6908ms step_avg:31.40ms
+step:221/1490 train_time:6936ms step_avg:31.38ms
+step:222/1490 train_time:6970ms step_avg:31.40ms
+step:223/1490 train_time:6998ms step_avg:31.38ms
+step:224/1490 train_time:7032ms step_avg:31.39ms
+step:225/1490 train_time:7060ms step_avg:31.38ms
+step:226/1490 train_time:7095ms step_avg:31.39ms
+step:227/1490 train_time:7122ms step_avg:31.37ms
+step:228/1490 train_time:7156ms step_avg:31.39ms
+step:229/1490 train_time:7184ms step_avg:31.37ms
+step:230/1490 train_time:7218ms step_avg:31.38ms
+step:231/1490 train_time:7246ms step_avg:31.37ms
+step:232/1490 train_time:7281ms step_avg:31.38ms
+step:233/1490 train_time:7309ms step_avg:31.37ms
+step:234/1490 train_time:7343ms step_avg:31.38ms
+step:235/1490 train_time:7370ms step_avg:31.36ms
+step:236/1490 train_time:7404ms step_avg:31.37ms
+step:237/1490 train_time:7433ms step_avg:31.36ms
+step:238/1490 train_time:7467ms step_avg:31.37ms
+step:239/1490 train_time:7495ms step_avg:31.36ms
+step:240/1490 train_time:7529ms step_avg:31.37ms
+step:241/1490 train_time:7557ms step_avg:31.36ms
+step:242/1490 train_time:7592ms step_avg:31.37ms
+step:243/1490 train_time:7620ms step_avg:31.36ms
+step:244/1490 train_time:7654ms step_avg:31.37ms
+step:245/1490 train_time:7682ms step_avg:31.36ms
+step:246/1490 train_time:7717ms step_avg:31.37ms
+step:247/1490 train_time:7745ms step_avg:31.36ms
+step:248/1490 train_time:7779ms step_avg:31.37ms
+step:249/1490 train_time:7807ms step_avg:31.35ms
+step:250/1490 train_time:7842ms step_avg:31.37ms
+step:250/1490 val_loss:4.4990 train_time:7884ms step_avg:31.54ms
+step:251/1490 train_time:7902ms step_avg:31.48ms
+step:252/1490 train_time:7921ms step_avg:31.43ms
+step:253/1490 train_time:7937ms step_avg:31.37ms
+step:254/1490 train_time:7970ms step_avg:31.38ms
+step:255/1490 train_time:8000ms step_avg:31.37ms
+step:256/1490 train_time:8036ms step_avg:31.39ms
+step:257/1490 train_time:8065ms step_avg:31.38ms
+step:258/1490 train_time:8100ms step_avg:31.40ms
+step:259/1490 train_time:8127ms step_avg:31.38ms
+step:260/1490 train_time:8162ms step_avg:31.39ms
+step:261/1490 train_time:8190ms step_avg:31.38ms
+step:262/1490 train_time:8224ms step_avg:31.39ms
+step:263/1490 train_time:8252ms step_avg:31.38ms
+step:264/1490 train_time:8286ms step_avg:31.38ms
+step:265/1490 train_time:8313ms step_avg:31.37ms
+step:266/1490 train_time:8347ms step_avg:31.38ms
+step:267/1490 train_time:8375ms step_avg:31.37ms
+step:268/1490 train_time:8409ms step_avg:31.38ms
+step:269/1490 train_time:8437ms step_avg:31.36ms
+step:270/1490 train_time:8471ms step_avg:31.38ms
+step:271/1490 train_time:8499ms step_avg:31.36ms
+step:272/1490 train_time:8533ms step_avg:31.37ms
+step:273/1490 train_time:8561ms step_avg:31.36ms
+step:274/1490 train_time:8595ms step_avg:31.37ms
+step:275/1490 train_time:8622ms step_avg:31.35ms
+step:276/1490 train_time:8656ms step_avg:31.36ms
+step:277/1490 train_time:8684ms step_avg:31.35ms
+step:278/1490 train_time:8718ms step_avg:31.36ms
+step:279/1490 train_time:8745ms step_avg:31.34ms
+step:280/1490 train_time:8779ms step_avg:31.36ms
+step:281/1490 train_time:8807ms step_avg:31.34ms
+step:282/1490 train_time:8842ms step_avg:31.35ms
+step:283/1490 train_time:8871ms step_avg:31.35ms
+step:284/1490 train_time:8906ms step_avg:31.36ms
+step:285/1490 train_time:8934ms step_avg:31.35ms
+step:286/1490 train_time:8969ms step_avg:31.36ms
+step:287/1490 train_time:8997ms step_avg:31.35ms
+step:288/1490 train_time:9032ms step_avg:31.36ms
+step:289/1490 train_time:9061ms step_avg:31.35ms
+step:290/1490 train_time:9096ms step_avg:31.36ms
+step:291/1490 train_time:9124ms step_avg:31.35ms
+step:292/1490 train_time:9159ms step_avg:31.37ms
+step:293/1490 train_time:9187ms step_avg:31.35ms
+step:294/1490 train_time:9221ms step_avg:31.37ms
+step:295/1490 train_time:9249ms step_avg:31.35ms
+step:296/1490 train_time:9284ms step_avg:31.36ms
+step:297/1490 train_time:9312ms step_avg:31.35ms
+step:298/1490 train_time:9346ms step_avg:31.36ms
+step:299/1490 train_time:9374ms step_avg:31.35ms
+step:300/1490 train_time:9408ms step_avg:31.36ms
+step:301/1490 train_time:9436ms step_avg:31.35ms
+step:302/1490 train_time:9470ms step_avg:31.36ms
+step:303/1490 train_time:9498ms step_avg:31.34ms
+step:304/1490 train_time:9531ms step_avg:31.35ms
+step:305/1490 train_time:9559ms step_avg:31.34ms
+step:306/1490 train_time:9594ms step_avg:31.35ms
+step:307/1490 train_time:9621ms step_avg:31.34ms
+step:308/1490 train_time:9655ms step_avg:31.35ms
+step:309/1490 train_time:9683ms step_avg:31.34ms
+step:310/1490 train_time:9717ms step_avg:31.35ms
+step:311/1490 train_time:9745ms step_avg:31.33ms
+step:312/1490 train_time:9779ms step_avg:31.34ms
+step:313/1490 train_time:9807ms step_avg:31.33ms
+step:314/1490 train_time:9842ms step_avg:31.34ms
+step:315/1490 train_time:9870ms step_avg:31.33ms
+step:316/1490 train_time:9904ms step_avg:31.34ms
+step:317/1490 train_time:9932ms step_avg:31.33ms
+step:318/1490 train_time:9967ms step_avg:31.34ms
+step:319/1490 train_time:9995ms step_avg:31.33ms
+step:320/1490 train_time:10029ms step_avg:31.34ms
+step:321/1490 train_time:10059ms step_avg:31.34ms
+step:322/1490 train_time:10093ms step_avg:31.35ms
+step:323/1490 train_time:10121ms step_avg:31.34ms
+step:324/1490 train_time:10156ms step_avg:31.35ms
+step:325/1490 train_time:10184ms step_avg:31.34ms
+step:326/1490 train_time:10219ms step_avg:31.35ms
+step:327/1490 train_time:10246ms step_avg:31.33ms
+step:328/1490 train_time:10281ms step_avg:31.35ms
+step:329/1490 train_time:10309ms step_avg:31.33ms
+step:330/1490 train_time:10344ms step_avg:31.34ms
+step:331/1490 train_time:10372ms step_avg:31.33ms
+step:332/1490 train_time:10406ms step_avg:31.34ms
+step:333/1490 train_time:10433ms step_avg:31.33ms
+step:334/1490 train_time:10468ms step_avg:31.34ms
+step:335/1490 train_time:10495ms step_avg:31.33ms
+step:336/1490 train_time:10530ms step_avg:31.34ms
+step:337/1490 train_time:10557ms step_avg:31.33ms
+step:338/1490 train_time:10591ms step_avg:31.33ms
+step:339/1490 train_time:10619ms step_avg:31.32ms
+step:340/1490 train_time:10653ms step_avg:31.33ms
+step:341/1490 train_time:10681ms step_avg:31.32ms
+step:342/1490 train_time:10715ms step_avg:31.33ms
+step:343/1490 train_time:10743ms step_avg:31.32ms
+step:344/1490 train_time:10778ms step_avg:31.33ms
+step:345/1490 train_time:10805ms step_avg:31.32ms
+step:346/1490 train_time:10840ms step_avg:31.33ms
+step:347/1490 train_time:10868ms step_avg:31.32ms
+step:348/1490 train_time:10903ms step_avg:31.33ms
+step:349/1490 train_time:10930ms step_avg:31.32ms
+step:350/1490 train_time:10965ms step_avg:31.33ms
+step:351/1490 train_time:10993ms step_avg:31.32ms
+step:352/1490 train_time:11027ms step_avg:31.33ms
+step:353/1490 train_time:11055ms step_avg:31.32ms
+step:354/1490 train_time:11089ms step_avg:31.33ms
+step:355/1490 train_time:11117ms step_avg:31.32ms
+step:356/1490 train_time:11152ms step_avg:31.33ms
+step:357/1490 train_time:11180ms step_avg:31.32ms
+step:358/1490 train_time:11215ms step_avg:31.33ms
+step:359/1490 train_time:11243ms step_avg:31.32ms
+step:360/1490 train_time:11278ms step_avg:31.33ms
+step:361/1490 train_time:11306ms step_avg:31.32ms
+step:362/1490 train_time:11341ms step_avg:31.33ms
+step:363/1490 train_time:11369ms step_avg:31.32ms
+step:364/1490 train_time:11403ms step_avg:31.33ms
+step:365/1490 train_time:11431ms step_avg:31.32ms
+step:366/1490 train_time:11465ms step_avg:31.33ms
+step:367/1490 train_time:11494ms step_avg:31.32ms
+step:368/1490 train_time:11528ms step_avg:31.33ms
+step:369/1490 train_time:11555ms step_avg:31.32ms
+step:370/1490 train_time:11590ms step_avg:31.32ms
+step:371/1490 train_time:11617ms step_avg:31.31ms
+step:372/1490 train_time:11651ms step_avg:31.32ms
+step:373/1490 train_time:11679ms step_avg:31.31ms
+step:374/1490 train_time:11713ms step_avg:31.32ms
+step:375/1490 train_time:11741ms step_avg:31.31ms
+step:376/1490 train_time:11776ms step_avg:31.32ms
+step:377/1490 train_time:11804ms step_avg:31.31ms
+step:378/1490 train_time:11838ms step_avg:31.32ms
+step:379/1490 train_time:11867ms step_avg:31.31ms
+step:380/1490 train_time:11902ms step_avg:31.32ms
+step:381/1490 train_time:11929ms step_avg:31.31ms
+step:382/1490 train_time:11964ms step_avg:31.32ms
+step:383/1490 train_time:11991ms step_avg:31.31ms
+step:384/1490 train_time:12026ms step_avg:31.32ms
+step:385/1490 train_time:12054ms step_avg:31.31ms
+step:386/1490 train_time:12088ms step_avg:31.32ms
+step:387/1490 train_time:12116ms step_avg:31.31ms
+step:388/1490 train_time:12150ms step_avg:31.31ms
+step:389/1490 train_time:12178ms step_avg:31.31ms
+step:390/1490 train_time:12212ms step_avg:31.31ms
+step:391/1490 train_time:12240ms step_avg:31.31ms
+step:392/1490 train_time:12275ms step_avg:31.31ms
+step:393/1490 train_time:12303ms step_avg:31.30ms
+step:394/1490 train_time:12338ms step_avg:31.32ms
+step:395/1490 train_time:12366ms step_avg:31.31ms
+step:396/1490 train_time:12401ms step_avg:31.32ms
+step:397/1490 train_time:12429ms step_avg:31.31ms
+step:398/1490 train_time:12463ms step_avg:31.31ms
+step:399/1490 train_time:12491ms step_avg:31.31ms
+step:400/1490 train_time:12525ms step_avg:31.31ms
+step:401/1490 train_time:12553ms step_avg:31.30ms
+step:402/1490 train_time:12587ms step_avg:31.31ms
+step:403/1490 train_time:12615ms step_avg:31.30ms
+step:404/1490 train_time:12649ms step_avg:31.31ms
+step:405/1490 train_time:12677ms step_avg:31.30ms
+step:406/1490 train_time:12712ms step_avg:31.31ms
+step:407/1490 train_time:12740ms step_avg:31.30ms
+step:408/1490 train_time:12775ms step_avg:31.31ms
+step:409/1490 train_time:12802ms step_avg:31.30ms
+step:410/1490 train_time:12837ms step_avg:31.31ms
+step:411/1490 train_time:12865ms step_avg:31.30ms
+step:412/1490 train_time:12900ms step_avg:31.31ms
+step:413/1490 train_time:12927ms step_avg:31.30ms
+step:414/1490 train_time:12962ms step_avg:31.31ms
+step:415/1490 train_time:12989ms step_avg:31.30ms
+step:416/1490 train_time:13024ms step_avg:31.31ms
+step:417/1490 train_time:13052ms step_avg:31.30ms
+step:418/1490 train_time:13087ms step_avg:31.31ms
+step:419/1490 train_time:13115ms step_avg:31.30ms
+step:420/1490 train_time:13149ms step_avg:31.31ms
+step:421/1490 train_time:13177ms step_avg:31.30ms
+step:422/1490 train_time:13211ms step_avg:31.31ms
+step:423/1490 train_time:13240ms step_avg:31.30ms
+step:424/1490 train_time:13274ms step_avg:31.31ms
+step:425/1490 train_time:13302ms step_avg:31.30ms
+step:426/1490 train_time:13337ms step_avg:31.31ms
+step:427/1490 train_time:13365ms step_avg:31.30ms
+step:428/1490 train_time:13400ms step_avg:31.31ms
+step:429/1490 train_time:13427ms step_avg:31.30ms
+step:430/1490 train_time:13463ms step_avg:31.31ms
+step:431/1490 train_time:13491ms step_avg:31.30ms
+step:432/1490 train_time:13525ms step_avg:31.31ms
+step:433/1490 train_time:13553ms step_avg:31.30ms
+step:434/1490 train_time:13587ms step_avg:31.31ms
+step:435/1490 train_time:13614ms step_avg:31.30ms
+step:436/1490 train_time:13649ms step_avg:31.30ms
+step:437/1490 train_time:13676ms step_avg:31.30ms
+step:438/1490 train_time:13711ms step_avg:31.30ms
+step:439/1490 train_time:13739ms step_avg:31.30ms
+step:440/1490 train_time:13773ms step_avg:31.30ms
+step:441/1490 train_time:13801ms step_avg:31.29ms
+step:442/1490 train_time:13835ms step_avg:31.30ms
+step:443/1490 train_time:13864ms step_avg:31.30ms
+step:444/1490 train_time:13899ms step_avg:31.30ms
+step:445/1490 train_time:13926ms step_avg:31.30ms
+step:446/1490 train_time:13961ms step_avg:31.30ms
+step:447/1490 train_time:13989ms step_avg:31.29ms
+step:448/1490 train_time:14023ms step_avg:31.30ms
+step:449/1490 train_time:14051ms step_avg:31.29ms
+step:450/1490 train_time:14085ms step_avg:31.30ms
+step:451/1490 train_time:14113ms step_avg:31.29ms
+step:452/1490 train_time:14147ms step_avg:31.30ms
+step:453/1490 train_time:14175ms step_avg:31.29ms
+step:454/1490 train_time:14210ms step_avg:31.30ms
+step:455/1490 train_time:14237ms step_avg:31.29ms
+step:456/1490 train_time:14272ms step_avg:31.30ms
+step:457/1490 train_time:14300ms step_avg:31.29ms
+step:458/1490 train_time:14334ms step_avg:31.30ms
+step:459/1490 train_time:14362ms step_avg:31.29ms
+step:460/1490 train_time:14397ms step_avg:31.30ms
+step:461/1490 train_time:14424ms step_avg:31.29ms
+step:462/1490 train_time:14459ms step_avg:31.30ms
+step:463/1490 train_time:14487ms step_avg:31.29ms
+step:464/1490 train_time:14522ms step_avg:31.30ms
+step:465/1490 train_time:14550ms step_avg:31.29ms
+step:466/1490 train_time:14584ms step_avg:31.30ms
+step:467/1490 train_time:14612ms step_avg:31.29ms
+step:468/1490 train_time:14646ms step_avg:31.30ms
+step:469/1490 train_time:14674ms step_avg:31.29ms
+step:470/1490 train_time:14709ms step_avg:31.30ms
+step:471/1490 train_time:14737ms step_avg:31.29ms
+step:472/1490 train_time:14771ms step_avg:31.29ms
+step:473/1490 train_time:14799ms step_avg:31.29ms
+step:474/1490 train_time:14834ms step_avg:31.29ms
+step:475/1490 train_time:14861ms step_avg:31.29ms
+step:476/1490 train_time:14896ms step_avg:31.29ms
+step:477/1490 train_time:14924ms step_avg:31.29ms
+step:478/1490 train_time:14958ms step_avg:31.29ms
+step:479/1490 train_time:14986ms step_avg:31.29ms
+step:480/1490 train_time:15021ms step_avg:31.29ms
+step:481/1490 train_time:15049ms step_avg:31.29ms
+step:482/1490 train_time:15084ms step_avg:31.29ms
+step:483/1490 train_time:15112ms step_avg:31.29ms
+step:484/1490 train_time:15149ms step_avg:31.30ms
+step:485/1490 train_time:15201ms step_avg:31.34ms
+step:486/1490 train_time:15260ms step_avg:31.40ms
+step:487/1490 train_time:15315ms step_avg:31.45ms
+step:488/1490 train_time:15374ms step_avg:31.50ms
+step:489/1490 train_time:15428ms step_avg:31.55ms
+step:490/1490 train_time:15489ms step_avg:31.61ms
+step:491/1490 train_time:15542ms step_avg:31.65ms
+step:492/1490 train_time:15602ms step_avg:31.71ms
+step:493/1490 train_time:15657ms step_avg:31.76ms
+step:494/1490 train_time:15716ms step_avg:31.81ms
+step:495/1490 train_time:15769ms step_avg:31.86ms
+step:496/1490 train_time:15829ms step_avg:31.91ms
+step:497/1490 train_time:15883ms step_avg:31.96ms
+step:498/1490 train_time:15943ms step_avg:32.01ms
+step:499/1490 train_time:15996ms step_avg:32.06ms
+step:500/1490 train_time:16057ms step_avg:32.11ms
+step:500/1490 val_loss:4.2308 train_time:16129ms step_avg:32.26ms
+step:501/1490 train_time:16147ms step_avg:32.23ms
+step:502/1490 train_time:16171ms step_avg:32.21ms
+step:503/1490 train_time:16226ms step_avg:32.26ms
+step:504/1490 train_time:16291ms step_avg:32.32ms
+step:505/1490 train_time:16347ms step_avg:32.37ms
+step:506/1490 train_time:16408ms step_avg:32.43ms
+step:507/1490 train_time:16461ms step_avg:32.47ms
+step:508/1490 train_time:16520ms step_avg:32.52ms
+step:509/1490 train_time:16574ms step_avg:32.56ms
+step:510/1490 train_time:16633ms step_avg:32.61ms
+step:511/1490 train_time:16686ms step_avg:32.65ms
+step:512/1490 train_time:16746ms step_avg:32.71ms
+step:513/1490 train_time:16799ms step_avg:32.75ms
+step:514/1490 train_time:16857ms step_avg:32.80ms
+step:515/1490 train_time:16910ms step_avg:32.84ms
+step:516/1490 train_time:16969ms step_avg:32.89ms
+step:517/1490 train_time:17022ms step_avg:32.93ms
+step:518/1490 train_time:17082ms step_avg:32.98ms
+step:519/1490 train_time:17138ms step_avg:33.02ms
+step:520/1490 train_time:17200ms step_avg:33.08ms
+step:521/1490 train_time:17257ms step_avg:33.12ms
+step:522/1490 train_time:17318ms step_avg:33.18ms
+step:523/1490 train_time:17372ms step_avg:33.22ms
+step:524/1490 train_time:17431ms step_avg:33.27ms
+step:525/1490 train_time:17485ms step_avg:33.31ms
+step:526/1490 train_time:17546ms step_avg:33.36ms
+step:527/1490 train_time:17599ms step_avg:33.39ms
+step:528/1490 train_time:17658ms step_avg:33.44ms
+step:529/1490 train_time:17712ms step_avg:33.48ms
+step:530/1490 train_time:17771ms step_avg:33.53ms
+step:531/1490 train_time:17825ms step_avg:33.57ms
+step:532/1490 train_time:17885ms step_avg:33.62ms
+step:533/1490 train_time:17938ms step_avg:33.66ms
+step:534/1490 train_time:17998ms step_avg:33.70ms
+step:535/1490 train_time:18051ms step_avg:33.74ms
+step:536/1490 train_time:18111ms step_avg:33.79ms
+step:537/1490 train_time:18165ms step_avg:33.83ms
+step:538/1490 train_time:18226ms step_avg:33.88ms
+step:539/1490 train_time:18280ms step_avg:33.91ms
+step:540/1490 train_time:18340ms step_avg:33.96ms
+step:541/1490 train_time:18394ms step_avg:34.00ms
+step:542/1490 train_time:18454ms step_avg:34.05ms
+step:543/1490 train_time:18508ms step_avg:34.09ms
+step:544/1490 train_time:18567ms step_avg:34.13ms
+step:545/1490 train_time:18621ms step_avg:34.17ms
+step:546/1490 train_time:18680ms step_avg:34.21ms
+step:547/1490 train_time:18734ms step_avg:34.25ms
+step:548/1490 train_time:18793ms step_avg:34.29ms
+step:549/1490 train_time:18847ms step_avg:34.33ms
+step:550/1490 train_time:18906ms step_avg:34.38ms
+step:551/1490 train_time:18959ms step_avg:34.41ms
+step:552/1490 train_time:19018ms step_avg:34.45ms
+step:553/1490 train_time:19072ms step_avg:34.49ms
+step:554/1490 train_time:19132ms step_avg:34.53ms
+step:555/1490 train_time:19186ms step_avg:34.57ms
+step:556/1490 train_time:19247ms step_avg:34.62ms
+step:557/1490 train_time:19301ms step_avg:34.65ms
+step:558/1490 train_time:19361ms step_avg:34.70ms
+step:559/1490 train_time:19416ms step_avg:34.73ms
+step:560/1490 train_time:19476ms step_avg:34.78ms
+step:561/1490 train_time:19529ms step_avg:34.81ms
+step:562/1490 train_time:19589ms step_avg:34.86ms
+step:563/1490 train_time:19643ms step_avg:34.89ms
+step:564/1490 train_time:19702ms step_avg:34.93ms
+step:565/1490 train_time:19756ms step_avg:34.97ms
+step:566/1490 train_time:19816ms step_avg:35.01ms
+step:567/1490 train_time:19869ms step_avg:35.04ms
+step:568/1490 train_time:19928ms step_avg:35.08ms
+step:569/1490 train_time:19981ms step_avg:35.12ms
+step:570/1490 train_time:20041ms step_avg:35.16ms
+step:571/1490 train_time:20095ms step_avg:35.19ms
+step:572/1490 train_time:20156ms step_avg:35.24ms
+step:573/1490 train_time:20210ms step_avg:35.27ms
+step:574/1490 train_time:20269ms step_avg:35.31ms
+step:575/1490 train_time:20323ms step_avg:35.35ms
+step:576/1490 train_time:20384ms step_avg:35.39ms
+step:577/1490 train_time:20438ms step_avg:35.42ms
+step:578/1490 train_time:20498ms step_avg:35.46ms
+step:579/1490 train_time:20552ms step_avg:35.50ms
+step:580/1490 train_time:20612ms step_avg:35.54ms
+step:581/1490 train_time:20665ms step_avg:35.57ms
+step:582/1490 train_time:20725ms step_avg:35.61ms
+step:583/1490 train_time:20778ms step_avg:35.64ms
+step:584/1490 train_time:20838ms step_avg:35.68ms
+step:585/1490 train_time:20892ms step_avg:35.71ms
+step:586/1490 train_time:20952ms step_avg:35.75ms
+step:587/1490 train_time:21006ms step_avg:35.79ms
+step:588/1490 train_time:21066ms step_avg:35.83ms
+step:589/1490 train_time:21119ms step_avg:35.86ms
+step:590/1490 train_time:21180ms step_avg:35.90ms
+step:591/1490 train_time:21235ms step_avg:35.93ms
+step:592/1490 train_time:21294ms step_avg:35.97ms
+step:593/1490 train_time:21348ms step_avg:36.00ms
+step:594/1490 train_time:21409ms step_avg:36.04ms
+step:595/1490 train_time:21462ms step_avg:36.07ms
+step:596/1490 train_time:21522ms step_avg:36.11ms
+step:597/1490 train_time:21576ms step_avg:36.14ms
+step:598/1490 train_time:21636ms step_avg:36.18ms
+step:599/1490 train_time:21690ms step_avg:36.21ms
+step:600/1490 train_time:21749ms step_avg:36.25ms
+step:601/1490 train_time:21802ms step_avg:36.28ms
+step:602/1490 train_time:21863ms step_avg:36.32ms
+step:603/1490 train_time:21917ms step_avg:36.35ms
+step:604/1490 train_time:21978ms step_avg:36.39ms
+step:605/1490 train_time:22031ms step_avg:36.42ms
+step:606/1490 train_time:22091ms step_avg:36.45ms
+step:607/1490 train_time:22145ms step_avg:36.48ms
+step:608/1490 train_time:22206ms step_avg:36.52ms
+step:609/1490 train_time:22260ms step_avg:36.55ms
+step:610/1490 train_time:22320ms step_avg:36.59ms
+step:611/1490 train_time:22373ms step_avg:36.62ms
+step:612/1490 train_time:22433ms step_avg:36.65ms
+step:613/1490 train_time:22487ms step_avg:36.68ms
+step:614/1490 train_time:22548ms step_avg:36.72ms
+step:615/1490 train_time:22602ms step_avg:36.75ms
+step:616/1490 train_time:22662ms step_avg:36.79ms
+step:617/1490 train_time:22715ms step_avg:36.82ms
+step:618/1490 train_time:22776ms step_avg:36.85ms
+step:619/1490 train_time:22829ms step_avg:36.88ms
+step:620/1490 train_time:22888ms step_avg:36.92ms
+step:621/1490 train_time:22942ms step_avg:36.94ms
+step:622/1490 train_time:23002ms step_avg:36.98ms
+step:623/1490 train_time:23057ms step_avg:37.01ms
+step:624/1490 train_time:23116ms step_avg:37.05ms
+step:625/1490 train_time:23169ms step_avg:37.07ms
+step:626/1490 train_time:23228ms step_avg:37.11ms
+step:627/1490 train_time:23282ms step_avg:37.13ms
+step:628/1490 train_time:23343ms step_avg:37.17ms
+step:629/1490 train_time:23397ms step_avg:37.20ms
+step:630/1490 train_time:23457ms step_avg:37.23ms
+step:631/1490 train_time:23510ms step_avg:37.26ms
+step:632/1490 train_time:23570ms step_avg:37.29ms
+step:633/1490 train_time:23625ms step_avg:37.32ms
+step:634/1490 train_time:23684ms step_avg:37.36ms
+step:635/1490 train_time:23738ms step_avg:37.38ms
+step:636/1490 train_time:23798ms step_avg:37.42ms
+step:637/1490 train_time:23852ms step_avg:37.44ms
+step:638/1490 train_time:23912ms step_avg:37.48ms
+step:639/1490 train_time:23965ms step_avg:37.50ms
+step:640/1490 train_time:24026ms step_avg:37.54ms
+step:641/1490 train_time:24079ms step_avg:37.56ms
+step:642/1490 train_time:24139ms step_avg:37.60ms
+step:643/1490 train_time:24194ms step_avg:37.63ms
+step:644/1490 train_time:24254ms step_avg:37.66ms
+step:645/1490 train_time:24309ms step_avg:37.69ms
+step:646/1490 train_time:24368ms step_avg:37.72ms
+step:647/1490 train_time:24423ms step_avg:37.75ms
+step:648/1490 train_time:24482ms step_avg:37.78ms
+step:649/1490 train_time:24537ms step_avg:37.81ms
+step:650/1490 train_time:24597ms step_avg:37.84ms
+step:651/1490 train_time:24652ms step_avg:37.87ms
+step:652/1490 train_time:24711ms step_avg:37.90ms
+step:653/1490 train_time:24765ms step_avg:37.92ms
+step:654/1490 train_time:24825ms step_avg:37.96ms
+step:655/1490 train_time:24878ms step_avg:37.98ms
+step:656/1490 train_time:24938ms step_avg:38.02ms
+step:657/1490 train_time:24992ms step_avg:38.04ms
+step:658/1490 train_time:25051ms step_avg:38.07ms
+step:659/1490 train_time:25105ms step_avg:38.10ms
+step:660/1490 train_time:25164ms step_avg:38.13ms
+step:661/1490 train_time:25218ms step_avg:38.15ms
+step:662/1490 train_time:25277ms step_avg:38.18ms
+step:663/1490 train_time:25332ms step_avg:38.21ms
+step:664/1490 train_time:25391ms step_avg:38.24ms
+step:665/1490 train_time:25445ms step_avg:38.26ms
+step:666/1490 train_time:25505ms step_avg:38.30ms
+step:667/1490 train_time:25560ms step_avg:38.32ms
+step:668/1490 train_time:25620ms step_avg:38.35ms
+step:669/1490 train_time:25674ms step_avg:38.38ms
+step:670/1490 train_time:25734ms step_avg:38.41ms
+step:671/1490 train_time:25787ms step_avg:38.43ms
+step:672/1490 train_time:25847ms step_avg:38.46ms
+step:673/1490 train_time:25901ms step_avg:38.49ms
+step:674/1490 train_time:25961ms step_avg:38.52ms
+step:675/1490 train_time:26016ms step_avg:38.54ms
+step:676/1490 train_time:26075ms step_avg:38.57ms
+step:677/1490 train_time:26129ms step_avg:38.59ms
+step:678/1490 train_time:26188ms step_avg:38.63ms
+step:679/1490 train_time:26243ms step_avg:38.65ms
+step:680/1490 train_time:26302ms step_avg:38.68ms
+step:681/1490 train_time:26356ms step_avg:38.70ms
+step:682/1490 train_time:26416ms step_avg:38.73ms
+step:683/1490 train_time:26469ms step_avg:38.75ms
+step:684/1490 train_time:26530ms step_avg:38.79ms
+step:685/1490 train_time:26583ms step_avg:38.81ms
+step:686/1490 train_time:26643ms step_avg:38.84ms
+step:687/1490 train_time:26698ms step_avg:38.86ms
+step:688/1490 train_time:26758ms step_avg:38.89ms
+step:689/1490 train_time:26812ms step_avg:38.91ms
+step:690/1490 train_time:26871ms step_avg:38.94ms
+step:691/1490 train_time:26926ms step_avg:38.97ms
+step:692/1490 train_time:26986ms step_avg:39.00ms
+step:693/1490 train_time:27039ms step_avg:39.02ms
+step:694/1490 train_time:27099ms step_avg:39.05ms
+step:695/1490 train_time:27155ms step_avg:39.07ms
+step:696/1490 train_time:27213ms step_avg:39.10ms
+step:697/1490 train_time:27267ms step_avg:39.12ms
+step:698/1490 train_time:27327ms step_avg:39.15ms
+step:699/1490 train_time:27381ms step_avg:39.17ms
+step:700/1490 train_time:27441ms step_avg:39.20ms
+step:701/1490 train_time:27495ms step_avg:39.22ms
+step:702/1490 train_time:27554ms step_avg:39.25ms
+step:703/1490 train_time:27608ms step_avg:39.27ms
+step:704/1490 train_time:27667ms step_avg:39.30ms
+step:705/1490 train_time:27722ms step_avg:39.32ms
+step:706/1490 train_time:27781ms step_avg:39.35ms
+step:707/1490 train_time:27835ms step_avg:39.37ms
+step:708/1490 train_time:27895ms step_avg:39.40ms
+step:709/1490 train_time:27948ms step_avg:39.42ms
+step:710/1490 train_time:28008ms step_avg:39.45ms
+step:711/1490 train_time:28062ms step_avg:39.47ms
+step:712/1490 train_time:28121ms step_avg:39.50ms
+step:713/1490 train_time:28174ms step_avg:39.51ms
+step:714/1490 train_time:28234ms step_avg:39.54ms
+step:715/1490 train_time:28287ms step_avg:39.56ms
+step:716/1490 train_time:28347ms step_avg:39.59ms
+step:717/1490 train_time:28402ms step_avg:39.61ms
+step:718/1490 train_time:28460ms step_avg:39.64ms
+step:719/1490 train_time:28515ms step_avg:39.66ms
+step:720/1490 train_time:28574ms step_avg:39.69ms
+step:721/1490 train_time:28627ms step_avg:39.70ms
+step:722/1490 train_time:28687ms step_avg:39.73ms
+step:723/1490 train_time:28741ms step_avg:39.75ms
+step:724/1490 train_time:28801ms step_avg:39.78ms
+step:725/1490 train_time:28854ms step_avg:39.80ms
+step:726/1490 train_time:28913ms step_avg:39.82ms
+step:727/1490 train_time:28966ms step_avg:39.84ms
+step:728/1490 train_time:29026ms step_avg:39.87ms
+step:729/1490 train_time:29079ms step_avg:39.89ms
+step:730/1490 train_time:29139ms step_avg:39.92ms
+step:731/1490 train_time:29194ms step_avg:39.94ms
+step:732/1490 train_time:29253ms step_avg:39.96ms
+step:733/1490 train_time:29307ms step_avg:39.98ms
+step:734/1490 train_time:29367ms step_avg:40.01ms
+step:735/1490 train_time:29421ms step_avg:40.03ms
+step:736/1490 train_time:29480ms step_avg:40.05ms
+step:737/1490 train_time:29534ms step_avg:40.07ms
+step:738/1490 train_time:29594ms step_avg:40.10ms
+step:739/1490 train_time:29648ms step_avg:40.12ms
+step:740/1490 train_time:29708ms step_avg:40.15ms
+step:741/1490 train_time:29762ms step_avg:40.16ms
+step:742/1490 train_time:29821ms step_avg:40.19ms
+step:743/1490 train_time:29875ms step_avg:40.21ms
+step:744/1490 train_time:29934ms step_avg:40.23ms
+step:745/1490 train_time:29988ms step_avg:40.25ms
+step:746/1490 train_time:30048ms step_avg:40.28ms
+step:747/1490 train_time:30102ms step_avg:40.30ms
+step:748/1490 train_time:30161ms step_avg:40.32ms
+step:749/1490 train_time:30215ms step_avg:40.34ms
+step:750/1490 train_time:30275ms step_avg:40.37ms
+step:750/1490 val_loss:3.8038 train_time:30348ms step_avg:40.46ms
+step:751/1490 train_time:30368ms step_avg:40.44ms
+step:752/1490 train_time:30392ms step_avg:40.42ms
+step:753/1490 train_time:30449ms step_avg:40.44ms
+step:754/1490 train_time:30513ms step_avg:40.47ms
+step:755/1490 train_time:30566ms step_avg:40.48ms
+step:756/1490 train_time:30626ms step_avg:40.51ms
+step:757/1490 train_time:30679ms step_avg:40.53ms
+step:758/1490 train_time:30738ms step_avg:40.55ms
+step:759/1490 train_time:30791ms step_avg:40.57ms
+step:760/1490 train_time:30849ms step_avg:40.59ms
+step:761/1490 train_time:30903ms step_avg:40.61ms
+step:762/1490 train_time:30962ms step_avg:40.63ms
+step:763/1490 train_time:31014ms step_avg:40.65ms
+step:764/1490 train_time:31072ms step_avg:40.67ms
+step:765/1490 train_time:31126ms step_avg:40.69ms
+step:766/1490 train_time:31185ms step_avg:40.71ms
+step:767/1490 train_time:31238ms step_avg:40.73ms
+step:768/1490 train_time:31299ms step_avg:40.75ms
+step:769/1490 train_time:31354ms step_avg:40.77ms
+step:770/1490 train_time:31415ms step_avg:40.80ms
+step:771/1490 train_time:31470ms step_avg:40.82ms
+step:772/1490 train_time:31531ms step_avg:40.84ms
+step:773/1490 train_time:31586ms step_avg:40.86ms
+step:774/1490 train_time:31646ms step_avg:40.89ms
+step:775/1490 train_time:31700ms step_avg:40.90ms
+step:776/1490 train_time:31759ms step_avg:40.93ms
+step:777/1490 train_time:31812ms step_avg:40.94ms
+step:778/1490 train_time:31871ms step_avg:40.97ms
+step:779/1490 train_time:31925ms step_avg:40.98ms
+step:780/1490 train_time:31983ms step_avg:41.00ms
+step:781/1490 train_time:32036ms step_avg:41.02ms
+step:782/1490 train_time:32094ms step_avg:41.04ms
+step:783/1490 train_time:32148ms step_avg:41.06ms
+step:784/1490 train_time:32207ms step_avg:41.08ms
+step:785/1490 train_time:32262ms step_avg:41.10ms
+step:786/1490 train_time:32322ms step_avg:41.12ms
+step:787/1490 train_time:32376ms step_avg:41.14ms
+step:788/1490 train_time:32437ms step_avg:41.16ms
+step:789/1490 train_time:32491ms step_avg:41.18ms
+step:790/1490 train_time:32551ms step_avg:41.20ms
+step:791/1490 train_time:32605ms step_avg:41.22ms
+step:792/1490 train_time:32666ms step_avg:41.24ms
+step:793/1490 train_time:32720ms step_avg:41.26ms
+step:794/1490 train_time:32780ms step_avg:41.28ms
+step:795/1490 train_time:32833ms step_avg:41.30ms
+step:796/1490 train_time:32892ms step_avg:41.32ms
+step:797/1490 train_time:32946ms step_avg:41.34ms
+step:798/1490 train_time:33005ms step_avg:41.36ms
+step:799/1490 train_time:33058ms step_avg:41.37ms
+step:800/1490 train_time:33117ms step_avg:41.40ms
+step:801/1490 train_time:33170ms step_avg:41.41ms
+step:802/1490 train_time:33229ms step_avg:41.43ms
+step:803/1490 train_time:33283ms step_avg:41.45ms
+step:804/1490 train_time:33343ms step_avg:41.47ms
+step:805/1490 train_time:33398ms step_avg:41.49ms
+step:806/1490 train_time:33457ms step_avg:41.51ms
+step:807/1490 train_time:33511ms step_avg:41.53ms
+step:808/1490 train_time:33572ms step_avg:41.55ms
+step:809/1490 train_time:33627ms step_avg:41.57ms
+step:810/1490 train_time:33687ms step_avg:41.59ms
+step:811/1490 train_time:33741ms step_avg:41.60ms
+step:812/1490 train_time:33801ms step_avg:41.63ms
+step:813/1490 train_time:33856ms step_avg:41.64ms
+step:814/1490 train_time:33915ms step_avg:41.66ms
+step:815/1490 train_time:33968ms step_avg:41.68ms
+step:816/1490 train_time:34028ms step_avg:41.70ms
+step:817/1490 train_time:34081ms step_avg:41.71ms
+step:818/1490 train_time:34140ms step_avg:41.74ms
+step:819/1490 train_time:34193ms step_avg:41.75ms
+step:820/1490 train_time:34252ms step_avg:41.77ms
+step:821/1490 train_time:34306ms step_avg:41.79ms
+step:822/1490 train_time:34366ms step_avg:41.81ms
+step:823/1490 train_time:34420ms step_avg:41.82ms
+step:824/1490 train_time:34481ms step_avg:41.85ms
+step:825/1490 train_time:34535ms step_avg:41.86ms
+step:826/1490 train_time:34596ms step_avg:41.88ms
+step:827/1490 train_time:34650ms step_avg:41.90ms
+step:828/1490 train_time:34710ms step_avg:41.92ms
+step:829/1490 train_time:34764ms step_avg:41.94ms
+step:830/1490 train_time:34824ms step_avg:41.96ms
+step:831/1490 train_time:34877ms step_avg:41.97ms
+step:832/1490 train_time:34936ms step_avg:41.99ms
+step:833/1490 train_time:34989ms step_avg:42.00ms
+step:834/1490 train_time:35048ms step_avg:42.02ms
+step:835/1490 train_time:35102ms step_avg:42.04ms
+step:836/1490 train_time:35161ms step_avg:42.06ms
+step:837/1490 train_time:35214ms step_avg:42.07ms
+step:838/1490 train_time:35274ms step_avg:42.09ms
+step:839/1490 train_time:35329ms step_avg:42.11ms
+step:840/1490 train_time:35389ms step_avg:42.13ms
+step:841/1490 train_time:35443ms step_avg:42.14ms
+step:842/1490 train_time:35503ms step_avg:42.16ms
+step:843/1490 train_time:35557ms step_avg:42.18ms
+step:844/1490 train_time:35618ms step_avg:42.20ms
+step:845/1490 train_time:35671ms step_avg:42.21ms
+step:846/1490 train_time:35731ms step_avg:42.23ms
+step:847/1490 train_time:35784ms step_avg:42.25ms
+step:848/1490 train_time:35843ms step_avg:42.27ms
+step:849/1490 train_time:35897ms step_avg:42.28ms
+step:850/1490 train_time:35955ms step_avg:42.30ms
+step:851/1490 train_time:36008ms step_avg:42.31ms
+step:852/1490 train_time:36068ms step_avg:42.33ms
+step:853/1490 train_time:36121ms step_avg:42.35ms
+step:854/1490 train_time:36180ms step_avg:42.37ms
+step:855/1490 train_time:36234ms step_avg:42.38ms
+step:856/1490 train_time:36293ms step_avg:42.40ms
+step:857/1490 train_time:36348ms step_avg:42.41ms
+step:858/1490 train_time:36408ms step_avg:42.43ms
+step:859/1490 train_time:36462ms step_avg:42.45ms
+step:860/1490 train_time:36523ms step_avg:42.47ms
+step:861/1490 train_time:36576ms step_avg:42.48ms
+step:862/1490 train_time:36636ms step_avg:42.50ms
+step:863/1490 train_time:36689ms step_avg:42.51ms
+step:864/1490 train_time:36749ms step_avg:42.53ms
+step:865/1490 train_time:36803ms step_avg:42.55ms
+step:866/1490 train_time:36862ms step_avg:42.57ms
+step:867/1490 train_time:36916ms step_avg:42.58ms
+step:868/1490 train_time:36975ms step_avg:42.60ms
+step:869/1490 train_time:37029ms step_avg:42.61ms
+step:870/1490 train_time:37088ms step_avg:42.63ms
+step:871/1490 train_time:37142ms step_avg:42.64ms
+step:872/1490 train_time:37201ms step_avg:42.66ms
+step:873/1490 train_time:37256ms step_avg:42.68ms
+step:874/1490 train_time:37315ms step_avg:42.69ms
+step:875/1490 train_time:37369ms step_avg:42.71ms
+step:876/1490 train_time:37429ms step_avg:42.73ms
+step:877/1490 train_time:37483ms step_avg:42.74ms
+step:878/1490 train_time:37544ms step_avg:42.76ms
+step:879/1490 train_time:37598ms step_avg:42.77ms
+step:880/1490 train_time:37657ms step_avg:42.79ms
+step:881/1490 train_time:37709ms step_avg:42.80ms
+step:882/1490 train_time:37770ms step_avg:42.82ms
+step:883/1490 train_time:37823ms step_avg:42.84ms
+step:884/1490 train_time:37882ms step_avg:42.85ms
+step:885/1490 train_time:37936ms step_avg:42.87ms
+step:886/1490 train_time:37995ms step_avg:42.88ms
+step:887/1490 train_time:38049ms step_avg:42.90ms
+step:888/1490 train_time:38108ms step_avg:42.91ms
+step:889/1490 train_time:38163ms step_avg:42.93ms
+step:890/1490 train_time:38222ms step_avg:42.95ms
+step:891/1490 train_time:38276ms step_avg:42.96ms
+step:892/1490 train_time:38336ms step_avg:42.98ms
+step:893/1490 train_time:38390ms step_avg:42.99ms
+step:894/1490 train_time:38449ms step_avg:43.01ms
+step:895/1490 train_time:38503ms step_avg:43.02ms
+step:896/1490 train_time:38563ms step_avg:43.04ms
+step:897/1490 train_time:38617ms step_avg:43.05ms
+step:898/1490 train_time:38677ms step_avg:43.07ms
+step:899/1490 train_time:38732ms step_avg:43.08ms
+step:900/1490 train_time:38791ms step_avg:43.10ms
+step:901/1490 train_time:38846ms step_avg:43.11ms
+step:902/1490 train_time:38905ms step_avg:43.13ms
+step:903/1490 train_time:38959ms step_avg:43.14ms
+step:904/1490 train_time:39018ms step_avg:43.16ms
+step:905/1490 train_time:39072ms step_avg:43.17ms
+step:906/1490 train_time:39131ms step_avg:43.19ms
+step:907/1490 train_time:39185ms step_avg:43.20ms
+step:908/1490 train_time:39244ms step_avg:43.22ms
+step:909/1490 train_time:39298ms step_avg:43.23ms
+step:910/1490 train_time:39357ms step_avg:43.25ms
+step:911/1490 train_time:39410ms step_avg:43.26ms
+step:912/1490 train_time:39470ms step_avg:43.28ms
+step:913/1490 train_time:39524ms step_avg:43.29ms
+step:914/1490 train_time:39584ms step_avg:43.31ms
+step:915/1490 train_time:39638ms step_avg:43.32ms
+step:916/1490 train_time:39698ms step_avg:43.34ms
+step:917/1490 train_time:39752ms step_avg:43.35ms
+step:918/1490 train_time:39812ms step_avg:43.37ms
+step:919/1490 train_time:39866ms step_avg:43.38ms
+step:920/1490 train_time:39926ms step_avg:43.40ms
+step:921/1490 train_time:39979ms step_avg:43.41ms
+step:922/1490 train_time:40038ms step_avg:43.43ms
+step:923/1490 train_time:40091ms step_avg:43.44ms
+step:924/1490 train_time:40152ms step_avg:43.45ms
+step:925/1490 train_time:40206ms step_avg:43.47ms
+step:926/1490 train_time:40266ms step_avg:43.48ms
+step:927/1490 train_time:40319ms step_avg:43.49ms
+step:928/1490 train_time:40379ms step_avg:43.51ms
+step:929/1490 train_time:40433ms step_avg:43.52ms
+step:930/1490 train_time:40492ms step_avg:43.54ms
+step:931/1490 train_time:40547ms step_avg:43.55ms
+step:932/1490 train_time:40608ms step_avg:43.57ms
+step:933/1490 train_time:40662ms step_avg:43.58ms
+step:934/1490 train_time:40722ms step_avg:43.60ms
+step:935/1490 train_time:40776ms step_avg:43.61ms
+step:936/1490 train_time:40835ms step_avg:43.63ms
+step:937/1490 train_time:40888ms step_avg:43.64ms
+step:938/1490 train_time:40948ms step_avg:43.65ms
+step:939/1490 train_time:41001ms step_avg:43.66ms
+step:940/1490 train_time:41062ms step_avg:43.68ms
+step:941/1490 train_time:41116ms step_avg:43.69ms
+step:942/1490 train_time:41174ms step_avg:43.71ms
+step:943/1490 train_time:41229ms step_avg:43.72ms
+step:944/1490 train_time:41288ms step_avg:43.74ms
+step:945/1490 train_time:41342ms step_avg:43.75ms
+step:946/1490 train_time:41402ms step_avg:43.77ms
+step:947/1490 train_time:41456ms step_avg:43.78ms
+step:948/1490 train_time:41515ms step_avg:43.79ms
+step:949/1490 train_time:41569ms step_avg:43.80ms
+step:950/1490 train_time:41630ms step_avg:43.82ms
+step:951/1490 train_time:41683ms step_avg:43.83ms
+step:952/1490 train_time:41743ms step_avg:43.85ms
+step:953/1490 train_time:41796ms step_avg:43.86ms
+step:954/1490 train_time:41856ms step_avg:43.87ms
+step:955/1490 train_time:41909ms step_avg:43.88ms
+step:956/1490 train_time:41969ms step_avg:43.90ms
+step:957/1490 train_time:42023ms step_avg:43.91ms
+step:958/1490 train_time:42082ms step_avg:43.93ms
+step:959/1490 train_time:42137ms step_avg:43.94ms
+step:960/1490 train_time:42197ms step_avg:43.96ms
+step:961/1490 train_time:42250ms step_avg:43.96ms
+step:962/1490 train_time:42310ms step_avg:43.98ms
+step:963/1490 train_time:42364ms step_avg:43.99ms
+step:964/1490 train_time:42424ms step_avg:44.01ms
+step:965/1490 train_time:42477ms step_avg:44.02ms
+step:966/1490 train_time:42537ms step_avg:44.03ms
+step:967/1490 train_time:42590ms step_avg:44.04ms
+step:968/1490 train_time:42654ms step_avg:44.06ms
+step:969/1490 train_time:42731ms step_avg:44.10ms
+step:970/1490 train_time:42817ms step_avg:44.14ms
+step:971/1490 train_time:42899ms step_avg:44.18ms
+step:972/1490 train_time:42984ms step_avg:44.22ms
+step:973/1490 train_time:43064ms step_avg:44.26ms
+step:974/1490 train_time:43150ms step_avg:44.30ms
+step:975/1490 train_time:43229ms step_avg:44.34ms
+step:976/1490 train_time:43316ms step_avg:44.38ms
+step:977/1490 train_time:43397ms step_avg:44.42ms
+step:978/1490 train_time:43482ms step_avg:44.46ms
+step:979/1490 train_time:43562ms step_avg:44.50ms
+step:980/1490 train_time:43648ms step_avg:44.54ms
+step:981/1490 train_time:43727ms step_avg:44.57ms
+step:982/1490 train_time:43812ms step_avg:44.62ms
+step:983/1490 train_time:43892ms step_avg:44.65ms
+step:984/1490 train_time:43978ms step_avg:44.69ms
+step:985/1490 train_time:44060ms step_avg:44.73ms
+step:986/1490 train_time:44146ms step_avg:44.77ms
+step:987/1490 train_time:44225ms step_avg:44.81ms
+step:988/1490 train_time:44310ms step_avg:44.85ms
+step:989/1490 train_time:44390ms step_avg:44.88ms
+step:990/1490 train_time:44475ms step_avg:44.92ms
+step:991/1490 train_time:44554ms step_avg:44.96ms
+step:992/1490 train_time:44639ms step_avg:45.00ms
+step:993/1490 train_time:44720ms step_avg:45.04ms
+step:994/1490 train_time:44807ms step_avg:45.08ms
+step:995/1490 train_time:44885ms step_avg:45.11ms
+step:996/1490 train_time:44970ms step_avg:45.15ms
+step:997/1490 train_time:45050ms step_avg:45.19ms
+step:998/1490 train_time:45135ms step_avg:45.23ms
+step:999/1490 train_time:45215ms step_avg:45.26ms
+step:1000/1490 train_time:45300ms step_avg:45.30ms
+step:1000/1490 val_loss:3.5162 train_time:45403ms step_avg:45.40ms
+step:1001/1490 train_time:45421ms step_avg:45.38ms
+step:1002/1490 train_time:45467ms step_avg:45.38ms
+step:1003/1490 train_time:45552ms step_avg:45.42ms
+step:1004/1490 train_time:45641ms step_avg:45.46ms
+step:1005/1490 train_time:45721ms step_avg:45.49ms
+step:1006/1490 train_time:45808ms step_avg:45.53ms
+step:1007/1490 train_time:45887ms step_avg:45.57ms
+step:1008/1490 train_time:45971ms step_avg:45.61ms
+step:1009/1490 train_time:46051ms step_avg:45.64ms
+step:1010/1490 train_time:46135ms step_avg:45.68ms
+step:1011/1490 train_time:46213ms step_avg:45.71ms
+step:1012/1490 train_time:46297ms step_avg:45.75ms
+step:1013/1490 train_time:46379ms step_avg:45.78ms
+step:1014/1490 train_time:46467ms step_avg:45.83ms
+step:1015/1490 train_time:46550ms step_avg:45.86ms
+step:1016/1490 train_time:46637ms step_avg:45.90ms
+step:1017/1490 train_time:46717ms step_avg:45.94ms
+step:1018/1490 train_time:46803ms step_avg:45.98ms
+step:1019/1490 train_time:46882ms step_avg:46.01ms
+step:1020/1490 train_time:46967ms step_avg:46.05ms
+step:1021/1490 train_time:47046ms step_avg:46.08ms
+step:1022/1490 train_time:47130ms step_avg:46.12ms
+step:1023/1490 train_time:47209ms step_avg:46.15ms
+step:1024/1490 train_time:47294ms step_avg:46.19ms
+step:1025/1490 train_time:47375ms step_avg:46.22ms
+step:1026/1490 train_time:47462ms step_avg:46.26ms
+step:1027/1490 train_time:47542ms step_avg:46.29ms
+step:1028/1490 train_time:47628ms step_avg:46.33ms
+step:1029/1490 train_time:47710ms step_avg:46.37ms
+step:1030/1490 train_time:47797ms step_avg:46.41ms
+step:1031/1490 train_time:47876ms step_avg:46.44ms
+step:1032/1490 train_time:47960ms step_avg:46.47ms
+step:1033/1490 train_time:48039ms step_avg:46.50ms
+step:1034/1490 train_time:48123ms step_avg:46.54ms
+step:1035/1490 train_time:48203ms step_avg:46.57ms
+step:1036/1490 train_time:48288ms step_avg:46.61ms
+step:1037/1490 train_time:48369ms step_avg:46.64ms
+step:1038/1490 train_time:48455ms step_avg:46.68ms
+step:1039/1490 train_time:48536ms step_avg:46.71ms
+step:1040/1490 train_time:48622ms step_avg:46.75ms
+step:1041/1490 train_time:48704ms step_avg:46.79ms
+step:1042/1490 train_time:48790ms step_avg:46.82ms
+step:1043/1490 train_time:48869ms step_avg:46.85ms
+step:1044/1490 train_time:48954ms step_avg:46.89ms
+step:1045/1490 train_time:49033ms step_avg:46.92ms
+step:1046/1490 train_time:49116ms step_avg:46.96ms
+step:1047/1490 train_time:49195ms step_avg:46.99ms
+step:1048/1490 train_time:49278ms step_avg:47.02ms
+step:1049/1490 train_time:49360ms step_avg:47.05ms
+step:1050/1490 train_time:49446ms step_avg:47.09ms
+step:1051/1490 train_time:49528ms step_avg:47.12ms
+step:1052/1490 train_time:49615ms step_avg:47.16ms
+step:1053/1490 train_time:49696ms step_avg:47.19ms
+step:1054/1490 train_time:49780ms step_avg:47.23ms
+step:1055/1490 train_time:49860ms step_avg:47.26ms
+step:1056/1490 train_time:49945ms step_avg:47.30ms
+step:1057/1490 train_time:50024ms step_avg:47.33ms
+step:1058/1490 train_time:50108ms step_avg:47.36ms
+step:1059/1490 train_time:50188ms step_avg:47.39ms
+step:1060/1490 train_time:50273ms step_avg:47.43ms
+step:1061/1490 train_time:50354ms step_avg:47.46ms
+step:1062/1490 train_time:50441ms step_avg:47.50ms
+step:1063/1490 train_time:50519ms step_avg:47.53ms
+step:1064/1490 train_time:50606ms step_avg:47.56ms
+step:1065/1490 train_time:50688ms step_avg:47.59ms
+step:1066/1490 train_time:50773ms step_avg:47.63ms
+step:1067/1490 train_time:50853ms step_avg:47.66ms
+step:1068/1490 train_time:50937ms step_avg:47.69ms
+step:1069/1490 train_time:51017ms step_avg:47.72ms
+step:1070/1490 train_time:51101ms step_avg:47.76ms
+step:1071/1490 train_time:51180ms step_avg:47.79ms
+step:1072/1490 train_time:51265ms step_avg:47.82ms
+step:1073/1490 train_time:51347ms step_avg:47.85ms
+step:1074/1490 train_time:51433ms step_avg:47.89ms
+step:1075/1490 train_time:51511ms step_avg:47.92ms
+step:1076/1490 train_time:51598ms step_avg:47.95ms
+step:1077/1490 train_time:51679ms step_avg:47.98ms
+step:1078/1490 train_time:51764ms step_avg:48.02ms
+step:1079/1490 train_time:51844ms step_avg:48.05ms
+step:1080/1490 train_time:51929ms step_avg:48.08ms
+step:1081/1490 train_time:52008ms step_avg:48.11ms
+step:1082/1490 train_time:52093ms step_avg:48.15ms
+step:1083/1490 train_time:52172ms step_avg:48.17ms
+step:1084/1490 train_time:52259ms step_avg:48.21ms
+step:1085/1490 train_time:52338ms step_avg:48.24ms
+step:1086/1490 train_time:52423ms step_avg:48.27ms
+step:1087/1490 train_time:52504ms step_avg:48.30ms
+step:1088/1490 train_time:52589ms step_avg:48.34ms
+step:1089/1490 train_time:52669ms step_avg:48.36ms
+step:1090/1490 train_time:52756ms step_avg:48.40ms
+step:1091/1490 train_time:52835ms step_avg:48.43ms
+step:1092/1490 train_time:52919ms step_avg:48.46ms
+step:1093/1490 train_time:52998ms step_avg:48.49ms
+step:1094/1490 train_time:53085ms step_avg:48.52ms
+step:1095/1490 train_time:53165ms step_avg:48.55ms
+step:1096/1490 train_time:53250ms step_avg:48.59ms
+step:1097/1490 train_time:53330ms step_avg:48.61ms
+step:1098/1490 train_time:53416ms step_avg:48.65ms
+step:1099/1490 train_time:53496ms step_avg:48.68ms
+step:1100/1490 train_time:53582ms step_avg:48.71ms
+step:1101/1490 train_time:53662ms step_avg:48.74ms
+step:1102/1490 train_time:53747ms step_avg:48.77ms
+step:1103/1490 train_time:53828ms step_avg:48.80ms
+step:1104/1490 train_time:53914ms step_avg:48.84ms
+step:1105/1490 train_time:53994ms step_avg:48.86ms
+step:1106/1490 train_time:54079ms step_avg:48.90ms
+step:1107/1490 train_time:54159ms step_avg:48.92ms
+step:1108/1490 train_time:54243ms step_avg:48.96ms
+step:1109/1490 train_time:54323ms step_avg:48.98ms
+step:1110/1490 train_time:54408ms step_avg:49.02ms
+step:1111/1490 train_time:54488ms step_avg:49.04ms
+step:1112/1490 train_time:54573ms step_avg:49.08ms
+step:1113/1490 train_time:54654ms step_avg:49.10ms
+step:1114/1490 train_time:54738ms step_avg:49.14ms
+step:1115/1490 train_time:54818ms step_avg:49.16ms
+step:1116/1490 train_time:54905ms step_avg:49.20ms
+step:1117/1490 train_time:54985ms step_avg:49.23ms
+step:1118/1490 train_time:55069ms step_avg:49.26ms
+step:1119/1490 train_time:55150ms step_avg:49.28ms
+step:1120/1490 train_time:55234ms step_avg:49.32ms
+step:1121/1490 train_time:55314ms step_avg:49.34ms
+step:1122/1490 train_time:55399ms step_avg:49.38ms
+step:1123/1490 train_time:55479ms step_avg:49.40ms
+step:1124/1490 train_time:55564ms step_avg:49.43ms
+step:1125/1490 train_time:55645ms step_avg:49.46ms
+step:1126/1490 train_time:55731ms step_avg:49.49ms
+step:1127/1490 train_time:55811ms step_avg:49.52ms
+step:1128/1490 train_time:55897ms step_avg:49.55ms
+step:1129/1490 train_time:55976ms step_avg:49.58ms
+step:1130/1490 train_time:56061ms step_avg:49.61ms
+step:1131/1490 train_time:56140ms step_avg:49.64ms
+step:1132/1490 train_time:56226ms step_avg:49.67ms
+step:1133/1490 train_time:56307ms step_avg:49.70ms
+step:1134/1490 train_time:56393ms step_avg:49.73ms
+step:1135/1490 train_time:56473ms step_avg:49.76ms
+step:1136/1490 train_time:56560ms step_avg:49.79ms
+step:1137/1490 train_time:56639ms step_avg:49.81ms
+step:1138/1490 train_time:56724ms step_avg:49.85ms
+step:1139/1490 train_time:56805ms step_avg:49.87ms
+step:1140/1490 train_time:56890ms step_avg:49.90ms
+step:1141/1490 train_time:56972ms step_avg:49.93ms
+step:1142/1490 train_time:57058ms step_avg:49.96ms
+step:1143/1490 train_time:57138ms step_avg:49.99ms
+step:1144/1490 train_time:57223ms step_avg:50.02ms
+step:1145/1490 train_time:57303ms step_avg:50.05ms
+step:1146/1490 train_time:57389ms step_avg:50.08ms
+step:1147/1490 train_time:57470ms step_avg:50.10ms
+step:1148/1490 train_time:57555ms step_avg:50.13ms
+step:1149/1490 train_time:57634ms step_avg:50.16ms
+step:1150/1490 train_time:57719ms step_avg:50.19ms
+step:1151/1490 train_time:57799ms step_avg:50.22ms
+step:1152/1490 train_time:57885ms step_avg:50.25ms
+step:1153/1490 train_time:57965ms step_avg:50.27ms
+step:1154/1490 train_time:58050ms step_avg:50.30ms
+step:1155/1490 train_time:58130ms step_avg:50.33ms
+step:1156/1490 train_time:58216ms step_avg:50.36ms
+step:1157/1490 train_time:58296ms step_avg:50.39ms
+step:1158/1490 train_time:58381ms step_avg:50.42ms
+step:1159/1490 train_time:58461ms step_avg:50.44ms
+step:1160/1490 train_time:58546ms step_avg:50.47ms
+step:1161/1490 train_time:58627ms step_avg:50.50ms
+step:1162/1490 train_time:58711ms step_avg:50.53ms
+step:1163/1490 train_time:58792ms step_avg:50.55ms
+step:1164/1490 train_time:58877ms step_avg:50.58ms
+step:1165/1490 train_time:58958ms step_avg:50.61ms
+step:1166/1490 train_time:59044ms step_avg:50.64ms
+step:1167/1490 train_time:59123ms step_avg:50.66ms
+step:1168/1490 train_time:59209ms step_avg:50.69ms
+step:1169/1490 train_time:59289ms step_avg:50.72ms
+step:1170/1490 train_time:59375ms step_avg:50.75ms
+step:1171/1490 train_time:59455ms step_avg:50.77ms
+step:1172/1490 train_time:59540ms step_avg:50.80ms
+step:1173/1490 train_time:59620ms step_avg:50.83ms
+step:1174/1490 train_time:59706ms step_avg:50.86ms
+step:1175/1490 train_time:59787ms step_avg:50.88ms
+step:1176/1490 train_time:59872ms step_avg:50.91ms
+step:1177/1490 train_time:59953ms step_avg:50.94ms
+step:1178/1490 train_time:60037ms step_avg:50.97ms
+step:1179/1490 train_time:60116ms step_avg:50.99ms
+step:1180/1490 train_time:60202ms step_avg:51.02ms
+step:1181/1490 train_time:60281ms step_avg:51.04ms
+step:1182/1490 train_time:60367ms step_avg:51.07ms
+step:1183/1490 train_time:60448ms step_avg:51.10ms
+step:1184/1490 train_time:60534ms step_avg:51.13ms
+step:1185/1490 train_time:60613ms step_avg:51.15ms
+step:1186/1490 train_time:60699ms step_avg:51.18ms
+step:1187/1490 train_time:60778ms step_avg:51.20ms
+step:1188/1490 train_time:60862ms step_avg:51.23ms
+step:1189/1490 train_time:60943ms step_avg:51.26ms
+step:1190/1490 train_time:61029ms step_avg:51.28ms
+step:1191/1490 train_time:61109ms step_avg:51.31ms
+step:1192/1490 train_time:61195ms step_avg:51.34ms
+step:1193/1490 train_time:61273ms step_avg:51.36ms
+step:1194/1490 train_time:61360ms step_avg:51.39ms
+step:1195/1490 train_time:61440ms step_avg:51.41ms
+step:1196/1490 train_time:61525ms step_avg:51.44ms
+step:1197/1490 train_time:61606ms step_avg:51.47ms
+step:1198/1490 train_time:61691ms step_avg:51.49ms
+step:1199/1490 train_time:61771ms step_avg:51.52ms
+step:1200/1490 train_time:61857ms step_avg:51.55ms
+step:1201/1490 train_time:61936ms step_avg:51.57ms
+step:1202/1490 train_time:62021ms step_avg:51.60ms
+step:1203/1490 train_time:62102ms step_avg:51.62ms
+step:1204/1490 train_time:62188ms step_avg:51.65ms
+step:1205/1490 train_time:62267ms step_avg:51.67ms
+step:1206/1490 train_time:62353ms step_avg:51.70ms
+step:1207/1490 train_time:62433ms step_avg:51.73ms
+step:1208/1490 train_time:62519ms step_avg:51.75ms
+step:1209/1490 train_time:62598ms step_avg:51.78ms
+step:1210/1490 train_time:62683ms step_avg:51.80ms
+step:1211/1490 train_time:62765ms step_avg:51.83ms
+step:1212/1490 train_time:62850ms step_avg:51.86ms
+step:1213/1490 train_time:62932ms step_avg:51.88ms
+step:1214/1490 train_time:63017ms step_avg:51.91ms
+step:1215/1490 train_time:63097ms step_avg:51.93ms
+step:1216/1490 train_time:63184ms step_avg:51.96ms
+step:1217/1490 train_time:63264ms step_avg:51.98ms
+step:1218/1490 train_time:63349ms step_avg:52.01ms
+step:1219/1490 train_time:63429ms step_avg:52.03ms
+step:1220/1490 train_time:63517ms step_avg:52.06ms
+step:1221/1490 train_time:63598ms step_avg:52.09ms
+step:1222/1490 train_time:63682ms step_avg:52.11ms
+step:1223/1490 train_time:63762ms step_avg:52.14ms
+step:1224/1490 train_time:63848ms step_avg:52.16ms
+step:1225/1490 train_time:63929ms step_avg:52.19ms
+step:1226/1490 train_time:64015ms step_avg:52.21ms
+step:1227/1490 train_time:64095ms step_avg:52.24ms
+step:1228/1490 train_time:64180ms step_avg:52.26ms
+step:1229/1490 train_time:64260ms step_avg:52.29ms
+step:1230/1490 train_time:64345ms step_avg:52.31ms
+step:1231/1490 train_time:64426ms step_avg:52.34ms
+step:1232/1490 train_time:64512ms step_avg:52.36ms
+step:1233/1490 train_time:64593ms step_avg:52.39ms
+step:1234/1490 train_time:64678ms step_avg:52.41ms
+step:1235/1490 train_time:64757ms step_avg:52.44ms
+step:1236/1490 train_time:64843ms step_avg:52.46ms
+step:1237/1490 train_time:64923ms step_avg:52.48ms
+step:1238/1490 train_time:65009ms step_avg:52.51ms
+step:1239/1490 train_time:65090ms step_avg:52.53ms
+step:1240/1490 train_time:65175ms step_avg:52.56ms
+step:1241/1490 train_time:65255ms step_avg:52.58ms
+step:1242/1490 train_time:65339ms step_avg:52.61ms
+step:1243/1490 train_time:65418ms step_avg:52.63ms
+step:1244/1490 train_time:65505ms step_avg:52.66ms
+step:1245/1490 train_time:65586ms step_avg:52.68ms
+step:1246/1490 train_time:65671ms step_avg:52.71ms
+step:1247/1490 train_time:65752ms step_avg:52.73ms
+step:1248/1490 train_time:65838ms step_avg:52.75ms
+step:1249/1490 train_time:65918ms step_avg:52.78ms
+step:1250/1490 train_time:66003ms step_avg:52.80ms
+step:1250/1490 val_loss:3.3713 train_time:66105ms step_avg:52.88ms
+step:1251/1490 train_time:66123ms step_avg:52.86ms
+step:1252/1490 train_time:66172ms step_avg:52.85ms
+step:1253/1490 train_time:66255ms step_avg:52.88ms
+step:1254/1490 train_time:66342ms step_avg:52.90ms
+step:1255/1490 train_time:66422ms step_avg:52.93ms
+step:1256/1490 train_time:66506ms step_avg:52.95ms
+step:1257/1490 train_time:66585ms step_avg:52.97ms
+step:1258/1490 train_time:66670ms step_avg:53.00ms
+step:1259/1490 train_time:66748ms step_avg:53.02ms
+step:1260/1490 train_time:66832ms step_avg:53.04ms
+step:1261/1490 train_time:66911ms step_avg:53.06ms
+step:1262/1490 train_time:66995ms step_avg:53.09ms
+step:1263/1490 train_time:67077ms step_avg:53.11ms
+step:1264/1490 train_time:67165ms step_avg:53.14ms
+step:1265/1490 train_time:67248ms step_avg:53.16ms
+step:1266/1490 train_time:67334ms step_avg:53.19ms
+step:1267/1490 train_time:67415ms step_avg:53.21ms
+step:1268/1490 train_time:67500ms step_avg:53.23ms
+step:1269/1490 train_time:67580ms step_avg:53.25ms
+step:1270/1490 train_time:67664ms step_avg:53.28ms
+step:1271/1490 train_time:67743ms step_avg:53.30ms
+step:1272/1490 train_time:67828ms step_avg:53.32ms
+step:1273/1490 train_time:67908ms step_avg:53.34ms
+step:1274/1490 train_time:67993ms step_avg:53.37ms
+step:1275/1490 train_time:68074ms step_avg:53.39ms
+step:1276/1490 train_time:68162ms step_avg:53.42ms
+step:1277/1490 train_time:68244ms step_avg:53.44ms
+step:1278/1490 train_time:68331ms step_avg:53.47ms
+step:1279/1490 train_time:68411ms step_avg:53.49ms
+step:1280/1490 train_time:68496ms step_avg:53.51ms
+step:1281/1490 train_time:68575ms step_avg:53.53ms
+step:1282/1490 train_time:68661ms step_avg:53.56ms
+step:1283/1490 train_time:68741ms step_avg:53.58ms
+step:1284/1490 train_time:68826ms step_avg:53.60ms
+step:1285/1490 train_time:68907ms step_avg:53.62ms
+step:1286/1490 train_time:68992ms step_avg:53.65ms
+step:1287/1490 train_time:69074ms step_avg:53.67ms
+step:1288/1490 train_time:69161ms step_avg:53.70ms
+step:1289/1490 train_time:69243ms step_avg:53.72ms
+step:1290/1490 train_time:69328ms step_avg:53.74ms
+step:1291/1490 train_time:69408ms step_avg:53.76ms
+step:1292/1490 train_time:69493ms step_avg:53.79ms
+step:1293/1490 train_time:69573ms step_avg:53.81ms
+step:1294/1490 train_time:69657ms step_avg:53.83ms
+step:1295/1490 train_time:69735ms step_avg:53.85ms
+step:1296/1490 train_time:69821ms step_avg:53.87ms
+step:1297/1490 train_time:69903ms step_avg:53.90ms
+step:1298/1490 train_time:69990ms step_avg:53.92ms
+step:1299/1490 train_time:70070ms step_avg:53.94ms
+step:1300/1490 train_time:70155ms step_avg:53.97ms
+step:1301/1490 train_time:70235ms step_avg:53.99ms
+step:1302/1490 train_time:70321ms step_avg:54.01ms
+step:1303/1490 train_time:70402ms step_avg:54.03ms
+step:1304/1490 train_time:70488ms step_avg:54.06ms
+step:1305/1490 train_time:70568ms step_avg:54.08ms
+step:1306/1490 train_time:70654ms step_avg:54.10ms
+step:1307/1490 train_time:70733ms step_avg:54.12ms
+step:1308/1490 train_time:70818ms step_avg:54.14ms
+step:1309/1490 train_time:70897ms step_avg:54.16ms
+step:1310/1490 train_time:70982ms step_avg:54.18ms
+step:1311/1490 train_time:71064ms step_avg:54.21ms
+step:1312/1490 train_time:71151ms step_avg:54.23ms
+step:1313/1490 train_time:71231ms step_avg:54.25ms
+step:1314/1490 train_time:71316ms step_avg:54.27ms
+step:1315/1490 train_time:71396ms step_avg:54.29ms
+step:1316/1490 train_time:71482ms step_avg:54.32ms
+step:1317/1490 train_time:71564ms step_avg:54.34ms
+step:1318/1490 train_time:71650ms step_avg:54.36ms
+step:1319/1490 train_time:71728ms step_avg:54.38ms
+step:1320/1490 train_time:71813ms step_avg:54.40ms
+step:1321/1490 train_time:71892ms step_avg:54.42ms
+step:1322/1490 train_time:71979ms step_avg:54.45ms
+step:1323/1490 train_time:72058ms step_avg:54.47ms
+step:1324/1490 train_time:72145ms step_avg:54.49ms
+step:1325/1490 train_time:72225ms step_avg:54.51ms
+step:1326/1490 train_time:72311ms step_avg:54.53ms
+step:1327/1490 train_time:72391ms step_avg:54.55ms
+step:1328/1490 train_time:72476ms step_avg:54.58ms
+step:1329/1490 train_time:72557ms step_avg:54.60ms
+step:1330/1490 train_time:72642ms step_avg:54.62ms
+step:1331/1490 train_time:72722ms step_avg:54.64ms
+step:1332/1490 train_time:72809ms step_avg:54.66ms
+step:1333/1490 train_time:72888ms step_avg:54.68ms
+step:1334/1490 train_time:72973ms step_avg:54.70ms
+step:1335/1490 train_time:73053ms step_avg:54.72ms
+step:1336/1490 train_time:73140ms step_avg:54.75ms
+step:1337/1490 train_time:73222ms step_avg:54.77ms
+step:1338/1490 train_time:73308ms step_avg:54.79ms
+step:1339/1490 train_time:73388ms step_avg:54.81ms
+step:1340/1490 train_time:73475ms step_avg:54.83ms
+step:1341/1490 train_time:73555ms step_avg:54.85ms
+step:1342/1490 train_time:73639ms step_avg:54.87ms
+step:1343/1490 train_time:73720ms step_avg:54.89ms
+step:1344/1490 train_time:73806ms step_avg:54.91ms
+step:1345/1490 train_time:73884ms step_avg:54.93ms
+step:1346/1490 train_time:73971ms step_avg:54.96ms
+step:1347/1490 train_time:74051ms step_avg:54.97ms
+step:1348/1490 train_time:74136ms step_avg:55.00ms
+step:1349/1490 train_time:74217ms step_avg:55.02ms
+step:1350/1490 train_time:74302ms step_avg:55.04ms
+step:1351/1490 train_time:74382ms step_avg:55.06ms
+step:1352/1490 train_time:74469ms step_avg:55.08ms
+step:1353/1490 train_time:74549ms step_avg:55.10ms
+step:1354/1490 train_time:74635ms step_avg:55.12ms
+step:1355/1490 train_time:74715ms step_avg:55.14ms
+step:1356/1490 train_time:74799ms step_avg:55.16ms
+step:1357/1490 train_time:74879ms step_avg:55.18ms
+step:1358/1490 train_time:74965ms step_avg:55.20ms
+step:1359/1490 train_time:75046ms step_avg:55.22ms
+step:1360/1490 train_time:75132ms step_avg:55.24ms
+step:1361/1490 train_time:75212ms step_avg:55.26ms
+step:1362/1490 train_time:75297ms step_avg:55.28ms
+step:1363/1490 train_time:75378ms step_avg:55.30ms
+step:1364/1490 train_time:75465ms step_avg:55.33ms
+step:1365/1490 train_time:75545ms step_avg:55.34ms
+step:1366/1490 train_time:75631ms step_avg:55.37ms
+step:1367/1490 train_time:75712ms step_avg:55.39ms
+step:1368/1490 train_time:75797ms step_avg:55.41ms
+step:1369/1490 train_time:75876ms step_avg:55.42ms
+step:1370/1490 train_time:75962ms step_avg:55.45ms
+step:1371/1490 train_time:76044ms step_avg:55.47ms
+step:1372/1490 train_time:76129ms step_avg:55.49ms
+step:1373/1490 train_time:76209ms step_avg:55.51ms
+step:1374/1490 train_time:76296ms step_avg:55.53ms
+step:1375/1490 train_time:76376ms step_avg:55.55ms
+step:1376/1490 train_time:76461ms step_avg:55.57ms
+step:1377/1490 train_time:76542ms step_avg:55.59ms
+step:1378/1490 train_time:76629ms step_avg:55.61ms
+step:1379/1490 train_time:76710ms step_avg:55.63ms
+step:1380/1490 train_time:76795ms step_avg:55.65ms
+step:1381/1490 train_time:76874ms step_avg:55.67ms
+step:1382/1490 train_time:76960ms step_avg:55.69ms
+step:1383/1490 train_time:77042ms step_avg:55.71ms
+step:1384/1490 train_time:77128ms step_avg:55.73ms
+step:1385/1490 train_time:77208ms step_avg:55.75ms
+step:1386/1490 train_time:77293ms step_avg:55.77ms
+step:1387/1490 train_time:77374ms step_avg:55.78ms
+step:1388/1490 train_time:77459ms step_avg:55.81ms
+step:1389/1490 train_time:77539ms step_avg:55.82ms
+step:1390/1490 train_time:77626ms step_avg:55.85ms
+step:1391/1490 train_time:77707ms step_avg:55.86ms
+step:1392/1490 train_time:77793ms step_avg:55.89ms
+step:1393/1490 train_time:77874ms step_avg:55.90ms
+step:1394/1490 train_time:77958ms step_avg:55.92ms
+step:1395/1490 train_time:78040ms step_avg:55.94ms
+step:1396/1490 train_time:78126ms step_avg:55.96ms
+step:1397/1490 train_time:78208ms step_avg:55.98ms
+step:1398/1490 train_time:78294ms step_avg:56.00ms
+step:1399/1490 train_time:78375ms step_avg:56.02ms
+step:1400/1490 train_time:78460ms step_avg:56.04ms
+step:1401/1490 train_time:78541ms step_avg:56.06ms
+step:1402/1490 train_time:78628ms step_avg:56.08ms
+step:1403/1490 train_time:78708ms step_avg:56.10ms
+step:1404/1490 train_time:78794ms step_avg:56.12ms
+step:1405/1490 train_time:78875ms step_avg:56.14ms
+step:1406/1490 train_time:78960ms step_avg:56.16ms
+step:1407/1490 train_time:79040ms step_avg:56.18ms
+step:1408/1490 train_time:79126ms step_avg:56.20ms
+step:1409/1490 train_time:79206ms step_avg:56.21ms
+step:1410/1490 train_time:79292ms step_avg:56.24ms
+step:1411/1490 train_time:79373ms step_avg:56.25ms
+step:1412/1490 train_time:79459ms step_avg:56.27ms
+step:1413/1490 train_time:79539ms step_avg:56.29ms
+step:1414/1490 train_time:79626ms step_avg:56.31ms
+step:1415/1490 train_time:79706ms step_avg:56.33ms
+step:1416/1490 train_time:79791ms step_avg:56.35ms
+step:1417/1490 train_time:79871ms step_avg:56.37ms
+step:1418/1490 train_time:79956ms step_avg:56.39ms
+step:1419/1490 train_time:80035ms step_avg:56.40ms
+step:1420/1490 train_time:80121ms step_avg:56.42ms
+step:1421/1490 train_time:80201ms step_avg:56.44ms
+step:1422/1490 train_time:80288ms step_avg:56.46ms
+step:1423/1490 train_time:80369ms step_avg:56.48ms
+step:1424/1490 train_time:80453ms step_avg:56.50ms
+step:1425/1490 train_time:80534ms step_avg:56.52ms
+step:1426/1490 train_time:80621ms step_avg:56.54ms
+step:1427/1490 train_time:80700ms step_avg:56.55ms
+step:1428/1490 train_time:80787ms step_avg:56.57ms
+step:1429/1490 train_time:80867ms step_avg:56.59ms
+step:1430/1490 train_time:80952ms step_avg:56.61ms
+step:1431/1490 train_time:81032ms step_avg:56.63ms
+step:1432/1490 train_time:81118ms step_avg:56.65ms
+step:1433/1490 train_time:81196ms step_avg:56.66ms
+step:1434/1490 train_time:81282ms step_avg:56.68ms
+step:1435/1490 train_time:81364ms step_avg:56.70ms
+step:1436/1490 train_time:81450ms step_avg:56.72ms
+step:1437/1490 train_time:81530ms step_avg:56.74ms
+step:1438/1490 train_time:81618ms step_avg:56.76ms
+step:1439/1490 train_time:81698ms step_avg:56.77ms
+step:1440/1490 train_time:81782ms step_avg:56.79ms
+step:1441/1490 train_time:81862ms step_avg:56.81ms
+step:1442/1490 train_time:81947ms step_avg:56.83ms
+step:1443/1490 train_time:82028ms step_avg:56.85ms
+step:1444/1490 train_time:82115ms step_avg:56.87ms
+step:1445/1490 train_time:82193ms step_avg:56.88ms
+step:1446/1490 train_time:82279ms step_avg:56.90ms
+step:1447/1490 train_time:82361ms step_avg:56.92ms
+step:1448/1490 train_time:82446ms step_avg:56.94ms
+step:1449/1490 train_time:82526ms step_avg:56.95ms
+step:1450/1490 train_time:82612ms step_avg:56.97ms
+step:1451/1490 train_time:82695ms step_avg:56.99ms
+step:1452/1490 train_time:82782ms step_avg:57.01ms
+step:1453/1490 train_time:82864ms step_avg:57.03ms
+step:1454/1490 train_time:82949ms step_avg:57.05ms
+step:1455/1490 train_time:83030ms step_avg:57.07ms
+step:1456/1490 train_time:83117ms step_avg:57.09ms
+step:1457/1490 train_time:83196ms step_avg:57.10ms
+step:1458/1490 train_time:83283ms step_avg:57.12ms
+step:1459/1490 train_time:83364ms step_avg:57.14ms
+step:1460/1490 train_time:83453ms step_avg:57.16ms
+step:1461/1490 train_time:83532ms step_avg:57.17ms
+step:1462/1490 train_time:83619ms step_avg:57.20ms
+step:1463/1490 train_time:83701ms step_avg:57.21ms
+step:1464/1490 train_time:83787ms step_avg:57.23ms
+step:1465/1490 train_time:83867ms step_avg:57.25ms
+step:1466/1490 train_time:83955ms step_avg:57.27ms
+step:1467/1490 train_time:84035ms step_avg:57.28ms
+step:1468/1490 train_time:84120ms step_avg:57.30ms
+step:1469/1490 train_time:84200ms step_avg:57.32ms
+step:1470/1490 train_time:84286ms step_avg:57.34ms
+step:1471/1490 train_time:84367ms step_avg:57.35ms
+step:1472/1490 train_time:84453ms step_avg:57.37ms
+step:1473/1490 train_time:84534ms step_avg:57.39ms
+step:1474/1490 train_time:84620ms step_avg:57.41ms
+step:1475/1490 train_time:84701ms step_avg:57.42ms
+step:1476/1490 train_time:84788ms step_avg:57.44ms
+step:1477/1490 train_time:84868ms step_avg:57.46ms
+step:1478/1490 train_time:84953ms step_avg:57.48ms
+step:1479/1490 train_time:85034ms step_avg:57.49ms
+step:1480/1490 train_time:85119ms step_avg:57.51ms
+step:1481/1490 train_time:85200ms step_avg:57.53ms
+step:1482/1490 train_time:85285ms step_avg:57.55ms
+step:1483/1490 train_time:85367ms step_avg:57.56ms
+step:1484/1490 train_time:85453ms step_avg:57.58ms
+step:1485/1490 train_time:85534ms step_avg:57.60ms
+step:1486/1490 train_time:85620ms step_avg:57.62ms
+step:1487/1490 train_time:85701ms step_avg:57.63ms
+step:1488/1490 train_time:85787ms step_avg:57.65ms
+step:1489/1490 train_time:85867ms step_avg:57.67ms
+step:1490/1490 train_time:85952ms step_avg:57.69ms
+step:1490/1490 val_loss:3.2787 train_time:86057ms step_avg:57.76ms
+peak memory allocated: 31277 MiB reserved: 47002 MiB

--- a/records/track_1_short/2026-04-4_FuseCEFwdAndBwd/runs/19ad9161-37c0-4985-8dd4-6db4e27f34b4.txt
+++ b/records/track_1_short/2026-04-4_FuseCEFwdAndBwd/runs/19ad9161-37c0-4985-8dd4-6db4e27f34b4.txt
@@ -1,0 +1,4731 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+CE_KERNEL_BLOCK_SIZE = 256
+CE_KERNEL_VOCAB_SIZE = 50304
+
+CE_KERNEL_DECLS = f"""
+constexpr int VOCAB_SIZE = {CE_KERNEL_VOCAB_SIZE};
+constexpr int BLOCK_SIZE = {CE_KERNEL_BLOCK_SIZE};
+"""
+
+CE_KERNEL_SOURCE = """
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+#define __nv_fp8_e5m2 char
+#define uint16_t unsigned short
+#define uint8_t unsigned char
+#define int64_t long long
+
+__device__ __forceinline__ __nv_fp8_e5m2 f32_to_fp8_e5m2(float x) {
+    uint16_t packed;
+    asm volatile(
+        "cvt.rn.satfinite.e5m2x2.f32 %0, %1, %2;"
+        : "=h"(packed)
+        : "f"(x), "f"(0.0f)
+    );
+    __nv_fp8_e5m2 result;
+    *reinterpret_cast<uint8_t*>(&result) = (packed & (0xFF << 8)) >> 8;
+    return result;
+}
+
+struct __align__(16) __nv_bfloat168 {
+    __nv_bfloat16 data[8];
+    __device__ __nv_bfloat16& operator[](int i) { return data[i]; }
+    __device__ const __nv_bfloat16& operator[](int i) const { return data[i]; }
+};
+
+struct __align__(8) __nv_fp8_e5m28 {
+    __nv_fp8_e5m2 data[8];
+    __device__ __nv_fp8_e5m2& operator[](int i) { return data[i]; }
+    __device__ const __nv_fp8_e5m2& operator[](int i) const { return data[i]; }
+};
+
+template<typename T> __device__ constexpr T CEIL_DIV(T a, T b) { return (a + b - 1) / b; }
+
+//__device__ float sigmoid(float x) {
+//  return 1.0f / (1.0f + __expf(-x));
+//}
+__device__ float sigmoid(float x) {
+  return 0.5f + __tanhf(x * 0.5f) * 0.5f;
+}
+
+extern "C"
+__launch_bounds__(BLOCK_SIZE, 2)
+__global__ void ce_fwd_bwd_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    const int64_t* __restrict__ targets,
+    const float* __restrict__ mtp_weights,
+    float* __restrict__ losses,
+    __nv_fp8_e5m2* grad_input,
+    int batch_size,
+    int n_predict,
+    double A_param,
+    double B_param,
+    double C_param,
+    double grad_s_param,
+    double grad_scale_param)
+{
+  constexpr int VEC_WIDTH = 8;
+  constexpr int NUM_FULL_LOADS = VOCAB_SIZE / (BLOCK_SIZE * VEC_WIDTH);
+  constexpr int NUM_LOADS = CEIL_DIV(VOCAB_SIZE, BLOCK_SIZE * VEC_WIDTH);
+
+  float A = (float)A_param;
+  float B = (float)B_param;
+  float C = (float)C_param;
+  float grad_s = (float)grad_s_param;
+  float grad_scale = (float)grad_scale_param;
+
+  extern __shared__ __nv_bfloat16 smem[];
+
+  static_assert(VEC_WIDTH == 8);
+
+  const __nv_bfloat16 *block_logit_ptr = logits + VOCAB_SIZE * blockIdx.x;
+
+  float inv_C = 1 / C;
+  float B_div_C = B * inv_C;
+  float thread_max = -CUDART_INF_F;
+
+  #pragma unroll 25
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 result = *(__nv_bfloat168*)(&block_logit_ptr[idx]);
+      __nv_bfloat168 result_sigmoid;
+      #pragma unroll
+      for (int k = 0; k < VEC_WIDTH; k++) {
+        float tmp = __bfloat162float(result[k]);
+        tmp = sigmoid(tmp * inv_C + B_div_C);
+        result_sigmoid[k] = __float2bfloat16(tmp);
+        tmp = A * tmp;
+        thread_max = max(tmp, thread_max);
+      }
+      *(__nv_bfloat168*)(&smem[idx]) = result_sigmoid;
+    }
+  }
+
+  constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+  int warp_id = threadIdx.x / 32;
+  __shared__ float block_maxs[NUM_WARPS];
+  __shared__ float block_sums[NUM_WARPS];
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_max = fmaxf(thread_max, __shfl_down_sync(0xFFFFFFFF, thread_max, offset));
+
+  if (threadIdx.x % 32 == 0) {
+    block_maxs[warp_id] = thread_max;
+  }
+
+  __syncthreads();
+
+  float block_max = -CUDART_INF_F;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_max = fmaxf(block_max, block_maxs[i]);
+  }
+
+  float thread_sum = 0.0f;
+  #pragma unroll 2
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_bfloat168 l;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      l = *(__nv_bfloat168*)(&smem[idx]);
+    }
+    #pragma unroll
+    for (int k = 0; k < VEC_WIDTH; k++) {
+      float tmp = A * __bfloat162float(l[k]);
+      tmp = __expf(tmp - block_max);
+      if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+        thread_sum += tmp;
+      }
+    }
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_sum += __shfl_down_sync(0xFFFFFFFF, thread_sum, offset);
+
+  if (threadIdx.x % 32 == 0) {
+    block_sums[warp_id] = thread_sum;
+  }
+
+  __syncthreads();
+
+  float block_sum = 0.0f;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_sum += block_sums[i];
+  }
+
+  float lse = block_max + __logf(block_sum);
+
+  if (threadIdx.x == 0) {
+    float total_loss = 0.0f;
+    for (int k = 0; k < n_predict; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size) {
+        float weight = mtp_weights[k];
+        int64_t target = targets[target_idx];
+        if (target >= 0 && target < VOCAB_SIZE) {
+          float z_target = A * __bfloat162float(smem[target]);
+          total_loss += weight * (lse - z_target);
+        }
+      }
+    }
+    losses[blockIdx.x] = total_loss;
+  }
+
+  float S_w = 0.0f;
+
+  for (int i = 0; i < n_predict; i++) {
+    S_w += mtp_weights[i];
+  }
+
+  #pragma unroll 4
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_fp8_e5m28 result;
+
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 sigmoid_us = *(__nv_bfloat168*)(&smem[idx]);
+      #pragma unroll
+      for (int j = 0; j < VEC_WIDTH; j++) {
+        float sigmoid_u = __bfloat162float(sigmoid_us[j]);
+        float z = A * sigmoid_u;
+        float p = __expf(z - lse);
+
+        float term1 = S_w * p;
+        float term2 = 0.0f;
+
+        float grad_z = term1 - term2;
+        float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+        auto result_tmp = f32_to_fp8_e5m2(grad_x);
+        result[j] = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+      }
+      *(__nv_fp8_e5m28*)(&grad_input[blockIdx.x * VOCAB_SIZE + idx]) = result;
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < n_predict && blockIdx.x + threadIdx.x < batch_size) {
+    int i = threadIdx.x;
+    int64_t target = targets[blockIdx.x + i];
+
+    float sigmoid_u = __bfloat162float(smem[target]);
+    float z = A * sigmoid_u;
+    float p = __expf(z - lse);
+
+    float term1 = S_w * p;
+    float term2 = 0.0f;
+
+    #pragma unroll
+    for (int k = 0; k < 3; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size && k < n_predict) {
+        if (targets[target_idx] == target) {
+          term2 += mtp_weights[k];
+        }
+      }
+    }
+
+    float grad_z = term1 - term2;
+    float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+    auto result_tmp = f32_to_fp8_e5m2(grad_x);
+    auto result = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+    grad_input[blockIdx.x * VOCAB_SIZE + target] = result;
+  }
+}
+"""
+
+
+ce_fwd_bwd_kernel = torch.cuda._compile_kernel(
+    CE_KERNEL_DECLS + CE_KERNEL_SOURCE,
+    "ce_fwd_bwd_kernel",
+    compute_capability="90",
+    cuda_include_dirs=["/usr/local/cuda/include/"],
+    nvcc_options=["-lineinfo", "--use_fast_math"],
+)
+ce_fwd_bwd_kernel.set_shared_memory_config(CE_KERNEL_VOCAB_SIZE * 2)
+
+@torch.library.custom_op("nanogpt::ce_fwd_bwd", mutates_args={"losses", "grad_input"})
+def ce_fwd_bwd(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    mtp_weights: torch.Tensor,
+    losses: torch.Tensor,
+    grad_input: torch.Tensor,
+    n_rows: int,
+    n_predict: int,
+    A: float,
+    B: float,
+    C: float,
+    grad_s: float,
+    grad_scale: float,
+) -> None:
+    grid = (n_rows, 1, 1)
+    ce_fwd_bwd_kernel(
+        grid,
+        (CE_KERNEL_BLOCK_SIZE, 1, 1),
+        (logits, targets, mtp_weights, losses, grad_input,
+         n_rows, n_predict, A, B, C, grad_s, grad_scale),
+        shared_mem=CE_KERNEL_VOCAB_SIZE * 2,
+    )
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, grad_scale, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+
+        ce_fwd_bwd(logits, targets, mtp_weights, losses, grad_input,
+             n_rows, n_predict, A, B, C, grad_s, grad_scale)
+        #grid = (n_rows,)
+        #fused_softcapped_entropy_fwd_kernel[grid](
+        #    logits, losses, lse, targets, mtp_weights,
+        #    logits.stride(0), logits.stride(1),
+        #    n_rows, n_cols, n_predict,
+        #    A, B, C,
+        #    BLOCK_SIZE=2048,
+        #    num_warps=2
+        #)
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_output = grad_output.contiguous()
+
+        #grad_input_ref = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        #grid = (n_rows,)
+        #fused_softcapped_entropy_bwd_kernel[grid](
+        #    grad_input_ref, grad_output, lse, logits, targets, mtp_weights,
+        #    logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+        #    n_rows, n_cols, n_predict,
+        #    A, B, C,
+        #    grad_s,
+        #    BLOCK_SIZE=1024,
+        #    num_warps=4,
+        #    N_PREDICT=n_predict,
+        #)
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.12.3 (main, Mar  3 2026, 12:15:18) [GCC 13.3.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sat Apr  4 05:29:50 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:8D:00.0 Off |                    0 |
+| N/A   32C    P0            118W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:91:00.0 Off |                    0 |
+| N/A   30C    P0            116W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:95:00.0 Off |                    0 |
+| N/A   32C    P0            120W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:99:00.0 Off |                    0 |
+| N/A   32C    P0            123W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AF:00.0 Off |                    0 |
+| N/A   31C    P0            117W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:B3:00.0 Off |                    0 |
+| N/A   32C    P0            119W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:B7:00.0 Off |                    0 |
+| N/A   30C    P0            117W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A           19008      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    1   N/A  N/A           19009      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    2   N/A  N/A           19010      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    3   N/A  N/A           19011      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    4   N/A  N/A           19012      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    5   N/A  N/A           19013      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    6   N/A  N/A           19014      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    7   N/A  N/A           19015      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8287 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:84ms step_avg:83.88ms
+step:2/1490 train_time:108ms step_avg:54.09ms
+step:3/1490 train_time:127ms step_avg:42.38ms
+step:4/1490 train_time:148ms step_avg:36.94ms
+step:5/1490 train_time:173ms step_avg:34.58ms
+step:6/1490 train_time:207ms step_avg:34.57ms
+step:7/1490 train_time:234ms step_avg:33.47ms
+step:8/1490 train_time:269ms step_avg:33.58ms
+step:9/1490 train_time:295ms step_avg:32.80ms
+step:10/1490 train_time:330ms step_avg:32.99ms
+step:11/1490 train_time:357ms step_avg:32.43ms
+step:12/1490 train_time:391ms step_avg:32.59ms
+step:13/1490 train_time:418ms step_avg:32.16ms
+step:14/1490 train_time:452ms step_avg:32.32ms
+step:15/1490 train_time:480ms step_avg:31.97ms
+step:16/1490 train_time:514ms step_avg:32.13ms
+step:17/1490 train_time:541ms step_avg:31.83ms
+step:18/1490 train_time:575ms step_avg:31.96ms
+step:19/1490 train_time:602ms step_avg:31.69ms
+step:20/1490 train_time:637ms step_avg:31.83ms
+step:21/1490 train_time:664ms step_avg:31.61ms
+step:22/1490 train_time:699ms step_avg:31.75ms
+step:23/1490 train_time:726ms step_avg:31.55ms
+step:24/1490 train_time:760ms step_avg:31.67ms
+step:25/1490 train_time:787ms step_avg:31.50ms
+step:26/1490 train_time:822ms step_avg:31.61ms
+step:27/1490 train_time:849ms step_avg:31.44ms
+step:28/1490 train_time:883ms step_avg:31.54ms
+step:29/1490 train_time:911ms step_avg:31.40ms
+step:30/1490 train_time:945ms step_avg:31.50ms
+step:31/1490 train_time:973ms step_avg:31.38ms
+step:32/1490 train_time:1008ms step_avg:31.49ms
+step:33/1490 train_time:1037ms step_avg:31.41ms
+step:34/1490 train_time:1071ms step_avg:31.51ms
+step:35/1490 train_time:1099ms step_avg:31.41ms
+step:36/1490 train_time:1134ms step_avg:31.50ms
+step:37/1490 train_time:1162ms step_avg:31.39ms
+step:38/1490 train_time:1196ms step_avg:31.48ms
+step:39/1490 train_time:1224ms step_avg:31.38ms
+step:40/1490 train_time:1258ms step_avg:31.46ms
+step:41/1490 train_time:1286ms step_avg:31.36ms
+step:42/1490 train_time:1320ms step_avg:31.44ms
+step:43/1490 train_time:1348ms step_avg:31.36ms
+step:44/1490 train_time:1383ms step_avg:31.42ms
+step:45/1490 train_time:1410ms step_avg:31.33ms
+step:46/1490 train_time:1444ms step_avg:31.40ms
+step:47/1490 train_time:1472ms step_avg:31.31ms
+step:48/1490 train_time:1506ms step_avg:31.38ms
+step:49/1490 train_time:1533ms step_avg:31.29ms
+step:50/1490 train_time:1568ms step_avg:31.35ms
+step:51/1490 train_time:1596ms step_avg:31.28ms
+step:52/1490 train_time:1630ms step_avg:31.35ms
+step:53/1490 train_time:1657ms step_avg:31.26ms
+step:54/1490 train_time:1691ms step_avg:31.31ms
+step:55/1490 train_time:1718ms step_avg:31.25ms
+step:56/1490 train_time:1753ms step_avg:31.30ms
+step:57/1490 train_time:1780ms step_avg:31.23ms
+step:58/1490 train_time:1815ms step_avg:31.29ms
+step:59/1490 train_time:1842ms step_avg:31.21ms
+step:60/1490 train_time:1876ms step_avg:31.27ms
+step:61/1490 train_time:1903ms step_avg:31.20ms
+step:62/1490 train_time:1938ms step_avg:31.26ms
+step:63/1490 train_time:1966ms step_avg:31.20ms
+step:64/1490 train_time:2001ms step_avg:31.27ms
+step:65/1490 train_time:2029ms step_avg:31.21ms
+step:66/1490 train_time:2063ms step_avg:31.26ms
+step:67/1490 train_time:2090ms step_avg:31.20ms
+step:68/1490 train_time:2125ms step_avg:31.25ms
+step:69/1490 train_time:2153ms step_avg:31.20ms
+step:70/1490 train_time:2187ms step_avg:31.24ms
+step:71/1490 train_time:2215ms step_avg:31.20ms
+step:72/1490 train_time:2250ms step_avg:31.24ms
+step:73/1490 train_time:2277ms step_avg:31.19ms
+step:74/1490 train_time:2312ms step_avg:31.24ms
+step:75/1490 train_time:2340ms step_avg:31.20ms
+step:76/1490 train_time:2374ms step_avg:31.24ms
+step:77/1490 train_time:2402ms step_avg:31.19ms
+step:78/1490 train_time:2436ms step_avg:31.23ms
+step:79/1490 train_time:2463ms step_avg:31.18ms
+step:80/1490 train_time:2498ms step_avg:31.22ms
+step:81/1490 train_time:2525ms step_avg:31.17ms
+step:82/1490 train_time:2559ms step_avg:31.21ms
+step:83/1490 train_time:2587ms step_avg:31.16ms
+step:84/1490 train_time:2621ms step_avg:31.20ms
+step:85/1490 train_time:2648ms step_avg:31.16ms
+step:86/1490 train_time:2683ms step_avg:31.19ms
+step:87/1490 train_time:2710ms step_avg:31.15ms
+step:88/1490 train_time:2744ms step_avg:31.18ms
+step:89/1490 train_time:2771ms step_avg:31.14ms
+step:90/1490 train_time:2806ms step_avg:31.18ms
+step:91/1490 train_time:2833ms step_avg:31.13ms
+step:92/1490 train_time:2868ms step_avg:31.17ms
+step:93/1490 train_time:2895ms step_avg:31.13ms
+step:94/1490 train_time:2930ms step_avg:31.17ms
+step:95/1490 train_time:2958ms step_avg:31.13ms
+step:96/1490 train_time:2992ms step_avg:31.17ms
+step:97/1490 train_time:3019ms step_avg:31.13ms
+step:98/1490 train_time:3054ms step_avg:31.16ms
+step:99/1490 train_time:3081ms step_avg:31.12ms
+step:100/1490 train_time:3116ms step_avg:31.16ms
+step:101/1490 train_time:3143ms step_avg:31.12ms
+step:102/1490 train_time:3178ms step_avg:31.16ms
+step:103/1490 train_time:3205ms step_avg:31.12ms
+step:104/1490 train_time:3240ms step_avg:31.15ms
+step:105/1490 train_time:3268ms step_avg:31.12ms
+step:106/1490 train_time:3302ms step_avg:31.15ms
+step:107/1490 train_time:3330ms step_avg:31.12ms
+step:108/1490 train_time:3364ms step_avg:31.15ms
+step:109/1490 train_time:3392ms step_avg:31.12ms
+step:110/1490 train_time:3426ms step_avg:31.15ms
+step:111/1490 train_time:3453ms step_avg:31.11ms
+step:112/1490 train_time:3488ms step_avg:31.14ms
+step:113/1490 train_time:3515ms step_avg:31.11ms
+step:114/1490 train_time:3550ms step_avg:31.14ms
+step:115/1490 train_time:3577ms step_avg:31.11ms
+step:116/1490 train_time:3611ms step_avg:31.13ms
+step:117/1490 train_time:3640ms step_avg:31.11ms
+step:118/1490 train_time:3674ms step_avg:31.13ms
+step:119/1490 train_time:3701ms step_avg:31.10ms
+step:120/1490 train_time:3735ms step_avg:31.12ms
+step:121/1490 train_time:3762ms step_avg:31.09ms
+step:122/1490 train_time:3797ms step_avg:31.12ms
+step:123/1490 train_time:3824ms step_avg:31.09ms
+step:124/1490 train_time:3858ms step_avg:31.12ms
+step:125/1490 train_time:3885ms step_avg:31.08ms
+step:126/1490 train_time:3920ms step_avg:31.11ms
+step:127/1490 train_time:3948ms step_avg:31.08ms
+step:128/1490 train_time:3982ms step_avg:31.11ms
+step:129/1490 train_time:4009ms step_avg:31.08ms
+step:130/1490 train_time:4044ms step_avg:31.11ms
+step:131/1490 train_time:4071ms step_avg:31.08ms
+step:132/1490 train_time:4106ms step_avg:31.10ms
+step:133/1490 train_time:4133ms step_avg:31.07ms
+step:134/1490 train_time:4167ms step_avg:31.10ms
+step:135/1490 train_time:4194ms step_avg:31.07ms
+step:136/1490 train_time:4229ms step_avg:31.09ms
+step:137/1490 train_time:4256ms step_avg:31.07ms
+step:138/1490 train_time:4291ms step_avg:31.09ms
+step:139/1490 train_time:4319ms step_avg:31.07ms
+step:140/1490 train_time:4354ms step_avg:31.10ms
+step:141/1490 train_time:4380ms step_avg:31.07ms
+step:142/1490 train_time:4415ms step_avg:31.09ms
+step:143/1490 train_time:4442ms step_avg:31.07ms
+step:144/1490 train_time:4477ms step_avg:31.09ms
+step:145/1490 train_time:4505ms step_avg:31.07ms
+step:146/1490 train_time:4539ms step_avg:31.09ms
+step:147/1490 train_time:4567ms step_avg:31.07ms
+step:148/1490 train_time:4602ms step_avg:31.09ms
+step:149/1490 train_time:4629ms step_avg:31.07ms
+step:150/1490 train_time:4663ms step_avg:31.09ms
+step:151/1490 train_time:4690ms step_avg:31.06ms
+step:152/1490 train_time:4724ms step_avg:31.08ms
+step:153/1490 train_time:4752ms step_avg:31.06ms
+step:154/1490 train_time:4786ms step_avg:31.08ms
+step:155/1490 train_time:4813ms step_avg:31.05ms
+step:156/1490 train_time:4848ms step_avg:31.08ms
+step:157/1490 train_time:4875ms step_avg:31.05ms
+step:158/1490 train_time:4909ms step_avg:31.07ms
+step:159/1490 train_time:4937ms step_avg:31.05ms
+step:160/1490 train_time:4972ms step_avg:31.07ms
+step:161/1490 train_time:4999ms step_avg:31.05ms
+step:162/1490 train_time:5033ms step_avg:31.07ms
+step:163/1490 train_time:5060ms step_avg:31.05ms
+step:164/1490 train_time:5095ms step_avg:31.07ms
+step:165/1490 train_time:5122ms step_avg:31.04ms
+step:166/1490 train_time:5157ms step_avg:31.06ms
+step:167/1490 train_time:5183ms step_avg:31.04ms
+step:168/1490 train_time:5218ms step_avg:31.06ms
+step:169/1490 train_time:5246ms step_avg:31.04ms
+step:170/1490 train_time:5281ms step_avg:31.06ms
+step:171/1490 train_time:5308ms step_avg:31.04ms
+step:172/1490 train_time:5342ms step_avg:31.06ms
+step:173/1490 train_time:5369ms step_avg:31.04ms
+step:174/1490 train_time:5403ms step_avg:31.05ms
+step:175/1490 train_time:5431ms step_avg:31.03ms
+step:176/1490 train_time:5465ms step_avg:31.05ms
+step:177/1490 train_time:5492ms step_avg:31.03ms
+step:178/1490 train_time:5527ms step_avg:31.05ms
+step:179/1490 train_time:5555ms step_avg:31.03ms
+step:180/1490 train_time:5589ms step_avg:31.05ms
+step:181/1490 train_time:5616ms step_avg:31.03ms
+step:182/1490 train_time:5651ms step_avg:31.05ms
+step:183/1490 train_time:5678ms step_avg:31.03ms
+step:184/1490 train_time:5713ms step_avg:31.05ms
+step:185/1490 train_time:5740ms step_avg:31.03ms
+step:186/1490 train_time:5774ms step_avg:31.05ms
+step:187/1490 train_time:5801ms step_avg:31.02ms
+step:188/1490 train_time:5836ms step_avg:31.04ms
+step:189/1490 train_time:5863ms step_avg:31.02ms
+step:190/1490 train_time:5897ms step_avg:31.04ms
+step:191/1490 train_time:5924ms step_avg:31.02ms
+step:192/1490 train_time:5959ms step_avg:31.04ms
+step:193/1490 train_time:5986ms step_avg:31.01ms
+step:194/1490 train_time:6020ms step_avg:31.03ms
+step:195/1490 train_time:6048ms step_avg:31.01ms
+step:196/1490 train_time:6082ms step_avg:31.03ms
+step:197/1490 train_time:6109ms step_avg:31.01ms
+step:198/1490 train_time:6144ms step_avg:31.03ms
+step:199/1490 train_time:6171ms step_avg:31.01ms
+step:200/1490 train_time:6205ms step_avg:31.03ms
+step:201/1490 train_time:6232ms step_avg:31.01ms
+step:202/1490 train_time:6266ms step_avg:31.02ms
+step:203/1490 train_time:6294ms step_avg:31.01ms
+step:204/1490 train_time:6328ms step_avg:31.02ms
+step:205/1490 train_time:6356ms step_avg:31.00ms
+step:206/1490 train_time:6390ms step_avg:31.02ms
+step:207/1490 train_time:6418ms step_avg:31.00ms
+step:208/1490 train_time:6453ms step_avg:31.02ms
+step:209/1490 train_time:6480ms step_avg:31.00ms
+step:210/1490 train_time:6514ms step_avg:31.02ms
+step:211/1490 train_time:6541ms step_avg:31.00ms
+step:212/1490 train_time:6576ms step_avg:31.02ms
+step:213/1490 train_time:6603ms step_avg:31.00ms
+step:214/1490 train_time:6638ms step_avg:31.02ms
+step:215/1490 train_time:6665ms step_avg:31.00ms
+step:216/1490 train_time:6700ms step_avg:31.02ms
+step:217/1490 train_time:6727ms step_avg:31.00ms
+step:218/1490 train_time:6762ms step_avg:31.02ms
+step:219/1490 train_time:6789ms step_avg:31.00ms
+step:220/1490 train_time:6823ms step_avg:31.01ms
+step:221/1490 train_time:6850ms step_avg:31.00ms
+step:222/1490 train_time:6884ms step_avg:31.01ms
+step:223/1490 train_time:6911ms step_avg:30.99ms
+step:224/1490 train_time:6946ms step_avg:31.01ms
+step:225/1490 train_time:6973ms step_avg:30.99ms
+step:226/1490 train_time:7007ms step_avg:31.01ms
+step:227/1490 train_time:7034ms step_avg:30.99ms
+step:228/1490 train_time:7069ms step_avg:31.00ms
+step:229/1490 train_time:7096ms step_avg:30.99ms
+step:230/1490 train_time:7130ms step_avg:31.00ms
+step:231/1490 train_time:7158ms step_avg:30.99ms
+step:232/1490 train_time:7192ms step_avg:31.00ms
+step:233/1490 train_time:7219ms step_avg:30.98ms
+step:234/1490 train_time:7254ms step_avg:31.00ms
+step:235/1490 train_time:7281ms step_avg:30.98ms
+step:236/1490 train_time:7315ms step_avg:31.00ms
+step:237/1490 train_time:7343ms step_avg:30.98ms
+step:238/1490 train_time:7377ms step_avg:31.00ms
+step:239/1490 train_time:7405ms step_avg:30.98ms
+step:240/1490 train_time:7439ms step_avg:31.00ms
+step:241/1490 train_time:7467ms step_avg:30.98ms
+step:242/1490 train_time:7501ms step_avg:31.00ms
+step:243/1490 train_time:7528ms step_avg:30.98ms
+step:244/1490 train_time:7563ms step_avg:30.99ms
+step:245/1490 train_time:7590ms step_avg:30.98ms
+step:246/1490 train_time:7624ms step_avg:30.99ms
+step:247/1490 train_time:7652ms step_avg:30.98ms
+step:248/1490 train_time:7686ms step_avg:30.99ms
+step:249/1490 train_time:7713ms step_avg:30.98ms
+step:250/1490 train_time:7747ms step_avg:30.99ms
+step:250/1490 val_loss:4.5190 train_time:7787ms step_avg:31.15ms
+step:251/1490 train_time:7803ms step_avg:31.09ms
+step:252/1490 train_time:7822ms step_avg:31.04ms
+step:253/1490 train_time:7840ms step_avg:30.99ms
+step:254/1490 train_time:7875ms step_avg:31.00ms
+step:255/1490 train_time:7903ms step_avg:30.99ms
+step:256/1490 train_time:7939ms step_avg:31.01ms
+step:257/1490 train_time:7967ms step_avg:31.00ms
+step:258/1490 train_time:8003ms step_avg:31.02ms
+step:259/1490 train_time:8029ms step_avg:31.00ms
+step:260/1490 train_time:8064ms step_avg:31.01ms
+step:261/1490 train_time:8092ms step_avg:31.00ms
+step:262/1490 train_time:8126ms step_avg:31.01ms
+step:263/1490 train_time:8153ms step_avg:31.00ms
+step:264/1490 train_time:8187ms step_avg:31.01ms
+step:265/1490 train_time:8214ms step_avg:31.00ms
+step:266/1490 train_time:8249ms step_avg:31.01ms
+step:267/1490 train_time:8276ms step_avg:31.00ms
+step:268/1490 train_time:8310ms step_avg:31.01ms
+step:269/1490 train_time:8337ms step_avg:30.99ms
+step:270/1490 train_time:8371ms step_avg:31.00ms
+step:271/1490 train_time:8398ms step_avg:30.99ms
+step:272/1490 train_time:8432ms step_avg:31.00ms
+step:273/1490 train_time:8459ms step_avg:30.99ms
+step:274/1490 train_time:8493ms step_avg:31.00ms
+step:275/1490 train_time:8520ms step_avg:30.98ms
+step:276/1490 train_time:8555ms step_avg:31.00ms
+step:277/1490 train_time:8582ms step_avg:30.98ms
+step:278/1490 train_time:8616ms step_avg:30.99ms
+step:279/1490 train_time:8643ms step_avg:30.98ms
+step:280/1490 train_time:8677ms step_avg:30.99ms
+step:281/1490 train_time:8704ms step_avg:30.98ms
+step:282/1490 train_time:8739ms step_avg:30.99ms
+step:283/1490 train_time:8766ms step_avg:30.98ms
+step:284/1490 train_time:8801ms step_avg:30.99ms
+step:285/1490 train_time:8829ms step_avg:30.98ms
+step:286/1490 train_time:8864ms step_avg:30.99ms
+step:287/1490 train_time:8892ms step_avg:30.98ms
+step:288/1490 train_time:8926ms step_avg:30.99ms
+step:289/1490 train_time:8954ms step_avg:30.98ms
+step:290/1490 train_time:8989ms step_avg:30.99ms
+step:291/1490 train_time:9016ms step_avg:30.98ms
+step:292/1490 train_time:9050ms step_avg:30.99ms
+step:293/1490 train_time:9078ms step_avg:30.98ms
+step:294/1490 train_time:9112ms step_avg:30.99ms
+step:295/1490 train_time:9140ms step_avg:30.98ms
+step:296/1490 train_time:9175ms step_avg:31.00ms
+step:297/1490 train_time:9202ms step_avg:30.98ms
+step:298/1490 train_time:9237ms step_avg:31.00ms
+step:299/1490 train_time:9263ms step_avg:30.98ms
+step:300/1490 train_time:9298ms step_avg:30.99ms
+step:301/1490 train_time:9325ms step_avg:30.98ms
+step:302/1490 train_time:9359ms step_avg:30.99ms
+step:303/1490 train_time:9387ms step_avg:30.98ms
+step:304/1490 train_time:9421ms step_avg:30.99ms
+step:305/1490 train_time:9449ms step_avg:30.98ms
+step:306/1490 train_time:9483ms step_avg:30.99ms
+step:307/1490 train_time:9510ms step_avg:30.98ms
+step:308/1490 train_time:9544ms step_avg:30.99ms
+step:309/1490 train_time:9572ms step_avg:30.98ms
+step:310/1490 train_time:9606ms step_avg:30.99ms
+step:311/1490 train_time:9633ms step_avg:30.97ms
+step:312/1490 train_time:9667ms step_avg:30.98ms
+step:313/1490 train_time:9694ms step_avg:30.97ms
+step:314/1490 train_time:9728ms step_avg:30.98ms
+step:315/1490 train_time:9755ms step_avg:30.97ms
+step:316/1490 train_time:9790ms step_avg:30.98ms
+step:317/1490 train_time:9817ms step_avg:30.97ms
+step:318/1490 train_time:9852ms step_avg:30.98ms
+step:319/1490 train_time:9880ms step_avg:30.97ms
+step:320/1490 train_time:9915ms step_avg:30.98ms
+step:321/1490 train_time:9942ms step_avg:30.97ms
+step:322/1490 train_time:9977ms step_avg:30.98ms
+step:323/1490 train_time:10004ms step_avg:30.97ms
+step:324/1490 train_time:10039ms step_avg:30.98ms
+step:325/1490 train_time:10066ms step_avg:30.97ms
+step:326/1490 train_time:10101ms step_avg:30.98ms
+step:327/1490 train_time:10128ms step_avg:30.97ms
+step:328/1490 train_time:10163ms step_avg:30.98ms
+step:329/1490 train_time:10190ms step_avg:30.97ms
+step:330/1490 train_time:10224ms step_avg:30.98ms
+step:331/1490 train_time:10251ms step_avg:30.97ms
+step:332/1490 train_time:10286ms step_avg:30.98ms
+step:333/1490 train_time:10313ms step_avg:30.97ms
+step:334/1490 train_time:10348ms step_avg:30.98ms
+step:335/1490 train_time:10375ms step_avg:30.97ms
+step:336/1490 train_time:10409ms step_avg:30.98ms
+step:337/1490 train_time:10436ms step_avg:30.97ms
+step:338/1490 train_time:10470ms step_avg:30.98ms
+step:339/1490 train_time:10498ms step_avg:30.97ms
+step:340/1490 train_time:10531ms step_avg:30.97ms
+step:341/1490 train_time:10559ms step_avg:30.97ms
+step:342/1490 train_time:10594ms step_avg:30.98ms
+step:343/1490 train_time:10621ms step_avg:30.96ms
+step:344/1490 train_time:10655ms step_avg:30.97ms
+step:345/1490 train_time:10682ms step_avg:30.96ms
+step:346/1490 train_time:10716ms step_avg:30.97ms
+step:347/1490 train_time:10743ms step_avg:30.96ms
+step:348/1490 train_time:10778ms step_avg:30.97ms
+step:349/1490 train_time:10805ms step_avg:30.96ms
+step:350/1490 train_time:10840ms step_avg:30.97ms
+step:351/1490 train_time:10867ms step_avg:30.96ms
+step:352/1490 train_time:10902ms step_avg:30.97ms
+step:353/1490 train_time:10929ms step_avg:30.96ms
+step:354/1490 train_time:10964ms step_avg:30.97ms
+step:355/1490 train_time:10991ms step_avg:30.96ms
+step:356/1490 train_time:11025ms step_avg:30.97ms
+step:357/1490 train_time:11052ms step_avg:30.96ms
+step:358/1490 train_time:11086ms step_avg:30.97ms
+step:359/1490 train_time:11113ms step_avg:30.96ms
+step:360/1490 train_time:11148ms step_avg:30.97ms
+step:361/1490 train_time:11175ms step_avg:30.96ms
+step:362/1490 train_time:11209ms step_avg:30.97ms
+step:363/1490 train_time:11236ms step_avg:30.95ms
+step:364/1490 train_time:11271ms step_avg:30.96ms
+step:365/1490 train_time:11298ms step_avg:30.95ms
+step:366/1490 train_time:11333ms step_avg:30.96ms
+step:367/1490 train_time:11360ms step_avg:30.95ms
+step:368/1490 train_time:11395ms step_avg:30.96ms
+step:369/1490 train_time:11422ms step_avg:30.95ms
+step:370/1490 train_time:11456ms step_avg:30.96ms
+step:371/1490 train_time:11483ms step_avg:30.95ms
+step:372/1490 train_time:11518ms step_avg:30.96ms
+step:373/1490 train_time:11544ms step_avg:30.95ms
+step:374/1490 train_time:11579ms step_avg:30.96ms
+step:375/1490 train_time:11606ms step_avg:30.95ms
+step:376/1490 train_time:11641ms step_avg:30.96ms
+step:377/1490 train_time:11668ms step_avg:30.95ms
+step:378/1490 train_time:11703ms step_avg:30.96ms
+step:379/1490 train_time:11730ms step_avg:30.95ms
+step:380/1490 train_time:11764ms step_avg:30.96ms
+step:381/1490 train_time:11791ms step_avg:30.95ms
+step:382/1490 train_time:11825ms step_avg:30.96ms
+step:383/1490 train_time:11853ms step_avg:30.95ms
+step:384/1490 train_time:11887ms step_avg:30.96ms
+step:385/1490 train_time:11914ms step_avg:30.95ms
+step:386/1490 train_time:11949ms step_avg:30.96ms
+step:387/1490 train_time:11976ms step_avg:30.95ms
+step:388/1490 train_time:12011ms step_avg:30.96ms
+step:389/1490 train_time:12038ms step_avg:30.95ms
+step:390/1490 train_time:12072ms step_avg:30.95ms
+step:391/1490 train_time:12100ms step_avg:30.95ms
+step:392/1490 train_time:12134ms step_avg:30.95ms
+step:393/1490 train_time:12161ms step_avg:30.94ms
+step:394/1490 train_time:12196ms step_avg:30.95ms
+step:395/1490 train_time:12223ms step_avg:30.94ms
+step:396/1490 train_time:12257ms step_avg:30.95ms
+step:397/1490 train_time:12285ms step_avg:30.94ms
+step:398/1490 train_time:12320ms step_avg:30.95ms
+step:399/1490 train_time:12347ms step_avg:30.94ms
+step:400/1490 train_time:12382ms step_avg:30.95ms
+step:401/1490 train_time:12409ms step_avg:30.94ms
+step:402/1490 train_time:12443ms step_avg:30.95ms
+step:403/1490 train_time:12470ms step_avg:30.94ms
+step:404/1490 train_time:12505ms step_avg:30.95ms
+step:405/1490 train_time:12532ms step_avg:30.94ms
+step:406/1490 train_time:12566ms step_avg:30.95ms
+step:407/1490 train_time:12593ms step_avg:30.94ms
+step:408/1490 train_time:12627ms step_avg:30.95ms
+step:409/1490 train_time:12654ms step_avg:30.94ms
+step:410/1490 train_time:12688ms step_avg:30.95ms
+step:411/1490 train_time:12716ms step_avg:30.94ms
+step:412/1490 train_time:12750ms step_avg:30.95ms
+step:413/1490 train_time:12778ms step_avg:30.94ms
+step:414/1490 train_time:12813ms step_avg:30.95ms
+step:415/1490 train_time:12840ms step_avg:30.94ms
+step:416/1490 train_time:12875ms step_avg:30.95ms
+step:417/1490 train_time:12902ms step_avg:30.94ms
+step:418/1490 train_time:12936ms step_avg:30.95ms
+step:419/1490 train_time:12963ms step_avg:30.94ms
+step:420/1490 train_time:12997ms step_avg:30.95ms
+step:421/1490 train_time:13024ms step_avg:30.94ms
+step:422/1490 train_time:13059ms step_avg:30.95ms
+step:423/1490 train_time:13087ms step_avg:30.94ms
+step:424/1490 train_time:13122ms step_avg:30.95ms
+step:425/1490 train_time:13149ms step_avg:30.94ms
+step:426/1490 train_time:13183ms step_avg:30.95ms
+step:427/1490 train_time:13211ms step_avg:30.94ms
+step:428/1490 train_time:13245ms step_avg:30.95ms
+step:429/1490 train_time:13272ms step_avg:30.94ms
+step:430/1490 train_time:13307ms step_avg:30.95ms
+step:431/1490 train_time:13334ms step_avg:30.94ms
+step:432/1490 train_time:13368ms step_avg:30.94ms
+step:433/1490 train_time:13396ms step_avg:30.94ms
+step:434/1490 train_time:13430ms step_avg:30.94ms
+step:435/1490 train_time:13458ms step_avg:30.94ms
+step:436/1490 train_time:13492ms step_avg:30.95ms
+step:437/1490 train_time:13520ms step_avg:30.94ms
+step:438/1490 train_time:13554ms step_avg:30.95ms
+step:439/1490 train_time:13581ms step_avg:30.94ms
+step:440/1490 train_time:13615ms step_avg:30.94ms
+step:441/1490 train_time:13643ms step_avg:30.94ms
+step:442/1490 train_time:13677ms step_avg:30.94ms
+step:443/1490 train_time:13704ms step_avg:30.93ms
+step:444/1490 train_time:13739ms step_avg:30.94ms
+step:445/1490 train_time:13766ms step_avg:30.93ms
+step:446/1490 train_time:13801ms step_avg:30.94ms
+step:447/1490 train_time:13827ms step_avg:30.93ms
+step:448/1490 train_time:13862ms step_avg:30.94ms
+step:449/1490 train_time:13889ms step_avg:30.93ms
+step:450/1490 train_time:13924ms step_avg:30.94ms
+step:451/1490 train_time:13951ms step_avg:30.93ms
+step:452/1490 train_time:13986ms step_avg:30.94ms
+step:453/1490 train_time:14013ms step_avg:30.93ms
+step:454/1490 train_time:14047ms step_avg:30.94ms
+step:455/1490 train_time:14075ms step_avg:30.93ms
+step:456/1490 train_time:14109ms step_avg:30.94ms
+step:457/1490 train_time:14137ms step_avg:30.93ms
+step:458/1490 train_time:14171ms step_avg:30.94ms
+step:459/1490 train_time:14199ms step_avg:30.93ms
+step:460/1490 train_time:14233ms step_avg:30.94ms
+step:461/1490 train_time:14260ms step_avg:30.93ms
+step:462/1490 train_time:14295ms step_avg:30.94ms
+step:463/1490 train_time:14322ms step_avg:30.93ms
+step:464/1490 train_time:14356ms step_avg:30.94ms
+step:465/1490 train_time:14383ms step_avg:30.93ms
+step:466/1490 train_time:14418ms step_avg:30.94ms
+step:467/1490 train_time:14445ms step_avg:30.93ms
+step:468/1490 train_time:14480ms step_avg:30.94ms
+step:469/1490 train_time:14507ms step_avg:30.93ms
+step:470/1490 train_time:14542ms step_avg:30.94ms
+step:471/1490 train_time:14569ms step_avg:30.93ms
+step:472/1490 train_time:14604ms step_avg:30.94ms
+step:473/1490 train_time:14631ms step_avg:30.93ms
+step:474/1490 train_time:14665ms step_avg:30.94ms
+step:475/1490 train_time:14692ms step_avg:30.93ms
+step:476/1490 train_time:14726ms step_avg:30.94ms
+step:477/1490 train_time:14753ms step_avg:30.93ms
+step:478/1490 train_time:14787ms step_avg:30.94ms
+step:479/1490 train_time:14814ms step_avg:30.93ms
+step:480/1490 train_time:14848ms step_avg:30.93ms
+step:481/1490 train_time:14876ms step_avg:30.93ms
+step:482/1490 train_time:14910ms step_avg:30.93ms
+step:483/1490 train_time:14937ms step_avg:30.93ms
+step:484/1490 train_time:14974ms step_avg:30.94ms
+step:485/1490 train_time:15026ms step_avg:30.98ms
+step:486/1490 train_time:15085ms step_avg:31.04ms
+step:487/1490 train_time:15138ms step_avg:31.08ms
+step:488/1490 train_time:15198ms step_avg:31.14ms
+step:489/1490 train_time:15251ms step_avg:31.19ms
+step:490/1490 train_time:15310ms step_avg:31.24ms
+step:491/1490 train_time:15363ms step_avg:31.29ms
+step:492/1490 train_time:15422ms step_avg:31.35ms
+step:493/1490 train_time:15476ms step_avg:31.39ms
+step:494/1490 train_time:15536ms step_avg:31.45ms
+step:495/1490 train_time:15589ms step_avg:31.49ms
+step:496/1490 train_time:15648ms step_avg:31.55ms
+step:497/1490 train_time:15702ms step_avg:31.59ms
+step:498/1490 train_time:15761ms step_avg:31.65ms
+step:499/1490 train_time:15815ms step_avg:31.69ms
+step:500/1490 train_time:15874ms step_avg:31.75ms
+step:500/1490 val_loss:4.2122 train_time:15942ms step_avg:31.88ms
+step:501/1490 train_time:15959ms step_avg:31.85ms
+step:502/1490 train_time:15987ms step_avg:31.85ms
+step:503/1490 train_time:16044ms step_avg:31.90ms
+step:504/1490 train_time:16105ms step_avg:31.95ms
+step:505/1490 train_time:16158ms step_avg:32.00ms
+step:506/1490 train_time:16218ms step_avg:32.05ms
+step:507/1490 train_time:16272ms step_avg:32.09ms
+step:508/1490 train_time:16329ms step_avg:32.14ms
+step:509/1490 train_time:16383ms step_avg:32.19ms
+step:510/1490 train_time:16441ms step_avg:32.24ms
+step:511/1490 train_time:16493ms step_avg:32.28ms
+step:512/1490 train_time:16551ms step_avg:32.33ms
+step:513/1490 train_time:16604ms step_avg:32.37ms
+step:514/1490 train_time:16663ms step_avg:32.42ms
+step:515/1490 train_time:16716ms step_avg:32.46ms
+step:516/1490 train_time:16775ms step_avg:32.51ms
+step:517/1490 train_time:16828ms step_avg:32.55ms
+step:518/1490 train_time:16887ms step_avg:32.60ms
+step:519/1490 train_time:16943ms step_avg:32.64ms
+step:520/1490 train_time:17003ms step_avg:32.70ms
+step:521/1490 train_time:17057ms step_avg:32.74ms
+step:522/1490 train_time:17116ms step_avg:32.79ms
+step:523/1490 train_time:17170ms step_avg:32.83ms
+step:524/1490 train_time:17228ms step_avg:32.88ms
+step:525/1490 train_time:17282ms step_avg:32.92ms
+step:526/1490 train_time:17342ms step_avg:32.97ms
+step:527/1490 train_time:17394ms step_avg:33.01ms
+step:528/1490 train_time:17452ms step_avg:33.05ms
+step:529/1490 train_time:17505ms step_avg:33.09ms
+step:530/1490 train_time:17563ms step_avg:33.14ms
+step:531/1490 train_time:17616ms step_avg:33.17ms
+step:532/1490 train_time:17675ms step_avg:33.22ms
+step:533/1490 train_time:17727ms step_avg:33.26ms
+step:534/1490 train_time:17786ms step_avg:33.31ms
+step:535/1490 train_time:17840ms step_avg:33.34ms
+step:536/1490 train_time:17900ms step_avg:33.40ms
+step:537/1490 train_time:17954ms step_avg:33.43ms
+step:538/1490 train_time:18013ms step_avg:33.48ms
+step:539/1490 train_time:18067ms step_avg:33.52ms
+step:540/1490 train_time:18126ms step_avg:33.57ms
+step:541/1490 train_time:18180ms step_avg:33.60ms
+step:542/1490 train_time:18240ms step_avg:33.65ms
+step:543/1490 train_time:18292ms step_avg:33.69ms
+step:544/1490 train_time:18351ms step_avg:33.73ms
+step:545/1490 train_time:18404ms step_avg:33.77ms
+step:546/1490 train_time:18462ms step_avg:33.81ms
+step:547/1490 train_time:18515ms step_avg:33.85ms
+step:548/1490 train_time:18574ms step_avg:33.89ms
+step:549/1490 train_time:18626ms step_avg:33.93ms
+step:550/1490 train_time:18684ms step_avg:33.97ms
+step:551/1490 train_time:18738ms step_avg:34.01ms
+step:552/1490 train_time:18797ms step_avg:34.05ms
+step:553/1490 train_time:18851ms step_avg:34.09ms
+step:554/1490 train_time:18911ms step_avg:34.13ms
+step:555/1490 train_time:18965ms step_avg:34.17ms
+step:556/1490 train_time:19025ms step_avg:34.22ms
+step:557/1490 train_time:19079ms step_avg:34.25ms
+step:558/1490 train_time:19138ms step_avg:34.30ms
+step:559/1490 train_time:19192ms step_avg:34.33ms
+step:560/1490 train_time:19250ms step_avg:34.38ms
+step:561/1490 train_time:19304ms step_avg:34.41ms
+step:562/1490 train_time:19363ms step_avg:34.45ms
+step:563/1490 train_time:19415ms step_avg:34.49ms
+step:564/1490 train_time:19474ms step_avg:34.53ms
+step:565/1490 train_time:19527ms step_avg:34.56ms
+step:566/1490 train_time:19587ms step_avg:34.61ms
+step:567/1490 train_time:19640ms step_avg:34.64ms
+step:568/1490 train_time:19698ms step_avg:34.68ms
+step:569/1490 train_time:19751ms step_avg:34.71ms
+step:570/1490 train_time:19809ms step_avg:34.75ms
+step:571/1490 train_time:19864ms step_avg:34.79ms
+step:572/1490 train_time:19923ms step_avg:34.83ms
+step:573/1490 train_time:19977ms step_avg:34.86ms
+step:574/1490 train_time:20037ms step_avg:34.91ms
+step:575/1490 train_time:20089ms step_avg:34.94ms
+step:576/1490 train_time:20149ms step_avg:34.98ms
+step:577/1490 train_time:20202ms step_avg:35.01ms
+step:578/1490 train_time:20261ms step_avg:35.05ms
+step:579/1490 train_time:20313ms step_avg:35.08ms
+step:580/1490 train_time:20372ms step_avg:35.12ms
+step:581/1490 train_time:20425ms step_avg:35.16ms
+step:582/1490 train_time:20485ms step_avg:35.20ms
+step:583/1490 train_time:20538ms step_avg:35.23ms
+step:584/1490 train_time:20596ms step_avg:35.27ms
+step:585/1490 train_time:20649ms step_avg:35.30ms
+step:586/1490 train_time:20708ms step_avg:35.34ms
+step:587/1490 train_time:20761ms step_avg:35.37ms
+step:588/1490 train_time:20821ms step_avg:35.41ms
+step:589/1490 train_time:20874ms step_avg:35.44ms
+step:590/1490 train_time:20933ms step_avg:35.48ms
+step:591/1490 train_time:20986ms step_avg:35.51ms
+step:592/1490 train_time:21046ms step_avg:35.55ms
+step:593/1490 train_time:21098ms step_avg:35.58ms
+step:594/1490 train_time:21158ms step_avg:35.62ms
+step:595/1490 train_time:21211ms step_avg:35.65ms
+step:596/1490 train_time:21270ms step_avg:35.69ms
+step:597/1490 train_time:21323ms step_avg:35.72ms
+step:598/1490 train_time:21382ms step_avg:35.76ms
+step:599/1490 train_time:21435ms step_avg:35.79ms
+step:600/1490 train_time:21494ms step_avg:35.82ms
+step:601/1490 train_time:21548ms step_avg:35.85ms
+step:602/1490 train_time:21606ms step_avg:35.89ms
+step:603/1490 train_time:21659ms step_avg:35.92ms
+step:604/1490 train_time:21718ms step_avg:35.96ms
+step:605/1490 train_time:21773ms step_avg:35.99ms
+step:606/1490 train_time:21831ms step_avg:36.02ms
+step:607/1490 train_time:21884ms step_avg:36.05ms
+step:608/1490 train_time:21944ms step_avg:36.09ms
+step:609/1490 train_time:21996ms step_avg:36.12ms
+step:610/1490 train_time:22056ms step_avg:36.16ms
+step:611/1490 train_time:22109ms step_avg:36.19ms
+step:612/1490 train_time:22168ms step_avg:36.22ms
+step:613/1490 train_time:22220ms step_avg:36.25ms
+step:614/1490 train_time:22280ms step_avg:36.29ms
+step:615/1490 train_time:22333ms step_avg:36.31ms
+step:616/1490 train_time:22391ms step_avg:36.35ms
+step:617/1490 train_time:22445ms step_avg:36.38ms
+step:618/1490 train_time:22504ms step_avg:36.41ms
+step:619/1490 train_time:22556ms step_avg:36.44ms
+step:620/1490 train_time:22615ms step_avg:36.48ms
+step:621/1490 train_time:22668ms step_avg:36.50ms
+step:622/1490 train_time:22727ms step_avg:36.54ms
+step:623/1490 train_time:22781ms step_avg:36.57ms
+step:624/1490 train_time:22840ms step_avg:36.60ms
+step:625/1490 train_time:22894ms step_avg:36.63ms
+step:626/1490 train_time:22952ms step_avg:36.66ms
+step:627/1490 train_time:23006ms step_avg:36.69ms
+step:628/1490 train_time:23064ms step_avg:36.73ms
+step:629/1490 train_time:23118ms step_avg:36.75ms
+step:630/1490 train_time:23177ms step_avg:36.79ms
+step:631/1490 train_time:23230ms step_avg:36.81ms
+step:632/1490 train_time:23289ms step_avg:36.85ms
+step:633/1490 train_time:23343ms step_avg:36.88ms
+step:634/1490 train_time:23402ms step_avg:36.91ms
+step:635/1490 train_time:23456ms step_avg:36.94ms
+step:636/1490 train_time:23513ms step_avg:36.97ms
+step:637/1490 train_time:23567ms step_avg:37.00ms
+step:638/1490 train_time:23627ms step_avg:37.03ms
+step:639/1490 train_time:23679ms step_avg:37.06ms
+step:640/1490 train_time:23739ms step_avg:37.09ms
+step:641/1490 train_time:23792ms step_avg:37.12ms
+step:642/1490 train_time:23852ms step_avg:37.15ms
+step:643/1490 train_time:23904ms step_avg:37.18ms
+step:644/1490 train_time:23964ms step_avg:37.21ms
+step:645/1490 train_time:24016ms step_avg:37.23ms
+step:646/1490 train_time:24075ms step_avg:37.27ms
+step:647/1490 train_time:24129ms step_avg:37.29ms
+step:648/1490 train_time:24188ms step_avg:37.33ms
+step:649/1490 train_time:24241ms step_avg:37.35ms
+step:650/1490 train_time:24301ms step_avg:37.39ms
+step:651/1490 train_time:24354ms step_avg:37.41ms
+step:652/1490 train_time:24413ms step_avg:37.44ms
+step:653/1490 train_time:24466ms step_avg:37.47ms
+step:654/1490 train_time:24526ms step_avg:37.50ms
+step:655/1490 train_time:24579ms step_avg:37.53ms
+step:656/1490 train_time:24638ms step_avg:37.56ms
+step:657/1490 train_time:24690ms step_avg:37.58ms
+step:658/1490 train_time:24749ms step_avg:37.61ms
+step:659/1490 train_time:24802ms step_avg:37.64ms
+step:660/1490 train_time:24861ms step_avg:37.67ms
+step:661/1490 train_time:24914ms step_avg:37.69ms
+step:662/1490 train_time:24973ms step_avg:37.72ms
+step:663/1490 train_time:25025ms step_avg:37.75ms
+step:664/1490 train_time:25085ms step_avg:37.78ms
+step:665/1490 train_time:25139ms step_avg:37.80ms
+step:666/1490 train_time:25197ms step_avg:37.83ms
+step:667/1490 train_time:25251ms step_avg:37.86ms
+step:668/1490 train_time:25310ms step_avg:37.89ms
+step:669/1490 train_time:25363ms step_avg:37.91ms
+step:670/1490 train_time:25422ms step_avg:37.94ms
+step:671/1490 train_time:25476ms step_avg:37.97ms
+step:672/1490 train_time:25535ms step_avg:38.00ms
+step:673/1490 train_time:25588ms step_avg:38.02ms
+step:674/1490 train_time:25647ms step_avg:38.05ms
+step:675/1490 train_time:25700ms step_avg:38.07ms
+step:676/1490 train_time:25759ms step_avg:38.11ms
+step:677/1490 train_time:25813ms step_avg:38.13ms
+step:678/1490 train_time:25871ms step_avg:38.16ms
+step:679/1490 train_time:25924ms step_avg:38.18ms
+step:680/1490 train_time:25984ms step_avg:38.21ms
+step:681/1490 train_time:26038ms step_avg:38.23ms
+step:682/1490 train_time:26097ms step_avg:38.27ms
+step:683/1490 train_time:26150ms step_avg:38.29ms
+step:684/1490 train_time:26209ms step_avg:38.32ms
+step:685/1490 train_time:26263ms step_avg:38.34ms
+step:686/1490 train_time:26321ms step_avg:38.37ms
+step:687/1490 train_time:26375ms step_avg:38.39ms
+step:688/1490 train_time:26434ms step_avg:38.42ms
+step:689/1490 train_time:26487ms step_avg:38.44ms
+step:690/1490 train_time:26546ms step_avg:38.47ms
+step:691/1490 train_time:26599ms step_avg:38.49ms
+step:692/1490 train_time:26658ms step_avg:38.52ms
+step:693/1490 train_time:26710ms step_avg:38.54ms
+step:694/1490 train_time:26770ms step_avg:38.57ms
+step:695/1490 train_time:26823ms step_avg:38.59ms
+step:696/1490 train_time:26882ms step_avg:38.62ms
+step:697/1490 train_time:26935ms step_avg:38.64ms
+step:698/1490 train_time:26994ms step_avg:38.67ms
+step:699/1490 train_time:27048ms step_avg:38.69ms
+step:700/1490 train_time:27107ms step_avg:38.72ms
+step:701/1490 train_time:27159ms step_avg:38.74ms
+step:702/1490 train_time:27219ms step_avg:38.77ms
+step:703/1490 train_time:27273ms step_avg:38.80ms
+step:704/1490 train_time:27331ms step_avg:38.82ms
+step:705/1490 train_time:27385ms step_avg:38.84ms
+step:706/1490 train_time:27444ms step_avg:38.87ms
+step:707/1490 train_time:27497ms step_avg:38.89ms
+step:708/1490 train_time:27556ms step_avg:38.92ms
+step:709/1490 train_time:27610ms step_avg:38.94ms
+step:710/1490 train_time:27668ms step_avg:38.97ms
+step:711/1490 train_time:27721ms step_avg:38.99ms
+step:712/1490 train_time:27780ms step_avg:39.02ms
+step:713/1490 train_time:27834ms step_avg:39.04ms
+step:714/1490 train_time:27892ms step_avg:39.06ms
+step:715/1490 train_time:27946ms step_avg:39.08ms
+step:716/1490 train_time:28005ms step_avg:39.11ms
+step:717/1490 train_time:28058ms step_avg:39.13ms
+step:718/1490 train_time:28118ms step_avg:39.16ms
+step:719/1490 train_time:28171ms step_avg:39.18ms
+step:720/1490 train_time:28229ms step_avg:39.21ms
+step:721/1490 train_time:28283ms step_avg:39.23ms
+step:722/1490 train_time:28343ms step_avg:39.26ms
+step:723/1490 train_time:28396ms step_avg:39.28ms
+step:724/1490 train_time:28455ms step_avg:39.30ms
+step:725/1490 train_time:28508ms step_avg:39.32ms
+step:726/1490 train_time:28567ms step_avg:39.35ms
+step:727/1490 train_time:28620ms step_avg:39.37ms
+step:728/1490 train_time:28679ms step_avg:39.39ms
+step:729/1490 train_time:28732ms step_avg:39.41ms
+step:730/1490 train_time:28790ms step_avg:39.44ms
+step:731/1490 train_time:28843ms step_avg:39.46ms
+step:732/1490 train_time:28902ms step_avg:39.48ms
+step:733/1490 train_time:28955ms step_avg:39.50ms
+step:734/1490 train_time:29014ms step_avg:39.53ms
+step:735/1490 train_time:29069ms step_avg:39.55ms
+step:736/1490 train_time:29128ms step_avg:39.58ms
+step:737/1490 train_time:29181ms step_avg:39.59ms
+step:738/1490 train_time:29241ms step_avg:39.62ms
+step:739/1490 train_time:29294ms step_avg:39.64ms
+step:740/1490 train_time:29353ms step_avg:39.67ms
+step:741/1490 train_time:29406ms step_avg:39.68ms
+step:742/1490 train_time:29465ms step_avg:39.71ms
+step:743/1490 train_time:29518ms step_avg:39.73ms
+step:744/1490 train_time:29578ms step_avg:39.75ms
+step:745/1490 train_time:29632ms step_avg:39.77ms
+step:746/1490 train_time:29689ms step_avg:39.80ms
+step:747/1490 train_time:29743ms step_avg:39.82ms
+step:748/1490 train_time:29802ms step_avg:39.84ms
+step:749/1490 train_time:29856ms step_avg:39.86ms
+step:750/1490 train_time:29914ms step_avg:39.89ms
+step:750/1490 val_loss:3.8097 train_time:29983ms step_avg:39.98ms
+step:751/1490 train_time:30000ms step_avg:39.95ms
+step:752/1490 train_time:30028ms step_avg:39.93ms
+step:753/1490 train_time:30083ms step_avg:39.95ms
+step:754/1490 train_time:30145ms step_avg:39.98ms
+step:755/1490 train_time:30200ms step_avg:40.00ms
+step:756/1490 train_time:30259ms step_avg:40.03ms
+step:757/1490 train_time:30312ms step_avg:40.04ms
+step:758/1490 train_time:30372ms step_avg:40.07ms
+step:759/1490 train_time:30425ms step_avg:40.08ms
+step:760/1490 train_time:30483ms step_avg:40.11ms
+step:761/1490 train_time:30536ms step_avg:40.13ms
+step:762/1490 train_time:30593ms step_avg:40.15ms
+step:763/1490 train_time:30645ms step_avg:40.16ms
+step:764/1490 train_time:30704ms step_avg:40.19ms
+step:765/1490 train_time:30757ms step_avg:40.21ms
+step:766/1490 train_time:30815ms step_avg:40.23ms
+step:767/1490 train_time:30868ms step_avg:40.25ms
+step:768/1490 train_time:30927ms step_avg:40.27ms
+step:769/1490 train_time:30981ms step_avg:40.29ms
+step:770/1490 train_time:31042ms step_avg:40.31ms
+step:771/1490 train_time:31097ms step_avg:40.33ms
+step:772/1490 train_time:31157ms step_avg:40.36ms
+step:773/1490 train_time:31211ms step_avg:40.38ms
+step:774/1490 train_time:31271ms step_avg:40.40ms
+step:775/1490 train_time:31324ms step_avg:40.42ms
+step:776/1490 train_time:31383ms step_avg:40.44ms
+step:777/1490 train_time:31435ms step_avg:40.46ms
+step:778/1490 train_time:31494ms step_avg:40.48ms
+step:779/1490 train_time:31546ms step_avg:40.50ms
+step:780/1490 train_time:31605ms step_avg:40.52ms
+step:781/1490 train_time:31658ms step_avg:40.53ms
+step:782/1490 train_time:31716ms step_avg:40.56ms
+step:783/1490 train_time:31769ms step_avg:40.57ms
+step:784/1490 train_time:31829ms step_avg:40.60ms
+step:785/1490 train_time:31882ms step_avg:40.61ms
+step:786/1490 train_time:31941ms step_avg:40.64ms
+step:787/1490 train_time:31996ms step_avg:40.66ms
+step:788/1490 train_time:32054ms step_avg:40.68ms
+step:789/1490 train_time:32108ms step_avg:40.70ms
+step:790/1490 train_time:32168ms step_avg:40.72ms
+step:791/1490 train_time:32221ms step_avg:40.73ms
+step:792/1490 train_time:32281ms step_avg:40.76ms
+step:793/1490 train_time:32335ms step_avg:40.78ms
+step:794/1490 train_time:32393ms step_avg:40.80ms
+step:795/1490 train_time:32446ms step_avg:40.81ms
+step:796/1490 train_time:32505ms step_avg:40.84ms
+step:797/1490 train_time:32558ms step_avg:40.85ms
+step:798/1490 train_time:32616ms step_avg:40.87ms
+step:799/1490 train_time:32669ms step_avg:40.89ms
+step:800/1490 train_time:32727ms step_avg:40.91ms
+step:801/1490 train_time:32781ms step_avg:40.92ms
+step:802/1490 train_time:32839ms step_avg:40.95ms
+step:803/1490 train_time:32892ms step_avg:40.96ms
+step:804/1490 train_time:32951ms step_avg:40.98ms
+step:805/1490 train_time:33004ms step_avg:41.00ms
+step:806/1490 train_time:33065ms step_avg:41.02ms
+step:807/1490 train_time:33118ms step_avg:41.04ms
+step:808/1490 train_time:33177ms step_avg:41.06ms
+step:809/1490 train_time:33230ms step_avg:41.07ms
+step:810/1490 train_time:33289ms step_avg:41.10ms
+step:811/1490 train_time:33342ms step_avg:41.11ms
+step:812/1490 train_time:33402ms step_avg:41.14ms
+step:813/1490 train_time:33456ms step_avg:41.15ms
+step:814/1490 train_time:33514ms step_avg:41.17ms
+step:815/1490 train_time:33568ms step_avg:41.19ms
+step:816/1490 train_time:33625ms step_avg:41.21ms
+step:817/1490 train_time:33678ms step_avg:41.22ms
+step:818/1490 train_time:33736ms step_avg:41.24ms
+step:819/1490 train_time:33789ms step_avg:41.26ms
+step:820/1490 train_time:33848ms step_avg:41.28ms
+step:821/1490 train_time:33902ms step_avg:41.29ms
+step:822/1490 train_time:33962ms step_avg:41.32ms
+step:823/1490 train_time:34015ms step_avg:41.33ms
+step:824/1490 train_time:34074ms step_avg:41.35ms
+step:825/1490 train_time:34127ms step_avg:41.37ms
+step:826/1490 train_time:34187ms step_avg:41.39ms
+step:827/1490 train_time:34240ms step_avg:41.40ms
+step:828/1490 train_time:34300ms step_avg:41.43ms
+step:829/1490 train_time:34354ms step_avg:41.44ms
+step:830/1490 train_time:34412ms step_avg:41.46ms
+step:831/1490 train_time:34466ms step_avg:41.47ms
+step:832/1490 train_time:34525ms step_avg:41.50ms
+step:833/1490 train_time:34578ms step_avg:41.51ms
+step:834/1490 train_time:34636ms step_avg:41.53ms
+step:835/1490 train_time:34690ms step_avg:41.54ms
+step:836/1490 train_time:34749ms step_avg:41.57ms
+step:837/1490 train_time:34802ms step_avg:41.58ms
+step:838/1490 train_time:34861ms step_avg:41.60ms
+step:839/1490 train_time:34914ms step_avg:41.61ms
+step:840/1490 train_time:34973ms step_avg:41.63ms
+step:841/1490 train_time:35027ms step_avg:41.65ms
+step:842/1490 train_time:35086ms step_avg:41.67ms
+step:843/1490 train_time:35140ms step_avg:41.68ms
+step:844/1490 train_time:35200ms step_avg:41.71ms
+step:845/1490 train_time:35253ms step_avg:41.72ms
+step:846/1490 train_time:35312ms step_avg:41.74ms
+step:847/1490 train_time:35366ms step_avg:41.75ms
+step:848/1490 train_time:35424ms step_avg:41.77ms
+step:849/1490 train_time:35478ms step_avg:41.79ms
+step:850/1490 train_time:35536ms step_avg:41.81ms
+step:851/1490 train_time:35590ms step_avg:41.82ms
+step:852/1490 train_time:35649ms step_avg:41.84ms
+step:853/1490 train_time:35702ms step_avg:41.86ms
+step:854/1490 train_time:35762ms step_avg:41.88ms
+step:855/1490 train_time:35815ms step_avg:41.89ms
+step:856/1490 train_time:35874ms step_avg:41.91ms
+step:857/1490 train_time:35927ms step_avg:41.92ms
+step:858/1490 train_time:35986ms step_avg:41.94ms
+step:859/1490 train_time:36038ms step_avg:41.95ms
+step:860/1490 train_time:36097ms step_avg:41.97ms
+step:861/1490 train_time:36151ms step_avg:41.99ms
+step:862/1490 train_time:36211ms step_avg:42.01ms
+step:863/1490 train_time:36265ms step_avg:42.02ms
+step:864/1490 train_time:36324ms step_avg:42.04ms
+step:865/1490 train_time:36378ms step_avg:42.06ms
+step:866/1490 train_time:36437ms step_avg:42.07ms
+step:867/1490 train_time:36490ms step_avg:42.09ms
+step:868/1490 train_time:36548ms step_avg:42.11ms
+step:869/1490 train_time:36602ms step_avg:42.12ms
+step:870/1490 train_time:36661ms step_avg:42.14ms
+step:871/1490 train_time:36714ms step_avg:42.15ms
+step:872/1490 train_time:36773ms step_avg:42.17ms
+step:873/1490 train_time:36826ms step_avg:42.18ms
+step:874/1490 train_time:36886ms step_avg:42.20ms
+step:875/1490 train_time:36938ms step_avg:42.22ms
+step:876/1490 train_time:36996ms step_avg:42.23ms
+step:877/1490 train_time:37050ms step_avg:42.25ms
+step:878/1490 train_time:37110ms step_avg:42.27ms
+step:879/1490 train_time:37164ms step_avg:42.28ms
+step:880/1490 train_time:37223ms step_avg:42.30ms
+step:881/1490 train_time:37277ms step_avg:42.31ms
+step:882/1490 train_time:37336ms step_avg:42.33ms
+step:883/1490 train_time:37390ms step_avg:42.34ms
+step:884/1490 train_time:37448ms step_avg:42.36ms
+step:885/1490 train_time:37501ms step_avg:42.37ms
+step:886/1490 train_time:37561ms step_avg:42.39ms
+step:887/1490 train_time:37614ms step_avg:42.41ms
+step:888/1490 train_time:37673ms step_avg:42.42ms
+step:889/1490 train_time:37726ms step_avg:42.44ms
+step:890/1490 train_time:37784ms step_avg:42.45ms
+step:891/1490 train_time:37838ms step_avg:42.47ms
+step:892/1490 train_time:37896ms step_avg:42.48ms
+step:893/1490 train_time:37950ms step_avg:42.50ms
+step:894/1490 train_time:38010ms step_avg:42.52ms
+step:895/1490 train_time:38063ms step_avg:42.53ms
+step:896/1490 train_time:38123ms step_avg:42.55ms
+step:897/1490 train_time:38176ms step_avg:42.56ms
+step:898/1490 train_time:38234ms step_avg:42.58ms
+step:899/1490 train_time:38288ms step_avg:42.59ms
+step:900/1490 train_time:38346ms step_avg:42.61ms
+step:901/1490 train_time:38400ms step_avg:42.62ms
+step:902/1490 train_time:38460ms step_avg:42.64ms
+step:903/1490 train_time:38513ms step_avg:42.65ms
+step:904/1490 train_time:38573ms step_avg:42.67ms
+step:905/1490 train_time:38625ms step_avg:42.68ms
+step:906/1490 train_time:38684ms step_avg:42.70ms
+step:907/1490 train_time:38738ms step_avg:42.71ms
+step:908/1490 train_time:38795ms step_avg:42.73ms
+step:909/1490 train_time:38848ms step_avg:42.74ms
+step:910/1490 train_time:38908ms step_avg:42.76ms
+step:911/1490 train_time:38961ms step_avg:42.77ms
+step:912/1490 train_time:39020ms step_avg:42.79ms
+step:913/1490 train_time:39074ms step_avg:42.80ms
+step:914/1490 train_time:39133ms step_avg:42.82ms
+step:915/1490 train_time:39187ms step_avg:42.83ms
+step:916/1490 train_time:39246ms step_avg:42.85ms
+step:917/1490 train_time:39301ms step_avg:42.86ms
+step:918/1490 train_time:39359ms step_avg:42.88ms
+step:919/1490 train_time:39413ms step_avg:42.89ms
+step:920/1490 train_time:39472ms step_avg:42.90ms
+step:921/1490 train_time:39526ms step_avg:42.92ms
+step:922/1490 train_time:39584ms step_avg:42.93ms
+step:923/1490 train_time:39638ms step_avg:42.94ms
+step:924/1490 train_time:39697ms step_avg:42.96ms
+step:925/1490 train_time:39751ms step_avg:42.97ms
+step:926/1490 train_time:39810ms step_avg:42.99ms
+step:927/1490 train_time:39863ms step_avg:43.00ms
+step:928/1490 train_time:39923ms step_avg:43.02ms
+step:929/1490 train_time:39977ms step_avg:43.03ms
+step:930/1490 train_time:40036ms step_avg:43.05ms
+step:931/1490 train_time:40089ms step_avg:43.06ms
+step:932/1490 train_time:40148ms step_avg:43.08ms
+step:933/1490 train_time:40201ms step_avg:43.09ms
+step:934/1490 train_time:40261ms step_avg:43.11ms
+step:935/1490 train_time:40314ms step_avg:43.12ms
+step:936/1490 train_time:40373ms step_avg:43.13ms
+step:937/1490 train_time:40427ms step_avg:43.14ms
+step:938/1490 train_time:40485ms step_avg:43.16ms
+step:939/1490 train_time:40537ms step_avg:43.17ms
+step:940/1490 train_time:40596ms step_avg:43.19ms
+step:941/1490 train_time:40650ms step_avg:43.20ms
+step:942/1490 train_time:40710ms step_avg:43.22ms
+step:943/1490 train_time:40762ms step_avg:43.23ms
+step:944/1490 train_time:40821ms step_avg:43.24ms
+step:945/1490 train_time:40874ms step_avg:43.25ms
+step:946/1490 train_time:40933ms step_avg:43.27ms
+step:947/1490 train_time:40987ms step_avg:43.28ms
+step:948/1490 train_time:41046ms step_avg:43.30ms
+step:949/1490 train_time:41099ms step_avg:43.31ms
+step:950/1490 train_time:41159ms step_avg:43.32ms
+step:951/1490 train_time:41212ms step_avg:43.34ms
+step:952/1490 train_time:41271ms step_avg:43.35ms
+step:953/1490 train_time:41324ms step_avg:43.36ms
+step:954/1490 train_time:41383ms step_avg:43.38ms
+step:955/1490 train_time:41436ms step_avg:43.39ms
+step:956/1490 train_time:41495ms step_avg:43.40ms
+step:957/1490 train_time:41548ms step_avg:43.42ms
+step:958/1490 train_time:41608ms step_avg:43.43ms
+step:959/1490 train_time:41661ms step_avg:43.44ms
+step:960/1490 train_time:41720ms step_avg:43.46ms
+step:961/1490 train_time:41774ms step_avg:43.47ms
+step:962/1490 train_time:41832ms step_avg:43.48ms
+step:963/1490 train_time:41886ms step_avg:43.50ms
+step:964/1490 train_time:41945ms step_avg:43.51ms
+step:965/1490 train_time:41998ms step_avg:43.52ms
+step:966/1490 train_time:42056ms step_avg:43.54ms
+step:967/1490 train_time:42110ms step_avg:43.55ms
+step:968/1490 train_time:42173ms step_avg:43.57ms
+step:969/1490 train_time:42251ms step_avg:43.60ms
+step:970/1490 train_time:42335ms step_avg:43.64ms
+step:971/1490 train_time:42412ms step_avg:43.68ms
+step:972/1490 train_time:42497ms step_avg:43.72ms
+step:973/1490 train_time:42577ms step_avg:43.76ms
+step:974/1490 train_time:42661ms step_avg:43.80ms
+step:975/1490 train_time:42741ms step_avg:43.84ms
+step:976/1490 train_time:42825ms step_avg:43.88ms
+step:977/1490 train_time:42905ms step_avg:43.91ms
+step:978/1490 train_time:42991ms step_avg:43.96ms
+step:979/1490 train_time:43069ms step_avg:43.99ms
+step:980/1490 train_time:43153ms step_avg:44.03ms
+step:981/1490 train_time:43233ms step_avg:44.07ms
+step:982/1490 train_time:43318ms step_avg:44.11ms
+step:983/1490 train_time:43397ms step_avg:44.15ms
+step:984/1490 train_time:43481ms step_avg:44.19ms
+step:985/1490 train_time:43561ms step_avg:44.22ms
+step:986/1490 train_time:43645ms step_avg:44.27ms
+step:987/1490 train_time:43726ms step_avg:44.30ms
+step:988/1490 train_time:43809ms step_avg:44.34ms
+step:989/1490 train_time:43891ms step_avg:44.38ms
+step:990/1490 train_time:43973ms step_avg:44.42ms
+step:991/1490 train_time:44052ms step_avg:44.45ms
+step:992/1490 train_time:44138ms step_avg:44.49ms
+step:993/1490 train_time:44217ms step_avg:44.53ms
+step:994/1490 train_time:44300ms step_avg:44.57ms
+step:995/1490 train_time:44379ms step_avg:44.60ms
+step:996/1490 train_time:44463ms step_avg:44.64ms
+step:997/1490 train_time:44544ms step_avg:44.68ms
+step:998/1490 train_time:44629ms step_avg:44.72ms
+step:999/1490 train_time:44708ms step_avg:44.75ms
+step:1000/1490 train_time:44793ms step_avg:44.79ms
+step:1000/1490 val_loss:3.5164 train_time:44892ms step_avg:44.89ms
+step:1001/1490 train_time:44909ms step_avg:44.86ms
+step:1002/1490 train_time:44960ms step_avg:44.87ms
+step:1003/1490 train_time:45042ms step_avg:44.91ms
+step:1004/1490 train_time:45129ms step_avg:44.95ms
+step:1005/1490 train_time:45209ms step_avg:44.98ms
+step:1006/1490 train_time:45291ms step_avg:45.02ms
+step:1007/1490 train_time:45370ms step_avg:45.05ms
+step:1008/1490 train_time:45454ms step_avg:45.09ms
+step:1009/1490 train_time:45533ms step_avg:45.13ms
+step:1010/1490 train_time:45616ms step_avg:45.16ms
+step:1011/1490 train_time:45695ms step_avg:45.20ms
+step:1012/1490 train_time:45780ms step_avg:45.24ms
+step:1013/1490 train_time:45861ms step_avg:45.27ms
+step:1014/1490 train_time:45946ms step_avg:45.31ms
+step:1015/1490 train_time:46027ms step_avg:45.35ms
+step:1016/1490 train_time:46113ms step_avg:45.39ms
+step:1017/1490 train_time:46191ms step_avg:45.42ms
+step:1018/1490 train_time:46276ms step_avg:45.46ms
+step:1019/1490 train_time:46356ms step_avg:45.49ms
+step:1020/1490 train_time:46440ms step_avg:45.53ms
+step:1021/1490 train_time:46518ms step_avg:45.56ms
+step:1022/1490 train_time:46602ms step_avg:45.60ms
+step:1023/1490 train_time:46681ms step_avg:45.63ms
+step:1024/1490 train_time:46766ms step_avg:45.67ms
+step:1025/1490 train_time:46846ms step_avg:45.70ms
+step:1026/1490 train_time:46932ms step_avg:45.74ms
+step:1027/1490 train_time:47013ms step_avg:45.78ms
+step:1028/1490 train_time:47098ms step_avg:45.82ms
+step:1029/1490 train_time:47177ms step_avg:45.85ms
+step:1030/1490 train_time:47260ms step_avg:45.88ms
+step:1031/1490 train_time:47340ms step_avg:45.92ms
+step:1032/1490 train_time:47424ms step_avg:45.95ms
+step:1033/1490 train_time:47503ms step_avg:45.99ms
+step:1034/1490 train_time:47588ms step_avg:46.02ms
+step:1035/1490 train_time:47666ms step_avg:46.05ms
+step:1036/1490 train_time:47751ms step_avg:46.09ms
+step:1037/1490 train_time:47830ms step_avg:46.12ms
+step:1038/1490 train_time:47916ms step_avg:46.16ms
+step:1039/1490 train_time:47997ms step_avg:46.20ms
+step:1040/1490 train_time:48081ms step_avg:46.23ms
+step:1041/1490 train_time:48159ms step_avg:46.26ms
+step:1042/1490 train_time:48244ms step_avg:46.30ms
+step:1043/1490 train_time:48323ms step_avg:46.33ms
+step:1044/1490 train_time:48408ms step_avg:46.37ms
+step:1045/1490 train_time:48486ms step_avg:46.40ms
+step:1046/1490 train_time:48570ms step_avg:46.43ms
+step:1047/1490 train_time:48650ms step_avg:46.47ms
+step:1048/1490 train_time:48734ms step_avg:46.50ms
+step:1049/1490 train_time:48813ms step_avg:46.53ms
+step:1050/1490 train_time:48899ms step_avg:46.57ms
+step:1051/1490 train_time:48978ms step_avg:46.60ms
+step:1052/1490 train_time:49063ms step_avg:46.64ms
+step:1053/1490 train_time:49143ms step_avg:46.67ms
+step:1054/1490 train_time:49227ms step_avg:46.71ms
+step:1055/1490 train_time:49306ms step_avg:46.74ms
+step:1056/1490 train_time:49390ms step_avg:46.77ms
+step:1057/1490 train_time:49470ms step_avg:46.80ms
+step:1058/1490 train_time:49553ms step_avg:46.84ms
+step:1059/1490 train_time:49633ms step_avg:46.87ms
+step:1060/1490 train_time:49717ms step_avg:46.90ms
+step:1061/1490 train_time:49796ms step_avg:46.93ms
+step:1062/1490 train_time:49879ms step_avg:46.97ms
+step:1063/1490 train_time:49959ms step_avg:47.00ms
+step:1064/1490 train_time:50043ms step_avg:47.03ms
+step:1065/1490 train_time:50122ms step_avg:47.06ms
+step:1066/1490 train_time:50207ms step_avg:47.10ms
+step:1067/1490 train_time:50288ms step_avg:47.13ms
+step:1068/1490 train_time:50372ms step_avg:47.16ms
+step:1069/1490 train_time:50451ms step_avg:47.19ms
+step:1070/1490 train_time:50535ms step_avg:47.23ms
+step:1071/1490 train_time:50615ms step_avg:47.26ms
+step:1072/1490 train_time:50700ms step_avg:47.29ms
+step:1073/1490 train_time:50778ms step_avg:47.32ms
+step:1074/1490 train_time:50863ms step_avg:47.36ms
+step:1075/1490 train_time:50945ms step_avg:47.39ms
+step:1076/1490 train_time:51029ms step_avg:47.42ms
+step:1077/1490 train_time:51108ms step_avg:47.45ms
+step:1078/1490 train_time:51193ms step_avg:47.49ms
+step:1079/1490 train_time:51271ms step_avg:47.52ms
+step:1080/1490 train_time:51355ms step_avg:47.55ms
+step:1081/1490 train_time:51434ms step_avg:47.58ms
+step:1082/1490 train_time:51520ms step_avg:47.62ms
+step:1083/1490 train_time:51600ms step_avg:47.65ms
+step:1084/1490 train_time:51684ms step_avg:47.68ms
+step:1085/1490 train_time:51762ms step_avg:47.71ms
+step:1086/1490 train_time:51849ms step_avg:47.74ms
+step:1087/1490 train_time:51929ms step_avg:47.77ms
+step:1088/1490 train_time:52013ms step_avg:47.81ms
+step:1089/1490 train_time:52093ms step_avg:47.84ms
+step:1090/1490 train_time:52177ms step_avg:47.87ms
+step:1091/1490 train_time:52255ms step_avg:47.90ms
+step:1092/1490 train_time:52340ms step_avg:47.93ms
+step:1093/1490 train_time:52418ms step_avg:47.96ms
+step:1094/1490 train_time:52503ms step_avg:47.99ms
+step:1095/1490 train_time:52582ms step_avg:48.02ms
+step:1096/1490 train_time:52666ms step_avg:48.05ms
+step:1097/1490 train_time:52746ms step_avg:48.08ms
+step:1098/1490 train_time:52830ms step_avg:48.11ms
+step:1099/1490 train_time:52910ms step_avg:48.14ms
+step:1100/1490 train_time:52995ms step_avg:48.18ms
+step:1101/1490 train_time:53074ms step_avg:48.21ms
+step:1102/1490 train_time:53158ms step_avg:48.24ms
+step:1103/1490 train_time:53236ms step_avg:48.27ms
+step:1104/1490 train_time:53321ms step_avg:48.30ms
+step:1105/1490 train_time:53400ms step_avg:48.33ms
+step:1106/1490 train_time:53484ms step_avg:48.36ms
+step:1107/1490 train_time:53563ms step_avg:48.39ms
+step:1108/1490 train_time:53648ms step_avg:48.42ms
+step:1109/1490 train_time:53727ms step_avg:48.45ms
+step:1110/1490 train_time:53812ms step_avg:48.48ms
+step:1111/1490 train_time:53891ms step_avg:48.51ms
+step:1112/1490 train_time:53976ms step_avg:48.54ms
+step:1113/1490 train_time:54055ms step_avg:48.57ms
+step:1114/1490 train_time:54141ms step_avg:48.60ms
+step:1115/1490 train_time:54220ms step_avg:48.63ms
+step:1116/1490 train_time:54305ms step_avg:48.66ms
+step:1117/1490 train_time:54384ms step_avg:48.69ms
+step:1118/1490 train_time:54468ms step_avg:48.72ms
+step:1119/1490 train_time:54548ms step_avg:48.75ms
+step:1120/1490 train_time:54632ms step_avg:48.78ms
+step:1121/1490 train_time:54711ms step_avg:48.81ms
+step:1122/1490 train_time:54796ms step_avg:48.84ms
+step:1123/1490 train_time:54875ms step_avg:48.86ms
+step:1124/1490 train_time:54959ms step_avg:48.90ms
+step:1125/1490 train_time:55039ms step_avg:48.92ms
+step:1126/1490 train_time:55124ms step_avg:48.96ms
+step:1127/1490 train_time:55202ms step_avg:48.98ms
+step:1128/1490 train_time:55288ms step_avg:49.01ms
+step:1129/1490 train_time:55367ms step_avg:49.04ms
+step:1130/1490 train_time:55452ms step_avg:49.07ms
+step:1131/1490 train_time:55532ms step_avg:49.10ms
+step:1132/1490 train_time:55616ms step_avg:49.13ms
+step:1133/1490 train_time:55694ms step_avg:49.16ms
+step:1134/1490 train_time:55780ms step_avg:49.19ms
+step:1135/1490 train_time:55859ms step_avg:49.22ms
+step:1136/1490 train_time:55944ms step_avg:49.25ms
+step:1137/1490 train_time:56022ms step_avg:49.27ms
+step:1138/1490 train_time:56107ms step_avg:49.30ms
+step:1139/1490 train_time:56186ms step_avg:49.33ms
+step:1140/1490 train_time:56269ms step_avg:49.36ms
+step:1141/1490 train_time:56351ms step_avg:49.39ms
+step:1142/1490 train_time:56437ms step_avg:49.42ms
+step:1143/1490 train_time:56515ms step_avg:49.44ms
+step:1144/1490 train_time:56601ms step_avg:49.48ms
+step:1145/1490 train_time:56679ms step_avg:49.50ms
+step:1146/1490 train_time:56763ms step_avg:49.53ms
+step:1147/1490 train_time:56843ms step_avg:49.56ms
+step:1148/1490 train_time:56928ms step_avg:49.59ms
+step:1149/1490 train_time:57008ms step_avg:49.62ms
+step:1150/1490 train_time:57093ms step_avg:49.65ms
+step:1151/1490 train_time:57171ms step_avg:49.67ms
+step:1152/1490 train_time:57254ms step_avg:49.70ms
+step:1153/1490 train_time:57333ms step_avg:49.73ms
+step:1154/1490 train_time:57420ms step_avg:49.76ms
+step:1155/1490 train_time:57500ms step_avg:49.78ms
+step:1156/1490 train_time:57583ms step_avg:49.81ms
+step:1157/1490 train_time:57661ms step_avg:49.84ms
+step:1158/1490 train_time:57746ms step_avg:49.87ms
+step:1159/1490 train_time:57825ms step_avg:49.89ms
+step:1160/1490 train_time:57910ms step_avg:49.92ms
+step:1161/1490 train_time:57990ms step_avg:49.95ms
+step:1162/1490 train_time:58074ms step_avg:49.98ms
+step:1163/1490 train_time:58153ms step_avg:50.00ms
+step:1164/1490 train_time:58237ms step_avg:50.03ms
+step:1165/1490 train_time:58315ms step_avg:50.06ms
+step:1166/1490 train_time:58401ms step_avg:50.09ms
+step:1167/1490 train_time:58480ms step_avg:50.11ms
+step:1168/1490 train_time:58565ms step_avg:50.14ms
+step:1169/1490 train_time:58644ms step_avg:50.17ms
+step:1170/1490 train_time:58728ms step_avg:50.20ms
+step:1171/1490 train_time:58807ms step_avg:50.22ms
+step:1172/1490 train_time:58892ms step_avg:50.25ms
+step:1173/1490 train_time:58971ms step_avg:50.27ms
+step:1174/1490 train_time:59056ms step_avg:50.30ms
+step:1175/1490 train_time:59135ms step_avg:50.33ms
+step:1176/1490 train_time:59219ms step_avg:50.36ms
+step:1177/1490 train_time:59300ms step_avg:50.38ms
+step:1178/1490 train_time:59384ms step_avg:50.41ms
+step:1179/1490 train_time:59462ms step_avg:50.43ms
+step:1180/1490 train_time:59547ms step_avg:50.46ms
+step:1181/1490 train_time:59626ms step_avg:50.49ms
+step:1182/1490 train_time:59710ms step_avg:50.52ms
+step:1183/1490 train_time:59788ms step_avg:50.54ms
+step:1184/1490 train_time:59872ms step_avg:50.57ms
+step:1185/1490 train_time:59953ms step_avg:50.59ms
+step:1186/1490 train_time:60037ms step_avg:50.62ms
+step:1187/1490 train_time:60117ms step_avg:50.65ms
+step:1188/1490 train_time:60202ms step_avg:50.67ms
+step:1189/1490 train_time:60280ms step_avg:50.70ms
+step:1190/1490 train_time:60365ms step_avg:50.73ms
+step:1191/1490 train_time:60446ms step_avg:50.75ms
+step:1192/1490 train_time:60530ms step_avg:50.78ms
+step:1193/1490 train_time:60609ms step_avg:50.80ms
+step:1194/1490 train_time:60694ms step_avg:50.83ms
+step:1195/1490 train_time:60774ms step_avg:50.86ms
+step:1196/1490 train_time:60858ms step_avg:50.88ms
+step:1197/1490 train_time:60938ms step_avg:50.91ms
+step:1198/1490 train_time:61022ms step_avg:50.94ms
+step:1199/1490 train_time:61100ms step_avg:50.96ms
+step:1200/1490 train_time:61185ms step_avg:50.99ms
+step:1201/1490 train_time:61264ms step_avg:51.01ms
+step:1202/1490 train_time:61349ms step_avg:51.04ms
+step:1203/1490 train_time:61430ms step_avg:51.06ms
+step:1204/1490 train_time:61514ms step_avg:51.09ms
+step:1205/1490 train_time:61594ms step_avg:51.12ms
+step:1206/1490 train_time:61679ms step_avg:51.14ms
+step:1207/1490 train_time:61758ms step_avg:51.17ms
+step:1208/1490 train_time:61842ms step_avg:51.19ms
+step:1209/1490 train_time:61921ms step_avg:51.22ms
+step:1210/1490 train_time:62006ms step_avg:51.25ms
+step:1211/1490 train_time:62085ms step_avg:51.27ms
+step:1212/1490 train_time:62169ms step_avg:51.29ms
+step:1213/1490 train_time:62249ms step_avg:51.32ms
+step:1214/1490 train_time:62334ms step_avg:51.35ms
+step:1215/1490 train_time:62413ms step_avg:51.37ms
+step:1216/1490 train_time:62498ms step_avg:51.40ms
+step:1217/1490 train_time:62576ms step_avg:51.42ms
+step:1218/1490 train_time:62660ms step_avg:51.45ms
+step:1219/1490 train_time:62740ms step_avg:51.47ms
+step:1220/1490 train_time:62824ms step_avg:51.49ms
+step:1221/1490 train_time:62903ms step_avg:51.52ms
+step:1222/1490 train_time:62987ms step_avg:51.54ms
+step:1223/1490 train_time:63066ms step_avg:51.57ms
+step:1224/1490 train_time:63152ms step_avg:51.59ms
+step:1225/1490 train_time:63231ms step_avg:51.62ms
+step:1226/1490 train_time:63316ms step_avg:51.64ms
+step:1227/1490 train_time:63395ms step_avg:51.67ms
+step:1228/1490 train_time:63480ms step_avg:51.69ms
+step:1229/1490 train_time:63560ms step_avg:51.72ms
+step:1230/1490 train_time:63645ms step_avg:51.74ms
+step:1231/1490 train_time:63723ms step_avg:51.77ms
+step:1232/1490 train_time:63808ms step_avg:51.79ms
+step:1233/1490 train_time:63887ms step_avg:51.81ms
+step:1234/1490 train_time:63971ms step_avg:51.84ms
+step:1235/1490 train_time:64051ms step_avg:51.86ms
+step:1236/1490 train_time:64138ms step_avg:51.89ms
+step:1237/1490 train_time:64217ms step_avg:51.91ms
+step:1238/1490 train_time:64301ms step_avg:51.94ms
+step:1239/1490 train_time:64380ms step_avg:51.96ms
+step:1240/1490 train_time:64464ms step_avg:51.99ms
+step:1241/1490 train_time:64544ms step_avg:52.01ms
+step:1242/1490 train_time:64627ms step_avg:52.03ms
+step:1243/1490 train_time:64707ms step_avg:52.06ms
+step:1244/1490 train_time:64792ms step_avg:52.08ms
+step:1245/1490 train_time:64871ms step_avg:52.11ms
+step:1246/1490 train_time:64956ms step_avg:52.13ms
+step:1247/1490 train_time:65035ms step_avg:52.15ms
+step:1248/1490 train_time:65120ms step_avg:52.18ms
+step:1249/1490 train_time:65199ms step_avg:52.20ms
+step:1250/1490 train_time:65282ms step_avg:52.23ms
+step:1250/1490 val_loss:3.3730 train_time:65381ms step_avg:52.30ms
+step:1251/1490 train_time:65399ms step_avg:52.28ms
+step:1252/1490 train_time:65451ms step_avg:52.28ms
+step:1253/1490 train_time:65535ms step_avg:52.30ms
+step:1254/1490 train_time:65620ms step_avg:52.33ms
+step:1255/1490 train_time:65699ms step_avg:52.35ms
+step:1256/1490 train_time:65783ms step_avg:52.38ms
+step:1257/1490 train_time:65863ms step_avg:52.40ms
+step:1258/1490 train_time:65948ms step_avg:52.42ms
+step:1259/1490 train_time:66025ms step_avg:52.44ms
+step:1260/1490 train_time:66109ms step_avg:52.47ms
+step:1261/1490 train_time:66186ms step_avg:52.49ms
+step:1262/1490 train_time:66272ms step_avg:52.51ms
+step:1263/1490 train_time:66350ms step_avg:52.53ms
+step:1264/1490 train_time:66437ms step_avg:52.56ms
+step:1265/1490 train_time:66521ms step_avg:52.59ms
+step:1266/1490 train_time:66607ms step_avg:52.61ms
+step:1267/1490 train_time:66687ms step_avg:52.63ms
+step:1268/1490 train_time:66772ms step_avg:52.66ms
+step:1269/1490 train_time:66850ms step_avg:52.68ms
+step:1270/1490 train_time:66933ms step_avg:52.70ms
+step:1271/1490 train_time:67011ms step_avg:52.72ms
+step:1272/1490 train_time:67095ms step_avg:52.75ms
+step:1273/1490 train_time:67172ms step_avg:52.77ms
+step:1274/1490 train_time:67257ms step_avg:52.79ms
+step:1275/1490 train_time:67335ms step_avg:52.81ms
+step:1276/1490 train_time:67422ms step_avg:52.84ms
+step:1277/1490 train_time:67503ms step_avg:52.86ms
+step:1278/1490 train_time:67588ms step_avg:52.89ms
+step:1279/1490 train_time:67669ms step_avg:52.91ms
+step:1280/1490 train_time:67753ms step_avg:52.93ms
+step:1281/1490 train_time:67832ms step_avg:52.95ms
+step:1282/1490 train_time:67917ms step_avg:52.98ms
+step:1283/1490 train_time:67995ms step_avg:53.00ms
+step:1284/1490 train_time:68077ms step_avg:53.02ms
+step:1285/1490 train_time:68157ms step_avg:53.04ms
+step:1286/1490 train_time:68242ms step_avg:53.07ms
+step:1287/1490 train_time:68322ms step_avg:53.09ms
+step:1288/1490 train_time:68407ms step_avg:53.11ms
+step:1289/1490 train_time:68485ms step_avg:53.13ms
+step:1290/1490 train_time:68572ms step_avg:53.16ms
+step:1291/1490 train_time:68652ms step_avg:53.18ms
+step:1292/1490 train_time:68736ms step_avg:53.20ms
+step:1293/1490 train_time:68816ms step_avg:53.22ms
+step:1294/1490 train_time:68901ms step_avg:53.25ms
+step:1295/1490 train_time:68980ms step_avg:53.27ms
+step:1296/1490 train_time:69063ms step_avg:53.29ms
+step:1297/1490 train_time:69142ms step_avg:53.31ms
+step:1298/1490 train_time:69227ms step_avg:53.33ms
+step:1299/1490 train_time:69306ms step_avg:53.35ms
+step:1300/1490 train_time:69390ms step_avg:53.38ms
+step:1301/1490 train_time:69470ms step_avg:53.40ms
+step:1302/1490 train_time:69555ms step_avg:53.42ms
+step:1303/1490 train_time:69635ms step_avg:53.44ms
+step:1304/1490 train_time:69720ms step_avg:53.47ms
+step:1305/1490 train_time:69801ms step_avg:53.49ms
+step:1306/1490 train_time:69886ms step_avg:53.51ms
+step:1307/1490 train_time:69966ms step_avg:53.53ms
+step:1308/1490 train_time:70048ms step_avg:53.55ms
+step:1309/1490 train_time:70126ms step_avg:53.57ms
+step:1310/1490 train_time:70211ms step_avg:53.60ms
+step:1311/1490 train_time:70289ms step_avg:53.62ms
+step:1312/1490 train_time:70374ms step_avg:53.64ms
+step:1313/1490 train_time:70454ms step_avg:53.66ms
+step:1314/1490 train_time:70539ms step_avg:53.68ms
+step:1315/1490 train_time:70619ms step_avg:53.70ms
+step:1316/1490 train_time:70704ms step_avg:53.73ms
+step:1317/1490 train_time:70784ms step_avg:53.75ms
+step:1318/1490 train_time:70869ms step_avg:53.77ms
+step:1319/1490 train_time:70949ms step_avg:53.79ms
+step:1320/1490 train_time:71033ms step_avg:53.81ms
+step:1321/1490 train_time:71113ms step_avg:53.83ms
+step:1322/1490 train_time:71197ms step_avg:53.86ms
+step:1323/1490 train_time:71275ms step_avg:53.87ms
+step:1324/1490 train_time:71361ms step_avg:53.90ms
+step:1325/1490 train_time:71440ms step_avg:53.92ms
+step:1326/1490 train_time:71526ms step_avg:53.94ms
+step:1327/1490 train_time:71606ms step_avg:53.96ms
+step:1328/1490 train_time:71692ms step_avg:53.98ms
+step:1329/1490 train_time:71772ms step_avg:54.00ms
+step:1330/1490 train_time:71856ms step_avg:54.03ms
+step:1331/1490 train_time:71935ms step_avg:54.05ms
+step:1332/1490 train_time:72020ms step_avg:54.07ms
+step:1333/1490 train_time:72099ms step_avg:54.09ms
+step:1334/1490 train_time:72184ms step_avg:54.11ms
+step:1335/1490 train_time:72264ms step_avg:54.13ms
+step:1336/1490 train_time:72349ms step_avg:54.15ms
+step:1337/1490 train_time:72428ms step_avg:54.17ms
+step:1338/1490 train_time:72513ms step_avg:54.19ms
+step:1339/1490 train_time:72593ms step_avg:54.21ms
+step:1340/1490 train_time:72678ms step_avg:54.24ms
+step:1341/1490 train_time:72757ms step_avg:54.26ms
+step:1342/1490 train_time:72842ms step_avg:54.28ms
+step:1343/1490 train_time:72922ms step_avg:54.30ms
+step:1344/1490 train_time:73006ms step_avg:54.32ms
+step:1345/1490 train_time:73084ms step_avg:54.34ms
+step:1346/1490 train_time:73169ms step_avg:54.36ms
+step:1347/1490 train_time:73248ms step_avg:54.38ms
+step:1348/1490 train_time:73333ms step_avg:54.40ms
+step:1349/1490 train_time:73413ms step_avg:54.42ms
+step:1350/1490 train_time:73496ms step_avg:54.44ms
+step:1351/1490 train_time:73576ms step_avg:54.46ms
+step:1352/1490 train_time:73661ms step_avg:54.48ms
+step:1353/1490 train_time:73740ms step_avg:54.50ms
+step:1354/1490 train_time:73824ms step_avg:54.52ms
+step:1355/1490 train_time:73905ms step_avg:54.54ms
+step:1356/1490 train_time:73990ms step_avg:54.56ms
+step:1357/1490 train_time:74068ms step_avg:54.58ms
+step:1358/1490 train_time:74154ms step_avg:54.61ms
+step:1359/1490 train_time:74233ms step_avg:54.62ms
+step:1360/1490 train_time:74317ms step_avg:54.64ms
+step:1361/1490 train_time:74395ms step_avg:54.66ms
+step:1362/1490 train_time:74480ms step_avg:54.68ms
+step:1363/1490 train_time:74561ms step_avg:54.70ms
+step:1364/1490 train_time:74645ms step_avg:54.73ms
+step:1365/1490 train_time:74725ms step_avg:54.74ms
+step:1366/1490 train_time:74811ms step_avg:54.77ms
+step:1367/1490 train_time:74890ms step_avg:54.78ms
+step:1368/1490 train_time:74976ms step_avg:54.81ms
+step:1369/1490 train_time:75055ms step_avg:54.82ms
+step:1370/1490 train_time:75139ms step_avg:54.85ms
+step:1371/1490 train_time:75217ms step_avg:54.86ms
+step:1372/1490 train_time:75302ms step_avg:54.89ms
+step:1373/1490 train_time:75383ms step_avg:54.90ms
+step:1374/1490 train_time:75468ms step_avg:54.93ms
+step:1375/1490 train_time:75548ms step_avg:54.94ms
+step:1376/1490 train_time:75633ms step_avg:54.97ms
+step:1377/1490 train_time:75711ms step_avg:54.98ms
+step:1378/1490 train_time:75796ms step_avg:55.00ms
+step:1379/1490 train_time:75875ms step_avg:55.02ms
+step:1380/1490 train_time:75961ms step_avg:55.04ms
+step:1381/1490 train_time:76040ms step_avg:55.06ms
+step:1382/1490 train_time:76125ms step_avg:55.08ms
+step:1383/1490 train_time:76205ms step_avg:55.10ms
+step:1384/1490 train_time:76289ms step_avg:55.12ms
+step:1385/1490 train_time:76368ms step_avg:55.14ms
+step:1386/1490 train_time:76454ms step_avg:55.16ms
+step:1387/1490 train_time:76532ms step_avg:55.18ms
+step:1388/1490 train_time:76617ms step_avg:55.20ms
+step:1389/1490 train_time:76695ms step_avg:55.22ms
+step:1390/1490 train_time:76781ms step_avg:55.24ms
+step:1391/1490 train_time:76861ms step_avg:55.26ms
+step:1392/1490 train_time:76946ms step_avg:55.28ms
+step:1393/1490 train_time:77026ms step_avg:55.29ms
+step:1394/1490 train_time:77111ms step_avg:55.32ms
+step:1395/1490 train_time:77190ms step_avg:55.33ms
+step:1396/1490 train_time:77274ms step_avg:55.35ms
+step:1397/1490 train_time:77354ms step_avg:55.37ms
+step:1398/1490 train_time:77439ms step_avg:55.39ms
+step:1399/1490 train_time:77519ms step_avg:55.41ms
+step:1400/1490 train_time:77603ms step_avg:55.43ms
+step:1401/1490 train_time:77683ms step_avg:55.45ms
+step:1402/1490 train_time:77771ms step_avg:55.47ms
+step:1403/1490 train_time:77852ms step_avg:55.49ms
+step:1404/1490 train_time:77935ms step_avg:55.51ms
+step:1405/1490 train_time:78014ms step_avg:55.53ms
+step:1406/1490 train_time:78098ms step_avg:55.55ms
+step:1407/1490 train_time:78178ms step_avg:55.56ms
+step:1408/1490 train_time:78263ms step_avg:55.58ms
+step:1409/1490 train_time:78344ms step_avg:55.60ms
+step:1410/1490 train_time:78439ms step_avg:55.63ms
+step:1411/1490 train_time:78510ms step_avg:55.64ms
+step:1412/1490 train_time:78593ms step_avg:55.66ms
+step:1413/1490 train_time:78672ms step_avg:55.68ms
+step:1414/1490 train_time:78758ms step_avg:55.70ms
+step:1415/1490 train_time:78836ms step_avg:55.71ms
+step:1416/1490 train_time:78921ms step_avg:55.74ms
+step:1417/1490 train_time:79002ms step_avg:55.75ms
+step:1418/1490 train_time:79086ms step_avg:55.77ms
+step:1419/1490 train_time:79165ms step_avg:55.79ms
+step:1420/1490 train_time:79250ms step_avg:55.81ms
+step:1421/1490 train_time:79329ms step_avg:55.83ms
+step:1422/1490 train_time:79415ms step_avg:55.85ms
+step:1423/1490 train_time:79494ms step_avg:55.86ms
+step:1424/1490 train_time:79577ms step_avg:55.88ms
+step:1425/1490 train_time:79657ms step_avg:55.90ms
+step:1426/1490 train_time:79741ms step_avg:55.92ms
+step:1427/1490 train_time:79822ms step_avg:55.94ms
+step:1428/1490 train_time:79907ms step_avg:55.96ms
+step:1429/1490 train_time:79987ms step_avg:55.97ms
+step:1430/1490 train_time:80071ms step_avg:55.99ms
+step:1431/1490 train_time:80151ms step_avg:56.01ms
+step:1432/1490 train_time:80235ms step_avg:56.03ms
+step:1433/1490 train_time:80314ms step_avg:56.05ms
+step:1434/1490 train_time:80401ms step_avg:56.07ms
+step:1435/1490 train_time:80478ms step_avg:56.08ms
+step:1436/1490 train_time:80563ms step_avg:56.10ms
+step:1437/1490 train_time:80643ms step_avg:56.12ms
+step:1438/1490 train_time:80728ms step_avg:56.14ms
+step:1439/1490 train_time:80807ms step_avg:56.16ms
+step:1440/1490 train_time:80893ms step_avg:56.18ms
+step:1441/1490 train_time:80972ms step_avg:56.19ms
+step:1442/1490 train_time:81056ms step_avg:56.21ms
+step:1443/1490 train_time:81136ms step_avg:56.23ms
+step:1444/1490 train_time:81221ms step_avg:56.25ms
+step:1445/1490 train_time:81301ms step_avg:56.26ms
+step:1446/1490 train_time:81386ms step_avg:56.28ms
+step:1447/1490 train_time:81466ms step_avg:56.30ms
+step:1448/1490 train_time:81550ms step_avg:56.32ms
+step:1449/1490 train_time:81629ms step_avg:56.33ms
+step:1450/1490 train_time:81714ms step_avg:56.35ms
+step:1451/1490 train_time:81796ms step_avg:56.37ms
+step:1452/1490 train_time:81883ms step_avg:56.39ms
+step:1453/1490 train_time:81963ms step_avg:56.41ms
+step:1454/1490 train_time:82048ms step_avg:56.43ms
+step:1455/1490 train_time:82128ms step_avg:56.45ms
+step:1456/1490 train_time:82213ms step_avg:56.47ms
+step:1457/1490 train_time:82293ms step_avg:56.48ms
+step:1458/1490 train_time:82378ms step_avg:56.50ms
+step:1459/1490 train_time:82457ms step_avg:56.52ms
+step:1460/1490 train_time:82541ms step_avg:56.53ms
+step:1461/1490 train_time:82622ms step_avg:56.55ms
+step:1462/1490 train_time:82706ms step_avg:56.57ms
+step:1463/1490 train_time:82787ms step_avg:56.59ms
+step:1464/1490 train_time:82871ms step_avg:56.61ms
+step:1465/1490 train_time:82952ms step_avg:56.62ms
+step:1466/1490 train_time:83036ms step_avg:56.64ms
+step:1467/1490 train_time:83116ms step_avg:56.66ms
+step:1468/1490 train_time:83202ms step_avg:56.68ms
+step:1469/1490 train_time:83280ms step_avg:56.69ms
+step:1470/1490 train_time:83366ms step_avg:56.71ms
+step:1471/1490 train_time:83446ms step_avg:56.73ms
+step:1472/1490 train_time:83531ms step_avg:56.75ms
+step:1473/1490 train_time:83610ms step_avg:56.76ms
+step:1474/1490 train_time:83695ms step_avg:56.78ms
+step:1475/1490 train_time:83774ms step_avg:56.80ms
+step:1476/1490 train_time:83860ms step_avg:56.82ms
+step:1477/1490 train_time:83940ms step_avg:56.83ms
+step:1478/1490 train_time:84026ms step_avg:56.85ms
+step:1479/1490 train_time:84108ms step_avg:56.87ms
+step:1480/1490 train_time:84193ms step_avg:56.89ms
+step:1481/1490 train_time:84273ms step_avg:56.90ms
+step:1482/1490 train_time:84356ms step_avg:56.92ms
+step:1483/1490 train_time:84435ms step_avg:56.94ms
+step:1484/1490 train_time:84522ms step_avg:56.96ms
+step:1485/1490 train_time:84603ms step_avg:56.97ms
+step:1486/1490 train_time:84689ms step_avg:56.99ms
+step:1487/1490 train_time:84769ms step_avg:57.01ms
+step:1488/1490 train_time:84854ms step_avg:57.03ms
+step:1489/1490 train_time:84934ms step_avg:57.04ms
+step:1490/1490 train_time:85018ms step_avg:57.06ms
+step:1490/1490 val_loss:3.2800 train_time:85116ms step_avg:57.12ms
+peak memory allocated: 31253 MiB reserved: 45848 MiB

--- a/records/track_1_short/2026-04-4_FuseCEFwdAndBwd/runs/3182d161-2b4b-41e4-8187-405e413e0736.txt
+++ b/records/track_1_short/2026-04-4_FuseCEFwdAndBwd/runs/3182d161-2b4b-41e4-8187-405e413e0736.txt
@@ -1,0 +1,4731 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+CE_KERNEL_BLOCK_SIZE = 256
+CE_KERNEL_VOCAB_SIZE = 50304
+
+CE_KERNEL_DECLS = f"""
+constexpr int VOCAB_SIZE = {CE_KERNEL_VOCAB_SIZE};
+constexpr int BLOCK_SIZE = {CE_KERNEL_BLOCK_SIZE};
+"""
+
+CE_KERNEL_SOURCE = """
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+#define __nv_fp8_e5m2 char
+#define uint16_t unsigned short
+#define uint8_t unsigned char
+#define int64_t long long
+
+__device__ __forceinline__ __nv_fp8_e5m2 f32_to_fp8_e5m2(float x) {
+    uint16_t packed;
+    asm volatile(
+        "cvt.rn.satfinite.e5m2x2.f32 %0, %1, %2;"
+        : "=h"(packed)
+        : "f"(x), "f"(0.0f)
+    );
+    __nv_fp8_e5m2 result;
+    *reinterpret_cast<uint8_t*>(&result) = (packed & (0xFF << 8)) >> 8;
+    return result;
+}
+
+struct __align__(16) __nv_bfloat168 {
+    __nv_bfloat16 data[8];
+    __device__ __nv_bfloat16& operator[](int i) { return data[i]; }
+    __device__ const __nv_bfloat16& operator[](int i) const { return data[i]; }
+};
+
+struct __align__(8) __nv_fp8_e5m28 {
+    __nv_fp8_e5m2 data[8];
+    __device__ __nv_fp8_e5m2& operator[](int i) { return data[i]; }
+    __device__ const __nv_fp8_e5m2& operator[](int i) const { return data[i]; }
+};
+
+template<typename T> __device__ constexpr T CEIL_DIV(T a, T b) { return (a + b - 1) / b; }
+
+//__device__ float sigmoid(float x) {
+//  return 1.0f / (1.0f + __expf(-x));
+//}
+__device__ float sigmoid(float x) {
+  return 0.5f + __tanhf(x * 0.5f) * 0.5f;
+}
+
+extern "C"
+__launch_bounds__(BLOCK_SIZE, 2)
+__global__ void ce_fwd_bwd_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    const int64_t* __restrict__ targets,
+    const float* __restrict__ mtp_weights,
+    float* __restrict__ losses,
+    __nv_fp8_e5m2* grad_input,
+    int batch_size,
+    int n_predict,
+    double A_param,
+    double B_param,
+    double C_param,
+    double grad_s_param,
+    double grad_scale_param)
+{
+  constexpr int VEC_WIDTH = 8;
+  constexpr int NUM_FULL_LOADS = VOCAB_SIZE / (BLOCK_SIZE * VEC_WIDTH);
+  constexpr int NUM_LOADS = CEIL_DIV(VOCAB_SIZE, BLOCK_SIZE * VEC_WIDTH);
+
+  float A = (float)A_param;
+  float B = (float)B_param;
+  float C = (float)C_param;
+  float grad_s = (float)grad_s_param;
+  float grad_scale = (float)grad_scale_param;
+
+  extern __shared__ __nv_bfloat16 smem[];
+
+  static_assert(VEC_WIDTH == 8);
+
+  const __nv_bfloat16 *block_logit_ptr = logits + VOCAB_SIZE * blockIdx.x;
+
+  float inv_C = 1 / C;
+  float B_div_C = B * inv_C;
+  float thread_max = -CUDART_INF_F;
+
+  #pragma unroll 25
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 result = *(__nv_bfloat168*)(&block_logit_ptr[idx]);
+      __nv_bfloat168 result_sigmoid;
+      #pragma unroll
+      for (int k = 0; k < VEC_WIDTH; k++) {
+        float tmp = __bfloat162float(result[k]);
+        tmp = sigmoid(tmp * inv_C + B_div_C);
+        result_sigmoid[k] = __float2bfloat16(tmp);
+        tmp = A * tmp;
+        thread_max = max(tmp, thread_max);
+      }
+      *(__nv_bfloat168*)(&smem[idx]) = result_sigmoid;
+    }
+  }
+
+  constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+  int warp_id = threadIdx.x / 32;
+  __shared__ float block_maxs[NUM_WARPS];
+  __shared__ float block_sums[NUM_WARPS];
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_max = fmaxf(thread_max, __shfl_down_sync(0xFFFFFFFF, thread_max, offset));
+
+  if (threadIdx.x % 32 == 0) {
+    block_maxs[warp_id] = thread_max;
+  }
+
+  __syncthreads();
+
+  float block_max = -CUDART_INF_F;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_max = fmaxf(block_max, block_maxs[i]);
+  }
+
+  float thread_sum = 0.0f;
+  #pragma unroll 2
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_bfloat168 l;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      l = *(__nv_bfloat168*)(&smem[idx]);
+    }
+    #pragma unroll
+    for (int k = 0; k < VEC_WIDTH; k++) {
+      float tmp = A * __bfloat162float(l[k]);
+      tmp = __expf(tmp - block_max);
+      if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+        thread_sum += tmp;
+      }
+    }
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_sum += __shfl_down_sync(0xFFFFFFFF, thread_sum, offset);
+
+  if (threadIdx.x % 32 == 0) {
+    block_sums[warp_id] = thread_sum;
+  }
+
+  __syncthreads();
+
+  float block_sum = 0.0f;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_sum += block_sums[i];
+  }
+
+  float lse = block_max + __logf(block_sum);
+
+  if (threadIdx.x == 0) {
+    float total_loss = 0.0f;
+    for (int k = 0; k < n_predict; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size) {
+        float weight = mtp_weights[k];
+        int64_t target = targets[target_idx];
+        if (target >= 0 && target < VOCAB_SIZE) {
+          float z_target = A * __bfloat162float(smem[target]);
+          total_loss += weight * (lse - z_target);
+        }
+      }
+    }
+    losses[blockIdx.x] = total_loss;
+  }
+
+  float S_w = 0.0f;
+
+  for (int i = 0; i < n_predict; i++) {
+    S_w += mtp_weights[i];
+  }
+
+  #pragma unroll 4
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_fp8_e5m28 result;
+
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 sigmoid_us = *(__nv_bfloat168*)(&smem[idx]);
+      #pragma unroll
+      for (int j = 0; j < VEC_WIDTH; j++) {
+        float sigmoid_u = __bfloat162float(sigmoid_us[j]);
+        float z = A * sigmoid_u;
+        float p = __expf(z - lse);
+
+        float term1 = S_w * p;
+        float term2 = 0.0f;
+
+        float grad_z = term1 - term2;
+        float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+        auto result_tmp = f32_to_fp8_e5m2(grad_x);
+        result[j] = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+      }
+      *(__nv_fp8_e5m28*)(&grad_input[blockIdx.x * VOCAB_SIZE + idx]) = result;
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < n_predict && blockIdx.x + threadIdx.x < batch_size) {
+    int i = threadIdx.x;
+    int64_t target = targets[blockIdx.x + i];
+
+    float sigmoid_u = __bfloat162float(smem[target]);
+    float z = A * sigmoid_u;
+    float p = __expf(z - lse);
+
+    float term1 = S_w * p;
+    float term2 = 0.0f;
+
+    #pragma unroll
+    for (int k = 0; k < 3; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size && k < n_predict) {
+        if (targets[target_idx] == target) {
+          term2 += mtp_weights[k];
+        }
+      }
+    }
+
+    float grad_z = term1 - term2;
+    float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+    auto result_tmp = f32_to_fp8_e5m2(grad_x);
+    auto result = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+    grad_input[blockIdx.x * VOCAB_SIZE + target] = result;
+  }
+}
+"""
+
+
+ce_fwd_bwd_kernel = torch.cuda._compile_kernel(
+    CE_KERNEL_DECLS + CE_KERNEL_SOURCE,
+    "ce_fwd_bwd_kernel",
+    compute_capability="90",
+    cuda_include_dirs=["/usr/local/cuda/include/"],
+    nvcc_options=["-lineinfo", "--use_fast_math"],
+)
+ce_fwd_bwd_kernel.set_shared_memory_config(CE_KERNEL_VOCAB_SIZE * 2)
+
+@torch.library.custom_op("nanogpt::ce_fwd_bwd", mutates_args={"losses", "grad_input"})
+def ce_fwd_bwd(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    mtp_weights: torch.Tensor,
+    losses: torch.Tensor,
+    grad_input: torch.Tensor,
+    n_rows: int,
+    n_predict: int,
+    A: float,
+    B: float,
+    C: float,
+    grad_s: float,
+    grad_scale: float,
+) -> None:
+    grid = (n_rows, 1, 1)
+    ce_fwd_bwd_kernel(
+        grid,
+        (CE_KERNEL_BLOCK_SIZE, 1, 1),
+        (logits, targets, mtp_weights, losses, grad_input,
+         n_rows, n_predict, A, B, C, grad_s, grad_scale),
+        shared_mem=CE_KERNEL_VOCAB_SIZE * 2,
+    )
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, grad_scale, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+
+        ce_fwd_bwd(logits, targets, mtp_weights, losses, grad_input,
+             n_rows, n_predict, A, B, C, grad_s, grad_scale)
+        #grid = (n_rows,)
+        #fused_softcapped_entropy_fwd_kernel[grid](
+        #    logits, losses, lse, targets, mtp_weights,
+        #    logits.stride(0), logits.stride(1),
+        #    n_rows, n_cols, n_predict,
+        #    A, B, C,
+        #    BLOCK_SIZE=2048,
+        #    num_warps=2
+        #)
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_output = grad_output.contiguous()
+
+        #grad_input_ref = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        #grid = (n_rows,)
+        #fused_softcapped_entropy_bwd_kernel[grid](
+        #    grad_input_ref, grad_output, lse, logits, targets, mtp_weights,
+        #    logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+        #    n_rows, n_cols, n_predict,
+        #    A, B, C,
+        #    grad_s,
+        #    BLOCK_SIZE=1024,
+        #    num_warps=4,
+        #    N_PREDICT=n_predict,
+        #)
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.12.3 (main, Mar  3 2026, 12:15:18) [GCC 13.3.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sat Apr  4 05:44:57 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:8D:00.0 Off |                    0 |
+| N/A   47C    P0            127W /  700W |    1521MiB /  81559MiB |      2%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:91:00.0 Off |                    0 |
+| N/A   37C    P0            120W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:95:00.0 Off |                    0 |
+| N/A   46C    P0            128W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:99:00.0 Off |                    0 |
+| N/A   38C    P0            128W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   46C    P0            123W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AF:00.0 Off |                    0 |
+| N/A   38C    P0            122W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:B3:00.0 Off |                    0 |
+| N/A   47C    P0            127W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:B7:00.0 Off |                    0 |
+| N/A   36C    P0            121W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A           39619      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    1   N/A  N/A           39620      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    2   N/A  N/A           39621      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    3   N/A  N/A           39622      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    4   N/A  N/A           39623      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    5   N/A  N/A           39624      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    6   N/A  N/A           39625      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    7   N/A  N/A           39626      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8305 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:80ms step_avg:80.33ms
+step:2/1490 train_time:102ms step_avg:51.14ms
+step:3/1490 train_time:120ms step_avg:40.05ms
+step:4/1490 train_time:147ms step_avg:36.64ms
+step:5/1490 train_time:173ms step_avg:34.54ms
+step:6/1490 train_time:207ms step_avg:34.56ms
+step:7/1490 train_time:234ms step_avg:33.40ms
+step:8/1490 train_time:269ms step_avg:33.59ms
+step:9/1490 train_time:295ms step_avg:32.80ms
+step:10/1490 train_time:330ms step_avg:32.98ms
+step:11/1490 train_time:357ms step_avg:32.42ms
+step:12/1490 train_time:391ms step_avg:32.62ms
+step:13/1490 train_time:418ms step_avg:32.18ms
+step:14/1490 train_time:453ms step_avg:32.36ms
+step:15/1490 train_time:480ms step_avg:31.99ms
+step:16/1490 train_time:514ms step_avg:32.13ms
+step:17/1490 train_time:541ms step_avg:31.83ms
+step:18/1490 train_time:575ms step_avg:31.97ms
+step:19/1490 train_time:603ms step_avg:31.72ms
+step:20/1490 train_time:638ms step_avg:31.88ms
+step:21/1490 train_time:665ms step_avg:31.65ms
+step:22/1490 train_time:699ms step_avg:31.79ms
+step:23/1490 train_time:727ms step_avg:31.59ms
+step:24/1490 train_time:761ms step_avg:31.70ms
+step:25/1490 train_time:788ms step_avg:31.52ms
+step:26/1490 train_time:823ms step_avg:31.64ms
+step:27/1490 train_time:850ms step_avg:31.47ms
+step:28/1490 train_time:884ms step_avg:31.58ms
+step:29/1490 train_time:911ms step_avg:31.43ms
+step:30/1490 train_time:945ms step_avg:31.51ms
+step:31/1490 train_time:973ms step_avg:31.38ms
+step:32/1490 train_time:1008ms step_avg:31.50ms
+step:33/1490 train_time:1037ms step_avg:31.44ms
+step:34/1490 train_time:1073ms step_avg:31.57ms
+step:35/1490 train_time:1101ms step_avg:31.46ms
+step:36/1490 train_time:1136ms step_avg:31.55ms
+step:37/1490 train_time:1163ms step_avg:31.45ms
+step:38/1490 train_time:1198ms step_avg:31.53ms
+step:39/1490 train_time:1226ms step_avg:31.45ms
+step:40/1490 train_time:1261ms step_avg:31.52ms
+step:41/1490 train_time:1288ms step_avg:31.42ms
+step:42/1490 train_time:1323ms step_avg:31.49ms
+step:43/1490 train_time:1350ms step_avg:31.40ms
+step:44/1490 train_time:1384ms step_avg:31.46ms
+step:45/1490 train_time:1412ms step_avg:31.37ms
+step:46/1490 train_time:1446ms step_avg:31.43ms
+step:47/1490 train_time:1473ms step_avg:31.34ms
+step:48/1490 train_time:1507ms step_avg:31.40ms
+step:49/1490 train_time:1535ms step_avg:31.32ms
+step:50/1490 train_time:1569ms step_avg:31.38ms
+step:51/1490 train_time:1597ms step_avg:31.31ms
+step:52/1490 train_time:1632ms step_avg:31.38ms
+step:53/1490 train_time:1659ms step_avg:31.31ms
+step:54/1490 train_time:1694ms step_avg:31.36ms
+step:55/1490 train_time:1721ms step_avg:31.29ms
+step:56/1490 train_time:1756ms step_avg:31.35ms
+step:57/1490 train_time:1782ms step_avg:31.27ms
+step:58/1490 train_time:1817ms step_avg:31.33ms
+step:59/1490 train_time:1844ms step_avg:31.26ms
+step:60/1490 train_time:1879ms step_avg:31.32ms
+step:61/1490 train_time:1907ms step_avg:31.26ms
+step:62/1490 train_time:1941ms step_avg:31.31ms
+step:63/1490 train_time:1969ms step_avg:31.25ms
+step:64/1490 train_time:2004ms step_avg:31.31ms
+step:65/1490 train_time:2031ms step_avg:31.25ms
+step:66/1490 train_time:2066ms step_avg:31.31ms
+step:67/1490 train_time:2094ms step_avg:31.25ms
+step:68/1490 train_time:2128ms step_avg:31.30ms
+step:69/1490 train_time:2156ms step_avg:31.25ms
+step:70/1490 train_time:2191ms step_avg:31.30ms
+step:71/1490 train_time:2219ms step_avg:31.25ms
+step:72/1490 train_time:2253ms step_avg:31.30ms
+step:73/1490 train_time:2280ms step_avg:31.24ms
+step:74/1490 train_time:2315ms step_avg:31.28ms
+step:75/1490 train_time:2342ms step_avg:31.23ms
+step:76/1490 train_time:2377ms step_avg:31.27ms
+step:77/1490 train_time:2404ms step_avg:31.23ms
+step:78/1490 train_time:2439ms step_avg:31.27ms
+step:79/1490 train_time:2467ms step_avg:31.23ms
+step:80/1490 train_time:2502ms step_avg:31.27ms
+step:81/1490 train_time:2529ms step_avg:31.23ms
+step:82/1490 train_time:2564ms step_avg:31.27ms
+step:83/1490 train_time:2591ms step_avg:31.22ms
+step:84/1490 train_time:2625ms step_avg:31.25ms
+step:85/1490 train_time:2652ms step_avg:31.20ms
+step:86/1490 train_time:2686ms step_avg:31.23ms
+step:87/1490 train_time:2713ms step_avg:31.19ms
+step:88/1490 train_time:2747ms step_avg:31.22ms
+step:89/1490 train_time:2775ms step_avg:31.18ms
+step:90/1490 train_time:2809ms step_avg:31.21ms
+step:91/1490 train_time:2837ms step_avg:31.18ms
+step:92/1490 train_time:2872ms step_avg:31.22ms
+step:93/1490 train_time:2899ms step_avg:31.18ms
+step:94/1490 train_time:2934ms step_avg:31.21ms
+step:95/1490 train_time:2961ms step_avg:31.17ms
+step:96/1490 train_time:2996ms step_avg:31.21ms
+step:97/1490 train_time:3023ms step_avg:31.17ms
+step:98/1490 train_time:3058ms step_avg:31.20ms
+step:99/1490 train_time:3085ms step_avg:31.16ms
+step:100/1490 train_time:3120ms step_avg:31.20ms
+step:101/1490 train_time:3148ms step_avg:31.16ms
+step:102/1490 train_time:3182ms step_avg:31.20ms
+step:103/1490 train_time:3210ms step_avg:31.16ms
+step:104/1490 train_time:3244ms step_avg:31.20ms
+step:105/1490 train_time:3272ms step_avg:31.16ms
+step:106/1490 train_time:3306ms step_avg:31.19ms
+step:107/1490 train_time:3333ms step_avg:31.15ms
+step:108/1490 train_time:3368ms step_avg:31.19ms
+step:109/1490 train_time:3396ms step_avg:31.15ms
+step:110/1490 train_time:3431ms step_avg:31.19ms
+step:111/1490 train_time:3458ms step_avg:31.15ms
+step:112/1490 train_time:3493ms step_avg:31.19ms
+step:113/1490 train_time:3520ms step_avg:31.15ms
+step:114/1490 train_time:3555ms step_avg:31.18ms
+step:115/1490 train_time:3582ms step_avg:31.15ms
+step:116/1490 train_time:3617ms step_avg:31.18ms
+step:117/1490 train_time:3645ms step_avg:31.15ms
+step:118/1490 train_time:3679ms step_avg:31.18ms
+step:119/1490 train_time:3707ms step_avg:31.15ms
+step:120/1490 train_time:3741ms step_avg:31.17ms
+step:121/1490 train_time:3768ms step_avg:31.14ms
+step:122/1490 train_time:3802ms step_avg:31.17ms
+step:123/1490 train_time:3830ms step_avg:31.14ms
+step:124/1490 train_time:3864ms step_avg:31.16ms
+step:125/1490 train_time:3892ms step_avg:31.13ms
+step:126/1490 train_time:3926ms step_avg:31.16ms
+step:127/1490 train_time:3952ms step_avg:31.12ms
+step:128/1490 train_time:3986ms step_avg:31.14ms
+step:129/1490 train_time:4014ms step_avg:31.12ms
+step:130/1490 train_time:4049ms step_avg:31.14ms
+step:131/1490 train_time:4076ms step_avg:31.11ms
+step:132/1490 train_time:4111ms step_avg:31.14ms
+step:133/1490 train_time:4138ms step_avg:31.11ms
+step:134/1490 train_time:4173ms step_avg:31.14ms
+step:135/1490 train_time:4200ms step_avg:31.11ms
+step:136/1490 train_time:4235ms step_avg:31.14ms
+step:137/1490 train_time:4262ms step_avg:31.11ms
+step:138/1490 train_time:4297ms step_avg:31.14ms
+step:139/1490 train_time:4324ms step_avg:31.11ms
+step:140/1490 train_time:4359ms step_avg:31.14ms
+step:141/1490 train_time:4387ms step_avg:31.11ms
+step:142/1490 train_time:4421ms step_avg:31.13ms
+step:143/1490 train_time:4449ms step_avg:31.11ms
+step:144/1490 train_time:4483ms step_avg:31.13ms
+step:145/1490 train_time:4510ms step_avg:31.11ms
+step:146/1490 train_time:4545ms step_avg:31.13ms
+step:147/1490 train_time:4572ms step_avg:31.10ms
+step:148/1490 train_time:4606ms step_avg:31.12ms
+step:149/1490 train_time:4633ms step_avg:31.10ms
+step:150/1490 train_time:4668ms step_avg:31.12ms
+step:151/1490 train_time:4695ms step_avg:31.10ms
+step:152/1490 train_time:4730ms step_avg:31.12ms
+step:153/1490 train_time:4758ms step_avg:31.10ms
+step:154/1490 train_time:4792ms step_avg:31.12ms
+step:155/1490 train_time:4820ms step_avg:31.09ms
+step:156/1490 train_time:4855ms step_avg:31.12ms
+step:157/1490 train_time:4882ms step_avg:31.09ms
+step:158/1490 train_time:4916ms step_avg:31.11ms
+step:159/1490 train_time:4943ms step_avg:31.09ms
+step:160/1490 train_time:4978ms step_avg:31.11ms
+step:161/1490 train_time:5005ms step_avg:31.09ms
+step:162/1490 train_time:5039ms step_avg:31.11ms
+step:163/1490 train_time:5068ms step_avg:31.09ms
+step:164/1490 train_time:5102ms step_avg:31.11ms
+step:165/1490 train_time:5130ms step_avg:31.09ms
+step:166/1490 train_time:5164ms step_avg:31.11ms
+step:167/1490 train_time:5191ms step_avg:31.09ms
+step:168/1490 train_time:5226ms step_avg:31.11ms
+step:169/1490 train_time:5253ms step_avg:31.08ms
+step:170/1490 train_time:5287ms step_avg:31.10ms
+step:171/1490 train_time:5315ms step_avg:31.08ms
+step:172/1490 train_time:5350ms step_avg:31.10ms
+step:173/1490 train_time:5377ms step_avg:31.08ms
+step:174/1490 train_time:5412ms step_avg:31.10ms
+step:175/1490 train_time:5440ms step_avg:31.08ms
+step:176/1490 train_time:5474ms step_avg:31.10ms
+step:177/1490 train_time:5501ms step_avg:31.08ms
+step:178/1490 train_time:5536ms step_avg:31.10ms
+step:179/1490 train_time:5564ms step_avg:31.08ms
+step:180/1490 train_time:5598ms step_avg:31.10ms
+step:181/1490 train_time:5626ms step_avg:31.08ms
+step:182/1490 train_time:5660ms step_avg:31.10ms
+step:183/1490 train_time:5687ms step_avg:31.08ms
+step:184/1490 train_time:5722ms step_avg:31.10ms
+step:185/1490 train_time:5749ms step_avg:31.08ms
+step:186/1490 train_time:5784ms step_avg:31.09ms
+step:187/1490 train_time:5811ms step_avg:31.07ms
+step:188/1490 train_time:5845ms step_avg:31.09ms
+step:189/1490 train_time:5872ms step_avg:31.07ms
+step:190/1490 train_time:5906ms step_avg:31.09ms
+step:191/1490 train_time:5934ms step_avg:31.07ms
+step:192/1490 train_time:5968ms step_avg:31.08ms
+step:193/1490 train_time:5995ms step_avg:31.06ms
+step:194/1490 train_time:6030ms step_avg:31.08ms
+step:195/1490 train_time:6058ms step_avg:31.07ms
+step:196/1490 train_time:6093ms step_avg:31.08ms
+step:197/1490 train_time:6120ms step_avg:31.06ms
+step:198/1490 train_time:6154ms step_avg:31.08ms
+step:199/1490 train_time:6181ms step_avg:31.06ms
+step:200/1490 train_time:6216ms step_avg:31.08ms
+step:201/1490 train_time:6243ms step_avg:31.06ms
+step:202/1490 train_time:6278ms step_avg:31.08ms
+step:203/1490 train_time:6305ms step_avg:31.06ms
+step:204/1490 train_time:6340ms step_avg:31.08ms
+step:205/1490 train_time:6368ms step_avg:31.06ms
+step:206/1490 train_time:6402ms step_avg:31.08ms
+step:207/1490 train_time:6429ms step_avg:31.06ms
+step:208/1490 train_time:6464ms step_avg:31.08ms
+step:209/1490 train_time:6490ms step_avg:31.05ms
+step:210/1490 train_time:6525ms step_avg:31.07ms
+step:211/1490 train_time:6552ms step_avg:31.05ms
+step:212/1490 train_time:6586ms step_avg:31.07ms
+step:213/1490 train_time:6614ms step_avg:31.05ms
+step:214/1490 train_time:6648ms step_avg:31.07ms
+step:215/1490 train_time:6675ms step_avg:31.05ms
+step:216/1490 train_time:6710ms step_avg:31.07ms
+step:217/1490 train_time:6737ms step_avg:31.05ms
+step:218/1490 train_time:6772ms step_avg:31.06ms
+step:219/1490 train_time:6799ms step_avg:31.05ms
+step:220/1490 train_time:6834ms step_avg:31.06ms
+step:221/1490 train_time:6861ms step_avg:31.04ms
+step:222/1490 train_time:6895ms step_avg:31.06ms
+step:223/1490 train_time:6922ms step_avg:31.04ms
+step:224/1490 train_time:6957ms step_avg:31.06ms
+step:225/1490 train_time:6984ms step_avg:31.04ms
+step:226/1490 train_time:7018ms step_avg:31.06ms
+step:227/1490 train_time:7046ms step_avg:31.04ms
+step:228/1490 train_time:7080ms step_avg:31.05ms
+step:229/1490 train_time:7108ms step_avg:31.04ms
+step:230/1490 train_time:7142ms step_avg:31.05ms
+step:231/1490 train_time:7169ms step_avg:31.04ms
+step:232/1490 train_time:7204ms step_avg:31.05ms
+step:233/1490 train_time:7231ms step_avg:31.03ms
+step:234/1490 train_time:7266ms step_avg:31.05ms
+step:235/1490 train_time:7292ms step_avg:31.03ms
+step:236/1490 train_time:7326ms step_avg:31.04ms
+step:237/1490 train_time:7354ms step_avg:31.03ms
+step:238/1490 train_time:7388ms step_avg:31.04ms
+step:239/1490 train_time:7415ms step_avg:31.03ms
+step:240/1490 train_time:7450ms step_avg:31.04ms
+step:241/1490 train_time:7477ms step_avg:31.03ms
+step:242/1490 train_time:7512ms step_avg:31.04ms
+step:243/1490 train_time:7539ms step_avg:31.03ms
+step:244/1490 train_time:7574ms step_avg:31.04ms
+step:245/1490 train_time:7601ms step_avg:31.02ms
+step:246/1490 train_time:7635ms step_avg:31.04ms
+step:247/1490 train_time:7662ms step_avg:31.02ms
+step:248/1490 train_time:7697ms step_avg:31.04ms
+step:249/1490 train_time:7724ms step_avg:31.02ms
+step:250/1490 train_time:7758ms step_avg:31.03ms
+step:250/1490 val_loss:4.5185 train_time:7798ms step_avg:31.19ms
+step:251/1490 train_time:7815ms step_avg:31.14ms
+step:252/1490 train_time:7835ms step_avg:31.09ms
+step:253/1490 train_time:7850ms step_avg:31.03ms
+step:254/1490 train_time:7885ms step_avg:31.04ms
+step:255/1490 train_time:7913ms step_avg:31.03ms
+step:256/1490 train_time:7949ms step_avg:31.05ms
+step:257/1490 train_time:7977ms step_avg:31.04ms
+step:258/1490 train_time:8011ms step_avg:31.05ms
+step:259/1490 train_time:8039ms step_avg:31.04ms
+step:260/1490 train_time:8073ms step_avg:31.05ms
+step:261/1490 train_time:8101ms step_avg:31.04ms
+step:262/1490 train_time:8136ms step_avg:31.05ms
+step:263/1490 train_time:8162ms step_avg:31.04ms
+step:264/1490 train_time:8197ms step_avg:31.05ms
+step:265/1490 train_time:8224ms step_avg:31.03ms
+step:266/1490 train_time:8259ms step_avg:31.05ms
+step:267/1490 train_time:8286ms step_avg:31.03ms
+step:268/1490 train_time:8320ms step_avg:31.05ms
+step:269/1490 train_time:8347ms step_avg:31.03ms
+step:270/1490 train_time:8381ms step_avg:31.04ms
+step:271/1490 train_time:8408ms step_avg:31.03ms
+step:272/1490 train_time:8443ms step_avg:31.04ms
+step:273/1490 train_time:8469ms step_avg:31.02ms
+step:274/1490 train_time:8503ms step_avg:31.03ms
+step:275/1490 train_time:8530ms step_avg:31.02ms
+step:276/1490 train_time:8564ms step_avg:31.03ms
+step:277/1490 train_time:8591ms step_avg:31.02ms
+step:278/1490 train_time:8625ms step_avg:31.03ms
+step:279/1490 train_time:8652ms step_avg:31.01ms
+step:280/1490 train_time:8687ms step_avg:31.02ms
+step:281/1490 train_time:8714ms step_avg:31.01ms
+step:282/1490 train_time:8748ms step_avg:31.02ms
+step:283/1490 train_time:8776ms step_avg:31.01ms
+step:284/1490 train_time:8811ms step_avg:31.02ms
+step:285/1490 train_time:8838ms step_avg:31.01ms
+step:286/1490 train_time:8873ms step_avg:31.03ms
+step:287/1490 train_time:8901ms step_avg:31.01ms
+step:288/1490 train_time:8937ms step_avg:31.03ms
+step:289/1490 train_time:8964ms step_avg:31.02ms
+step:290/1490 train_time:8999ms step_avg:31.03ms
+step:291/1490 train_time:9026ms step_avg:31.02ms
+step:292/1490 train_time:9061ms step_avg:31.03ms
+step:293/1490 train_time:9088ms step_avg:31.02ms
+step:294/1490 train_time:9123ms step_avg:31.03ms
+step:295/1490 train_time:9150ms step_avg:31.02ms
+step:296/1490 train_time:9185ms step_avg:31.03ms
+step:297/1490 train_time:9212ms step_avg:31.02ms
+step:298/1490 train_time:9246ms step_avg:31.03ms
+step:299/1490 train_time:9274ms step_avg:31.02ms
+step:300/1490 train_time:9308ms step_avg:31.03ms
+step:301/1490 train_time:9336ms step_avg:31.02ms
+step:302/1490 train_time:9370ms step_avg:31.03ms
+step:303/1490 train_time:9398ms step_avg:31.01ms
+step:304/1490 train_time:9432ms step_avg:31.03ms
+step:305/1490 train_time:9459ms step_avg:31.01ms
+step:306/1490 train_time:9493ms step_avg:31.02ms
+step:307/1490 train_time:9520ms step_avg:31.01ms
+step:308/1490 train_time:9554ms step_avg:31.02ms
+step:309/1490 train_time:9582ms step_avg:31.01ms
+step:310/1490 train_time:9616ms step_avg:31.02ms
+step:311/1490 train_time:9643ms step_avg:31.01ms
+step:312/1490 train_time:9677ms step_avg:31.02ms
+step:313/1490 train_time:9705ms step_avg:31.01ms
+step:314/1490 train_time:9739ms step_avg:31.01ms
+step:315/1490 train_time:9766ms step_avg:31.00ms
+step:316/1490 train_time:9800ms step_avg:31.01ms
+step:317/1490 train_time:9828ms step_avg:31.00ms
+step:318/1490 train_time:9862ms step_avg:31.01ms
+step:319/1490 train_time:9889ms step_avg:31.00ms
+step:320/1490 train_time:9923ms step_avg:31.01ms
+step:321/1490 train_time:9951ms step_avg:31.00ms
+step:322/1490 train_time:9985ms step_avg:31.01ms
+step:323/1490 train_time:10013ms step_avg:31.00ms
+step:324/1490 train_time:10047ms step_avg:31.01ms
+step:325/1490 train_time:10075ms step_avg:31.00ms
+step:326/1490 train_time:10110ms step_avg:31.01ms
+step:327/1490 train_time:10137ms step_avg:31.00ms
+step:328/1490 train_time:10172ms step_avg:31.01ms
+step:329/1490 train_time:10199ms step_avg:31.00ms
+step:330/1490 train_time:10233ms step_avg:31.01ms
+step:331/1490 train_time:10261ms step_avg:31.00ms
+step:332/1490 train_time:10296ms step_avg:31.01ms
+step:333/1490 train_time:10323ms step_avg:31.00ms
+step:334/1490 train_time:10358ms step_avg:31.01ms
+step:335/1490 train_time:10385ms step_avg:31.00ms
+step:336/1490 train_time:10419ms step_avg:31.01ms
+step:337/1490 train_time:10447ms step_avg:31.00ms
+step:338/1490 train_time:10481ms step_avg:31.01ms
+step:339/1490 train_time:10508ms step_avg:31.00ms
+step:340/1490 train_time:10542ms step_avg:31.01ms
+step:341/1490 train_time:10569ms step_avg:30.99ms
+step:342/1490 train_time:10604ms step_avg:31.00ms
+step:343/1490 train_time:10630ms step_avg:30.99ms
+step:344/1490 train_time:10665ms step_avg:31.00ms
+step:345/1490 train_time:10692ms step_avg:30.99ms
+step:346/1490 train_time:10727ms step_avg:31.00ms
+step:347/1490 train_time:10754ms step_avg:30.99ms
+step:348/1490 train_time:10788ms step_avg:31.00ms
+step:349/1490 train_time:10815ms step_avg:30.99ms
+step:350/1490 train_time:10850ms step_avg:31.00ms
+step:351/1490 train_time:10877ms step_avg:30.99ms
+step:352/1490 train_time:10911ms step_avg:31.00ms
+step:353/1490 train_time:10938ms step_avg:30.99ms
+step:354/1490 train_time:10973ms step_avg:31.00ms
+step:355/1490 train_time:11000ms step_avg:30.99ms
+step:356/1490 train_time:11035ms step_avg:31.00ms
+step:357/1490 train_time:11063ms step_avg:30.99ms
+step:358/1490 train_time:11097ms step_avg:31.00ms
+step:359/1490 train_time:11124ms step_avg:30.99ms
+step:360/1490 train_time:11159ms step_avg:31.00ms
+step:361/1490 train_time:11186ms step_avg:30.99ms
+step:362/1490 train_time:11220ms step_avg:31.00ms
+step:363/1490 train_time:11247ms step_avg:30.98ms
+step:364/1490 train_time:11282ms step_avg:30.99ms
+step:365/1490 train_time:11309ms step_avg:30.98ms
+step:366/1490 train_time:11343ms step_avg:30.99ms
+step:367/1490 train_time:11371ms step_avg:30.98ms
+step:368/1490 train_time:11405ms step_avg:30.99ms
+step:369/1490 train_time:11432ms step_avg:30.98ms
+step:370/1490 train_time:11466ms step_avg:30.99ms
+step:371/1490 train_time:11494ms step_avg:30.98ms
+step:372/1490 train_time:11528ms step_avg:30.99ms
+step:373/1490 train_time:11556ms step_avg:30.98ms
+step:374/1490 train_time:11591ms step_avg:30.99ms
+step:375/1490 train_time:11617ms step_avg:30.98ms
+step:376/1490 train_time:11651ms step_avg:30.99ms
+step:377/1490 train_time:11679ms step_avg:30.98ms
+step:378/1490 train_time:11713ms step_avg:30.99ms
+step:379/1490 train_time:11740ms step_avg:30.98ms
+step:380/1490 train_time:11775ms step_avg:30.99ms
+step:381/1490 train_time:11802ms step_avg:30.98ms
+step:382/1490 train_time:11837ms step_avg:30.99ms
+step:383/1490 train_time:11864ms step_avg:30.98ms
+step:384/1490 train_time:11899ms step_avg:30.99ms
+step:385/1490 train_time:11926ms step_avg:30.98ms
+step:386/1490 train_time:11960ms step_avg:30.99ms
+step:387/1490 train_time:11987ms step_avg:30.98ms
+step:388/1490 train_time:12022ms step_avg:30.98ms
+step:389/1490 train_time:12049ms step_avg:30.97ms
+step:390/1490 train_time:12083ms step_avg:30.98ms
+step:391/1490 train_time:12110ms step_avg:30.97ms
+step:392/1490 train_time:12145ms step_avg:30.98ms
+step:393/1490 train_time:12172ms step_avg:30.97ms
+step:394/1490 train_time:12207ms step_avg:30.98ms
+step:395/1490 train_time:12234ms step_avg:30.97ms
+step:396/1490 train_time:12269ms step_avg:30.98ms
+step:397/1490 train_time:12296ms step_avg:30.97ms
+step:398/1490 train_time:12331ms step_avg:30.98ms
+step:399/1490 train_time:12358ms step_avg:30.97ms
+step:400/1490 train_time:12392ms step_avg:30.98ms
+step:401/1490 train_time:12419ms step_avg:30.97ms
+step:402/1490 train_time:12453ms step_avg:30.98ms
+step:403/1490 train_time:12481ms step_avg:30.97ms
+step:404/1490 train_time:12516ms step_avg:30.98ms
+step:405/1490 train_time:12543ms step_avg:30.97ms
+step:406/1490 train_time:12578ms step_avg:30.98ms
+step:407/1490 train_time:12605ms step_avg:30.97ms
+step:408/1490 train_time:12639ms step_avg:30.98ms
+step:409/1490 train_time:12667ms step_avg:30.97ms
+step:410/1490 train_time:12700ms step_avg:30.98ms
+step:411/1490 train_time:12728ms step_avg:30.97ms
+step:412/1490 train_time:12762ms step_avg:30.98ms
+step:413/1490 train_time:12789ms step_avg:30.97ms
+step:414/1490 train_time:12824ms step_avg:30.97ms
+step:415/1490 train_time:12851ms step_avg:30.97ms
+step:416/1490 train_time:12885ms step_avg:30.97ms
+step:417/1490 train_time:12912ms step_avg:30.96ms
+step:418/1490 train_time:12946ms step_avg:30.97ms
+step:419/1490 train_time:12974ms step_avg:30.96ms
+step:420/1490 train_time:13009ms step_avg:30.97ms
+step:421/1490 train_time:13036ms step_avg:30.96ms
+step:422/1490 train_time:13071ms step_avg:30.97ms
+step:423/1490 train_time:13098ms step_avg:30.96ms
+step:424/1490 train_time:13132ms step_avg:30.97ms
+step:425/1490 train_time:13159ms step_avg:30.96ms
+step:426/1490 train_time:13193ms step_avg:30.97ms
+step:427/1490 train_time:13220ms step_avg:30.96ms
+step:428/1490 train_time:13255ms step_avg:30.97ms
+step:429/1490 train_time:13282ms step_avg:30.96ms
+step:430/1490 train_time:13317ms step_avg:30.97ms
+step:431/1490 train_time:13344ms step_avg:30.96ms
+step:432/1490 train_time:13378ms step_avg:30.97ms
+step:433/1490 train_time:13406ms step_avg:30.96ms
+step:434/1490 train_time:13440ms step_avg:30.97ms
+step:435/1490 train_time:13468ms step_avg:30.96ms
+step:436/1490 train_time:13502ms step_avg:30.97ms
+step:437/1490 train_time:13529ms step_avg:30.96ms
+step:438/1490 train_time:13563ms step_avg:30.97ms
+step:439/1490 train_time:13590ms step_avg:30.96ms
+step:440/1490 train_time:13625ms step_avg:30.96ms
+step:441/1490 train_time:13652ms step_avg:30.96ms
+step:442/1490 train_time:13686ms step_avg:30.96ms
+step:443/1490 train_time:13714ms step_avg:30.96ms
+step:444/1490 train_time:13748ms step_avg:30.96ms
+step:445/1490 train_time:13775ms step_avg:30.95ms
+step:446/1490 train_time:13810ms step_avg:30.96ms
+step:447/1490 train_time:13837ms step_avg:30.95ms
+step:448/1490 train_time:13871ms step_avg:30.96ms
+step:449/1490 train_time:13898ms step_avg:30.95ms
+step:450/1490 train_time:13932ms step_avg:30.96ms
+step:451/1490 train_time:13959ms step_avg:30.95ms
+step:452/1490 train_time:13994ms step_avg:30.96ms
+step:453/1490 train_time:14021ms step_avg:30.95ms
+step:454/1490 train_time:14056ms step_avg:30.96ms
+step:455/1490 train_time:14083ms step_avg:30.95ms
+step:456/1490 train_time:14118ms step_avg:30.96ms
+step:457/1490 train_time:14145ms step_avg:30.95ms
+step:458/1490 train_time:14179ms step_avg:30.96ms
+step:459/1490 train_time:14206ms step_avg:30.95ms
+step:460/1490 train_time:14241ms step_avg:30.96ms
+step:461/1490 train_time:14268ms step_avg:30.95ms
+step:462/1490 train_time:14302ms step_avg:30.96ms
+step:463/1490 train_time:14329ms step_avg:30.95ms
+step:464/1490 train_time:14364ms step_avg:30.96ms
+step:465/1490 train_time:14391ms step_avg:30.95ms
+step:466/1490 train_time:14425ms step_avg:30.95ms
+step:467/1490 train_time:14452ms step_avg:30.95ms
+step:468/1490 train_time:14487ms step_avg:30.96ms
+step:469/1490 train_time:14514ms step_avg:30.95ms
+step:470/1490 train_time:14549ms step_avg:30.95ms
+step:471/1490 train_time:14576ms step_avg:30.95ms
+step:472/1490 train_time:14611ms step_avg:30.96ms
+step:473/1490 train_time:14638ms step_avg:30.95ms
+step:474/1490 train_time:14672ms step_avg:30.95ms
+step:475/1490 train_time:14700ms step_avg:30.95ms
+step:476/1490 train_time:14734ms step_avg:30.95ms
+step:477/1490 train_time:14761ms step_avg:30.95ms
+step:478/1490 train_time:14796ms step_avg:30.95ms
+step:479/1490 train_time:14823ms step_avg:30.95ms
+step:480/1490 train_time:14857ms step_avg:30.95ms
+step:481/1490 train_time:14885ms step_avg:30.95ms
+step:482/1490 train_time:14919ms step_avg:30.95ms
+step:483/1490 train_time:14946ms step_avg:30.94ms
+step:484/1490 train_time:14983ms step_avg:30.96ms
+step:485/1490 train_time:15036ms step_avg:31.00ms
+step:486/1490 train_time:15094ms step_avg:31.06ms
+step:487/1490 train_time:15148ms step_avg:31.10ms
+step:488/1490 train_time:15207ms step_avg:31.16ms
+step:489/1490 train_time:15260ms step_avg:31.21ms
+step:490/1490 train_time:15320ms step_avg:31.26ms
+step:491/1490 train_time:15372ms step_avg:31.31ms
+step:492/1490 train_time:15432ms step_avg:31.37ms
+step:493/1490 train_time:15485ms step_avg:31.41ms
+step:494/1490 train_time:15545ms step_avg:31.47ms
+step:495/1490 train_time:15598ms step_avg:31.51ms
+step:496/1490 train_time:15657ms step_avg:31.57ms
+step:497/1490 train_time:15710ms step_avg:31.61ms
+step:498/1490 train_time:15770ms step_avg:31.67ms
+step:499/1490 train_time:15823ms step_avg:31.71ms
+step:500/1490 train_time:15882ms step_avg:31.76ms
+step:500/1490 val_loss:4.2162 train_time:15950ms step_avg:31.90ms
+step:501/1490 train_time:15967ms step_avg:31.87ms
+step:502/1490 train_time:15997ms step_avg:31.87ms
+step:503/1490 train_time:16050ms step_avg:31.91ms
+step:504/1490 train_time:16113ms step_avg:31.97ms
+step:505/1490 train_time:16170ms step_avg:32.02ms
+step:506/1490 train_time:16229ms step_avg:32.07ms
+step:507/1490 train_time:16282ms step_avg:32.11ms
+step:508/1490 train_time:16340ms step_avg:32.17ms
+step:509/1490 train_time:16393ms step_avg:32.21ms
+step:510/1490 train_time:16451ms step_avg:32.26ms
+step:511/1490 train_time:16504ms step_avg:32.30ms
+step:512/1490 train_time:16562ms step_avg:32.35ms
+step:513/1490 train_time:16615ms step_avg:32.39ms
+step:514/1490 train_time:16672ms step_avg:32.44ms
+step:515/1490 train_time:16725ms step_avg:32.48ms
+step:516/1490 train_time:16785ms step_avg:32.53ms
+step:517/1490 train_time:16838ms step_avg:32.57ms
+step:518/1490 train_time:16897ms step_avg:32.62ms
+step:519/1490 train_time:16950ms step_avg:32.66ms
+step:520/1490 train_time:17011ms step_avg:32.71ms
+step:521/1490 train_time:17065ms step_avg:32.75ms
+step:522/1490 train_time:17125ms step_avg:32.81ms
+step:523/1490 train_time:17180ms step_avg:32.85ms
+step:524/1490 train_time:17239ms step_avg:32.90ms
+step:525/1490 train_time:17292ms step_avg:32.94ms
+step:526/1490 train_time:17351ms step_avg:32.99ms
+step:527/1490 train_time:17403ms step_avg:33.02ms
+step:528/1490 train_time:17462ms step_avg:33.07ms
+step:529/1490 train_time:17515ms step_avg:33.11ms
+step:530/1490 train_time:17572ms step_avg:33.15ms
+step:531/1490 train_time:17625ms step_avg:33.19ms
+step:532/1490 train_time:17683ms step_avg:33.24ms
+step:533/1490 train_time:17736ms step_avg:33.28ms
+step:534/1490 train_time:17795ms step_avg:33.32ms
+step:535/1490 train_time:17848ms step_avg:33.36ms
+step:536/1490 train_time:17907ms step_avg:33.41ms
+step:537/1490 train_time:17961ms step_avg:33.45ms
+step:538/1490 train_time:18021ms step_avg:33.50ms
+step:539/1490 train_time:18075ms step_avg:33.54ms
+step:540/1490 train_time:18135ms step_avg:33.58ms
+step:541/1490 train_time:18190ms step_avg:33.62ms
+step:542/1490 train_time:18249ms step_avg:33.67ms
+step:543/1490 train_time:18302ms step_avg:33.70ms
+step:544/1490 train_time:18361ms step_avg:33.75ms
+step:545/1490 train_time:18414ms step_avg:33.79ms
+step:546/1490 train_time:18472ms step_avg:33.83ms
+step:547/1490 train_time:18525ms step_avg:33.87ms
+step:548/1490 train_time:18584ms step_avg:33.91ms
+step:549/1490 train_time:18637ms step_avg:33.95ms
+step:550/1490 train_time:18695ms step_avg:33.99ms
+step:551/1490 train_time:18747ms step_avg:34.02ms
+step:552/1490 train_time:18806ms step_avg:34.07ms
+step:553/1490 train_time:18860ms step_avg:34.10ms
+step:554/1490 train_time:18919ms step_avg:34.15ms
+step:555/1490 train_time:18973ms step_avg:34.19ms
+step:556/1490 train_time:19033ms step_avg:34.23ms
+step:557/1490 train_time:19086ms step_avg:34.27ms
+step:558/1490 train_time:19146ms step_avg:34.31ms
+step:559/1490 train_time:19198ms step_avg:34.34ms
+step:560/1490 train_time:19258ms step_avg:34.39ms
+step:561/1490 train_time:19311ms step_avg:34.42ms
+step:562/1490 train_time:19370ms step_avg:34.47ms
+step:563/1490 train_time:19423ms step_avg:34.50ms
+step:564/1490 train_time:19483ms step_avg:34.54ms
+step:565/1490 train_time:19536ms step_avg:34.58ms
+step:566/1490 train_time:19594ms step_avg:34.62ms
+step:567/1490 train_time:19647ms step_avg:34.65ms
+step:568/1490 train_time:19705ms step_avg:34.69ms
+step:569/1490 train_time:19758ms step_avg:34.72ms
+step:570/1490 train_time:19818ms step_avg:34.77ms
+step:571/1490 train_time:19871ms step_avg:34.80ms
+step:572/1490 train_time:19930ms step_avg:34.84ms
+step:573/1490 train_time:19984ms step_avg:34.88ms
+step:574/1490 train_time:20045ms step_avg:34.92ms
+step:575/1490 train_time:20098ms step_avg:34.95ms
+step:576/1490 train_time:20157ms step_avg:34.99ms
+step:577/1490 train_time:20210ms step_avg:35.03ms
+step:578/1490 train_time:20269ms step_avg:35.07ms
+step:579/1490 train_time:20323ms step_avg:35.10ms
+step:580/1490 train_time:20383ms step_avg:35.14ms
+step:581/1490 train_time:20436ms step_avg:35.17ms
+step:582/1490 train_time:20495ms step_avg:35.21ms
+step:583/1490 train_time:20547ms step_avg:35.24ms
+step:584/1490 train_time:20605ms step_avg:35.28ms
+step:585/1490 train_time:20659ms step_avg:35.31ms
+step:586/1490 train_time:20717ms step_avg:35.35ms
+step:587/1490 train_time:20771ms step_avg:35.39ms
+step:588/1490 train_time:20829ms step_avg:35.42ms
+step:589/1490 train_time:20884ms step_avg:35.46ms
+step:590/1490 train_time:20943ms step_avg:35.50ms
+step:591/1490 train_time:20996ms step_avg:35.53ms
+step:592/1490 train_time:21055ms step_avg:35.57ms
+step:593/1490 train_time:21108ms step_avg:35.60ms
+step:594/1490 train_time:21167ms step_avg:35.64ms
+step:595/1490 train_time:21220ms step_avg:35.66ms
+step:596/1490 train_time:21280ms step_avg:35.70ms
+step:597/1490 train_time:21333ms step_avg:35.73ms
+step:598/1490 train_time:21392ms step_avg:35.77ms
+step:599/1490 train_time:21445ms step_avg:35.80ms
+step:600/1490 train_time:21503ms step_avg:35.84ms
+step:601/1490 train_time:21557ms step_avg:35.87ms
+step:602/1490 train_time:21615ms step_avg:35.91ms
+step:603/1490 train_time:21668ms step_avg:35.93ms
+step:604/1490 train_time:21727ms step_avg:35.97ms
+step:605/1490 train_time:21782ms step_avg:36.00ms
+step:606/1490 train_time:21840ms step_avg:36.04ms
+step:607/1490 train_time:21894ms step_avg:36.07ms
+step:608/1490 train_time:21953ms step_avg:36.11ms
+step:609/1490 train_time:22005ms step_avg:36.13ms
+step:610/1490 train_time:22065ms step_avg:36.17ms
+step:611/1490 train_time:22118ms step_avg:36.20ms
+step:612/1490 train_time:22179ms step_avg:36.24ms
+step:613/1490 train_time:22232ms step_avg:36.27ms
+step:614/1490 train_time:22290ms step_avg:36.30ms
+step:615/1490 train_time:22343ms step_avg:36.33ms
+step:616/1490 train_time:22402ms step_avg:36.37ms
+step:617/1490 train_time:22456ms step_avg:36.40ms
+step:618/1490 train_time:22515ms step_avg:36.43ms
+step:619/1490 train_time:22568ms step_avg:36.46ms
+step:620/1490 train_time:22627ms step_avg:36.50ms
+step:621/1490 train_time:22681ms step_avg:36.52ms
+step:622/1490 train_time:22740ms step_avg:36.56ms
+step:623/1490 train_time:22794ms step_avg:36.59ms
+step:624/1490 train_time:22852ms step_avg:36.62ms
+step:625/1490 train_time:22904ms step_avg:36.65ms
+step:626/1490 train_time:22964ms step_avg:36.68ms
+step:627/1490 train_time:23017ms step_avg:36.71ms
+step:628/1490 train_time:23076ms step_avg:36.75ms
+step:629/1490 train_time:23129ms step_avg:36.77ms
+step:630/1490 train_time:23188ms step_avg:36.81ms
+step:631/1490 train_time:23242ms step_avg:36.83ms
+step:632/1490 train_time:23301ms step_avg:36.87ms
+step:633/1490 train_time:23356ms step_avg:36.90ms
+step:634/1490 train_time:23413ms step_avg:36.93ms
+step:635/1490 train_time:23467ms step_avg:36.96ms
+step:636/1490 train_time:23526ms step_avg:36.99ms
+step:637/1490 train_time:23580ms step_avg:37.02ms
+step:638/1490 train_time:23640ms step_avg:37.05ms
+step:639/1490 train_time:23692ms step_avg:37.08ms
+step:640/1490 train_time:23751ms step_avg:37.11ms
+step:641/1490 train_time:23804ms step_avg:37.14ms
+step:642/1490 train_time:23863ms step_avg:37.17ms
+step:643/1490 train_time:23916ms step_avg:37.20ms
+step:644/1490 train_time:23975ms step_avg:37.23ms
+step:645/1490 train_time:24027ms step_avg:37.25ms
+step:646/1490 train_time:24087ms step_avg:37.29ms
+step:647/1490 train_time:24141ms step_avg:37.31ms
+step:648/1490 train_time:24199ms step_avg:37.34ms
+step:649/1490 train_time:24253ms step_avg:37.37ms
+step:650/1490 train_time:24312ms step_avg:37.40ms
+step:651/1490 train_time:24366ms step_avg:37.43ms
+step:652/1490 train_time:24424ms step_avg:37.46ms
+step:653/1490 train_time:24478ms step_avg:37.49ms
+step:654/1490 train_time:24538ms step_avg:37.52ms
+step:655/1490 train_time:24591ms step_avg:37.54ms
+step:656/1490 train_time:24650ms step_avg:37.58ms
+step:657/1490 train_time:24703ms step_avg:37.60ms
+step:658/1490 train_time:24763ms step_avg:37.63ms
+step:659/1490 train_time:24816ms step_avg:37.66ms
+step:660/1490 train_time:24874ms step_avg:37.69ms
+step:661/1490 train_time:24927ms step_avg:37.71ms
+step:662/1490 train_time:24987ms step_avg:37.74ms
+step:663/1490 train_time:25040ms step_avg:37.77ms
+step:664/1490 train_time:25099ms step_avg:37.80ms
+step:665/1490 train_time:25152ms step_avg:37.82ms
+step:666/1490 train_time:25211ms step_avg:37.85ms
+step:667/1490 train_time:25265ms step_avg:37.88ms
+step:668/1490 train_time:25324ms step_avg:37.91ms
+step:669/1490 train_time:25377ms step_avg:37.93ms
+step:670/1490 train_time:25436ms step_avg:37.96ms
+step:671/1490 train_time:25488ms step_avg:37.99ms
+step:672/1490 train_time:25548ms step_avg:38.02ms
+step:673/1490 train_time:25600ms step_avg:38.04ms
+step:674/1490 train_time:25659ms step_avg:38.07ms
+step:675/1490 train_time:25713ms step_avg:38.09ms
+step:676/1490 train_time:25772ms step_avg:38.12ms
+step:677/1490 train_time:25825ms step_avg:38.15ms
+step:678/1490 train_time:25884ms step_avg:38.18ms
+step:679/1490 train_time:25938ms step_avg:38.20ms
+step:680/1490 train_time:25996ms step_avg:38.23ms
+step:681/1490 train_time:26050ms step_avg:38.25ms
+step:682/1490 train_time:26109ms step_avg:38.28ms
+step:683/1490 train_time:26163ms step_avg:38.31ms
+step:684/1490 train_time:26222ms step_avg:38.34ms
+step:685/1490 train_time:26275ms step_avg:38.36ms
+step:686/1490 train_time:26334ms step_avg:38.39ms
+step:687/1490 train_time:26387ms step_avg:38.41ms
+step:688/1490 train_time:26447ms step_avg:38.44ms
+step:689/1490 train_time:26500ms step_avg:38.46ms
+step:690/1490 train_time:26559ms step_avg:38.49ms
+step:691/1490 train_time:26612ms step_avg:38.51ms
+step:692/1490 train_time:26671ms step_avg:38.54ms
+step:693/1490 train_time:26724ms step_avg:38.56ms
+step:694/1490 train_time:26783ms step_avg:38.59ms
+step:695/1490 train_time:26837ms step_avg:38.61ms
+step:696/1490 train_time:26895ms step_avg:38.64ms
+step:697/1490 train_time:26949ms step_avg:38.66ms
+step:698/1490 train_time:27008ms step_avg:38.69ms
+step:699/1490 train_time:27062ms step_avg:38.72ms
+step:700/1490 train_time:27120ms step_avg:38.74ms
+step:701/1490 train_time:27174ms step_avg:38.76ms
+step:702/1490 train_time:27232ms step_avg:38.79ms
+step:703/1490 train_time:27286ms step_avg:38.81ms
+step:704/1490 train_time:27345ms step_avg:38.84ms
+step:705/1490 train_time:27398ms step_avg:38.86ms
+step:706/1490 train_time:27458ms step_avg:38.89ms
+step:707/1490 train_time:27511ms step_avg:38.91ms
+step:708/1490 train_time:27570ms step_avg:38.94ms
+step:709/1490 train_time:27623ms step_avg:38.96ms
+step:710/1490 train_time:27682ms step_avg:38.99ms
+step:711/1490 train_time:27735ms step_avg:39.01ms
+step:712/1490 train_time:27793ms step_avg:39.04ms
+step:713/1490 train_time:27847ms step_avg:39.06ms
+step:714/1490 train_time:27906ms step_avg:39.08ms
+step:715/1490 train_time:27959ms step_avg:39.10ms
+step:716/1490 train_time:28018ms step_avg:39.13ms
+step:717/1490 train_time:28072ms step_avg:39.15ms
+step:718/1490 train_time:28131ms step_avg:39.18ms
+step:719/1490 train_time:28185ms step_avg:39.20ms
+step:720/1490 train_time:28244ms step_avg:39.23ms
+step:721/1490 train_time:28296ms step_avg:39.25ms
+step:722/1490 train_time:28356ms step_avg:39.27ms
+step:723/1490 train_time:28410ms step_avg:39.29ms
+step:724/1490 train_time:28469ms step_avg:39.32ms
+step:725/1490 train_time:28522ms step_avg:39.34ms
+step:726/1490 train_time:28581ms step_avg:39.37ms
+step:727/1490 train_time:28634ms step_avg:39.39ms
+step:728/1490 train_time:28693ms step_avg:39.41ms
+step:729/1490 train_time:28746ms step_avg:39.43ms
+step:730/1490 train_time:28804ms step_avg:39.46ms
+step:731/1490 train_time:28857ms step_avg:39.48ms
+step:732/1490 train_time:28916ms step_avg:39.50ms
+step:733/1490 train_time:28970ms step_avg:39.52ms
+step:734/1490 train_time:29029ms step_avg:39.55ms
+step:735/1490 train_time:29083ms step_avg:39.57ms
+step:736/1490 train_time:29142ms step_avg:39.60ms
+step:737/1490 train_time:29195ms step_avg:39.61ms
+step:738/1490 train_time:29253ms step_avg:39.64ms
+step:739/1490 train_time:29306ms step_avg:39.66ms
+step:740/1490 train_time:29366ms step_avg:39.68ms
+step:741/1490 train_time:29418ms step_avg:39.70ms
+step:742/1490 train_time:29478ms step_avg:39.73ms
+step:743/1490 train_time:29531ms step_avg:39.75ms
+step:744/1490 train_time:29590ms step_avg:39.77ms
+step:745/1490 train_time:29644ms step_avg:39.79ms
+step:746/1490 train_time:29702ms step_avg:39.82ms
+step:747/1490 train_time:29757ms step_avg:39.84ms
+step:748/1490 train_time:29815ms step_avg:39.86ms
+step:749/1490 train_time:29869ms step_avg:39.88ms
+step:750/1490 train_time:29928ms step_avg:39.90ms
+step:750/1490 val_loss:3.8017 train_time:29996ms step_avg:39.99ms
+step:751/1490 train_time:30014ms step_avg:39.96ms
+step:752/1490 train_time:30041ms step_avg:39.95ms
+step:753/1490 train_time:30099ms step_avg:39.97ms
+step:754/1490 train_time:30161ms step_avg:40.00ms
+step:755/1490 train_time:30215ms step_avg:40.02ms
+step:756/1490 train_time:30274ms step_avg:40.04ms
+step:757/1490 train_time:30326ms step_avg:40.06ms
+step:758/1490 train_time:30384ms step_avg:40.08ms
+step:759/1490 train_time:30437ms step_avg:40.10ms
+step:760/1490 train_time:30494ms step_avg:40.12ms
+step:761/1490 train_time:30547ms step_avg:40.14ms
+step:762/1490 train_time:30606ms step_avg:40.16ms
+step:763/1490 train_time:30658ms step_avg:40.18ms
+step:764/1490 train_time:30716ms step_avg:40.20ms
+step:765/1490 train_time:30769ms step_avg:40.22ms
+step:766/1490 train_time:30827ms step_avg:40.24ms
+step:767/1490 train_time:30879ms step_avg:40.26ms
+step:768/1490 train_time:30939ms step_avg:40.28ms
+step:769/1490 train_time:30994ms step_avg:40.30ms
+step:770/1490 train_time:31054ms step_avg:40.33ms
+step:771/1490 train_time:31110ms step_avg:40.35ms
+step:772/1490 train_time:31170ms step_avg:40.38ms
+step:773/1490 train_time:31224ms step_avg:40.39ms
+step:774/1490 train_time:31283ms step_avg:40.42ms
+step:775/1490 train_time:31336ms step_avg:40.43ms
+step:776/1490 train_time:31394ms step_avg:40.46ms
+step:777/1490 train_time:31447ms step_avg:40.47ms
+step:778/1490 train_time:31506ms step_avg:40.50ms
+step:779/1490 train_time:31558ms step_avg:40.51ms
+step:780/1490 train_time:31617ms step_avg:40.53ms
+step:781/1490 train_time:31670ms step_avg:40.55ms
+step:782/1490 train_time:31729ms step_avg:40.57ms
+step:783/1490 train_time:31781ms step_avg:40.59ms
+step:784/1490 train_time:31840ms step_avg:40.61ms
+step:785/1490 train_time:31893ms step_avg:40.63ms
+step:786/1490 train_time:31952ms step_avg:40.65ms
+step:787/1490 train_time:32007ms step_avg:40.67ms
+step:788/1490 train_time:32068ms step_avg:40.70ms
+step:789/1490 train_time:32122ms step_avg:40.71ms
+step:790/1490 train_time:32182ms step_avg:40.74ms
+step:791/1490 train_time:32235ms step_avg:40.75ms
+step:792/1490 train_time:32293ms step_avg:40.77ms
+step:793/1490 train_time:32346ms step_avg:40.79ms
+step:794/1490 train_time:32406ms step_avg:40.81ms
+step:795/1490 train_time:32459ms step_avg:40.83ms
+step:796/1490 train_time:32517ms step_avg:40.85ms
+step:797/1490 train_time:32570ms step_avg:40.87ms
+step:798/1490 train_time:32628ms step_avg:40.89ms
+step:799/1490 train_time:32681ms step_avg:40.90ms
+step:800/1490 train_time:32740ms step_avg:40.92ms
+step:801/1490 train_time:32794ms step_avg:40.94ms
+step:802/1490 train_time:32852ms step_avg:40.96ms
+step:803/1490 train_time:32906ms step_avg:40.98ms
+step:804/1490 train_time:32966ms step_avg:41.00ms
+step:805/1490 train_time:33019ms step_avg:41.02ms
+step:806/1490 train_time:33080ms step_avg:41.04ms
+step:807/1490 train_time:33133ms step_avg:41.06ms
+step:808/1490 train_time:33192ms step_avg:41.08ms
+step:809/1490 train_time:33245ms step_avg:41.09ms
+step:810/1490 train_time:33305ms step_avg:41.12ms
+step:811/1490 train_time:33358ms step_avg:41.13ms
+step:812/1490 train_time:33418ms step_avg:41.15ms
+step:813/1490 train_time:33471ms step_avg:41.17ms
+step:814/1490 train_time:33530ms step_avg:41.19ms
+step:815/1490 train_time:33583ms step_avg:41.21ms
+step:816/1490 train_time:33641ms step_avg:41.23ms
+step:817/1490 train_time:33695ms step_avg:41.24ms
+step:818/1490 train_time:33753ms step_avg:41.26ms
+step:819/1490 train_time:33807ms step_avg:41.28ms
+step:820/1490 train_time:33866ms step_avg:41.30ms
+step:821/1490 train_time:33919ms step_avg:41.31ms
+step:822/1490 train_time:33978ms step_avg:41.34ms
+step:823/1490 train_time:34031ms step_avg:41.35ms
+step:824/1490 train_time:34090ms step_avg:41.37ms
+step:825/1490 train_time:34144ms step_avg:41.39ms
+step:826/1490 train_time:34204ms step_avg:41.41ms
+step:827/1490 train_time:34258ms step_avg:41.42ms
+step:828/1490 train_time:34317ms step_avg:41.45ms
+step:829/1490 train_time:34371ms step_avg:41.46ms
+step:830/1490 train_time:34431ms step_avg:41.48ms
+step:831/1490 train_time:34484ms step_avg:41.50ms
+step:832/1490 train_time:34543ms step_avg:41.52ms
+step:833/1490 train_time:34596ms step_avg:41.53ms
+step:834/1490 train_time:34654ms step_avg:41.55ms
+step:835/1490 train_time:34708ms step_avg:41.57ms
+step:836/1490 train_time:34767ms step_avg:41.59ms
+step:837/1490 train_time:34820ms step_avg:41.60ms
+step:838/1490 train_time:34878ms step_avg:41.62ms
+step:839/1490 train_time:34931ms step_avg:41.63ms
+step:840/1490 train_time:34990ms step_avg:41.66ms
+step:841/1490 train_time:35044ms step_avg:41.67ms
+step:842/1490 train_time:35103ms step_avg:41.69ms
+step:843/1490 train_time:35157ms step_avg:41.70ms
+step:844/1490 train_time:35217ms step_avg:41.73ms
+step:845/1490 train_time:35270ms step_avg:41.74ms
+step:846/1490 train_time:35328ms step_avg:41.76ms
+step:847/1490 train_time:35382ms step_avg:41.77ms
+step:848/1490 train_time:35441ms step_avg:41.79ms
+step:849/1490 train_time:35496ms step_avg:41.81ms
+step:850/1490 train_time:35555ms step_avg:41.83ms
+step:851/1490 train_time:35609ms step_avg:41.84ms
+step:852/1490 train_time:35668ms step_avg:41.86ms
+step:853/1490 train_time:35720ms step_avg:41.88ms
+step:854/1490 train_time:35779ms step_avg:41.90ms
+step:855/1490 train_time:35833ms step_avg:41.91ms
+step:856/1490 train_time:35892ms step_avg:41.93ms
+step:857/1490 train_time:35946ms step_avg:41.94ms
+step:858/1490 train_time:36005ms step_avg:41.96ms
+step:859/1490 train_time:36057ms step_avg:41.98ms
+step:860/1490 train_time:36116ms step_avg:42.00ms
+step:861/1490 train_time:36170ms step_avg:42.01ms
+step:862/1490 train_time:36229ms step_avg:42.03ms
+step:863/1490 train_time:36283ms step_avg:42.04ms
+step:864/1490 train_time:36342ms step_avg:42.06ms
+step:865/1490 train_time:36396ms step_avg:42.08ms
+step:866/1490 train_time:36454ms step_avg:42.09ms
+step:867/1490 train_time:36508ms step_avg:42.11ms
+step:868/1490 train_time:36568ms step_avg:42.13ms
+step:869/1490 train_time:36621ms step_avg:42.14ms
+step:870/1490 train_time:36680ms step_avg:42.16ms
+step:871/1490 train_time:36732ms step_avg:42.17ms
+step:872/1490 train_time:36791ms step_avg:42.19ms
+step:873/1490 train_time:36844ms step_avg:42.20ms
+step:874/1490 train_time:36904ms step_avg:42.22ms
+step:875/1490 train_time:36957ms step_avg:42.24ms
+step:876/1490 train_time:37015ms step_avg:42.25ms
+step:877/1490 train_time:37069ms step_avg:42.27ms
+step:878/1490 train_time:37128ms step_avg:42.29ms
+step:879/1490 train_time:37181ms step_avg:42.30ms
+step:880/1490 train_time:37240ms step_avg:42.32ms
+step:881/1490 train_time:37294ms step_avg:42.33ms
+step:882/1490 train_time:37353ms step_avg:42.35ms
+step:883/1490 train_time:37407ms step_avg:42.36ms
+step:884/1490 train_time:37467ms step_avg:42.38ms
+step:885/1490 train_time:37520ms step_avg:42.40ms
+step:886/1490 train_time:37578ms step_avg:42.41ms
+step:887/1490 train_time:37631ms step_avg:42.43ms
+step:888/1490 train_time:37690ms step_avg:42.44ms
+step:889/1490 train_time:37743ms step_avg:42.46ms
+step:890/1490 train_time:37803ms step_avg:42.48ms
+step:891/1490 train_time:37857ms step_avg:42.49ms
+step:892/1490 train_time:37916ms step_avg:42.51ms
+step:893/1490 train_time:37969ms step_avg:42.52ms
+step:894/1490 train_time:38027ms step_avg:42.54ms
+step:895/1490 train_time:38081ms step_avg:42.55ms
+step:896/1490 train_time:38140ms step_avg:42.57ms
+step:897/1490 train_time:38194ms step_avg:42.58ms
+step:898/1490 train_time:38252ms step_avg:42.60ms
+step:899/1490 train_time:38306ms step_avg:42.61ms
+step:900/1490 train_time:38365ms step_avg:42.63ms
+step:901/1490 train_time:38419ms step_avg:42.64ms
+step:902/1490 train_time:38478ms step_avg:42.66ms
+step:903/1490 train_time:38531ms step_avg:42.67ms
+step:904/1490 train_time:38590ms step_avg:42.69ms
+step:905/1490 train_time:38643ms step_avg:42.70ms
+step:906/1490 train_time:38702ms step_avg:42.72ms
+step:907/1490 train_time:38756ms step_avg:42.73ms
+step:908/1490 train_time:38814ms step_avg:42.75ms
+step:909/1490 train_time:38868ms step_avg:42.76ms
+step:910/1490 train_time:38926ms step_avg:42.78ms
+step:911/1490 train_time:38980ms step_avg:42.79ms
+step:912/1490 train_time:39038ms step_avg:42.80ms
+step:913/1490 train_time:39092ms step_avg:42.82ms
+step:914/1490 train_time:39151ms step_avg:42.83ms
+step:915/1490 train_time:39205ms step_avg:42.85ms
+step:916/1490 train_time:39264ms step_avg:42.86ms
+step:917/1490 train_time:39317ms step_avg:42.88ms
+step:918/1490 train_time:39376ms step_avg:42.89ms
+step:919/1490 train_time:39429ms step_avg:42.90ms
+step:920/1490 train_time:39489ms step_avg:42.92ms
+step:921/1490 train_time:39542ms step_avg:42.93ms
+step:922/1490 train_time:39601ms step_avg:42.95ms
+step:923/1490 train_time:39655ms step_avg:42.96ms
+step:924/1490 train_time:39713ms step_avg:42.98ms
+step:925/1490 train_time:39767ms step_avg:42.99ms
+step:926/1490 train_time:39825ms step_avg:43.01ms
+step:927/1490 train_time:39878ms step_avg:43.02ms
+step:928/1490 train_time:39937ms step_avg:43.04ms
+step:929/1490 train_time:39990ms step_avg:43.05ms
+step:930/1490 train_time:40049ms step_avg:43.06ms
+step:931/1490 train_time:40104ms step_avg:43.08ms
+step:932/1490 train_time:40164ms step_avg:43.09ms
+step:933/1490 train_time:40217ms step_avg:43.10ms
+step:934/1490 train_time:40276ms step_avg:43.12ms
+step:935/1490 train_time:40329ms step_avg:43.13ms
+step:936/1490 train_time:40388ms step_avg:43.15ms
+step:937/1490 train_time:40441ms step_avg:43.16ms
+step:938/1490 train_time:40500ms step_avg:43.18ms
+step:939/1490 train_time:40554ms step_avg:43.19ms
+step:940/1490 train_time:40612ms step_avg:43.20ms
+step:941/1490 train_time:40666ms step_avg:43.22ms
+step:942/1490 train_time:40725ms step_avg:43.23ms
+step:943/1490 train_time:40778ms step_avg:43.24ms
+step:944/1490 train_time:40837ms step_avg:43.26ms
+step:945/1490 train_time:40891ms step_avg:43.27ms
+step:946/1490 train_time:40950ms step_avg:43.29ms
+step:947/1490 train_time:41004ms step_avg:43.30ms
+step:948/1490 train_time:41063ms step_avg:43.32ms
+step:949/1490 train_time:41116ms step_avg:43.33ms
+step:950/1490 train_time:41175ms step_avg:43.34ms
+step:951/1490 train_time:41228ms step_avg:43.35ms
+step:952/1490 train_time:41287ms step_avg:43.37ms
+step:953/1490 train_time:41340ms step_avg:43.38ms
+step:954/1490 train_time:41400ms step_avg:43.40ms
+step:955/1490 train_time:41453ms step_avg:43.41ms
+step:956/1490 train_time:41512ms step_avg:43.42ms
+step:957/1490 train_time:41566ms step_avg:43.43ms
+step:958/1490 train_time:41625ms step_avg:43.45ms
+step:959/1490 train_time:41679ms step_avg:43.46ms
+step:960/1490 train_time:41738ms step_avg:43.48ms
+step:961/1490 train_time:41791ms step_avg:43.49ms
+step:962/1490 train_time:41850ms step_avg:43.50ms
+step:963/1490 train_time:41904ms step_avg:43.51ms
+step:964/1490 train_time:41963ms step_avg:43.53ms
+step:965/1490 train_time:42016ms step_avg:43.54ms
+step:966/1490 train_time:42075ms step_avg:43.56ms
+step:967/1490 train_time:42129ms step_avg:43.57ms
+step:968/1490 train_time:42190ms step_avg:43.59ms
+step:969/1490 train_time:42269ms step_avg:43.62ms
+step:970/1490 train_time:42353ms step_avg:43.66ms
+step:971/1490 train_time:42433ms step_avg:43.70ms
+step:972/1490 train_time:42518ms step_avg:43.74ms
+step:973/1490 train_time:42597ms step_avg:43.78ms
+step:974/1490 train_time:42682ms step_avg:43.82ms
+step:975/1490 train_time:42761ms step_avg:43.86ms
+step:976/1490 train_time:42845ms step_avg:43.90ms
+step:977/1490 train_time:42925ms step_avg:43.94ms
+step:978/1490 train_time:43011ms step_avg:43.98ms
+step:979/1490 train_time:43091ms step_avg:44.02ms
+step:980/1490 train_time:43175ms step_avg:44.06ms
+step:981/1490 train_time:43254ms step_avg:44.09ms
+step:982/1490 train_time:43340ms step_avg:44.13ms
+step:983/1490 train_time:43420ms step_avg:44.17ms
+step:984/1490 train_time:43505ms step_avg:44.21ms
+step:985/1490 train_time:43585ms step_avg:44.25ms
+step:986/1490 train_time:43670ms step_avg:44.29ms
+step:987/1490 train_time:43748ms step_avg:44.32ms
+step:988/1490 train_time:43833ms step_avg:44.37ms
+step:989/1490 train_time:43912ms step_avg:44.40ms
+step:990/1490 train_time:43997ms step_avg:44.44ms
+step:991/1490 train_time:44076ms step_avg:44.48ms
+step:992/1490 train_time:44161ms step_avg:44.52ms
+step:993/1490 train_time:44240ms step_avg:44.55ms
+step:994/1490 train_time:44325ms step_avg:44.59ms
+step:995/1490 train_time:44404ms step_avg:44.63ms
+step:996/1490 train_time:44489ms step_avg:44.67ms
+step:997/1490 train_time:44568ms step_avg:44.70ms
+step:998/1490 train_time:44653ms step_avg:44.74ms
+step:999/1490 train_time:44732ms step_avg:44.78ms
+step:1000/1490 train_time:44815ms step_avg:44.81ms
+step:1000/1490 val_loss:3.5160 train_time:44912ms step_avg:44.91ms
+step:1001/1490 train_time:44930ms step_avg:44.89ms
+step:1002/1490 train_time:44982ms step_avg:44.89ms
+step:1003/1490 train_time:45065ms step_avg:44.93ms
+step:1004/1490 train_time:45154ms step_avg:44.97ms
+step:1005/1490 train_time:45233ms step_avg:45.01ms
+step:1006/1490 train_time:45317ms step_avg:45.05ms
+step:1007/1490 train_time:45395ms step_avg:45.08ms
+step:1008/1490 train_time:45478ms step_avg:45.12ms
+step:1009/1490 train_time:45556ms step_avg:45.15ms
+step:1010/1490 train_time:45641ms step_avg:45.19ms
+step:1011/1490 train_time:45718ms step_avg:45.22ms
+step:1012/1490 train_time:45803ms step_avg:45.26ms
+step:1013/1490 train_time:45883ms step_avg:45.29ms
+step:1014/1490 train_time:45971ms step_avg:45.34ms
+step:1015/1490 train_time:46052ms step_avg:45.37ms
+step:1016/1490 train_time:46137ms step_avg:45.41ms
+step:1017/1490 train_time:46216ms step_avg:45.44ms
+step:1018/1490 train_time:46301ms step_avg:45.48ms
+step:1019/1490 train_time:46380ms step_avg:45.52ms
+step:1020/1490 train_time:46464ms step_avg:45.55ms
+step:1021/1490 train_time:46542ms step_avg:45.59ms
+step:1022/1490 train_time:46626ms step_avg:45.62ms
+step:1023/1490 train_time:46704ms step_avg:45.65ms
+step:1024/1490 train_time:46789ms step_avg:45.69ms
+step:1025/1490 train_time:46868ms step_avg:45.72ms
+step:1026/1490 train_time:46954ms step_avg:45.76ms
+step:1027/1490 train_time:47035ms step_avg:45.80ms
+step:1028/1490 train_time:47122ms step_avg:45.84ms
+step:1029/1490 train_time:47202ms step_avg:45.87ms
+step:1030/1490 train_time:47285ms step_avg:45.91ms
+step:1031/1490 train_time:47364ms step_avg:45.94ms
+step:1032/1490 train_time:47449ms step_avg:45.98ms
+step:1033/1490 train_time:47529ms step_avg:46.01ms
+step:1034/1490 train_time:47613ms step_avg:46.05ms
+step:1035/1490 train_time:47692ms step_avg:46.08ms
+step:1036/1490 train_time:47776ms step_avg:46.12ms
+step:1037/1490 train_time:47856ms step_avg:46.15ms
+step:1038/1490 train_time:47942ms step_avg:46.19ms
+step:1039/1490 train_time:48022ms step_avg:46.22ms
+step:1040/1490 train_time:48106ms step_avg:46.26ms
+step:1041/1490 train_time:48186ms step_avg:46.29ms
+step:1042/1490 train_time:48271ms step_avg:46.33ms
+step:1043/1490 train_time:48351ms step_avg:46.36ms
+step:1044/1490 train_time:48436ms step_avg:46.39ms
+step:1045/1490 train_time:48514ms step_avg:46.43ms
+step:1046/1490 train_time:48599ms step_avg:46.46ms
+step:1047/1490 train_time:48677ms step_avg:46.49ms
+step:1048/1490 train_time:48761ms step_avg:46.53ms
+step:1049/1490 train_time:48841ms step_avg:46.56ms
+step:1050/1490 train_time:48926ms step_avg:46.60ms
+step:1051/1490 train_time:49007ms step_avg:46.63ms
+step:1052/1490 train_time:49091ms step_avg:46.66ms
+step:1053/1490 train_time:49170ms step_avg:46.70ms
+step:1054/1490 train_time:49255ms step_avg:46.73ms
+step:1055/1490 train_time:49335ms step_avg:46.76ms
+step:1056/1490 train_time:49419ms step_avg:46.80ms
+step:1057/1490 train_time:49499ms step_avg:46.83ms
+step:1058/1490 train_time:49583ms step_avg:46.87ms
+step:1059/1490 train_time:49662ms step_avg:46.90ms
+step:1060/1490 train_time:49747ms step_avg:46.93ms
+step:1061/1490 train_time:49826ms step_avg:46.96ms
+step:1062/1490 train_time:49912ms step_avg:47.00ms
+step:1063/1490 train_time:49991ms step_avg:47.03ms
+step:1064/1490 train_time:50075ms step_avg:47.06ms
+step:1065/1490 train_time:50155ms step_avg:47.09ms
+step:1066/1490 train_time:50241ms step_avg:47.13ms
+step:1067/1490 train_time:50320ms step_avg:47.16ms
+step:1068/1490 train_time:50404ms step_avg:47.20ms
+step:1069/1490 train_time:50483ms step_avg:47.22ms
+step:1070/1490 train_time:50567ms step_avg:47.26ms
+step:1071/1490 train_time:50647ms step_avg:47.29ms
+step:1072/1490 train_time:50731ms step_avg:47.32ms
+step:1073/1490 train_time:50810ms step_avg:47.35ms
+step:1074/1490 train_time:50896ms step_avg:47.39ms
+step:1075/1490 train_time:50975ms step_avg:47.42ms
+step:1076/1490 train_time:51059ms step_avg:47.45ms
+step:1077/1490 train_time:51139ms step_avg:47.48ms
+step:1078/1490 train_time:51225ms step_avg:47.52ms
+step:1079/1490 train_time:51304ms step_avg:47.55ms
+step:1080/1490 train_time:51389ms step_avg:47.58ms
+step:1081/1490 train_time:51468ms step_avg:47.61ms
+step:1082/1490 train_time:51552ms step_avg:47.65ms
+step:1083/1490 train_time:51633ms step_avg:47.68ms
+step:1084/1490 train_time:51717ms step_avg:47.71ms
+step:1085/1490 train_time:51796ms step_avg:47.74ms
+step:1086/1490 train_time:51881ms step_avg:47.77ms
+step:1087/1490 train_time:51960ms step_avg:47.80ms
+step:1088/1490 train_time:52044ms step_avg:47.83ms
+step:1089/1490 train_time:52122ms step_avg:47.86ms
+step:1090/1490 train_time:52208ms step_avg:47.90ms
+step:1091/1490 train_time:52288ms step_avg:47.93ms
+step:1092/1490 train_time:52374ms step_avg:47.96ms
+step:1093/1490 train_time:52452ms step_avg:47.99ms
+step:1094/1490 train_time:52539ms step_avg:48.02ms
+step:1095/1490 train_time:52617ms step_avg:48.05ms
+step:1096/1490 train_time:52701ms step_avg:48.09ms
+step:1097/1490 train_time:52781ms step_avg:48.11ms
+step:1098/1490 train_time:52866ms step_avg:48.15ms
+step:1099/1490 train_time:52945ms step_avg:48.18ms
+step:1100/1490 train_time:53030ms step_avg:48.21ms
+step:1101/1490 train_time:53111ms step_avg:48.24ms
+step:1102/1490 train_time:53195ms step_avg:48.27ms
+step:1103/1490 train_time:53274ms step_avg:48.30ms
+step:1104/1490 train_time:53359ms step_avg:48.33ms
+step:1105/1490 train_time:53439ms step_avg:48.36ms
+step:1106/1490 train_time:53524ms step_avg:48.39ms
+step:1107/1490 train_time:53602ms step_avg:48.42ms
+step:1108/1490 train_time:53686ms step_avg:48.45ms
+step:1109/1490 train_time:53766ms step_avg:48.48ms
+step:1110/1490 train_time:53850ms step_avg:48.51ms
+step:1111/1490 train_time:53931ms step_avg:48.54ms
+step:1112/1490 train_time:54016ms step_avg:48.58ms
+step:1113/1490 train_time:54095ms step_avg:48.60ms
+step:1114/1490 train_time:54180ms step_avg:48.64ms
+step:1115/1490 train_time:54260ms step_avg:48.66ms
+step:1116/1490 train_time:54343ms step_avg:48.69ms
+step:1117/1490 train_time:54423ms step_avg:48.72ms
+step:1118/1490 train_time:54509ms step_avg:48.76ms
+step:1119/1490 train_time:54588ms step_avg:48.78ms
+step:1120/1490 train_time:54672ms step_avg:48.81ms
+step:1121/1490 train_time:54751ms step_avg:48.84ms
+step:1122/1490 train_time:54836ms step_avg:48.87ms
+step:1123/1490 train_time:54915ms step_avg:48.90ms
+step:1124/1490 train_time:55000ms step_avg:48.93ms
+step:1125/1490 train_time:55079ms step_avg:48.96ms
+step:1126/1490 train_time:55164ms step_avg:48.99ms
+step:1127/1490 train_time:55245ms step_avg:49.02ms
+step:1128/1490 train_time:55330ms step_avg:49.05ms
+step:1129/1490 train_time:55409ms step_avg:49.08ms
+step:1130/1490 train_time:55494ms step_avg:49.11ms
+step:1131/1490 train_time:55572ms step_avg:49.14ms
+step:1132/1490 train_time:55656ms step_avg:49.17ms
+step:1133/1490 train_time:55735ms step_avg:49.19ms
+step:1134/1490 train_time:55822ms step_avg:49.23ms
+step:1135/1490 train_time:55901ms step_avg:49.25ms
+step:1136/1490 train_time:55985ms step_avg:49.28ms
+step:1137/1490 train_time:56065ms step_avg:49.31ms
+step:1138/1490 train_time:56150ms step_avg:49.34ms
+step:1139/1490 train_time:56230ms step_avg:49.37ms
+step:1140/1490 train_time:56316ms step_avg:49.40ms
+step:1141/1490 train_time:56397ms step_avg:49.43ms
+step:1142/1490 train_time:56481ms step_avg:49.46ms
+step:1143/1490 train_time:56560ms step_avg:49.48ms
+step:1144/1490 train_time:56643ms step_avg:49.51ms
+step:1145/1490 train_time:56723ms step_avg:49.54ms
+step:1146/1490 train_time:56807ms step_avg:49.57ms
+step:1147/1490 train_time:56885ms step_avg:49.59ms
+step:1148/1490 train_time:56970ms step_avg:49.63ms
+step:1149/1490 train_time:57050ms step_avg:49.65ms
+step:1150/1490 train_time:57135ms step_avg:49.68ms
+step:1151/1490 train_time:57214ms step_avg:49.71ms
+step:1152/1490 train_time:57300ms step_avg:49.74ms
+step:1153/1490 train_time:57380ms step_avg:49.77ms
+step:1154/1490 train_time:57464ms step_avg:49.80ms
+step:1155/1490 train_time:57544ms step_avg:49.82ms
+step:1156/1490 train_time:57627ms step_avg:49.85ms
+step:1157/1490 train_time:57706ms step_avg:49.88ms
+step:1158/1490 train_time:57790ms step_avg:49.90ms
+step:1159/1490 train_time:57870ms step_avg:49.93ms
+step:1160/1490 train_time:57954ms step_avg:49.96ms
+step:1161/1490 train_time:58035ms step_avg:49.99ms
+step:1162/1490 train_time:58119ms step_avg:50.02ms
+step:1163/1490 train_time:58199ms step_avg:50.04ms
+step:1164/1490 train_time:58283ms step_avg:50.07ms
+step:1165/1490 train_time:58362ms step_avg:50.10ms
+step:1166/1490 train_time:58448ms step_avg:50.13ms
+step:1167/1490 train_time:58528ms step_avg:50.15ms
+step:1168/1490 train_time:58612ms step_avg:50.18ms
+step:1169/1490 train_time:58691ms step_avg:50.21ms
+step:1170/1490 train_time:58775ms step_avg:50.24ms
+step:1171/1490 train_time:58855ms step_avg:50.26ms
+step:1172/1490 train_time:58940ms step_avg:50.29ms
+step:1173/1490 train_time:59020ms step_avg:50.32ms
+step:1174/1490 train_time:59104ms step_avg:50.34ms
+step:1175/1490 train_time:59182ms step_avg:50.37ms
+step:1176/1490 train_time:59267ms step_avg:50.40ms
+step:1177/1490 train_time:59348ms step_avg:50.42ms
+step:1178/1490 train_time:59433ms step_avg:50.45ms
+step:1179/1490 train_time:59513ms step_avg:50.48ms
+step:1180/1490 train_time:59598ms step_avg:50.51ms
+step:1181/1490 train_time:59677ms step_avg:50.53ms
+step:1182/1490 train_time:59761ms step_avg:50.56ms
+step:1183/1490 train_time:59841ms step_avg:50.58ms
+step:1184/1490 train_time:59925ms step_avg:50.61ms
+step:1185/1490 train_time:60005ms step_avg:50.64ms
+step:1186/1490 train_time:60091ms step_avg:50.67ms
+step:1187/1490 train_time:60170ms step_avg:50.69ms
+step:1188/1490 train_time:60255ms step_avg:50.72ms
+step:1189/1490 train_time:60335ms step_avg:50.74ms
+step:1190/1490 train_time:60420ms step_avg:50.77ms
+step:1191/1490 train_time:60500ms step_avg:50.80ms
+step:1192/1490 train_time:60585ms step_avg:50.83ms
+step:1193/1490 train_time:60663ms step_avg:50.85ms
+step:1194/1490 train_time:60749ms step_avg:50.88ms
+step:1195/1490 train_time:60828ms step_avg:50.90ms
+step:1196/1490 train_time:60912ms step_avg:50.93ms
+step:1197/1490 train_time:60992ms step_avg:50.95ms
+step:1198/1490 train_time:61076ms step_avg:50.98ms
+step:1199/1490 train_time:61155ms step_avg:51.01ms
+step:1200/1490 train_time:61241ms step_avg:51.03ms
+step:1201/1490 train_time:61320ms step_avg:51.06ms
+step:1202/1490 train_time:61405ms step_avg:51.09ms
+step:1203/1490 train_time:61484ms step_avg:51.11ms
+step:1204/1490 train_time:61569ms step_avg:51.14ms
+step:1205/1490 train_time:61651ms step_avg:51.16ms
+step:1206/1490 train_time:61735ms step_avg:51.19ms
+step:1207/1490 train_time:61814ms step_avg:51.21ms
+step:1208/1490 train_time:61899ms step_avg:51.24ms
+step:1209/1490 train_time:61977ms step_avg:51.26ms
+step:1210/1490 train_time:62062ms step_avg:51.29ms
+step:1211/1490 train_time:62142ms step_avg:51.31ms
+step:1212/1490 train_time:62227ms step_avg:51.34ms
+step:1213/1490 train_time:62306ms step_avg:51.37ms
+step:1214/1490 train_time:62391ms step_avg:51.39ms
+step:1215/1490 train_time:62471ms step_avg:51.42ms
+step:1216/1490 train_time:62557ms step_avg:51.44ms
+step:1217/1490 train_time:62636ms step_avg:51.47ms
+step:1218/1490 train_time:62721ms step_avg:51.50ms
+step:1219/1490 train_time:62801ms step_avg:51.52ms
+step:1220/1490 train_time:62885ms step_avg:51.55ms
+step:1221/1490 train_time:62965ms step_avg:51.57ms
+step:1222/1490 train_time:63051ms step_avg:51.60ms
+step:1223/1490 train_time:63132ms step_avg:51.62ms
+step:1224/1490 train_time:63216ms step_avg:51.65ms
+step:1225/1490 train_time:63295ms step_avg:51.67ms
+step:1226/1490 train_time:63379ms step_avg:51.70ms
+step:1227/1490 train_time:63459ms step_avg:51.72ms
+step:1228/1490 train_time:63544ms step_avg:51.75ms
+step:1229/1490 train_time:63623ms step_avg:51.77ms
+step:1230/1490 train_time:63709ms step_avg:51.80ms
+step:1231/1490 train_time:63790ms step_avg:51.82ms
+step:1232/1490 train_time:63875ms step_avg:51.85ms
+step:1233/1490 train_time:63955ms step_avg:51.87ms
+step:1234/1490 train_time:64039ms step_avg:51.90ms
+step:1235/1490 train_time:64119ms step_avg:51.92ms
+step:1236/1490 train_time:64204ms step_avg:51.94ms
+step:1237/1490 train_time:64283ms step_avg:51.97ms
+step:1238/1490 train_time:64367ms step_avg:51.99ms
+step:1239/1490 train_time:64448ms step_avg:52.02ms
+step:1240/1490 train_time:64532ms step_avg:52.04ms
+step:1241/1490 train_time:64612ms step_avg:52.06ms
+step:1242/1490 train_time:64698ms step_avg:52.09ms
+step:1243/1490 train_time:64776ms step_avg:52.11ms
+step:1244/1490 train_time:64861ms step_avg:52.14ms
+step:1245/1490 train_time:64941ms step_avg:52.16ms
+step:1246/1490 train_time:65026ms step_avg:52.19ms
+step:1247/1490 train_time:65105ms step_avg:52.21ms
+step:1248/1490 train_time:65190ms step_avg:52.24ms
+step:1249/1490 train_time:65269ms step_avg:52.26ms
+step:1250/1490 train_time:65354ms step_avg:52.28ms
+step:1250/1490 val_loss:3.3715 train_time:65451ms step_avg:52.36ms
+step:1251/1490 train_time:65471ms step_avg:52.33ms
+step:1252/1490 train_time:65523ms step_avg:52.33ms
+step:1253/1490 train_time:65605ms step_avg:52.36ms
+step:1254/1490 train_time:65690ms step_avg:52.38ms
+step:1255/1490 train_time:65768ms step_avg:52.40ms
+step:1256/1490 train_time:65852ms step_avg:52.43ms
+step:1257/1490 train_time:65930ms step_avg:52.45ms
+step:1258/1490 train_time:66013ms step_avg:52.47ms
+step:1259/1490 train_time:66092ms step_avg:52.50ms
+step:1260/1490 train_time:66176ms step_avg:52.52ms
+step:1261/1490 train_time:66256ms step_avg:52.54ms
+step:1262/1490 train_time:66340ms step_avg:52.57ms
+step:1263/1490 train_time:66421ms step_avg:52.59ms
+step:1264/1490 train_time:66509ms step_avg:52.62ms
+step:1265/1490 train_time:66590ms step_avg:52.64ms
+step:1266/1490 train_time:66674ms step_avg:52.67ms
+step:1267/1490 train_time:66754ms step_avg:52.69ms
+step:1268/1490 train_time:66839ms step_avg:52.71ms
+step:1269/1490 train_time:66919ms step_avg:52.73ms
+step:1270/1490 train_time:67003ms step_avg:52.76ms
+step:1271/1490 train_time:67080ms step_avg:52.78ms
+step:1272/1490 train_time:67164ms step_avg:52.80ms
+step:1273/1490 train_time:67242ms step_avg:52.82ms
+step:1274/1490 train_time:67328ms step_avg:52.85ms
+step:1275/1490 train_time:67408ms step_avg:52.87ms
+step:1276/1490 train_time:67493ms step_avg:52.89ms
+step:1277/1490 train_time:67573ms step_avg:52.92ms
+step:1278/1490 train_time:67659ms step_avg:52.94ms
+step:1279/1490 train_time:67742ms step_avg:52.96ms
+step:1280/1490 train_time:67826ms step_avg:52.99ms
+step:1281/1490 train_time:67904ms step_avg:53.01ms
+step:1282/1490 train_time:67988ms step_avg:53.03ms
+step:1283/1490 train_time:68067ms step_avg:53.05ms
+step:1284/1490 train_time:68151ms step_avg:53.08ms
+step:1285/1490 train_time:68228ms step_avg:53.10ms
+step:1286/1490 train_time:68314ms step_avg:53.12ms
+step:1287/1490 train_time:68393ms step_avg:53.14ms
+step:1288/1490 train_time:68479ms step_avg:53.17ms
+step:1289/1490 train_time:68560ms step_avg:53.19ms
+step:1290/1490 train_time:68644ms step_avg:53.21ms
+step:1291/1490 train_time:68724ms step_avg:53.23ms
+step:1292/1490 train_time:68810ms step_avg:53.26ms
+step:1293/1490 train_time:68889ms step_avg:53.28ms
+step:1294/1490 train_time:68972ms step_avg:53.30ms
+step:1295/1490 train_time:69051ms step_avg:53.32ms
+step:1296/1490 train_time:69135ms step_avg:53.34ms
+step:1297/1490 train_time:69214ms step_avg:53.36ms
+step:1298/1490 train_time:69299ms step_avg:53.39ms
+step:1299/1490 train_time:69379ms step_avg:53.41ms
+step:1300/1490 train_time:69464ms step_avg:53.43ms
+step:1301/1490 train_time:69545ms step_avg:53.45ms
+step:1302/1490 train_time:69631ms step_avg:53.48ms
+step:1303/1490 train_time:69711ms step_avg:53.50ms
+step:1304/1490 train_time:69795ms step_avg:53.52ms
+step:1305/1490 train_time:69874ms step_avg:53.54ms
+step:1306/1490 train_time:69959ms step_avg:53.57ms
+step:1307/1490 train_time:70039ms step_avg:53.59ms
+step:1308/1490 train_time:70123ms step_avg:53.61ms
+step:1309/1490 train_time:70202ms step_avg:53.63ms
+step:1310/1490 train_time:70286ms step_avg:53.65ms
+step:1311/1490 train_time:70366ms step_avg:53.67ms
+step:1312/1490 train_time:70451ms step_avg:53.70ms
+step:1313/1490 train_time:70531ms step_avg:53.72ms
+step:1314/1490 train_time:70617ms step_avg:53.74ms
+step:1315/1490 train_time:70696ms step_avg:53.76ms
+step:1316/1490 train_time:70781ms step_avg:53.79ms
+step:1317/1490 train_time:70861ms step_avg:53.81ms
+step:1318/1490 train_time:70948ms step_avg:53.83ms
+step:1319/1490 train_time:71028ms step_avg:53.85ms
+step:1320/1490 train_time:71112ms step_avg:53.87ms
+step:1321/1490 train_time:71190ms step_avg:53.89ms
+step:1322/1490 train_time:71274ms step_avg:53.91ms
+step:1323/1490 train_time:71353ms step_avg:53.93ms
+step:1324/1490 train_time:71439ms step_avg:53.96ms
+step:1325/1490 train_time:71519ms step_avg:53.98ms
+step:1326/1490 train_time:71605ms step_avg:54.00ms
+step:1327/1490 train_time:71684ms step_avg:54.02ms
+step:1328/1490 train_time:71769ms step_avg:54.04ms
+step:1329/1490 train_time:71850ms step_avg:54.06ms
+step:1330/1490 train_time:71934ms step_avg:54.09ms
+step:1331/1490 train_time:72014ms step_avg:54.10ms
+step:1332/1490 train_time:72098ms step_avg:54.13ms
+step:1333/1490 train_time:72177ms step_avg:54.15ms
+step:1334/1490 train_time:72262ms step_avg:54.17ms
+step:1335/1490 train_time:72341ms step_avg:54.19ms
+step:1336/1490 train_time:72427ms step_avg:54.21ms
+step:1337/1490 train_time:72507ms step_avg:54.23ms
+step:1338/1490 train_time:72592ms step_avg:54.25ms
+step:1339/1490 train_time:72672ms step_avg:54.27ms
+step:1340/1490 train_time:72758ms step_avg:54.30ms
+step:1341/1490 train_time:72839ms step_avg:54.32ms
+step:1342/1490 train_time:72923ms step_avg:54.34ms
+step:1343/1490 train_time:73002ms step_avg:54.36ms
+step:1344/1490 train_time:73087ms step_avg:54.38ms
+step:1345/1490 train_time:73168ms step_avg:54.40ms
+step:1346/1490 train_time:73251ms step_avg:54.42ms
+step:1347/1490 train_time:73329ms step_avg:54.44ms
+step:1348/1490 train_time:73414ms step_avg:54.46ms
+step:1349/1490 train_time:73493ms step_avg:54.48ms
+step:1350/1490 train_time:73578ms step_avg:54.50ms
+step:1351/1490 train_time:73660ms step_avg:54.52ms
+step:1352/1490 train_time:73744ms step_avg:54.54ms
+step:1353/1490 train_time:73824ms step_avg:54.56ms
+step:1354/1490 train_time:73911ms step_avg:54.59ms
+step:1355/1490 train_time:73989ms step_avg:54.60ms
+step:1356/1490 train_time:74072ms step_avg:54.63ms
+step:1357/1490 train_time:74151ms step_avg:54.64ms
+step:1358/1490 train_time:74236ms step_avg:54.67ms
+step:1359/1490 train_time:74316ms step_avg:54.68ms
+step:1360/1490 train_time:74400ms step_avg:54.71ms
+step:1361/1490 train_time:74479ms step_avg:54.72ms
+step:1362/1490 train_time:74563ms step_avg:54.75ms
+step:1363/1490 train_time:74644ms step_avg:54.76ms
+step:1364/1490 train_time:74731ms step_avg:54.79ms
+step:1365/1490 train_time:74811ms step_avg:54.81ms
+step:1366/1490 train_time:74895ms step_avg:54.83ms
+step:1367/1490 train_time:74975ms step_avg:54.85ms
+step:1368/1490 train_time:75060ms step_avg:54.87ms
+step:1369/1490 train_time:75139ms step_avg:54.89ms
+step:1370/1490 train_time:75224ms step_avg:54.91ms
+step:1371/1490 train_time:75303ms step_avg:54.93ms
+step:1372/1490 train_time:75387ms step_avg:54.95ms
+step:1373/1490 train_time:75467ms step_avg:54.96ms
+step:1374/1490 train_time:75553ms step_avg:54.99ms
+step:1375/1490 train_time:75631ms step_avg:55.00ms
+step:1376/1490 train_time:75717ms step_avg:55.03ms
+step:1377/1490 train_time:75796ms step_avg:55.04ms
+step:1378/1490 train_time:75881ms step_avg:55.07ms
+step:1379/1490 train_time:75962ms step_avg:55.08ms
+step:1380/1490 train_time:76047ms step_avg:55.11ms
+step:1381/1490 train_time:76125ms step_avg:55.12ms
+step:1382/1490 train_time:76210ms step_avg:55.14ms
+step:1383/1490 train_time:76289ms step_avg:55.16ms
+step:1384/1490 train_time:76373ms step_avg:55.18ms
+step:1385/1490 train_time:76454ms step_avg:55.20ms
+step:1386/1490 train_time:76539ms step_avg:55.22ms
+step:1387/1490 train_time:76620ms step_avg:55.24ms
+step:1388/1490 train_time:76705ms step_avg:55.26ms
+step:1389/1490 train_time:76784ms step_avg:55.28ms
+step:1390/1490 train_time:76869ms step_avg:55.30ms
+step:1391/1490 train_time:76948ms step_avg:55.32ms
+step:1392/1490 train_time:77034ms step_avg:55.34ms
+step:1393/1490 train_time:77113ms step_avg:55.36ms
+step:1394/1490 train_time:77197ms step_avg:55.38ms
+step:1395/1490 train_time:77277ms step_avg:55.40ms
+step:1396/1490 train_time:77363ms step_avg:55.42ms
+step:1397/1490 train_time:77442ms step_avg:55.43ms
+step:1398/1490 train_time:77526ms step_avg:55.46ms
+step:1399/1490 train_time:77605ms step_avg:55.47ms
+step:1400/1490 train_time:77690ms step_avg:55.49ms
+step:1401/1490 train_time:77770ms step_avg:55.51ms
+step:1402/1490 train_time:77856ms step_avg:55.53ms
+step:1403/1490 train_time:77934ms step_avg:55.55ms
+step:1404/1490 train_time:78021ms step_avg:55.57ms
+step:1405/1490 train_time:78100ms step_avg:55.59ms
+step:1406/1490 train_time:78185ms step_avg:55.61ms
+step:1407/1490 train_time:78265ms step_avg:55.63ms
+step:1408/1490 train_time:78350ms step_avg:55.65ms
+step:1409/1490 train_time:78429ms step_avg:55.66ms
+step:1410/1490 train_time:78514ms step_avg:55.68ms
+step:1411/1490 train_time:78592ms step_avg:55.70ms
+step:1412/1490 train_time:78678ms step_avg:55.72ms
+step:1413/1490 train_time:78760ms step_avg:55.74ms
+step:1414/1490 train_time:78845ms step_avg:55.76ms
+step:1415/1490 train_time:78925ms step_avg:55.78ms
+step:1416/1490 train_time:79009ms step_avg:55.80ms
+step:1417/1490 train_time:79087ms step_avg:55.81ms
+step:1418/1490 train_time:79172ms step_avg:55.83ms
+step:1419/1490 train_time:79252ms step_avg:55.85ms
+step:1420/1490 train_time:79337ms step_avg:55.87ms
+step:1421/1490 train_time:79417ms step_avg:55.89ms
+step:1422/1490 train_time:79501ms step_avg:55.91ms
+step:1423/1490 train_time:79580ms step_avg:55.92ms
+step:1424/1490 train_time:79665ms step_avg:55.94ms
+step:1425/1490 train_time:79744ms step_avg:55.96ms
+step:1426/1490 train_time:79830ms step_avg:55.98ms
+step:1427/1490 train_time:79909ms step_avg:56.00ms
+step:1428/1490 train_time:79994ms step_avg:56.02ms
+step:1429/1490 train_time:80073ms step_avg:56.03ms
+step:1430/1490 train_time:80158ms step_avg:56.05ms
+step:1431/1490 train_time:80238ms step_avg:56.07ms
+step:1432/1490 train_time:80323ms step_avg:56.09ms
+step:1433/1490 train_time:80401ms step_avg:56.11ms
+step:1434/1490 train_time:80486ms step_avg:56.13ms
+step:1435/1490 train_time:80565ms step_avg:56.14ms
+step:1436/1490 train_time:80650ms step_avg:56.16ms
+step:1437/1490 train_time:80729ms step_avg:56.18ms
+step:1438/1490 train_time:80815ms step_avg:56.20ms
+step:1439/1490 train_time:80894ms step_avg:56.22ms
+step:1440/1490 train_time:80980ms step_avg:56.24ms
+step:1441/1490 train_time:81060ms step_avg:56.25ms
+step:1442/1490 train_time:81147ms step_avg:56.27ms
+step:1443/1490 train_time:81225ms step_avg:56.29ms
+step:1444/1490 train_time:81311ms step_avg:56.31ms
+step:1445/1490 train_time:81389ms step_avg:56.32ms
+step:1446/1490 train_time:81473ms step_avg:56.34ms
+step:1447/1490 train_time:81552ms step_avg:56.36ms
+step:1448/1490 train_time:81638ms step_avg:56.38ms
+step:1449/1490 train_time:81718ms step_avg:56.40ms
+step:1450/1490 train_time:81803ms step_avg:56.42ms
+step:1451/1490 train_time:81886ms step_avg:56.43ms
+step:1452/1490 train_time:81973ms step_avg:56.46ms
+step:1453/1490 train_time:82052ms step_avg:56.47ms
+step:1454/1490 train_time:82138ms step_avg:56.49ms
+step:1455/1490 train_time:82218ms step_avg:56.51ms
+step:1456/1490 train_time:82304ms step_avg:56.53ms
+step:1457/1490 train_time:82383ms step_avg:56.54ms
+step:1458/1490 train_time:82469ms step_avg:56.56ms
+step:1459/1490 train_time:82549ms step_avg:56.58ms
+step:1460/1490 train_time:82635ms step_avg:56.60ms
+step:1461/1490 train_time:82715ms step_avg:56.62ms
+step:1462/1490 train_time:82799ms step_avg:56.63ms
+step:1463/1490 train_time:82880ms step_avg:56.65ms
+step:1464/1490 train_time:82965ms step_avg:56.67ms
+step:1465/1490 train_time:83045ms step_avg:56.69ms
+step:1466/1490 train_time:83130ms step_avg:56.71ms
+step:1467/1490 train_time:83211ms step_avg:56.72ms
+step:1468/1490 train_time:83296ms step_avg:56.74ms
+step:1469/1490 train_time:83375ms step_avg:56.76ms
+step:1470/1490 train_time:83461ms step_avg:56.78ms
+step:1471/1490 train_time:83541ms step_avg:56.79ms
+step:1472/1490 train_time:83625ms step_avg:56.81ms
+step:1473/1490 train_time:83706ms step_avg:56.83ms
+step:1474/1490 train_time:83791ms step_avg:56.85ms
+step:1475/1490 train_time:83871ms step_avg:56.86ms
+step:1476/1490 train_time:83956ms step_avg:56.88ms
+step:1477/1490 train_time:84035ms step_avg:56.90ms
+step:1478/1490 train_time:84120ms step_avg:56.91ms
+step:1479/1490 train_time:84200ms step_avg:56.93ms
+step:1480/1490 train_time:84286ms step_avg:56.95ms
+step:1481/1490 train_time:84366ms step_avg:56.97ms
+step:1482/1490 train_time:84451ms step_avg:56.98ms
+step:1483/1490 train_time:84531ms step_avg:57.00ms
+step:1484/1490 train_time:84618ms step_avg:57.02ms
+step:1485/1490 train_time:84698ms step_avg:57.04ms
+step:1486/1490 train_time:84783ms step_avg:57.05ms
+step:1487/1490 train_time:84862ms step_avg:57.07ms
+step:1488/1490 train_time:84949ms step_avg:57.09ms
+step:1489/1490 train_time:85030ms step_avg:57.11ms
+step:1490/1490 train_time:85113ms step_avg:57.12ms
+step:1490/1490 val_loss:3.2795 train_time:85212ms step_avg:57.19ms
+peak memory allocated: 31276 MiB reserved: 45046 MiB

--- a/records/track_1_short/2026-04-4_FuseCEFwdAndBwd/runs/7595aaba-f748-446e-8a5f-f43ea525aac0.txt
+++ b/records/track_1_short/2026-04-4_FuseCEFwdAndBwd/runs/7595aaba-f748-446e-8a5f-f43ea525aac0.txt
@@ -1,0 +1,4731 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+CE_KERNEL_BLOCK_SIZE = 256
+CE_KERNEL_VOCAB_SIZE = 50304
+
+CE_KERNEL_DECLS = f"""
+constexpr int VOCAB_SIZE = {CE_KERNEL_VOCAB_SIZE};
+constexpr int BLOCK_SIZE = {CE_KERNEL_BLOCK_SIZE};
+"""
+
+CE_KERNEL_SOURCE = """
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+#define __nv_fp8_e5m2 char
+#define uint16_t unsigned short
+#define uint8_t unsigned char
+#define int64_t long long
+
+__device__ __forceinline__ __nv_fp8_e5m2 f32_to_fp8_e5m2(float x) {
+    uint16_t packed;
+    asm volatile(
+        "cvt.rn.satfinite.e5m2x2.f32 %0, %1, %2;"
+        : "=h"(packed)
+        : "f"(x), "f"(0.0f)
+    );
+    __nv_fp8_e5m2 result;
+    *reinterpret_cast<uint8_t*>(&result) = (packed & (0xFF << 8)) >> 8;
+    return result;
+}
+
+struct __align__(16) __nv_bfloat168 {
+    __nv_bfloat16 data[8];
+    __device__ __nv_bfloat16& operator[](int i) { return data[i]; }
+    __device__ const __nv_bfloat16& operator[](int i) const { return data[i]; }
+};
+
+struct __align__(8) __nv_fp8_e5m28 {
+    __nv_fp8_e5m2 data[8];
+    __device__ __nv_fp8_e5m2& operator[](int i) { return data[i]; }
+    __device__ const __nv_fp8_e5m2& operator[](int i) const { return data[i]; }
+};
+
+template<typename T> __device__ constexpr T CEIL_DIV(T a, T b) { return (a + b - 1) / b; }
+
+//__device__ float sigmoid(float x) {
+//  return 1.0f / (1.0f + __expf(-x));
+//}
+__device__ float sigmoid(float x) {
+  return 0.5f + __tanhf(x * 0.5f) * 0.5f;
+}
+
+extern "C"
+__launch_bounds__(BLOCK_SIZE, 2)
+__global__ void ce_fwd_bwd_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    const int64_t* __restrict__ targets,
+    const float* __restrict__ mtp_weights,
+    float* __restrict__ losses,
+    __nv_fp8_e5m2* grad_input,
+    int batch_size,
+    int n_predict,
+    double A_param,
+    double B_param,
+    double C_param,
+    double grad_s_param,
+    double grad_scale_param)
+{
+  constexpr int VEC_WIDTH = 8;
+  constexpr int NUM_FULL_LOADS = VOCAB_SIZE / (BLOCK_SIZE * VEC_WIDTH);
+  constexpr int NUM_LOADS = CEIL_DIV(VOCAB_SIZE, BLOCK_SIZE * VEC_WIDTH);
+
+  float A = (float)A_param;
+  float B = (float)B_param;
+  float C = (float)C_param;
+  float grad_s = (float)grad_s_param;
+  float grad_scale = (float)grad_scale_param;
+
+  extern __shared__ __nv_bfloat16 smem[];
+
+  static_assert(VEC_WIDTH == 8);
+
+  const __nv_bfloat16 *block_logit_ptr = logits + VOCAB_SIZE * blockIdx.x;
+
+  float inv_C = 1 / C;
+  float B_div_C = B * inv_C;
+  float thread_max = -CUDART_INF_F;
+
+  #pragma unroll 25
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 result = *(__nv_bfloat168*)(&block_logit_ptr[idx]);
+      __nv_bfloat168 result_sigmoid;
+      #pragma unroll
+      for (int k = 0; k < VEC_WIDTH; k++) {
+        float tmp = __bfloat162float(result[k]);
+        tmp = sigmoid(tmp * inv_C + B_div_C);
+        result_sigmoid[k] = __float2bfloat16(tmp);
+        tmp = A * tmp;
+        thread_max = max(tmp, thread_max);
+      }
+      *(__nv_bfloat168*)(&smem[idx]) = result_sigmoid;
+    }
+  }
+
+  constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+  int warp_id = threadIdx.x / 32;
+  __shared__ float block_maxs[NUM_WARPS];
+  __shared__ float block_sums[NUM_WARPS];
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_max = fmaxf(thread_max, __shfl_down_sync(0xFFFFFFFF, thread_max, offset));
+
+  if (threadIdx.x % 32 == 0) {
+    block_maxs[warp_id] = thread_max;
+  }
+
+  __syncthreads();
+
+  float block_max = -CUDART_INF_F;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_max = fmaxf(block_max, block_maxs[i]);
+  }
+
+  float thread_sum = 0.0f;
+  #pragma unroll 2
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_bfloat168 l;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      l = *(__nv_bfloat168*)(&smem[idx]);
+    }
+    #pragma unroll
+    for (int k = 0; k < VEC_WIDTH; k++) {
+      float tmp = A * __bfloat162float(l[k]);
+      tmp = __expf(tmp - block_max);
+      if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+        thread_sum += tmp;
+      }
+    }
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_sum += __shfl_down_sync(0xFFFFFFFF, thread_sum, offset);
+
+  if (threadIdx.x % 32 == 0) {
+    block_sums[warp_id] = thread_sum;
+  }
+
+  __syncthreads();
+
+  float block_sum = 0.0f;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_sum += block_sums[i];
+  }
+
+  float lse = block_max + __logf(block_sum);
+
+  if (threadIdx.x == 0) {
+    float total_loss = 0.0f;
+    for (int k = 0; k < n_predict; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size) {
+        float weight = mtp_weights[k];
+        int64_t target = targets[target_idx];
+        if (target >= 0 && target < VOCAB_SIZE) {
+          float z_target = A * __bfloat162float(smem[target]);
+          total_loss += weight * (lse - z_target);
+        }
+      }
+    }
+    losses[blockIdx.x] = total_loss;
+  }
+
+  float S_w = 0.0f;
+
+  for (int i = 0; i < n_predict; i++) {
+    S_w += mtp_weights[i];
+  }
+
+  #pragma unroll 4
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_fp8_e5m28 result;
+
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 sigmoid_us = *(__nv_bfloat168*)(&smem[idx]);
+      #pragma unroll
+      for (int j = 0; j < VEC_WIDTH; j++) {
+        float sigmoid_u = __bfloat162float(sigmoid_us[j]);
+        float z = A * sigmoid_u;
+        float p = __expf(z - lse);
+
+        float term1 = S_w * p;
+        float term2 = 0.0f;
+
+        float grad_z = term1 - term2;
+        float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+        auto result_tmp = f32_to_fp8_e5m2(grad_x);
+        result[j] = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+      }
+      *(__nv_fp8_e5m28*)(&grad_input[blockIdx.x * VOCAB_SIZE + idx]) = result;
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < n_predict && blockIdx.x + threadIdx.x < batch_size) {
+    int i = threadIdx.x;
+    int64_t target = targets[blockIdx.x + i];
+
+    float sigmoid_u = __bfloat162float(smem[target]);
+    float z = A * sigmoid_u;
+    float p = __expf(z - lse);
+
+    float term1 = S_w * p;
+    float term2 = 0.0f;
+
+    #pragma unroll
+    for (int k = 0; k < 3; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size && k < n_predict) {
+        if (targets[target_idx] == target) {
+          term2 += mtp_weights[k];
+        }
+      }
+    }
+
+    float grad_z = term1 - term2;
+    float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+    auto result_tmp = f32_to_fp8_e5m2(grad_x);
+    auto result = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+    grad_input[blockIdx.x * VOCAB_SIZE + target] = result;
+  }
+}
+"""
+
+
+ce_fwd_bwd_kernel = torch.cuda._compile_kernel(
+    CE_KERNEL_DECLS + CE_KERNEL_SOURCE,
+    "ce_fwd_bwd_kernel",
+    compute_capability="90",
+    cuda_include_dirs=["/usr/local/cuda/include/"],
+    nvcc_options=["-lineinfo", "--use_fast_math"],
+)
+ce_fwd_bwd_kernel.set_shared_memory_config(CE_KERNEL_VOCAB_SIZE * 2)
+
+@torch.library.custom_op("nanogpt::ce_fwd_bwd", mutates_args={"losses", "grad_input"})
+def ce_fwd_bwd(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    mtp_weights: torch.Tensor,
+    losses: torch.Tensor,
+    grad_input: torch.Tensor,
+    n_rows: int,
+    n_predict: int,
+    A: float,
+    B: float,
+    C: float,
+    grad_s: float,
+    grad_scale: float,
+) -> None:
+    grid = (n_rows, 1, 1)
+    ce_fwd_bwd_kernel(
+        grid,
+        (CE_KERNEL_BLOCK_SIZE, 1, 1),
+        (logits, targets, mtp_weights, losses, grad_input,
+         n_rows, n_predict, A, B, C, grad_s, grad_scale),
+        shared_mem=CE_KERNEL_VOCAB_SIZE * 2,
+    )
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, grad_scale, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+
+        ce_fwd_bwd(logits, targets, mtp_weights, losses, grad_input,
+             n_rows, n_predict, A, B, C, grad_s, grad_scale)
+        #grid = (n_rows,)
+        #fused_softcapped_entropy_fwd_kernel[grid](
+        #    logits, losses, lse, targets, mtp_weights,
+        #    logits.stride(0), logits.stride(1),
+        #    n_rows, n_cols, n_predict,
+        #    A, B, C,
+        #    BLOCK_SIZE=2048,
+        #    num_warps=2
+        #)
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_output = grad_output.contiguous()
+
+        #grad_input_ref = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        #grid = (n_rows,)
+        #fused_softcapped_entropy_bwd_kernel[grid](
+        #    grad_input_ref, grad_output, lse, logits, targets, mtp_weights,
+        #    logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+        #    n_rows, n_cols, n_predict,
+        #    A, B, C,
+        #    grad_s,
+        #    BLOCK_SIZE=1024,
+        #    num_warps=4,
+        #    N_PREDICT=n_predict,
+        #)
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.12.3 (main, Mar  3 2026, 12:15:18) [GCC 13.3.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sat Apr  4 05:35:50 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:8D:00.0 Off |                    0 |
+| N/A   42C    P0            124W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:91:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:95:00.0 Off |                    0 |
+| N/A   41C    P0            125W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:99:00.0 Off |                    0 |
+| N/A   36C    P0            125W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   41C    P0            120W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AF:00.0 Off |                    0 |
+| N/A   36C    P0            119W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:B3:00.0 Off |                    0 |
+| N/A   43C    P0            124W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:B7:00.0 Off |                    0 |
+| N/A   34C    P0            120W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A           30620      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    1   N/A  N/A           30621      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    2   N/A  N/A           30622      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    3   N/A  N/A           30623      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    4   N/A  N/A           30624      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    5   N/A  N/A           30625      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    6   N/A  N/A           30626      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    7   N/A  N/A           30627      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8271 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:81ms step_avg:80.55ms
+step:2/1490 train_time:103ms step_avg:51.54ms
+step:3/1490 train_time:122ms step_avg:40.51ms
+step:4/1490 train_time:145ms step_avg:36.33ms
+step:5/1490 train_time:171ms step_avg:34.27ms
+step:6/1490 train_time:206ms step_avg:34.31ms
+step:7/1490 train_time:232ms step_avg:33.19ms
+step:8/1490 train_time:267ms step_avg:33.38ms
+step:9/1490 train_time:293ms step_avg:32.59ms
+step:10/1490 train_time:328ms step_avg:32.79ms
+step:11/1490 train_time:354ms step_avg:32.22ms
+step:12/1490 train_time:389ms step_avg:32.40ms
+step:13/1490 train_time:416ms step_avg:31.99ms
+step:14/1490 train_time:450ms step_avg:32.16ms
+step:15/1490 train_time:477ms step_avg:31.81ms
+step:16/1490 train_time:512ms step_avg:31.97ms
+step:17/1490 train_time:539ms step_avg:31.69ms
+step:18/1490 train_time:574ms step_avg:31.87ms
+step:19/1490 train_time:601ms step_avg:31.62ms
+step:20/1490 train_time:635ms step_avg:31.74ms
+step:21/1490 train_time:662ms step_avg:31.53ms
+step:22/1490 train_time:697ms step_avg:31.67ms
+step:23/1490 train_time:724ms step_avg:31.46ms
+step:24/1490 train_time:758ms step_avg:31.57ms
+step:25/1490 train_time:785ms step_avg:31.40ms
+step:26/1490 train_time:819ms step_avg:31.51ms
+step:27/1490 train_time:846ms step_avg:31.35ms
+step:28/1490 train_time:881ms step_avg:31.46ms
+step:29/1490 train_time:908ms step_avg:31.31ms
+step:30/1490 train_time:942ms step_avg:31.41ms
+step:31/1490 train_time:971ms step_avg:31.31ms
+step:32/1490 train_time:1006ms step_avg:31.44ms
+step:33/1490 train_time:1034ms step_avg:31.35ms
+step:34/1490 train_time:1070ms step_avg:31.48ms
+step:35/1490 train_time:1098ms step_avg:31.36ms
+step:36/1490 train_time:1133ms step_avg:31.47ms
+step:37/1490 train_time:1161ms step_avg:31.37ms
+step:38/1490 train_time:1196ms step_avg:31.46ms
+step:39/1490 train_time:1223ms step_avg:31.36ms
+step:40/1490 train_time:1257ms step_avg:31.43ms
+step:41/1490 train_time:1285ms step_avg:31.33ms
+step:42/1490 train_time:1319ms step_avg:31.40ms
+step:43/1490 train_time:1346ms step_avg:31.29ms
+step:44/1490 train_time:1380ms step_avg:31.36ms
+step:45/1490 train_time:1407ms step_avg:31.26ms
+step:46/1490 train_time:1441ms step_avg:31.32ms
+step:47/1490 train_time:1468ms step_avg:31.23ms
+step:48/1490 train_time:1502ms step_avg:31.30ms
+step:49/1490 train_time:1530ms step_avg:31.23ms
+step:50/1490 train_time:1564ms step_avg:31.28ms
+step:51/1490 train_time:1592ms step_avg:31.21ms
+step:52/1490 train_time:1626ms step_avg:31.27ms
+step:53/1490 train_time:1654ms step_avg:31.20ms
+step:54/1490 train_time:1688ms step_avg:31.26ms
+step:55/1490 train_time:1715ms step_avg:31.18ms
+step:56/1490 train_time:1750ms step_avg:31.24ms
+step:57/1490 train_time:1777ms step_avg:31.17ms
+step:58/1490 train_time:1811ms step_avg:31.22ms
+step:59/1490 train_time:1839ms step_avg:31.16ms
+step:60/1490 train_time:1873ms step_avg:31.22ms
+step:61/1490 train_time:1900ms step_avg:31.15ms
+step:62/1490 train_time:1935ms step_avg:31.21ms
+step:63/1490 train_time:1963ms step_avg:31.15ms
+step:64/1490 train_time:1997ms step_avg:31.20ms
+step:65/1490 train_time:2025ms step_avg:31.15ms
+step:66/1490 train_time:2059ms step_avg:31.20ms
+step:67/1490 train_time:2087ms step_avg:31.15ms
+step:68/1490 train_time:2122ms step_avg:31.20ms
+step:69/1490 train_time:2149ms step_avg:31.15ms
+step:70/1490 train_time:2184ms step_avg:31.20ms
+step:71/1490 train_time:2212ms step_avg:31.15ms
+step:72/1490 train_time:2246ms step_avg:31.20ms
+step:73/1490 train_time:2274ms step_avg:31.14ms
+step:74/1490 train_time:2308ms step_avg:31.19ms
+step:75/1490 train_time:2335ms step_avg:31.14ms
+step:76/1490 train_time:2371ms step_avg:31.19ms
+step:77/1490 train_time:2397ms step_avg:31.13ms
+step:78/1490 train_time:2432ms step_avg:31.18ms
+step:79/1490 train_time:2459ms step_avg:31.12ms
+step:80/1490 train_time:2494ms step_avg:31.17ms
+step:81/1490 train_time:2521ms step_avg:31.13ms
+step:82/1490 train_time:2555ms step_avg:31.16ms
+step:83/1490 train_time:2583ms step_avg:31.11ms
+step:84/1490 train_time:2617ms step_avg:31.15ms
+step:85/1490 train_time:2644ms step_avg:31.11ms
+step:86/1490 train_time:2679ms step_avg:31.15ms
+step:87/1490 train_time:2706ms step_avg:31.10ms
+step:88/1490 train_time:2739ms step_avg:31.13ms
+step:89/1490 train_time:2767ms step_avg:31.09ms
+step:90/1490 train_time:2801ms step_avg:31.12ms
+step:91/1490 train_time:2828ms step_avg:31.08ms
+step:92/1490 train_time:2863ms step_avg:31.12ms
+step:93/1490 train_time:2890ms step_avg:31.08ms
+step:94/1490 train_time:2925ms step_avg:31.11ms
+step:95/1490 train_time:2952ms step_avg:31.08ms
+step:96/1490 train_time:2987ms step_avg:31.11ms
+step:97/1490 train_time:3014ms step_avg:31.07ms
+step:98/1490 train_time:3048ms step_avg:31.11ms
+step:99/1490 train_time:3076ms step_avg:31.07ms
+step:100/1490 train_time:3111ms step_avg:31.11ms
+step:101/1490 train_time:3138ms step_avg:31.07ms
+step:102/1490 train_time:3174ms step_avg:31.11ms
+step:103/1490 train_time:3201ms step_avg:31.08ms
+step:104/1490 train_time:3235ms step_avg:31.11ms
+step:105/1490 train_time:3263ms step_avg:31.07ms
+step:106/1490 train_time:3298ms step_avg:31.11ms
+step:107/1490 train_time:3325ms step_avg:31.08ms
+step:108/1490 train_time:3359ms step_avg:31.10ms
+step:109/1490 train_time:3387ms step_avg:31.07ms
+step:110/1490 train_time:3421ms step_avg:31.10ms
+step:111/1490 train_time:3449ms step_avg:31.07ms
+step:112/1490 train_time:3483ms step_avg:31.10ms
+step:113/1490 train_time:3511ms step_avg:31.07ms
+step:114/1490 train_time:3545ms step_avg:31.10ms
+step:115/1490 train_time:3573ms step_avg:31.07ms
+step:116/1490 train_time:3607ms step_avg:31.10ms
+step:117/1490 train_time:3634ms step_avg:31.06ms
+step:118/1490 train_time:3669ms step_avg:31.09ms
+step:119/1490 train_time:3696ms step_avg:31.06ms
+step:120/1490 train_time:3730ms step_avg:31.09ms
+step:121/1490 train_time:3758ms step_avg:31.05ms
+step:122/1490 train_time:3792ms step_avg:31.08ms
+step:123/1490 train_time:3820ms step_avg:31.05ms
+step:124/1490 train_time:3854ms step_avg:31.08ms
+step:125/1490 train_time:3882ms step_avg:31.06ms
+step:126/1490 train_time:3916ms step_avg:31.08ms
+step:127/1490 train_time:3944ms step_avg:31.05ms
+step:128/1490 train_time:3978ms step_avg:31.08ms
+step:129/1490 train_time:4005ms step_avg:31.05ms
+step:130/1490 train_time:4039ms step_avg:31.07ms
+step:131/1490 train_time:4066ms step_avg:31.04ms
+step:132/1490 train_time:4100ms step_avg:31.06ms
+step:133/1490 train_time:4128ms step_avg:31.04ms
+step:134/1490 train_time:4162ms step_avg:31.06ms
+step:135/1490 train_time:4190ms step_avg:31.04ms
+step:136/1490 train_time:4224ms step_avg:31.06ms
+step:137/1490 train_time:4252ms step_avg:31.04ms
+step:138/1490 train_time:4287ms step_avg:31.06ms
+step:139/1490 train_time:4314ms step_avg:31.03ms
+step:140/1490 train_time:4348ms step_avg:31.06ms
+step:141/1490 train_time:4375ms step_avg:31.03ms
+step:142/1490 train_time:4410ms step_avg:31.06ms
+step:143/1490 train_time:4438ms step_avg:31.03ms
+step:144/1490 train_time:4473ms step_avg:31.06ms
+step:145/1490 train_time:4500ms step_avg:31.03ms
+step:146/1490 train_time:4534ms step_avg:31.06ms
+step:147/1490 train_time:4562ms step_avg:31.03ms
+step:148/1490 train_time:4596ms step_avg:31.05ms
+step:149/1490 train_time:4623ms step_avg:31.03ms
+step:150/1490 train_time:4657ms step_avg:31.05ms
+step:151/1490 train_time:4684ms step_avg:31.02ms
+step:152/1490 train_time:4719ms step_avg:31.04ms
+step:153/1490 train_time:4746ms step_avg:31.02ms
+step:154/1490 train_time:4781ms step_avg:31.05ms
+step:155/1490 train_time:4808ms step_avg:31.02ms
+step:156/1490 train_time:4843ms step_avg:31.04ms
+step:157/1490 train_time:4870ms step_avg:31.02ms
+step:158/1490 train_time:4905ms step_avg:31.04ms
+step:159/1490 train_time:4932ms step_avg:31.02ms
+step:160/1490 train_time:4967ms step_avg:31.04ms
+step:161/1490 train_time:4994ms step_avg:31.02ms
+step:162/1490 train_time:5028ms step_avg:31.04ms
+step:163/1490 train_time:5055ms step_avg:31.02ms
+step:164/1490 train_time:5090ms step_avg:31.04ms
+step:165/1490 train_time:5117ms step_avg:31.01ms
+step:166/1490 train_time:5152ms step_avg:31.03ms
+step:167/1490 train_time:5180ms step_avg:31.02ms
+step:168/1490 train_time:5214ms step_avg:31.04ms
+step:169/1490 train_time:5242ms step_avg:31.02ms
+step:170/1490 train_time:5276ms step_avg:31.04ms
+step:171/1490 train_time:5303ms step_avg:31.01ms
+step:172/1490 train_time:5337ms step_avg:31.03ms
+step:173/1490 train_time:5365ms step_avg:31.01ms
+step:174/1490 train_time:5399ms step_avg:31.03ms
+step:175/1490 train_time:5426ms step_avg:31.01ms
+step:176/1490 train_time:5460ms step_avg:31.02ms
+step:177/1490 train_time:5488ms step_avg:31.00ms
+step:178/1490 train_time:5522ms step_avg:31.02ms
+step:179/1490 train_time:5549ms step_avg:31.00ms
+step:180/1490 train_time:5584ms step_avg:31.02ms
+step:181/1490 train_time:5611ms step_avg:31.00ms
+step:182/1490 train_time:5645ms step_avg:31.02ms
+step:183/1490 train_time:5673ms step_avg:31.00ms
+step:184/1490 train_time:5707ms step_avg:31.02ms
+step:185/1490 train_time:5734ms step_avg:31.00ms
+step:186/1490 train_time:5769ms step_avg:31.01ms
+step:187/1490 train_time:5795ms step_avg:30.99ms
+step:188/1490 train_time:5830ms step_avg:31.01ms
+step:189/1490 train_time:5857ms step_avg:30.99ms
+step:190/1490 train_time:5892ms step_avg:31.01ms
+step:191/1490 train_time:5919ms step_avg:30.99ms
+step:192/1490 train_time:5954ms step_avg:31.01ms
+step:193/1490 train_time:5982ms step_avg:30.99ms
+step:194/1490 train_time:6016ms step_avg:31.01ms
+step:195/1490 train_time:6043ms step_avg:30.99ms
+step:196/1490 train_time:6077ms step_avg:31.01ms
+step:197/1490 train_time:6105ms step_avg:30.99ms
+step:198/1490 train_time:6139ms step_avg:31.01ms
+step:199/1490 train_time:6166ms step_avg:30.98ms
+step:200/1490 train_time:6200ms step_avg:31.00ms
+step:201/1490 train_time:6228ms step_avg:30.99ms
+step:202/1490 train_time:6262ms step_avg:31.00ms
+step:203/1490 train_time:6290ms step_avg:30.98ms
+step:204/1490 train_time:6324ms step_avg:31.00ms
+step:205/1490 train_time:6352ms step_avg:30.98ms
+step:206/1490 train_time:6387ms step_avg:31.00ms
+step:207/1490 train_time:6414ms step_avg:30.98ms
+step:208/1490 train_time:6448ms step_avg:31.00ms
+step:209/1490 train_time:6475ms step_avg:30.98ms
+step:210/1490 train_time:6509ms step_avg:31.00ms
+step:211/1490 train_time:6537ms step_avg:30.98ms
+step:212/1490 train_time:6572ms step_avg:31.00ms
+step:213/1490 train_time:6599ms step_avg:30.98ms
+step:214/1490 train_time:6634ms step_avg:31.00ms
+step:215/1490 train_time:6661ms step_avg:30.98ms
+step:216/1490 train_time:6696ms step_avg:31.00ms
+step:217/1490 train_time:6723ms step_avg:30.98ms
+step:218/1490 train_time:6757ms step_avg:31.00ms
+step:219/1490 train_time:6784ms step_avg:30.98ms
+step:220/1490 train_time:6818ms step_avg:30.99ms
+step:221/1490 train_time:6845ms step_avg:30.97ms
+step:222/1490 train_time:6880ms step_avg:30.99ms
+step:223/1490 train_time:6907ms step_avg:30.97ms
+step:224/1490 train_time:6941ms step_avg:30.99ms
+step:225/1490 train_time:6969ms step_avg:30.97ms
+step:226/1490 train_time:7003ms step_avg:30.99ms
+step:227/1490 train_time:7030ms step_avg:30.97ms
+step:228/1490 train_time:7065ms step_avg:30.99ms
+step:229/1490 train_time:7092ms step_avg:30.97ms
+step:230/1490 train_time:7127ms step_avg:30.99ms
+step:231/1490 train_time:7154ms step_avg:30.97ms
+step:232/1490 train_time:7189ms step_avg:30.99ms
+step:233/1490 train_time:7216ms step_avg:30.97ms
+step:234/1490 train_time:7250ms step_avg:30.98ms
+step:235/1490 train_time:7277ms step_avg:30.97ms
+step:236/1490 train_time:7312ms step_avg:30.98ms
+step:237/1490 train_time:7339ms step_avg:30.97ms
+step:238/1490 train_time:7374ms step_avg:30.98ms
+step:239/1490 train_time:7401ms step_avg:30.97ms
+step:240/1490 train_time:7436ms step_avg:30.98ms
+step:241/1490 train_time:7463ms step_avg:30.97ms
+step:242/1490 train_time:7497ms step_avg:30.98ms
+step:243/1490 train_time:7524ms step_avg:30.96ms
+step:244/1490 train_time:7558ms step_avg:30.98ms
+step:245/1490 train_time:7586ms step_avg:30.96ms
+step:246/1490 train_time:7620ms step_avg:30.98ms
+step:247/1490 train_time:7647ms step_avg:30.96ms
+step:248/1490 train_time:7682ms step_avg:30.97ms
+step:249/1490 train_time:7709ms step_avg:30.96ms
+step:250/1490 train_time:7743ms step_avg:30.97ms
+step:250/1490 val_loss:4.4997 train_time:7783ms step_avg:31.13ms
+step:251/1490 train_time:7800ms step_avg:31.08ms
+step:252/1490 train_time:7820ms step_avg:31.03ms
+step:253/1490 train_time:7835ms step_avg:30.97ms
+step:254/1490 train_time:7869ms step_avg:30.98ms
+step:255/1490 train_time:7898ms step_avg:30.97ms
+step:256/1490 train_time:7934ms step_avg:30.99ms
+step:257/1490 train_time:7961ms step_avg:30.98ms
+step:258/1490 train_time:7995ms step_avg:30.99ms
+step:259/1490 train_time:8022ms step_avg:30.97ms
+step:260/1490 train_time:8057ms step_avg:30.99ms
+step:261/1490 train_time:8084ms step_avg:30.97ms
+step:262/1490 train_time:8118ms step_avg:30.99ms
+step:263/1490 train_time:8146ms step_avg:30.97ms
+step:264/1490 train_time:8181ms step_avg:30.99ms
+step:265/1490 train_time:8208ms step_avg:30.97ms
+step:266/1490 train_time:8242ms step_avg:30.98ms
+step:267/1490 train_time:8269ms step_avg:30.97ms
+step:268/1490 train_time:8303ms step_avg:30.98ms
+step:269/1490 train_time:8330ms step_avg:30.97ms
+step:270/1490 train_time:8365ms step_avg:30.98ms
+step:271/1490 train_time:8391ms step_avg:30.96ms
+step:272/1490 train_time:8425ms step_avg:30.98ms
+step:273/1490 train_time:8452ms step_avg:30.96ms
+step:274/1490 train_time:8487ms step_avg:30.97ms
+step:275/1490 train_time:8514ms step_avg:30.96ms
+step:276/1490 train_time:8549ms step_avg:30.97ms
+step:277/1490 train_time:8576ms step_avg:30.96ms
+step:278/1490 train_time:8610ms step_avg:30.97ms
+step:279/1490 train_time:8637ms step_avg:30.96ms
+step:280/1490 train_time:8671ms step_avg:30.97ms
+step:281/1490 train_time:8699ms step_avg:30.96ms
+step:282/1490 train_time:8734ms step_avg:30.97ms
+step:283/1490 train_time:8761ms step_avg:30.96ms
+step:284/1490 train_time:8795ms step_avg:30.97ms
+step:285/1490 train_time:8823ms step_avg:30.96ms
+step:286/1490 train_time:8857ms step_avg:30.97ms
+step:287/1490 train_time:8885ms step_avg:30.96ms
+step:288/1490 train_time:8920ms step_avg:30.97ms
+step:289/1490 train_time:8947ms step_avg:30.96ms
+step:290/1490 train_time:8982ms step_avg:30.97ms
+step:291/1490 train_time:9009ms step_avg:30.96ms
+step:292/1490 train_time:9043ms step_avg:30.97ms
+step:293/1490 train_time:9071ms step_avg:30.96ms
+step:294/1490 train_time:9106ms step_avg:30.97ms
+step:295/1490 train_time:9133ms step_avg:30.96ms
+step:296/1490 train_time:9167ms step_avg:30.97ms
+step:297/1490 train_time:9194ms step_avg:30.96ms
+step:298/1490 train_time:9229ms step_avg:30.97ms
+step:299/1490 train_time:9256ms step_avg:30.96ms
+step:300/1490 train_time:9290ms step_avg:30.97ms
+step:301/1490 train_time:9317ms step_avg:30.95ms
+step:302/1490 train_time:9351ms step_avg:30.96ms
+step:303/1490 train_time:9378ms step_avg:30.95ms
+step:304/1490 train_time:9412ms step_avg:30.96ms
+step:305/1490 train_time:9439ms step_avg:30.95ms
+step:306/1490 train_time:9474ms step_avg:30.96ms
+step:307/1490 train_time:9501ms step_avg:30.95ms
+step:308/1490 train_time:9535ms step_avg:30.96ms
+step:309/1490 train_time:9562ms step_avg:30.95ms
+step:310/1490 train_time:9596ms step_avg:30.96ms
+step:311/1490 train_time:9623ms step_avg:30.94ms
+step:312/1490 train_time:9657ms step_avg:30.95ms
+step:313/1490 train_time:9685ms step_avg:30.94ms
+step:314/1490 train_time:9720ms step_avg:30.95ms
+step:315/1490 train_time:9747ms step_avg:30.94ms
+step:316/1490 train_time:9782ms step_avg:30.96ms
+step:317/1490 train_time:9809ms step_avg:30.94ms
+step:318/1490 train_time:9843ms step_avg:30.95ms
+step:319/1490 train_time:9870ms step_avg:30.94ms
+step:320/1490 train_time:9905ms step_avg:30.95ms
+step:321/1490 train_time:9933ms step_avg:30.94ms
+step:322/1490 train_time:9967ms step_avg:30.95ms
+step:323/1490 train_time:9995ms step_avg:30.94ms
+step:324/1490 train_time:10029ms step_avg:30.95ms
+step:325/1490 train_time:10056ms step_avg:30.94ms
+step:326/1490 train_time:10090ms step_avg:30.95ms
+step:327/1490 train_time:10118ms step_avg:30.94ms
+step:328/1490 train_time:10152ms step_avg:30.95ms
+step:329/1490 train_time:10179ms step_avg:30.94ms
+step:330/1490 train_time:10214ms step_avg:30.95ms
+step:331/1490 train_time:10241ms step_avg:30.94ms
+step:332/1490 train_time:10275ms step_avg:30.95ms
+step:333/1490 train_time:10302ms step_avg:30.94ms
+step:334/1490 train_time:10337ms step_avg:30.95ms
+step:335/1490 train_time:10364ms step_avg:30.94ms
+step:336/1490 train_time:10398ms step_avg:30.95ms
+step:337/1490 train_time:10425ms step_avg:30.94ms
+step:338/1490 train_time:10460ms step_avg:30.95ms
+step:339/1490 train_time:10487ms step_avg:30.93ms
+step:340/1490 train_time:10521ms step_avg:30.94ms
+step:341/1490 train_time:10548ms step_avg:30.93ms
+step:342/1490 train_time:10582ms step_avg:30.94ms
+step:343/1490 train_time:10609ms step_avg:30.93ms
+step:344/1490 train_time:10643ms step_avg:30.94ms
+step:345/1490 train_time:10671ms step_avg:30.93ms
+step:346/1490 train_time:10705ms step_avg:30.94ms
+step:347/1490 train_time:10732ms step_avg:30.93ms
+step:348/1490 train_time:10767ms step_avg:30.94ms
+step:349/1490 train_time:10794ms step_avg:30.93ms
+step:350/1490 train_time:10829ms step_avg:30.94ms
+step:351/1490 train_time:10856ms step_avg:30.93ms
+step:352/1490 train_time:10890ms step_avg:30.94ms
+step:353/1490 train_time:10918ms step_avg:30.93ms
+step:354/1490 train_time:10952ms step_avg:30.94ms
+step:355/1490 train_time:10979ms step_avg:30.93ms
+step:356/1490 train_time:11014ms step_avg:30.94ms
+step:357/1490 train_time:11041ms step_avg:30.93ms
+step:358/1490 train_time:11076ms step_avg:30.94ms
+step:359/1490 train_time:11103ms step_avg:30.93ms
+step:360/1490 train_time:11137ms step_avg:30.94ms
+step:361/1490 train_time:11165ms step_avg:30.93ms
+step:362/1490 train_time:11199ms step_avg:30.94ms
+step:363/1490 train_time:11226ms step_avg:30.93ms
+step:364/1490 train_time:11261ms step_avg:30.94ms
+step:365/1490 train_time:11288ms step_avg:30.93ms
+step:366/1490 train_time:11323ms step_avg:30.94ms
+step:367/1490 train_time:11350ms step_avg:30.93ms
+step:368/1490 train_time:11384ms step_avg:30.93ms
+step:369/1490 train_time:11411ms step_avg:30.92ms
+step:370/1490 train_time:11445ms step_avg:30.93ms
+step:371/1490 train_time:11472ms step_avg:30.92ms
+step:372/1490 train_time:11507ms step_avg:30.93ms
+step:373/1490 train_time:11534ms step_avg:30.92ms
+step:374/1490 train_time:11568ms step_avg:30.93ms
+step:375/1490 train_time:11596ms step_avg:30.92ms
+step:376/1490 train_time:11630ms step_avg:30.93ms
+step:377/1490 train_time:11657ms step_avg:30.92ms
+step:378/1490 train_time:11691ms step_avg:30.93ms
+step:379/1490 train_time:11718ms step_avg:30.92ms
+step:380/1490 train_time:11753ms step_avg:30.93ms
+step:381/1490 train_time:11780ms step_avg:30.92ms
+step:382/1490 train_time:11815ms step_avg:30.93ms
+step:383/1490 train_time:11842ms step_avg:30.92ms
+step:384/1490 train_time:11876ms step_avg:30.93ms
+step:385/1490 train_time:11903ms step_avg:30.92ms
+step:386/1490 train_time:11938ms step_avg:30.93ms
+step:387/1490 train_time:11966ms step_avg:30.92ms
+step:388/1490 train_time:12000ms step_avg:30.93ms
+step:389/1490 train_time:12027ms step_avg:30.92ms
+step:390/1490 train_time:12061ms step_avg:30.93ms
+step:391/1490 train_time:12088ms step_avg:30.92ms
+step:392/1490 train_time:12123ms step_avg:30.92ms
+step:393/1490 train_time:12150ms step_avg:30.92ms
+step:394/1490 train_time:12185ms step_avg:30.93ms
+step:395/1490 train_time:12212ms step_avg:30.92ms
+step:396/1490 train_time:12247ms step_avg:30.93ms
+step:397/1490 train_time:12274ms step_avg:30.92ms
+step:398/1490 train_time:12309ms step_avg:30.93ms
+step:399/1490 train_time:12336ms step_avg:30.92ms
+step:400/1490 train_time:12371ms step_avg:30.93ms
+step:401/1490 train_time:12398ms step_avg:30.92ms
+step:402/1490 train_time:12432ms step_avg:30.93ms
+step:403/1490 train_time:12459ms step_avg:30.92ms
+step:404/1490 train_time:12493ms step_avg:30.92ms
+step:405/1490 train_time:12520ms step_avg:30.91ms
+step:406/1490 train_time:12555ms step_avg:30.92ms
+step:407/1490 train_time:12582ms step_avg:30.91ms
+step:408/1490 train_time:12616ms step_avg:30.92ms
+step:409/1490 train_time:12644ms step_avg:30.91ms
+step:410/1490 train_time:12679ms step_avg:30.92ms
+step:411/1490 train_time:12706ms step_avg:30.91ms
+step:412/1490 train_time:12741ms step_avg:30.92ms
+step:413/1490 train_time:12768ms step_avg:30.91ms
+step:414/1490 train_time:12802ms step_avg:30.92ms
+step:415/1490 train_time:12829ms step_avg:30.91ms
+step:416/1490 train_time:12863ms step_avg:30.92ms
+step:417/1490 train_time:12890ms step_avg:30.91ms
+step:418/1490 train_time:12925ms step_avg:30.92ms
+step:419/1490 train_time:12952ms step_avg:30.91ms
+step:420/1490 train_time:12986ms step_avg:30.92ms
+step:421/1490 train_time:13014ms step_avg:30.91ms
+step:422/1490 train_time:13048ms step_avg:30.92ms
+step:423/1490 train_time:13076ms step_avg:30.91ms
+step:424/1490 train_time:13110ms step_avg:30.92ms
+step:425/1490 train_time:13137ms step_avg:30.91ms
+step:426/1490 train_time:13172ms step_avg:30.92ms
+step:427/1490 train_time:13199ms step_avg:30.91ms
+step:428/1490 train_time:13233ms step_avg:30.92ms
+step:429/1490 train_time:13260ms step_avg:30.91ms
+step:430/1490 train_time:13294ms step_avg:30.92ms
+step:431/1490 train_time:13322ms step_avg:30.91ms
+step:432/1490 train_time:13356ms step_avg:30.92ms
+step:433/1490 train_time:13384ms step_avg:30.91ms
+step:434/1490 train_time:13418ms step_avg:30.92ms
+step:435/1490 train_time:13445ms step_avg:30.91ms
+step:436/1490 train_time:13480ms step_avg:30.92ms
+step:437/1490 train_time:13507ms step_avg:30.91ms
+step:438/1490 train_time:13542ms step_avg:30.92ms
+step:439/1490 train_time:13569ms step_avg:30.91ms
+step:440/1490 train_time:13603ms step_avg:30.92ms
+step:441/1490 train_time:13630ms step_avg:30.91ms
+step:442/1490 train_time:13665ms step_avg:30.92ms
+step:443/1490 train_time:13692ms step_avg:30.91ms
+step:444/1490 train_time:13727ms step_avg:30.92ms
+step:445/1490 train_time:13754ms step_avg:30.91ms
+step:446/1490 train_time:13789ms step_avg:30.92ms
+step:447/1490 train_time:13816ms step_avg:30.91ms
+step:448/1490 train_time:13850ms step_avg:30.91ms
+step:449/1490 train_time:13877ms step_avg:30.91ms
+step:450/1490 train_time:13911ms step_avg:30.91ms
+step:451/1490 train_time:13939ms step_avg:30.91ms
+step:452/1490 train_time:13973ms step_avg:30.91ms
+step:453/1490 train_time:14000ms step_avg:30.90ms
+step:454/1490 train_time:14034ms step_avg:30.91ms
+step:455/1490 train_time:14061ms step_avg:30.90ms
+step:456/1490 train_time:14095ms step_avg:30.91ms
+step:457/1490 train_time:14122ms step_avg:30.90ms
+step:458/1490 train_time:14157ms step_avg:30.91ms
+step:459/1490 train_time:14184ms step_avg:30.90ms
+step:460/1490 train_time:14218ms step_avg:30.91ms
+step:461/1490 train_time:14246ms step_avg:30.90ms
+step:462/1490 train_time:14280ms step_avg:30.91ms
+step:463/1490 train_time:14308ms step_avg:30.90ms
+step:464/1490 train_time:14342ms step_avg:30.91ms
+step:465/1490 train_time:14369ms step_avg:30.90ms
+step:466/1490 train_time:14404ms step_avg:30.91ms
+step:467/1490 train_time:14431ms step_avg:30.90ms
+step:468/1490 train_time:14466ms step_avg:30.91ms
+step:469/1490 train_time:14493ms step_avg:30.90ms
+step:470/1490 train_time:14527ms step_avg:30.91ms
+step:471/1490 train_time:14555ms step_avg:30.90ms
+step:472/1490 train_time:14589ms step_avg:30.91ms
+step:473/1490 train_time:14617ms step_avg:30.90ms
+step:474/1490 train_time:14651ms step_avg:30.91ms
+step:475/1490 train_time:14678ms step_avg:30.90ms
+step:476/1490 train_time:14712ms step_avg:30.91ms
+step:477/1490 train_time:14739ms step_avg:30.90ms
+step:478/1490 train_time:14774ms step_avg:30.91ms
+step:479/1490 train_time:14801ms step_avg:30.90ms
+step:480/1490 train_time:14835ms step_avg:30.91ms
+step:481/1490 train_time:14862ms step_avg:30.90ms
+step:482/1490 train_time:14896ms step_avg:30.91ms
+step:483/1490 train_time:14924ms step_avg:30.90ms
+step:484/1490 train_time:14961ms step_avg:30.91ms
+step:485/1490 train_time:15013ms step_avg:30.95ms
+step:486/1490 train_time:15071ms step_avg:31.01ms
+step:487/1490 train_time:15125ms step_avg:31.06ms
+step:488/1490 train_time:15185ms step_avg:31.12ms
+step:489/1490 train_time:15238ms step_avg:31.16ms
+step:490/1490 train_time:15297ms step_avg:31.22ms
+step:491/1490 train_time:15351ms step_avg:31.26ms
+step:492/1490 train_time:15410ms step_avg:31.32ms
+step:493/1490 train_time:15463ms step_avg:31.37ms
+step:494/1490 train_time:15522ms step_avg:31.42ms
+step:495/1490 train_time:15576ms step_avg:31.47ms
+step:496/1490 train_time:15636ms step_avg:31.52ms
+step:497/1490 train_time:15689ms step_avg:31.57ms
+step:498/1490 train_time:15748ms step_avg:31.62ms
+step:499/1490 train_time:15803ms step_avg:31.67ms
+step:500/1490 train_time:15861ms step_avg:31.72ms
+step:500/1490 val_loss:4.2005 train_time:15929ms step_avg:31.86ms
+step:501/1490 train_time:15946ms step_avg:31.83ms
+step:502/1490 train_time:15976ms step_avg:31.82ms
+step:503/1490 train_time:16029ms step_avg:31.87ms
+step:504/1490 train_time:16093ms step_avg:31.93ms
+step:505/1490 train_time:16148ms step_avg:31.98ms
+step:506/1490 train_time:16207ms step_avg:32.03ms
+step:507/1490 train_time:16261ms step_avg:32.07ms
+step:508/1490 train_time:16319ms step_avg:32.12ms
+step:509/1490 train_time:16372ms step_avg:32.16ms
+step:510/1490 train_time:16431ms step_avg:32.22ms
+step:511/1490 train_time:16483ms step_avg:32.26ms
+step:512/1490 train_time:16541ms step_avg:32.31ms
+step:513/1490 train_time:16594ms step_avg:32.35ms
+step:514/1490 train_time:16652ms step_avg:32.40ms
+step:515/1490 train_time:16704ms step_avg:32.44ms
+step:516/1490 train_time:16763ms step_avg:32.49ms
+step:517/1490 train_time:16816ms step_avg:32.53ms
+step:518/1490 train_time:16875ms step_avg:32.58ms
+step:519/1490 train_time:16929ms step_avg:32.62ms
+step:520/1490 train_time:16988ms step_avg:32.67ms
+step:521/1490 train_time:17043ms step_avg:32.71ms
+step:522/1490 train_time:17103ms step_avg:32.77ms
+step:523/1490 train_time:17158ms step_avg:32.81ms
+step:524/1490 train_time:17217ms step_avg:32.86ms
+step:525/1490 train_time:17270ms step_avg:32.89ms
+step:526/1490 train_time:17328ms step_avg:32.94ms
+step:527/1490 train_time:17381ms step_avg:32.98ms
+step:528/1490 train_time:17439ms step_avg:33.03ms
+step:529/1490 train_time:17491ms step_avg:33.06ms
+step:530/1490 train_time:17550ms step_avg:33.11ms
+step:531/1490 train_time:17602ms step_avg:33.15ms
+step:532/1490 train_time:17661ms step_avg:33.20ms
+step:533/1490 train_time:17714ms step_avg:33.23ms
+step:534/1490 train_time:17772ms step_avg:33.28ms
+step:535/1490 train_time:17825ms step_avg:33.32ms
+step:536/1490 train_time:17884ms step_avg:33.36ms
+step:537/1490 train_time:17938ms step_avg:33.40ms
+step:538/1490 train_time:17997ms step_avg:33.45ms
+step:539/1490 train_time:18052ms step_avg:33.49ms
+step:540/1490 train_time:18112ms step_avg:33.54ms
+step:541/1490 train_time:18165ms step_avg:33.58ms
+step:542/1490 train_time:18225ms step_avg:33.63ms
+step:543/1490 train_time:18278ms step_avg:33.66ms
+step:544/1490 train_time:18337ms step_avg:33.71ms
+step:545/1490 train_time:18389ms step_avg:33.74ms
+step:546/1490 train_time:18448ms step_avg:33.79ms
+step:547/1490 train_time:18500ms step_avg:33.82ms
+step:548/1490 train_time:18559ms step_avg:33.87ms
+step:549/1490 train_time:18612ms step_avg:33.90ms
+step:550/1490 train_time:18670ms step_avg:33.95ms
+step:551/1490 train_time:18723ms step_avg:33.98ms
+step:552/1490 train_time:18781ms step_avg:34.02ms
+step:553/1490 train_time:18835ms step_avg:34.06ms
+step:554/1490 train_time:18894ms step_avg:34.10ms
+step:555/1490 train_time:18948ms step_avg:34.14ms
+step:556/1490 train_time:19007ms step_avg:34.18ms
+step:557/1490 train_time:19060ms step_avg:34.22ms
+step:558/1490 train_time:19120ms step_avg:34.27ms
+step:559/1490 train_time:19173ms step_avg:34.30ms
+step:560/1490 train_time:19232ms step_avg:34.34ms
+step:561/1490 train_time:19286ms step_avg:34.38ms
+step:562/1490 train_time:19345ms step_avg:34.42ms
+step:563/1490 train_time:19398ms step_avg:34.45ms
+step:564/1490 train_time:19458ms step_avg:34.50ms
+step:565/1490 train_time:19511ms step_avg:34.53ms
+step:566/1490 train_time:19569ms step_avg:34.57ms
+step:567/1490 train_time:19622ms step_avg:34.61ms
+step:568/1490 train_time:19680ms step_avg:34.65ms
+step:569/1490 train_time:19733ms step_avg:34.68ms
+step:570/1490 train_time:19792ms step_avg:34.72ms
+step:571/1490 train_time:19845ms step_avg:34.76ms
+step:572/1490 train_time:19905ms step_avg:34.80ms
+step:573/1490 train_time:19959ms step_avg:34.83ms
+step:574/1490 train_time:20019ms step_avg:34.88ms
+step:575/1490 train_time:20072ms step_avg:34.91ms
+step:576/1490 train_time:20131ms step_avg:34.95ms
+step:577/1490 train_time:20184ms step_avg:34.98ms
+step:578/1490 train_time:20243ms step_avg:35.02ms
+step:579/1490 train_time:20296ms step_avg:35.05ms
+step:580/1490 train_time:20355ms step_avg:35.10ms
+step:581/1490 train_time:20408ms step_avg:35.13ms
+step:582/1490 train_time:20466ms step_avg:35.17ms
+step:583/1490 train_time:20520ms step_avg:35.20ms
+step:584/1490 train_time:20578ms step_avg:35.24ms
+step:585/1490 train_time:20631ms step_avg:35.27ms
+step:586/1490 train_time:20689ms step_avg:35.31ms
+step:587/1490 train_time:20742ms step_avg:35.34ms
+step:588/1490 train_time:20801ms step_avg:35.38ms
+step:589/1490 train_time:20855ms step_avg:35.41ms
+step:590/1490 train_time:20914ms step_avg:35.45ms
+step:591/1490 train_time:20967ms step_avg:35.48ms
+step:592/1490 train_time:21026ms step_avg:35.52ms
+step:593/1490 train_time:21079ms step_avg:35.55ms
+step:594/1490 train_time:21138ms step_avg:35.59ms
+step:595/1490 train_time:21191ms step_avg:35.62ms
+step:596/1490 train_time:21251ms step_avg:35.66ms
+step:597/1490 train_time:21304ms step_avg:35.69ms
+step:598/1490 train_time:21363ms step_avg:35.72ms
+step:599/1490 train_time:21417ms step_avg:35.76ms
+step:600/1490 train_time:21476ms step_avg:35.79ms
+step:601/1490 train_time:21529ms step_avg:35.82ms
+step:602/1490 train_time:21587ms step_avg:35.86ms
+step:603/1490 train_time:21641ms step_avg:35.89ms
+step:604/1490 train_time:21700ms step_avg:35.93ms
+step:605/1490 train_time:21753ms step_avg:35.96ms
+step:606/1490 train_time:21812ms step_avg:35.99ms
+step:607/1490 train_time:21864ms step_avg:36.02ms
+step:608/1490 train_time:21924ms step_avg:36.06ms
+step:609/1490 train_time:21977ms step_avg:36.09ms
+step:610/1490 train_time:22036ms step_avg:36.12ms
+step:611/1490 train_time:22088ms step_avg:36.15ms
+step:612/1490 train_time:22148ms step_avg:36.19ms
+step:613/1490 train_time:22200ms step_avg:36.22ms
+step:614/1490 train_time:22260ms step_avg:36.25ms
+step:615/1490 train_time:22314ms step_avg:36.28ms
+step:616/1490 train_time:22372ms step_avg:36.32ms
+step:617/1490 train_time:22426ms step_avg:36.35ms
+step:618/1490 train_time:22485ms step_avg:36.38ms
+step:619/1490 train_time:22538ms step_avg:36.41ms
+step:620/1490 train_time:22597ms step_avg:36.45ms
+step:621/1490 train_time:22650ms step_avg:36.47ms
+step:622/1490 train_time:22709ms step_avg:36.51ms
+step:623/1490 train_time:22762ms step_avg:36.54ms
+step:624/1490 train_time:22821ms step_avg:36.57ms
+step:625/1490 train_time:22874ms step_avg:36.60ms
+step:626/1490 train_time:22933ms step_avg:36.63ms
+step:627/1490 train_time:22986ms step_avg:36.66ms
+step:628/1490 train_time:23044ms step_avg:36.69ms
+step:629/1490 train_time:23098ms step_avg:36.72ms
+step:630/1490 train_time:23157ms step_avg:36.76ms
+step:631/1490 train_time:23210ms step_avg:36.78ms
+step:632/1490 train_time:23269ms step_avg:36.82ms
+step:633/1490 train_time:23322ms step_avg:36.84ms
+step:634/1490 train_time:23380ms step_avg:36.88ms
+step:635/1490 train_time:23434ms step_avg:36.90ms
+step:636/1490 train_time:23493ms step_avg:36.94ms
+step:637/1490 train_time:23547ms step_avg:36.97ms
+step:638/1490 train_time:23606ms step_avg:37.00ms
+step:639/1490 train_time:23659ms step_avg:37.02ms
+step:640/1490 train_time:23719ms step_avg:37.06ms
+step:641/1490 train_time:23771ms step_avg:37.08ms
+step:642/1490 train_time:23830ms step_avg:37.12ms
+step:643/1490 train_time:23882ms step_avg:37.14ms
+step:644/1490 train_time:23942ms step_avg:37.18ms
+step:645/1490 train_time:23995ms step_avg:37.20ms
+step:646/1490 train_time:24054ms step_avg:37.24ms
+step:647/1490 train_time:24108ms step_avg:37.26ms
+step:648/1490 train_time:24166ms step_avg:37.29ms
+step:649/1490 train_time:24220ms step_avg:37.32ms
+step:650/1490 train_time:24278ms step_avg:37.35ms
+step:651/1490 train_time:24332ms step_avg:37.38ms
+step:652/1490 train_time:24390ms step_avg:37.41ms
+step:653/1490 train_time:24444ms step_avg:37.43ms
+step:654/1490 train_time:24503ms step_avg:37.47ms
+step:655/1490 train_time:24556ms step_avg:37.49ms
+step:656/1490 train_time:24615ms step_avg:37.52ms
+step:657/1490 train_time:24668ms step_avg:37.55ms
+step:658/1490 train_time:24727ms step_avg:37.58ms
+step:659/1490 train_time:24780ms step_avg:37.60ms
+step:660/1490 train_time:24839ms step_avg:37.63ms
+step:661/1490 train_time:24891ms step_avg:37.66ms
+step:662/1490 train_time:24950ms step_avg:37.69ms
+step:663/1490 train_time:25004ms step_avg:37.71ms
+step:664/1490 train_time:25063ms step_avg:37.75ms
+step:665/1490 train_time:25117ms step_avg:37.77ms
+step:666/1490 train_time:25176ms step_avg:37.80ms
+step:667/1490 train_time:25229ms step_avg:37.82ms
+step:668/1490 train_time:25288ms step_avg:37.86ms
+step:669/1490 train_time:25341ms step_avg:37.88ms
+step:670/1490 train_time:25400ms step_avg:37.91ms
+step:671/1490 train_time:25454ms step_avg:37.93ms
+step:672/1490 train_time:25514ms step_avg:37.97ms
+step:673/1490 train_time:25567ms step_avg:37.99ms
+step:674/1490 train_time:25625ms step_avg:38.02ms
+step:675/1490 train_time:25679ms step_avg:38.04ms
+step:676/1490 train_time:25738ms step_avg:38.07ms
+step:677/1490 train_time:25791ms step_avg:38.10ms
+step:678/1490 train_time:25851ms step_avg:38.13ms
+step:679/1490 train_time:25904ms step_avg:38.15ms
+step:680/1490 train_time:25963ms step_avg:38.18ms
+step:681/1490 train_time:26016ms step_avg:38.20ms
+step:682/1490 train_time:26076ms step_avg:38.23ms
+step:683/1490 train_time:26129ms step_avg:38.26ms
+step:684/1490 train_time:26188ms step_avg:38.29ms
+step:685/1490 train_time:26242ms step_avg:38.31ms
+step:686/1490 train_time:26300ms step_avg:38.34ms
+step:687/1490 train_time:26355ms step_avg:38.36ms
+step:688/1490 train_time:26413ms step_avg:38.39ms
+step:689/1490 train_time:26467ms step_avg:38.41ms
+step:690/1490 train_time:26526ms step_avg:38.44ms
+step:691/1490 train_time:26579ms step_avg:38.46ms
+step:692/1490 train_time:26638ms step_avg:38.49ms
+step:693/1490 train_time:26691ms step_avg:38.51ms
+step:694/1490 train_time:26750ms step_avg:38.54ms
+step:695/1490 train_time:26803ms step_avg:38.57ms
+step:696/1490 train_time:26862ms step_avg:38.59ms
+step:697/1490 train_time:26915ms step_avg:38.62ms
+step:698/1490 train_time:26974ms step_avg:38.64ms
+step:699/1490 train_time:27028ms step_avg:38.67ms
+step:700/1490 train_time:27086ms step_avg:38.69ms
+step:701/1490 train_time:27140ms step_avg:38.72ms
+step:702/1490 train_time:27199ms step_avg:38.75ms
+step:703/1490 train_time:27254ms step_avg:38.77ms
+step:704/1490 train_time:27313ms step_avg:38.80ms
+step:705/1490 train_time:27367ms step_avg:38.82ms
+step:706/1490 train_time:27425ms step_avg:38.85ms
+step:707/1490 train_time:27478ms step_avg:38.87ms
+step:708/1490 train_time:27537ms step_avg:38.89ms
+step:709/1490 train_time:27590ms step_avg:38.91ms
+step:710/1490 train_time:27649ms step_avg:38.94ms
+step:711/1490 train_time:27701ms step_avg:38.96ms
+step:712/1490 train_time:27761ms step_avg:38.99ms
+step:713/1490 train_time:27814ms step_avg:39.01ms
+step:714/1490 train_time:27873ms step_avg:39.04ms
+step:715/1490 train_time:27926ms step_avg:39.06ms
+step:716/1490 train_time:27985ms step_avg:39.08ms
+step:717/1490 train_time:28038ms step_avg:39.11ms
+step:718/1490 train_time:28097ms step_avg:39.13ms
+step:719/1490 train_time:28151ms step_avg:39.15ms
+step:720/1490 train_time:28209ms step_avg:39.18ms
+step:721/1490 train_time:28262ms step_avg:39.20ms
+step:722/1490 train_time:28322ms step_avg:39.23ms
+step:723/1490 train_time:28374ms step_avg:39.25ms
+step:724/1490 train_time:28434ms step_avg:39.27ms
+step:725/1490 train_time:28487ms step_avg:39.29ms
+step:726/1490 train_time:28546ms step_avg:39.32ms
+step:727/1490 train_time:28599ms step_avg:39.34ms
+step:728/1490 train_time:28658ms step_avg:39.37ms
+step:729/1490 train_time:28710ms step_avg:39.38ms
+step:730/1490 train_time:28769ms step_avg:39.41ms
+step:731/1490 train_time:28823ms step_avg:39.43ms
+step:732/1490 train_time:28882ms step_avg:39.46ms
+step:733/1490 train_time:28935ms step_avg:39.48ms
+step:734/1490 train_time:28994ms step_avg:39.50ms
+step:735/1490 train_time:29049ms step_avg:39.52ms
+step:736/1490 train_time:29106ms step_avg:39.55ms
+step:737/1490 train_time:29160ms step_avg:39.57ms
+step:738/1490 train_time:29219ms step_avg:39.59ms
+step:739/1490 train_time:29272ms step_avg:39.61ms
+step:740/1490 train_time:29331ms step_avg:39.64ms
+step:741/1490 train_time:29384ms step_avg:39.65ms
+step:742/1490 train_time:29443ms step_avg:39.68ms
+step:743/1490 train_time:29496ms step_avg:39.70ms
+step:744/1490 train_time:29555ms step_avg:39.73ms
+step:745/1490 train_time:29608ms step_avg:39.74ms
+step:746/1490 train_time:29666ms step_avg:39.77ms
+step:747/1490 train_time:29720ms step_avg:39.79ms
+step:748/1490 train_time:29778ms step_avg:39.81ms
+step:749/1490 train_time:29832ms step_avg:39.83ms
+step:750/1490 train_time:29891ms step_avg:39.85ms
+step:750/1490 val_loss:3.8053 train_time:29960ms step_avg:39.95ms
+step:751/1490 train_time:29977ms step_avg:39.92ms
+step:752/1490 train_time:30006ms step_avg:39.90ms
+step:753/1490 train_time:30063ms step_avg:39.92ms
+step:754/1490 train_time:30124ms step_avg:39.95ms
+step:755/1490 train_time:30178ms step_avg:39.97ms
+step:756/1490 train_time:30237ms step_avg:40.00ms
+step:757/1490 train_time:30289ms step_avg:40.01ms
+step:758/1490 train_time:30348ms step_avg:40.04ms
+step:759/1490 train_time:30400ms step_avg:40.05ms
+step:760/1490 train_time:30459ms step_avg:40.08ms
+step:761/1490 train_time:30512ms step_avg:40.09ms
+step:762/1490 train_time:30569ms step_avg:40.12ms
+step:763/1490 train_time:30621ms step_avg:40.13ms
+step:764/1490 train_time:30679ms step_avg:40.16ms
+step:765/1490 train_time:30732ms step_avg:40.17ms
+step:766/1490 train_time:30790ms step_avg:40.20ms
+step:767/1490 train_time:30844ms step_avg:40.21ms
+step:768/1490 train_time:30902ms step_avg:40.24ms
+step:769/1490 train_time:30958ms step_avg:40.26ms
+step:770/1490 train_time:31018ms step_avg:40.28ms
+step:771/1490 train_time:31073ms step_avg:40.30ms
+step:772/1490 train_time:31132ms step_avg:40.33ms
+step:773/1490 train_time:31187ms step_avg:40.34ms
+step:774/1490 train_time:31246ms step_avg:40.37ms
+step:775/1490 train_time:31298ms step_avg:40.38ms
+step:776/1490 train_time:31357ms step_avg:40.41ms
+step:777/1490 train_time:31410ms step_avg:40.42ms
+step:778/1490 train_time:31468ms step_avg:40.45ms
+step:779/1490 train_time:31520ms step_avg:40.46ms
+step:780/1490 train_time:31578ms step_avg:40.49ms
+step:781/1490 train_time:31632ms step_avg:40.50ms
+step:782/1490 train_time:31690ms step_avg:40.52ms
+step:783/1490 train_time:31743ms step_avg:40.54ms
+step:784/1490 train_time:31802ms step_avg:40.56ms
+step:785/1490 train_time:31855ms step_avg:40.58ms
+step:786/1490 train_time:31913ms step_avg:40.60ms
+step:787/1490 train_time:31968ms step_avg:40.62ms
+step:788/1490 train_time:32028ms step_avg:40.64ms
+step:789/1490 train_time:32083ms step_avg:40.66ms
+step:790/1490 train_time:32144ms step_avg:40.69ms
+step:791/1490 train_time:32196ms step_avg:40.70ms
+step:792/1490 train_time:32255ms step_avg:40.73ms
+step:793/1490 train_time:32308ms step_avg:40.74ms
+step:794/1490 train_time:32367ms step_avg:40.76ms
+step:795/1490 train_time:32419ms step_avg:40.78ms
+step:796/1490 train_time:32478ms step_avg:40.80ms
+step:797/1490 train_time:32531ms step_avg:40.82ms
+step:798/1490 train_time:32589ms step_avg:40.84ms
+step:799/1490 train_time:32643ms step_avg:40.86ms
+step:800/1490 train_time:32701ms step_avg:40.88ms
+step:801/1490 train_time:32754ms step_avg:40.89ms
+step:802/1490 train_time:32812ms step_avg:40.91ms
+step:803/1490 train_time:32867ms step_avg:40.93ms
+step:804/1490 train_time:32926ms step_avg:40.95ms
+step:805/1490 train_time:32981ms step_avg:40.97ms
+step:806/1490 train_time:33041ms step_avg:40.99ms
+step:807/1490 train_time:33095ms step_avg:41.01ms
+step:808/1490 train_time:33154ms step_avg:41.03ms
+step:809/1490 train_time:33207ms step_avg:41.05ms
+step:810/1490 train_time:33266ms step_avg:41.07ms
+step:811/1490 train_time:33320ms step_avg:41.08ms
+step:812/1490 train_time:33378ms step_avg:41.11ms
+step:813/1490 train_time:33431ms step_avg:41.12ms
+step:814/1490 train_time:33490ms step_avg:41.14ms
+step:815/1490 train_time:33543ms step_avg:41.16ms
+step:816/1490 train_time:33601ms step_avg:41.18ms
+step:817/1490 train_time:33655ms step_avg:41.19ms
+step:818/1490 train_time:33713ms step_avg:41.21ms
+step:819/1490 train_time:33767ms step_avg:41.23ms
+step:820/1490 train_time:33826ms step_avg:41.25ms
+step:821/1490 train_time:33879ms step_avg:41.27ms
+step:822/1490 train_time:33938ms step_avg:41.29ms
+step:823/1490 train_time:33992ms step_avg:41.30ms
+step:824/1490 train_time:34051ms step_avg:41.32ms
+step:825/1490 train_time:34105ms step_avg:41.34ms
+step:826/1490 train_time:34163ms step_avg:41.36ms
+step:827/1490 train_time:34216ms step_avg:41.37ms
+step:828/1490 train_time:34276ms step_avg:41.40ms
+step:829/1490 train_time:34328ms step_avg:41.41ms
+step:830/1490 train_time:34387ms step_avg:41.43ms
+step:831/1490 train_time:34441ms step_avg:41.45ms
+step:832/1490 train_time:34500ms step_avg:41.47ms
+step:833/1490 train_time:34553ms step_avg:41.48ms
+step:834/1490 train_time:34611ms step_avg:41.50ms
+step:835/1490 train_time:34665ms step_avg:41.52ms
+step:836/1490 train_time:34724ms step_avg:41.54ms
+step:837/1490 train_time:34778ms step_avg:41.55ms
+step:838/1490 train_time:34837ms step_avg:41.57ms
+step:839/1490 train_time:34890ms step_avg:41.59ms
+step:840/1490 train_time:34949ms step_avg:41.61ms
+step:841/1490 train_time:35003ms step_avg:41.62ms
+step:842/1490 train_time:35063ms step_avg:41.64ms
+step:843/1490 train_time:35116ms step_avg:41.66ms
+step:844/1490 train_time:35175ms step_avg:41.68ms
+step:845/1490 train_time:35228ms step_avg:41.69ms
+step:846/1490 train_time:35287ms step_avg:41.71ms
+step:847/1490 train_time:35340ms step_avg:41.72ms
+step:848/1490 train_time:35399ms step_avg:41.74ms
+step:849/1490 train_time:35453ms step_avg:41.76ms
+step:850/1490 train_time:35510ms step_avg:41.78ms
+step:851/1490 train_time:35565ms step_avg:41.79ms
+step:852/1490 train_time:35623ms step_avg:41.81ms
+step:853/1490 train_time:35677ms step_avg:41.82ms
+step:854/1490 train_time:35735ms step_avg:41.84ms
+step:855/1490 train_time:35788ms step_avg:41.86ms
+step:856/1490 train_time:35847ms step_avg:41.88ms
+step:857/1490 train_time:35900ms step_avg:41.89ms
+step:858/1490 train_time:35959ms step_avg:41.91ms
+step:859/1490 train_time:36013ms step_avg:41.92ms
+step:860/1490 train_time:36072ms step_avg:41.94ms
+step:861/1490 train_time:36126ms step_avg:41.96ms
+step:862/1490 train_time:36185ms step_avg:41.98ms
+step:863/1490 train_time:36239ms step_avg:41.99ms
+step:864/1490 train_time:36298ms step_avg:42.01ms
+step:865/1490 train_time:36351ms step_avg:42.02ms
+step:866/1490 train_time:36410ms step_avg:42.04ms
+step:867/1490 train_time:36463ms step_avg:42.06ms
+step:868/1490 train_time:36522ms step_avg:42.08ms
+step:869/1490 train_time:36575ms step_avg:42.09ms
+step:870/1490 train_time:36634ms step_avg:42.11ms
+step:871/1490 train_time:36687ms step_avg:42.12ms
+step:872/1490 train_time:36746ms step_avg:42.14ms
+step:873/1490 train_time:36799ms step_avg:42.15ms
+step:874/1490 train_time:36858ms step_avg:42.17ms
+step:875/1490 train_time:36910ms step_avg:42.18ms
+step:876/1490 train_time:36970ms step_avg:42.20ms
+step:877/1490 train_time:37024ms step_avg:42.22ms
+step:878/1490 train_time:37083ms step_avg:42.24ms
+step:879/1490 train_time:37136ms step_avg:42.25ms
+step:880/1490 train_time:37194ms step_avg:42.27ms
+step:881/1490 train_time:37248ms step_avg:42.28ms
+step:882/1490 train_time:37307ms step_avg:42.30ms
+step:883/1490 train_time:37361ms step_avg:42.31ms
+step:884/1490 train_time:37419ms step_avg:42.33ms
+step:885/1490 train_time:37472ms step_avg:42.34ms
+step:886/1490 train_time:37531ms step_avg:42.36ms
+step:887/1490 train_time:37585ms step_avg:42.37ms
+step:888/1490 train_time:37644ms step_avg:42.39ms
+step:889/1490 train_time:37696ms step_avg:42.40ms
+step:890/1490 train_time:37755ms step_avg:42.42ms
+step:891/1490 train_time:37808ms step_avg:42.43ms
+step:892/1490 train_time:37867ms step_avg:42.45ms
+step:893/1490 train_time:37920ms step_avg:42.46ms
+step:894/1490 train_time:37980ms step_avg:42.48ms
+step:895/1490 train_time:38034ms step_avg:42.50ms
+step:896/1490 train_time:38092ms step_avg:42.51ms
+step:897/1490 train_time:38146ms step_avg:42.53ms
+step:898/1490 train_time:38205ms step_avg:42.54ms
+step:899/1490 train_time:38258ms step_avg:42.56ms
+step:900/1490 train_time:38318ms step_avg:42.58ms
+step:901/1490 train_time:38372ms step_avg:42.59ms
+step:902/1490 train_time:38430ms step_avg:42.61ms
+step:903/1490 train_time:38484ms step_avg:42.62ms
+step:904/1490 train_time:38544ms step_avg:42.64ms
+step:905/1490 train_time:38596ms step_avg:42.65ms
+step:906/1490 train_time:38655ms step_avg:42.67ms
+step:907/1490 train_time:38708ms step_avg:42.68ms
+step:908/1490 train_time:38767ms step_avg:42.69ms
+step:909/1490 train_time:38820ms step_avg:42.71ms
+step:910/1490 train_time:38879ms step_avg:42.72ms
+step:911/1490 train_time:38932ms step_avg:42.74ms
+step:912/1490 train_time:38990ms step_avg:42.75ms
+step:913/1490 train_time:39045ms step_avg:42.77ms
+step:914/1490 train_time:39103ms step_avg:42.78ms
+step:915/1490 train_time:39156ms step_avg:42.79ms
+step:916/1490 train_time:39215ms step_avg:42.81ms
+step:917/1490 train_time:39268ms step_avg:42.82ms
+step:918/1490 train_time:39327ms step_avg:42.84ms
+step:919/1490 train_time:39381ms step_avg:42.85ms
+step:920/1490 train_time:39441ms step_avg:42.87ms
+step:921/1490 train_time:39494ms step_avg:42.88ms
+step:922/1490 train_time:39552ms step_avg:42.90ms
+step:923/1490 train_time:39605ms step_avg:42.91ms
+step:924/1490 train_time:39664ms step_avg:42.93ms
+step:925/1490 train_time:39716ms step_avg:42.94ms
+step:926/1490 train_time:39776ms step_avg:42.95ms
+step:927/1490 train_time:39829ms step_avg:42.97ms
+step:928/1490 train_time:39888ms step_avg:42.98ms
+step:929/1490 train_time:39941ms step_avg:42.99ms
+step:930/1490 train_time:40001ms step_avg:43.01ms
+step:931/1490 train_time:40055ms step_avg:43.02ms
+step:932/1490 train_time:40113ms step_avg:43.04ms
+step:933/1490 train_time:40167ms step_avg:43.05ms
+step:934/1490 train_time:40226ms step_avg:43.07ms
+step:935/1490 train_time:40279ms step_avg:43.08ms
+step:936/1490 train_time:40338ms step_avg:43.10ms
+step:937/1490 train_time:40392ms step_avg:43.11ms
+step:938/1490 train_time:40451ms step_avg:43.12ms
+step:939/1490 train_time:40504ms step_avg:43.13ms
+step:940/1490 train_time:40562ms step_avg:43.15ms
+step:941/1490 train_time:40615ms step_avg:43.16ms
+step:942/1490 train_time:40674ms step_avg:43.18ms
+step:943/1490 train_time:40726ms step_avg:43.19ms
+step:944/1490 train_time:40786ms step_avg:43.21ms
+step:945/1490 train_time:40839ms step_avg:43.22ms
+step:946/1490 train_time:40899ms step_avg:43.23ms
+step:947/1490 train_time:40952ms step_avg:43.24ms
+step:948/1490 train_time:41010ms step_avg:43.26ms
+step:949/1490 train_time:41064ms step_avg:43.27ms
+step:950/1490 train_time:41123ms step_avg:43.29ms
+step:951/1490 train_time:41177ms step_avg:43.30ms
+step:952/1490 train_time:41235ms step_avg:43.31ms
+step:953/1490 train_time:41288ms step_avg:43.32ms
+step:954/1490 train_time:41348ms step_avg:43.34ms
+step:955/1490 train_time:41400ms step_avg:43.35ms
+step:956/1490 train_time:41459ms step_avg:43.37ms
+step:957/1490 train_time:41513ms step_avg:43.38ms
+step:958/1490 train_time:41571ms step_avg:43.39ms
+step:959/1490 train_time:41624ms step_avg:43.40ms
+step:960/1490 train_time:41684ms step_avg:43.42ms
+step:961/1490 train_time:41737ms step_avg:43.43ms
+step:962/1490 train_time:41795ms step_avg:43.45ms
+step:963/1490 train_time:41848ms step_avg:43.46ms
+step:964/1490 train_time:41908ms step_avg:43.47ms
+step:965/1490 train_time:41961ms step_avg:43.48ms
+step:966/1490 train_time:42020ms step_avg:43.50ms
+step:967/1490 train_time:42074ms step_avg:43.51ms
+step:968/1490 train_time:42135ms step_avg:43.53ms
+step:969/1490 train_time:42215ms step_avg:43.57ms
+step:970/1490 train_time:42300ms step_avg:43.61ms
+step:971/1490 train_time:42378ms step_avg:43.64ms
+step:972/1490 train_time:42462ms step_avg:43.68ms
+step:973/1490 train_time:42541ms step_avg:43.72ms
+step:974/1490 train_time:42627ms step_avg:43.76ms
+step:975/1490 train_time:42706ms step_avg:43.80ms
+step:976/1490 train_time:42791ms step_avg:43.84ms
+step:977/1490 train_time:42870ms step_avg:43.88ms
+step:978/1490 train_time:42956ms step_avg:43.92ms
+step:979/1490 train_time:43035ms step_avg:43.96ms
+step:980/1490 train_time:43120ms step_avg:44.00ms
+step:981/1490 train_time:43200ms step_avg:44.04ms
+step:982/1490 train_time:43285ms step_avg:44.08ms
+step:983/1490 train_time:43364ms step_avg:44.11ms
+step:984/1490 train_time:43447ms step_avg:44.15ms
+step:985/1490 train_time:43527ms step_avg:44.19ms
+step:986/1490 train_time:43614ms step_avg:44.23ms
+step:987/1490 train_time:43693ms step_avg:44.27ms
+step:988/1490 train_time:43776ms step_avg:44.31ms
+step:989/1490 train_time:43855ms step_avg:44.34ms
+step:990/1490 train_time:43940ms step_avg:44.38ms
+step:991/1490 train_time:44019ms step_avg:44.42ms
+step:992/1490 train_time:44104ms step_avg:44.46ms
+step:993/1490 train_time:44183ms step_avg:44.49ms
+step:994/1490 train_time:44267ms step_avg:44.53ms
+step:995/1490 train_time:44345ms step_avg:44.57ms
+step:996/1490 train_time:44431ms step_avg:44.61ms
+step:997/1490 train_time:44510ms step_avg:44.64ms
+step:998/1490 train_time:44595ms step_avg:44.68ms
+step:999/1490 train_time:44674ms step_avg:44.72ms
+step:1000/1490 train_time:44759ms step_avg:44.76ms
+step:1000/1490 val_loss:3.5161 train_time:44856ms step_avg:44.86ms
+step:1001/1490 train_time:44875ms step_avg:44.83ms
+step:1002/1490 train_time:44926ms step_avg:44.84ms
+step:1003/1490 train_time:45008ms step_avg:44.87ms
+step:1004/1490 train_time:45096ms step_avg:44.92ms
+step:1005/1490 train_time:45174ms step_avg:44.95ms
+step:1006/1490 train_time:45257ms step_avg:44.99ms
+step:1007/1490 train_time:45337ms step_avg:45.02ms
+step:1008/1490 train_time:45421ms step_avg:45.06ms
+step:1009/1490 train_time:45500ms step_avg:45.09ms
+step:1010/1490 train_time:45583ms step_avg:45.13ms
+step:1011/1490 train_time:45660ms step_avg:45.16ms
+step:1012/1490 train_time:45744ms step_avg:45.20ms
+step:1013/1490 train_time:45824ms step_avg:45.24ms
+step:1014/1490 train_time:45909ms step_avg:45.28ms
+step:1015/1490 train_time:45991ms step_avg:45.31ms
+step:1016/1490 train_time:46077ms step_avg:45.35ms
+step:1017/1490 train_time:46156ms step_avg:45.38ms
+step:1018/1490 train_time:46242ms step_avg:45.42ms
+step:1019/1490 train_time:46321ms step_avg:45.46ms
+step:1020/1490 train_time:46405ms step_avg:45.50ms
+step:1021/1490 train_time:46484ms step_avg:45.53ms
+step:1022/1490 train_time:46568ms step_avg:45.57ms
+step:1023/1490 train_time:46645ms step_avg:45.60ms
+step:1024/1490 train_time:46730ms step_avg:45.63ms
+step:1025/1490 train_time:46809ms step_avg:45.67ms
+step:1026/1490 train_time:46894ms step_avg:45.71ms
+step:1027/1490 train_time:46977ms step_avg:45.74ms
+step:1028/1490 train_time:47062ms step_avg:45.78ms
+step:1029/1490 train_time:47142ms step_avg:45.81ms
+step:1030/1490 train_time:47228ms step_avg:45.85ms
+step:1031/1490 train_time:47307ms step_avg:45.88ms
+step:1032/1490 train_time:47392ms step_avg:45.92ms
+step:1033/1490 train_time:47472ms step_avg:45.96ms
+step:1034/1490 train_time:47556ms step_avg:45.99ms
+step:1035/1490 train_time:47635ms step_avg:46.02ms
+step:1036/1490 train_time:47719ms step_avg:46.06ms
+step:1037/1490 train_time:47798ms step_avg:46.09ms
+step:1038/1490 train_time:47884ms step_avg:46.13ms
+step:1039/1490 train_time:47964ms step_avg:46.16ms
+step:1040/1490 train_time:48049ms step_avg:46.20ms
+step:1041/1490 train_time:48129ms step_avg:46.23ms
+step:1042/1490 train_time:48214ms step_avg:46.27ms
+step:1043/1490 train_time:48294ms step_avg:46.30ms
+step:1044/1490 train_time:48378ms step_avg:46.34ms
+step:1045/1490 train_time:48456ms step_avg:46.37ms
+step:1046/1490 train_time:48540ms step_avg:46.41ms
+step:1047/1490 train_time:48619ms step_avg:46.44ms
+step:1048/1490 train_time:48703ms step_avg:46.47ms
+step:1049/1490 train_time:48782ms step_avg:46.50ms
+step:1050/1490 train_time:48865ms step_avg:46.54ms
+step:1051/1490 train_time:48946ms step_avg:46.57ms
+step:1052/1490 train_time:49031ms step_avg:46.61ms
+step:1053/1490 train_time:49112ms step_avg:46.64ms
+step:1054/1490 train_time:49196ms step_avg:46.68ms
+step:1055/1490 train_time:49276ms step_avg:46.71ms
+step:1056/1490 train_time:49359ms step_avg:46.74ms
+step:1057/1490 train_time:49439ms step_avg:46.77ms
+step:1058/1490 train_time:49523ms step_avg:46.81ms
+step:1059/1490 train_time:49603ms step_avg:46.84ms
+step:1060/1490 train_time:49687ms step_avg:46.87ms
+step:1061/1490 train_time:49765ms step_avg:46.90ms
+step:1062/1490 train_time:49849ms step_avg:46.94ms
+step:1063/1490 train_time:49929ms step_avg:46.97ms
+step:1064/1490 train_time:50013ms step_avg:47.00ms
+step:1065/1490 train_time:50093ms step_avg:47.04ms
+step:1066/1490 train_time:50178ms step_avg:47.07ms
+step:1067/1490 train_time:50258ms step_avg:47.10ms
+step:1068/1490 train_time:50343ms step_avg:47.14ms
+step:1069/1490 train_time:50422ms step_avg:47.17ms
+step:1070/1490 train_time:50506ms step_avg:47.20ms
+step:1071/1490 train_time:50585ms step_avg:47.23ms
+step:1072/1490 train_time:50669ms step_avg:47.27ms
+step:1073/1490 train_time:50748ms step_avg:47.30ms
+step:1074/1490 train_time:50832ms step_avg:47.33ms
+step:1075/1490 train_time:50912ms step_avg:47.36ms
+step:1076/1490 train_time:50997ms step_avg:47.39ms
+step:1077/1490 train_time:51076ms step_avg:47.42ms
+step:1078/1490 train_time:51160ms step_avg:47.46ms
+step:1079/1490 train_time:51240ms step_avg:47.49ms
+step:1080/1490 train_time:51326ms step_avg:47.52ms
+step:1081/1490 train_time:51405ms step_avg:47.55ms
+step:1082/1490 train_time:51490ms step_avg:47.59ms
+step:1083/1490 train_time:51568ms step_avg:47.62ms
+step:1084/1490 train_time:51652ms step_avg:47.65ms
+step:1085/1490 train_time:51731ms step_avg:47.68ms
+step:1086/1490 train_time:51816ms step_avg:47.71ms
+step:1087/1490 train_time:51895ms step_avg:47.74ms
+step:1088/1490 train_time:51979ms step_avg:47.78ms
+step:1089/1490 train_time:52058ms step_avg:47.80ms
+step:1090/1490 train_time:52144ms step_avg:47.84ms
+step:1091/1490 train_time:52224ms step_avg:47.87ms
+step:1092/1490 train_time:52308ms step_avg:47.90ms
+step:1093/1490 train_time:52388ms step_avg:47.93ms
+step:1094/1490 train_time:52472ms step_avg:47.96ms
+step:1095/1490 train_time:52553ms step_avg:47.99ms
+step:1096/1490 train_time:52639ms step_avg:48.03ms
+step:1097/1490 train_time:52719ms step_avg:48.06ms
+step:1098/1490 train_time:52802ms step_avg:48.09ms
+step:1099/1490 train_time:52881ms step_avg:48.12ms
+step:1100/1490 train_time:52965ms step_avg:48.15ms
+step:1101/1490 train_time:53045ms step_avg:48.18ms
+step:1102/1490 train_time:53130ms step_avg:48.21ms
+step:1103/1490 train_time:53209ms step_avg:48.24ms
+step:1104/1490 train_time:53293ms step_avg:48.27ms
+step:1105/1490 train_time:53372ms step_avg:48.30ms
+step:1106/1490 train_time:53455ms step_avg:48.33ms
+step:1107/1490 train_time:53535ms step_avg:48.36ms
+step:1108/1490 train_time:53621ms step_avg:48.39ms
+step:1109/1490 train_time:53700ms step_avg:48.42ms
+step:1110/1490 train_time:53783ms step_avg:48.45ms
+step:1111/1490 train_time:53863ms step_avg:48.48ms
+step:1112/1490 train_time:53947ms step_avg:48.51ms
+step:1113/1490 train_time:54027ms step_avg:48.54ms
+step:1114/1490 train_time:54111ms step_avg:48.57ms
+step:1115/1490 train_time:54191ms step_avg:48.60ms
+step:1116/1490 train_time:54276ms step_avg:48.63ms
+step:1117/1490 train_time:54354ms step_avg:48.66ms
+step:1118/1490 train_time:54438ms step_avg:48.69ms
+step:1119/1490 train_time:54519ms step_avg:48.72ms
+step:1120/1490 train_time:54603ms step_avg:48.75ms
+step:1121/1490 train_time:54681ms step_avg:48.78ms
+step:1122/1490 train_time:54765ms step_avg:48.81ms
+step:1123/1490 train_time:54845ms step_avg:48.84ms
+step:1124/1490 train_time:54930ms step_avg:48.87ms
+step:1125/1490 train_time:55009ms step_avg:48.90ms
+step:1126/1490 train_time:55095ms step_avg:48.93ms
+step:1127/1490 train_time:55174ms step_avg:48.96ms
+step:1128/1490 train_time:55260ms step_avg:48.99ms
+step:1129/1490 train_time:55339ms step_avg:49.02ms
+step:1130/1490 train_time:55423ms step_avg:49.05ms
+step:1131/1490 train_time:55503ms step_avg:49.07ms
+step:1132/1490 train_time:55587ms step_avg:49.11ms
+step:1133/1490 train_time:55665ms step_avg:49.13ms
+step:1134/1490 train_time:55750ms step_avg:49.16ms
+step:1135/1490 train_time:55831ms step_avg:49.19ms
+step:1136/1490 train_time:55916ms step_avg:49.22ms
+step:1137/1490 train_time:55994ms step_avg:49.25ms
+step:1138/1490 train_time:56079ms step_avg:49.28ms
+step:1139/1490 train_time:56159ms step_avg:49.31ms
+step:1140/1490 train_time:56243ms step_avg:49.34ms
+step:1141/1490 train_time:56323ms step_avg:49.36ms
+step:1142/1490 train_time:56407ms step_avg:49.39ms
+step:1143/1490 train_time:56487ms step_avg:49.42ms
+step:1144/1490 train_time:56572ms step_avg:49.45ms
+step:1145/1490 train_time:56651ms step_avg:49.48ms
+step:1146/1490 train_time:56735ms step_avg:49.51ms
+step:1147/1490 train_time:56814ms step_avg:49.53ms
+step:1148/1490 train_time:56899ms step_avg:49.56ms
+step:1149/1490 train_time:56979ms step_avg:49.59ms
+step:1150/1490 train_time:57064ms step_avg:49.62ms
+step:1151/1490 train_time:57143ms step_avg:49.65ms
+step:1152/1490 train_time:57227ms step_avg:49.68ms
+step:1153/1490 train_time:57306ms step_avg:49.70ms
+step:1154/1490 train_time:57391ms step_avg:49.73ms
+step:1155/1490 train_time:57471ms step_avg:49.76ms
+step:1156/1490 train_time:57556ms step_avg:49.79ms
+step:1157/1490 train_time:57635ms step_avg:49.81ms
+step:1158/1490 train_time:57719ms step_avg:49.84ms
+step:1159/1490 train_time:57799ms step_avg:49.87ms
+step:1160/1490 train_time:57883ms step_avg:49.90ms
+step:1161/1490 train_time:57961ms step_avg:49.92ms
+step:1162/1490 train_time:58045ms step_avg:49.95ms
+step:1163/1490 train_time:58125ms step_avg:49.98ms
+step:1164/1490 train_time:58209ms step_avg:50.01ms
+step:1165/1490 train_time:58288ms step_avg:50.03ms
+step:1166/1490 train_time:58373ms step_avg:50.06ms
+step:1167/1490 train_time:58453ms step_avg:50.09ms
+step:1168/1490 train_time:58538ms step_avg:50.12ms
+step:1169/1490 train_time:58618ms step_avg:50.14ms
+step:1170/1490 train_time:58703ms step_avg:50.17ms
+step:1171/1490 train_time:58782ms step_avg:50.20ms
+step:1172/1490 train_time:58865ms step_avg:50.23ms
+step:1173/1490 train_time:58944ms step_avg:50.25ms
+step:1174/1490 train_time:59029ms step_avg:50.28ms
+step:1175/1490 train_time:59109ms step_avg:50.31ms
+step:1176/1490 train_time:59194ms step_avg:50.34ms
+step:1177/1490 train_time:59275ms step_avg:50.36ms
+step:1178/1490 train_time:59359ms step_avg:50.39ms
+step:1179/1490 train_time:59439ms step_avg:50.41ms
+step:1180/1490 train_time:59525ms step_avg:50.44ms
+step:1181/1490 train_time:59602ms step_avg:50.47ms
+step:1182/1490 train_time:59688ms step_avg:50.50ms
+step:1183/1490 train_time:59767ms step_avg:50.52ms
+step:1184/1490 train_time:59851ms step_avg:50.55ms
+step:1185/1490 train_time:59931ms step_avg:50.57ms
+step:1186/1490 train_time:60016ms step_avg:50.60ms
+step:1187/1490 train_time:60096ms step_avg:50.63ms
+step:1188/1490 train_time:60179ms step_avg:50.66ms
+step:1189/1490 train_time:60258ms step_avg:50.68ms
+step:1190/1490 train_time:60344ms step_avg:50.71ms
+step:1191/1490 train_time:60423ms step_avg:50.73ms
+step:1192/1490 train_time:60508ms step_avg:50.76ms
+step:1193/1490 train_time:60586ms step_avg:50.78ms
+step:1194/1490 train_time:60671ms step_avg:50.81ms
+step:1195/1490 train_time:60750ms step_avg:50.84ms
+step:1196/1490 train_time:60835ms step_avg:50.87ms
+step:1197/1490 train_time:60915ms step_avg:50.89ms
+step:1198/1490 train_time:61001ms step_avg:50.92ms
+step:1199/1490 train_time:61080ms step_avg:50.94ms
+step:1200/1490 train_time:61163ms step_avg:50.97ms
+step:1201/1490 train_time:61243ms step_avg:50.99ms
+step:1202/1490 train_time:61328ms step_avg:51.02ms
+step:1203/1490 train_time:61408ms step_avg:51.05ms
+step:1204/1490 train_time:61493ms step_avg:51.07ms
+step:1205/1490 train_time:61572ms step_avg:51.10ms
+step:1206/1490 train_time:61658ms step_avg:51.13ms
+step:1207/1490 train_time:61736ms step_avg:51.15ms
+step:1208/1490 train_time:61823ms step_avg:51.18ms
+step:1209/1490 train_time:61902ms step_avg:51.20ms
+step:1210/1490 train_time:61986ms step_avg:51.23ms
+step:1211/1490 train_time:62064ms step_avg:51.25ms
+step:1212/1490 train_time:62148ms step_avg:51.28ms
+step:1213/1490 train_time:62229ms step_avg:51.30ms
+step:1214/1490 train_time:62313ms step_avg:51.33ms
+step:1215/1490 train_time:62392ms step_avg:51.35ms
+step:1216/1490 train_time:62479ms step_avg:51.38ms
+step:1217/1490 train_time:62557ms step_avg:51.40ms
+step:1218/1490 train_time:62641ms step_avg:51.43ms
+step:1219/1490 train_time:62720ms step_avg:51.45ms
+step:1220/1490 train_time:62805ms step_avg:51.48ms
+step:1221/1490 train_time:62884ms step_avg:51.50ms
+step:1222/1490 train_time:62969ms step_avg:51.53ms
+step:1223/1490 train_time:63049ms step_avg:51.55ms
+step:1224/1490 train_time:63134ms step_avg:51.58ms
+step:1225/1490 train_time:63212ms step_avg:51.60ms
+step:1226/1490 train_time:63297ms step_avg:51.63ms
+step:1227/1490 train_time:63377ms step_avg:51.65ms
+step:1228/1490 train_time:63461ms step_avg:51.68ms
+step:1229/1490 train_time:63541ms step_avg:51.70ms
+step:1230/1490 train_time:63625ms step_avg:51.73ms
+step:1231/1490 train_time:63704ms step_avg:51.75ms
+step:1232/1490 train_time:63789ms step_avg:51.78ms
+step:1233/1490 train_time:63869ms step_avg:51.80ms
+step:1234/1490 train_time:63952ms step_avg:51.83ms
+step:1235/1490 train_time:64033ms step_avg:51.85ms
+step:1236/1490 train_time:64119ms step_avg:51.88ms
+step:1237/1490 train_time:64198ms step_avg:51.90ms
+step:1238/1490 train_time:64283ms step_avg:51.92ms
+step:1239/1490 train_time:64362ms step_avg:51.95ms
+step:1240/1490 train_time:64447ms step_avg:51.97ms
+step:1241/1490 train_time:64527ms step_avg:52.00ms
+step:1242/1490 train_time:64613ms step_avg:52.02ms
+step:1243/1490 train_time:64693ms step_avg:52.05ms
+step:1244/1490 train_time:64777ms step_avg:52.07ms
+step:1245/1490 train_time:64856ms step_avg:52.09ms
+step:1246/1490 train_time:64942ms step_avg:52.12ms
+step:1247/1490 train_time:65020ms step_avg:52.14ms
+step:1248/1490 train_time:65106ms step_avg:52.17ms
+step:1249/1490 train_time:65185ms step_avg:52.19ms
+step:1250/1490 train_time:65269ms step_avg:52.22ms
+step:1250/1490 val_loss:3.3718 train_time:65369ms step_avg:52.30ms
+step:1251/1490 train_time:65387ms step_avg:52.27ms
+step:1252/1490 train_time:65438ms step_avg:52.27ms
+step:1253/1490 train_time:65519ms step_avg:52.29ms
+step:1254/1490 train_time:65605ms step_avg:52.32ms
+step:1255/1490 train_time:65682ms step_avg:52.34ms
+step:1256/1490 train_time:65766ms step_avg:52.36ms
+step:1257/1490 train_time:65845ms step_avg:52.38ms
+step:1258/1490 train_time:65929ms step_avg:52.41ms
+step:1259/1490 train_time:66008ms step_avg:52.43ms
+step:1260/1490 train_time:66090ms step_avg:52.45ms
+step:1261/1490 train_time:66168ms step_avg:52.47ms
+step:1262/1490 train_time:66252ms step_avg:52.50ms
+step:1263/1490 train_time:66332ms step_avg:52.52ms
+step:1264/1490 train_time:66418ms step_avg:52.55ms
+step:1265/1490 train_time:66499ms step_avg:52.57ms
+step:1266/1490 train_time:66587ms step_avg:52.60ms
+step:1267/1490 train_time:66667ms step_avg:52.62ms
+step:1268/1490 train_time:66751ms step_avg:52.64ms
+step:1269/1490 train_time:66831ms step_avg:52.66ms
+step:1270/1490 train_time:66914ms step_avg:52.69ms
+step:1271/1490 train_time:66993ms step_avg:52.71ms
+step:1272/1490 train_time:67076ms step_avg:52.73ms
+step:1273/1490 train_time:67155ms step_avg:52.75ms
+step:1274/1490 train_time:67240ms step_avg:52.78ms
+step:1275/1490 train_time:67319ms step_avg:52.80ms
+step:1276/1490 train_time:67404ms step_avg:52.82ms
+step:1277/1490 train_time:67484ms step_avg:52.85ms
+step:1278/1490 train_time:67569ms step_avg:52.87ms
+step:1279/1490 train_time:67650ms step_avg:52.89ms
+step:1280/1490 train_time:67737ms step_avg:52.92ms
+step:1281/1490 train_time:67816ms step_avg:52.94ms
+step:1282/1490 train_time:67901ms step_avg:52.97ms
+step:1283/1490 train_time:67981ms step_avg:52.99ms
+step:1284/1490 train_time:68065ms step_avg:53.01ms
+step:1285/1490 train_time:68144ms step_avg:53.03ms
+step:1286/1490 train_time:68228ms step_avg:53.05ms
+step:1287/1490 train_time:68308ms step_avg:53.08ms
+step:1288/1490 train_time:68393ms step_avg:53.10ms
+step:1289/1490 train_time:68473ms step_avg:53.12ms
+step:1290/1490 train_time:68557ms step_avg:53.15ms
+step:1291/1490 train_time:68638ms step_avg:53.17ms
+step:1292/1490 train_time:68722ms step_avg:53.19ms
+step:1293/1490 train_time:68801ms step_avg:53.21ms
+step:1294/1490 train_time:68886ms step_avg:53.24ms
+step:1295/1490 train_time:68964ms step_avg:53.25ms
+step:1296/1490 train_time:69048ms step_avg:53.28ms
+step:1297/1490 train_time:69127ms step_avg:53.30ms
+step:1298/1490 train_time:69212ms step_avg:53.32ms
+step:1299/1490 train_time:69291ms step_avg:53.34ms
+step:1300/1490 train_time:69376ms step_avg:53.37ms
+step:1301/1490 train_time:69456ms step_avg:53.39ms
+step:1302/1490 train_time:69541ms step_avg:53.41ms
+step:1303/1490 train_time:69621ms step_avg:53.43ms
+step:1304/1490 train_time:69706ms step_avg:53.46ms
+step:1305/1490 train_time:69786ms step_avg:53.48ms
+step:1306/1490 train_time:69871ms step_avg:53.50ms
+step:1307/1490 train_time:69950ms step_avg:53.52ms
+step:1308/1490 train_time:70034ms step_avg:53.54ms
+step:1309/1490 train_time:70112ms step_avg:53.56ms
+step:1310/1490 train_time:70197ms step_avg:53.59ms
+step:1311/1490 train_time:70275ms step_avg:53.60ms
+step:1312/1490 train_time:70361ms step_avg:53.63ms
+step:1313/1490 train_time:70441ms step_avg:53.65ms
+step:1314/1490 train_time:70526ms step_avg:53.67ms
+step:1315/1490 train_time:70604ms step_avg:53.69ms
+step:1316/1490 train_time:70690ms step_avg:53.72ms
+step:1317/1490 train_time:70769ms step_avg:53.74ms
+step:1318/1490 train_time:70854ms step_avg:53.76ms
+step:1319/1490 train_time:70933ms step_avg:53.78ms
+step:1320/1490 train_time:71017ms step_avg:53.80ms
+step:1321/1490 train_time:71096ms step_avg:53.82ms
+step:1322/1490 train_time:71181ms step_avg:53.84ms
+step:1323/1490 train_time:71261ms step_avg:53.86ms
+step:1324/1490 train_time:71345ms step_avg:53.89ms
+step:1325/1490 train_time:71424ms step_avg:53.90ms
+step:1326/1490 train_time:71508ms step_avg:53.93ms
+step:1327/1490 train_time:71588ms step_avg:53.95ms
+step:1328/1490 train_time:71673ms step_avg:53.97ms
+step:1329/1490 train_time:71753ms step_avg:53.99ms
+step:1330/1490 train_time:71837ms step_avg:54.01ms
+step:1331/1490 train_time:71916ms step_avg:54.03ms
+step:1332/1490 train_time:72001ms step_avg:54.06ms
+step:1333/1490 train_time:72082ms step_avg:54.07ms
+step:1334/1490 train_time:72166ms step_avg:54.10ms
+step:1335/1490 train_time:72245ms step_avg:54.12ms
+step:1336/1490 train_time:72330ms step_avg:54.14ms
+step:1337/1490 train_time:72409ms step_avg:54.16ms
+step:1338/1490 train_time:72494ms step_avg:54.18ms
+step:1339/1490 train_time:72573ms step_avg:54.20ms
+step:1340/1490 train_time:72658ms step_avg:54.22ms
+step:1341/1490 train_time:72739ms step_avg:54.24ms
+step:1342/1490 train_time:72823ms step_avg:54.26ms
+step:1343/1490 train_time:72902ms step_avg:54.28ms
+step:1344/1490 train_time:72988ms step_avg:54.31ms
+step:1345/1490 train_time:73067ms step_avg:54.32ms
+step:1346/1490 train_time:73152ms step_avg:54.35ms
+step:1347/1490 train_time:73230ms step_avg:54.37ms
+step:1348/1490 train_time:73315ms step_avg:54.39ms
+step:1349/1490 train_time:73394ms step_avg:54.41ms
+step:1350/1490 train_time:73479ms step_avg:54.43ms
+step:1351/1490 train_time:73558ms step_avg:54.45ms
+step:1352/1490 train_time:73642ms step_avg:54.47ms
+step:1353/1490 train_time:73722ms step_avg:54.49ms
+step:1354/1490 train_time:73807ms step_avg:54.51ms
+step:1355/1490 train_time:73886ms step_avg:54.53ms
+step:1356/1490 train_time:73970ms step_avg:54.55ms
+step:1357/1490 train_time:74049ms step_avg:54.57ms
+step:1358/1490 train_time:74135ms step_avg:54.59ms
+step:1359/1490 train_time:74214ms step_avg:54.61ms
+step:1360/1490 train_time:74298ms step_avg:54.63ms
+step:1361/1490 train_time:74378ms step_avg:54.65ms
+step:1362/1490 train_time:74463ms step_avg:54.67ms
+step:1363/1490 train_time:74542ms step_avg:54.69ms
+step:1364/1490 train_time:74628ms step_avg:54.71ms
+step:1365/1490 train_time:74708ms step_avg:54.73ms
+step:1366/1490 train_time:74791ms step_avg:54.75ms
+step:1367/1490 train_time:74869ms step_avg:54.77ms
+step:1368/1490 train_time:74955ms step_avg:54.79ms
+step:1369/1490 train_time:75036ms step_avg:54.81ms
+step:1370/1490 train_time:75121ms step_avg:54.83ms
+step:1371/1490 train_time:75200ms step_avg:54.85ms
+step:1372/1490 train_time:75286ms step_avg:54.87ms
+step:1373/1490 train_time:75364ms step_avg:54.89ms
+step:1374/1490 train_time:75449ms step_avg:54.91ms
+step:1375/1490 train_time:75527ms step_avg:54.93ms
+step:1376/1490 train_time:75612ms step_avg:54.95ms
+step:1377/1490 train_time:75691ms step_avg:54.97ms
+step:1378/1490 train_time:75776ms step_avg:54.99ms
+step:1379/1490 train_time:75856ms step_avg:55.01ms
+step:1380/1490 train_time:75942ms step_avg:55.03ms
+step:1381/1490 train_time:76020ms step_avg:55.05ms
+step:1382/1490 train_time:76105ms step_avg:55.07ms
+step:1383/1490 train_time:76185ms step_avg:55.09ms
+step:1384/1490 train_time:76269ms step_avg:55.11ms
+step:1385/1490 train_time:76349ms step_avg:55.13ms
+step:1386/1490 train_time:76433ms step_avg:55.15ms
+step:1387/1490 train_time:76512ms step_avg:55.16ms
+step:1388/1490 train_time:76597ms step_avg:55.19ms
+step:1389/1490 train_time:76676ms step_avg:55.20ms
+step:1390/1490 train_time:76760ms step_avg:55.22ms
+step:1391/1490 train_time:76840ms step_avg:55.24ms
+step:1392/1490 train_time:76924ms step_avg:55.26ms
+step:1393/1490 train_time:77003ms step_avg:55.28ms
+step:1394/1490 train_time:77089ms step_avg:55.30ms
+step:1395/1490 train_time:77167ms step_avg:55.32ms
+step:1396/1490 train_time:77251ms step_avg:55.34ms
+step:1397/1490 train_time:77331ms step_avg:55.36ms
+step:1398/1490 train_time:77417ms step_avg:55.38ms
+step:1399/1490 train_time:77496ms step_avg:55.39ms
+step:1400/1490 train_time:77581ms step_avg:55.41ms
+step:1401/1490 train_time:77660ms step_avg:55.43ms
+step:1402/1490 train_time:77745ms step_avg:55.45ms
+step:1403/1490 train_time:77825ms step_avg:55.47ms
+step:1404/1490 train_time:77911ms step_avg:55.49ms
+step:1405/1490 train_time:77990ms step_avg:55.51ms
+step:1406/1490 train_time:78073ms step_avg:55.53ms
+step:1407/1490 train_time:78152ms step_avg:55.55ms
+step:1408/1490 train_time:78238ms step_avg:55.57ms
+step:1409/1490 train_time:78318ms step_avg:55.58ms
+step:1410/1490 train_time:78403ms step_avg:55.60ms
+step:1411/1490 train_time:78482ms step_avg:55.62ms
+step:1412/1490 train_time:78567ms step_avg:55.64ms
+step:1413/1490 train_time:78648ms step_avg:55.66ms
+step:1414/1490 train_time:78731ms step_avg:55.68ms
+step:1415/1490 train_time:78810ms step_avg:55.70ms
+step:1416/1490 train_time:78896ms step_avg:55.72ms
+step:1417/1490 train_time:78976ms step_avg:55.73ms
+step:1418/1490 train_time:79061ms step_avg:55.76ms
+step:1419/1490 train_time:79142ms step_avg:55.77ms
+step:1420/1490 train_time:79226ms step_avg:55.79ms
+step:1421/1490 train_time:79305ms step_avg:55.81ms
+step:1422/1490 train_time:79390ms step_avg:55.83ms
+step:1423/1490 train_time:79469ms step_avg:55.85ms
+step:1424/1490 train_time:79553ms step_avg:55.87ms
+step:1425/1490 train_time:79633ms step_avg:55.88ms
+step:1426/1490 train_time:79718ms step_avg:55.90ms
+step:1427/1490 train_time:79798ms step_avg:55.92ms
+step:1428/1490 train_time:79882ms step_avg:55.94ms
+step:1429/1490 train_time:79961ms step_avg:55.96ms
+step:1430/1490 train_time:80047ms step_avg:55.98ms
+step:1431/1490 train_time:80127ms step_avg:55.99ms
+step:1432/1490 train_time:80210ms step_avg:56.01ms
+step:1433/1490 train_time:80290ms step_avg:56.03ms
+step:1434/1490 train_time:80376ms step_avg:56.05ms
+step:1435/1490 train_time:80455ms step_avg:56.07ms
+step:1436/1490 train_time:80540ms step_avg:56.09ms
+step:1437/1490 train_time:80619ms step_avg:56.10ms
+step:1438/1490 train_time:80705ms step_avg:56.12ms
+step:1439/1490 train_time:80785ms step_avg:56.14ms
+step:1440/1490 train_time:80868ms step_avg:56.16ms
+step:1441/1490 train_time:80949ms step_avg:56.18ms
+step:1442/1490 train_time:81036ms step_avg:56.20ms
+step:1443/1490 train_time:81115ms step_avg:56.21ms
+step:1444/1490 train_time:81201ms step_avg:56.23ms
+step:1445/1490 train_time:81281ms step_avg:56.25ms
+step:1446/1490 train_time:81366ms step_avg:56.27ms
+step:1447/1490 train_time:81445ms step_avg:56.29ms
+step:1448/1490 train_time:81530ms step_avg:56.31ms
+step:1449/1490 train_time:81608ms step_avg:56.32ms
+step:1450/1490 train_time:81693ms step_avg:56.34ms
+step:1451/1490 train_time:81776ms step_avg:56.36ms
+step:1452/1490 train_time:81862ms step_avg:56.38ms
+step:1453/1490 train_time:81942ms step_avg:56.40ms
+step:1454/1490 train_time:82029ms step_avg:56.42ms
+step:1455/1490 train_time:82108ms step_avg:56.43ms
+step:1456/1490 train_time:82192ms step_avg:56.45ms
+step:1457/1490 train_time:82271ms step_avg:56.47ms
+step:1458/1490 train_time:82357ms step_avg:56.49ms
+step:1459/1490 train_time:82438ms step_avg:56.50ms
+step:1460/1490 train_time:82523ms step_avg:56.52ms
+step:1461/1490 train_time:82602ms step_avg:56.54ms
+step:1462/1490 train_time:82689ms step_avg:56.56ms
+step:1463/1490 train_time:82769ms step_avg:56.57ms
+step:1464/1490 train_time:82854ms step_avg:56.59ms
+step:1465/1490 train_time:82936ms step_avg:56.61ms
+step:1466/1490 train_time:83021ms step_avg:56.63ms
+step:1467/1490 train_time:83102ms step_avg:56.65ms
+step:1468/1490 train_time:83189ms step_avg:56.67ms
+step:1469/1490 train_time:83268ms step_avg:56.68ms
+step:1470/1490 train_time:83352ms step_avg:56.70ms
+step:1471/1490 train_time:83431ms step_avg:56.72ms
+step:1472/1490 train_time:83516ms step_avg:56.74ms
+step:1473/1490 train_time:83597ms step_avg:56.75ms
+step:1474/1490 train_time:83682ms step_avg:56.77ms
+step:1475/1490 train_time:83761ms step_avg:56.79ms
+step:1476/1490 train_time:83846ms step_avg:56.81ms
+step:1477/1490 train_time:83926ms step_avg:56.82ms
+step:1478/1490 train_time:84010ms step_avg:56.84ms
+step:1479/1490 train_time:84089ms step_avg:56.86ms
+step:1480/1490 train_time:84175ms step_avg:56.88ms
+step:1481/1490 train_time:84255ms step_avg:56.89ms
+step:1482/1490 train_time:84340ms step_avg:56.91ms
+step:1483/1490 train_time:84420ms step_avg:56.93ms
+step:1484/1490 train_time:84506ms step_avg:56.94ms
+step:1485/1490 train_time:84586ms step_avg:56.96ms
+step:1486/1490 train_time:84671ms step_avg:56.98ms
+step:1487/1490 train_time:84751ms step_avg:56.99ms
+step:1488/1490 train_time:84839ms step_avg:57.02ms
+step:1489/1490 train_time:84920ms step_avg:57.03ms
+step:1490/1490 train_time:85005ms step_avg:57.05ms
+step:1490/1490 val_loss:3.2785 train_time:85103ms step_avg:57.12ms
+peak memory allocated: 31295 MiB reserved: 45826 MiB

--- a/records/track_1_short/2026-04-4_FuseCEFwdAndBwd/runs/c37bef41-e56d-49a5-8bd2-43c468e6bcea.txt
+++ b/records/track_1_short/2026-04-4_FuseCEFwdAndBwd/runs/c37bef41-e56d-49a5-8bd2-43c468e6bcea.txt
@@ -1,0 +1,4731 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+CE_KERNEL_BLOCK_SIZE = 256
+CE_KERNEL_VOCAB_SIZE = 50304
+
+CE_KERNEL_DECLS = f"""
+constexpr int VOCAB_SIZE = {CE_KERNEL_VOCAB_SIZE};
+constexpr int BLOCK_SIZE = {CE_KERNEL_BLOCK_SIZE};
+"""
+
+CE_KERNEL_SOURCE = """
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+#define __nv_fp8_e5m2 char
+#define uint16_t unsigned short
+#define uint8_t unsigned char
+#define int64_t long long
+
+__device__ __forceinline__ __nv_fp8_e5m2 f32_to_fp8_e5m2(float x) {
+    uint16_t packed;
+    asm volatile(
+        "cvt.rn.satfinite.e5m2x2.f32 %0, %1, %2;"
+        : "=h"(packed)
+        : "f"(x), "f"(0.0f)
+    );
+    __nv_fp8_e5m2 result;
+    *reinterpret_cast<uint8_t*>(&result) = (packed & (0xFF << 8)) >> 8;
+    return result;
+}
+
+struct __align__(16) __nv_bfloat168 {
+    __nv_bfloat16 data[8];
+    __device__ __nv_bfloat16& operator[](int i) { return data[i]; }
+    __device__ const __nv_bfloat16& operator[](int i) const { return data[i]; }
+};
+
+struct __align__(8) __nv_fp8_e5m28 {
+    __nv_fp8_e5m2 data[8];
+    __device__ __nv_fp8_e5m2& operator[](int i) { return data[i]; }
+    __device__ const __nv_fp8_e5m2& operator[](int i) const { return data[i]; }
+};
+
+template<typename T> __device__ constexpr T CEIL_DIV(T a, T b) { return (a + b - 1) / b; }
+
+//__device__ float sigmoid(float x) {
+//  return 1.0f / (1.0f + __expf(-x));
+//}
+__device__ float sigmoid(float x) {
+  return 0.5f + __tanhf(x * 0.5f) * 0.5f;
+}
+
+extern "C"
+__launch_bounds__(BLOCK_SIZE, 2)
+__global__ void ce_fwd_bwd_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    const int64_t* __restrict__ targets,
+    const float* __restrict__ mtp_weights,
+    float* __restrict__ losses,
+    __nv_fp8_e5m2* grad_input,
+    int batch_size,
+    int n_predict,
+    double A_param,
+    double B_param,
+    double C_param,
+    double grad_s_param,
+    double grad_scale_param)
+{
+  constexpr int VEC_WIDTH = 8;
+  constexpr int NUM_FULL_LOADS = VOCAB_SIZE / (BLOCK_SIZE * VEC_WIDTH);
+  constexpr int NUM_LOADS = CEIL_DIV(VOCAB_SIZE, BLOCK_SIZE * VEC_WIDTH);
+
+  float A = (float)A_param;
+  float B = (float)B_param;
+  float C = (float)C_param;
+  float grad_s = (float)grad_s_param;
+  float grad_scale = (float)grad_scale_param;
+
+  extern __shared__ __nv_bfloat16 smem[];
+
+  static_assert(VEC_WIDTH == 8);
+
+  const __nv_bfloat16 *block_logit_ptr = logits + VOCAB_SIZE * blockIdx.x;
+
+  float inv_C = 1 / C;
+  float B_div_C = B * inv_C;
+  float thread_max = -CUDART_INF_F;
+
+  #pragma unroll 25
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 result = *(__nv_bfloat168*)(&block_logit_ptr[idx]);
+      __nv_bfloat168 result_sigmoid;
+      #pragma unroll
+      for (int k = 0; k < VEC_WIDTH; k++) {
+        float tmp = __bfloat162float(result[k]);
+        tmp = sigmoid(tmp * inv_C + B_div_C);
+        result_sigmoid[k] = __float2bfloat16(tmp);
+        tmp = A * tmp;
+        thread_max = max(tmp, thread_max);
+      }
+      *(__nv_bfloat168*)(&smem[idx]) = result_sigmoid;
+    }
+  }
+
+  constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+  int warp_id = threadIdx.x / 32;
+  __shared__ float block_maxs[NUM_WARPS];
+  __shared__ float block_sums[NUM_WARPS];
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_max = fmaxf(thread_max, __shfl_down_sync(0xFFFFFFFF, thread_max, offset));
+
+  if (threadIdx.x % 32 == 0) {
+    block_maxs[warp_id] = thread_max;
+  }
+
+  __syncthreads();
+
+  float block_max = -CUDART_INF_F;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_max = fmaxf(block_max, block_maxs[i]);
+  }
+
+  float thread_sum = 0.0f;
+  #pragma unroll 2
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_bfloat168 l;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      l = *(__nv_bfloat168*)(&smem[idx]);
+    }
+    #pragma unroll
+    for (int k = 0; k < VEC_WIDTH; k++) {
+      float tmp = A * __bfloat162float(l[k]);
+      tmp = __expf(tmp - block_max);
+      if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+        thread_sum += tmp;
+      }
+    }
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_sum += __shfl_down_sync(0xFFFFFFFF, thread_sum, offset);
+
+  if (threadIdx.x % 32 == 0) {
+    block_sums[warp_id] = thread_sum;
+  }
+
+  __syncthreads();
+
+  float block_sum = 0.0f;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_sum += block_sums[i];
+  }
+
+  float lse = block_max + __logf(block_sum);
+
+  if (threadIdx.x == 0) {
+    float total_loss = 0.0f;
+    for (int k = 0; k < n_predict; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size) {
+        float weight = mtp_weights[k];
+        int64_t target = targets[target_idx];
+        if (target >= 0 && target < VOCAB_SIZE) {
+          float z_target = A * __bfloat162float(smem[target]);
+          total_loss += weight * (lse - z_target);
+        }
+      }
+    }
+    losses[blockIdx.x] = total_loss;
+  }
+
+  float S_w = 0.0f;
+
+  for (int i = 0; i < n_predict; i++) {
+    S_w += mtp_weights[i];
+  }
+
+  #pragma unroll 4
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_fp8_e5m28 result;
+
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 sigmoid_us = *(__nv_bfloat168*)(&smem[idx]);
+      #pragma unroll
+      for (int j = 0; j < VEC_WIDTH; j++) {
+        float sigmoid_u = __bfloat162float(sigmoid_us[j]);
+        float z = A * sigmoid_u;
+        float p = __expf(z - lse);
+
+        float term1 = S_w * p;
+        float term2 = 0.0f;
+
+        float grad_z = term1 - term2;
+        float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+        auto result_tmp = f32_to_fp8_e5m2(grad_x);
+        result[j] = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+      }
+      *(__nv_fp8_e5m28*)(&grad_input[blockIdx.x * VOCAB_SIZE + idx]) = result;
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < n_predict && blockIdx.x + threadIdx.x < batch_size) {
+    int i = threadIdx.x;
+    int64_t target = targets[blockIdx.x + i];
+
+    float sigmoid_u = __bfloat162float(smem[target]);
+    float z = A * sigmoid_u;
+    float p = __expf(z - lse);
+
+    float term1 = S_w * p;
+    float term2 = 0.0f;
+
+    #pragma unroll
+    for (int k = 0; k < 3; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size && k < n_predict) {
+        if (targets[target_idx] == target) {
+          term2 += mtp_weights[k];
+        }
+      }
+    }
+
+    float grad_z = term1 - term2;
+    float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+    auto result_tmp = f32_to_fp8_e5m2(grad_x);
+    auto result = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+    grad_input[blockIdx.x * VOCAB_SIZE + target] = result;
+  }
+}
+"""
+
+
+ce_fwd_bwd_kernel = torch.cuda._compile_kernel(
+    CE_KERNEL_DECLS + CE_KERNEL_SOURCE,
+    "ce_fwd_bwd_kernel",
+    compute_capability="90",
+    cuda_include_dirs=["/usr/local/cuda/include/"],
+    nvcc_options=["-lineinfo", "--use_fast_math"],
+)
+ce_fwd_bwd_kernel.set_shared_memory_config(CE_KERNEL_VOCAB_SIZE * 2)
+
+@torch.library.custom_op("nanogpt::ce_fwd_bwd", mutates_args={"losses", "grad_input"})
+def ce_fwd_bwd(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    mtp_weights: torch.Tensor,
+    losses: torch.Tensor,
+    grad_input: torch.Tensor,
+    n_rows: int,
+    n_predict: int,
+    A: float,
+    B: float,
+    C: float,
+    grad_s: float,
+    grad_scale: float,
+) -> None:
+    grid = (n_rows, 1, 1)
+    ce_fwd_bwd_kernel(
+        grid,
+        (CE_KERNEL_BLOCK_SIZE, 1, 1),
+        (logits, targets, mtp_weights, losses, grad_input,
+         n_rows, n_predict, A, B, C, grad_s, grad_scale),
+        shared_mem=CE_KERNEL_VOCAB_SIZE * 2,
+    )
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, grad_scale, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+
+        ce_fwd_bwd(logits, targets, mtp_weights, losses, grad_input,
+             n_rows, n_predict, A, B, C, grad_s, grad_scale)
+        #grid = (n_rows,)
+        #fused_softcapped_entropy_fwd_kernel[grid](
+        #    logits, losses, lse, targets, mtp_weights,
+        #    logits.stride(0), logits.stride(1),
+        #    n_rows, n_cols, n_predict,
+        #    A, B, C,
+        #    BLOCK_SIZE=2048,
+        #    num_warps=2
+        #)
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_output = grad_output.contiguous()
+
+        #grad_input_ref = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        #grid = (n_rows,)
+        #fused_softcapped_entropy_bwd_kernel[grid](
+        #    grad_input_ref, grad_output, lse, logits, targets, mtp_weights,
+        #    logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+        #    n_rows, n_cols, n_predict,
+        #    A, B, C,
+        #    grad_s,
+        #    BLOCK_SIZE=1024,
+        #    num_warps=4,
+        #    N_PREDICT=n_predict,
+        #)
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.12.3 (main, Mar  3 2026, 12:15:18) [GCC 13.3.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sat Apr  4 05:38:54 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:8D:00.0 Off |                    0 |
+| N/A   46C    P0            127W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:91:00.0 Off |                    0 |
+| N/A   36C    P0            120W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:95:00.0 Off |                    0 |
+| N/A   45C    P0            127W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:99:00.0 Off |                    0 |
+| N/A   37C    P0            127W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   45C    P0            122W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AF:00.0 Off |                    0 |
+| N/A   37C    P0            121W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:B3:00.0 Off |                    0 |
+| N/A   46C    P0            126W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:B7:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A           33613      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    1   N/A  N/A           33614      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    2   N/A  N/A           33615      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    3   N/A  N/A           33616      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    4   N/A  N/A           33617      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    5   N/A  N/A           33618      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    6   N/A  N/A           33619      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    7   N/A  N/A           33620      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8318 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:82ms step_avg:81.76ms
+step:2/1490 train_time:104ms step_avg:52.11ms
+step:3/1490 train_time:123ms step_avg:40.89ms
+step:4/1490 train_time:150ms step_avg:37.45ms
+step:5/1490 train_time:176ms step_avg:35.21ms
+step:6/1490 train_time:211ms step_avg:35.13ms
+step:7/1490 train_time:237ms step_avg:33.92ms
+step:8/1490 train_time:272ms step_avg:34.00ms
+step:9/1490 train_time:299ms step_avg:33.23ms
+step:10/1490 train_time:334ms step_avg:33.40ms
+step:11/1490 train_time:360ms step_avg:32.77ms
+step:12/1490 train_time:395ms step_avg:32.90ms
+step:13/1490 train_time:422ms step_avg:32.45ms
+step:14/1490 train_time:456ms step_avg:32.57ms
+step:15/1490 train_time:483ms step_avg:32.20ms
+step:16/1490 train_time:517ms step_avg:32.32ms
+step:17/1490 train_time:544ms step_avg:32.03ms
+step:18/1490 train_time:579ms step_avg:32.14ms
+step:19/1490 train_time:606ms step_avg:31.88ms
+step:20/1490 train_time:640ms step_avg:32.01ms
+step:21/1490 train_time:667ms step_avg:31.78ms
+step:22/1490 train_time:701ms step_avg:31.88ms
+step:23/1490 train_time:729ms step_avg:31.68ms
+step:24/1490 train_time:763ms step_avg:31.79ms
+step:25/1490 train_time:790ms step_avg:31.61ms
+step:26/1490 train_time:825ms step_avg:31.72ms
+step:27/1490 train_time:852ms step_avg:31.54ms
+step:28/1490 train_time:886ms step_avg:31.64ms
+step:29/1490 train_time:913ms step_avg:31.48ms
+step:30/1490 train_time:948ms step_avg:31.59ms
+step:31/1490 train_time:975ms step_avg:31.46ms
+step:32/1490 train_time:1012ms step_avg:31.62ms
+step:33/1490 train_time:1042ms step_avg:31.57ms
+step:34/1490 train_time:1078ms step_avg:31.69ms
+step:35/1490 train_time:1106ms step_avg:31.60ms
+step:36/1490 train_time:1140ms step_avg:31.67ms
+step:37/1490 train_time:1168ms step_avg:31.57ms
+step:38/1490 train_time:1202ms step_avg:31.64ms
+step:39/1490 train_time:1230ms step_avg:31.54ms
+step:40/1490 train_time:1265ms step_avg:31.62ms
+step:41/1490 train_time:1292ms step_avg:31.52ms
+step:42/1490 train_time:1327ms step_avg:31.60ms
+step:43/1490 train_time:1354ms step_avg:31.49ms
+step:44/1490 train_time:1389ms step_avg:31.56ms
+step:45/1490 train_time:1416ms step_avg:31.46ms
+step:46/1490 train_time:1450ms step_avg:31.52ms
+step:47/1490 train_time:1477ms step_avg:31.43ms
+step:48/1490 train_time:1512ms step_avg:31.50ms
+step:49/1490 train_time:1539ms step_avg:31.41ms
+step:50/1490 train_time:1574ms step_avg:31.48ms
+step:51/1490 train_time:1601ms step_avg:31.40ms
+step:52/1490 train_time:1636ms step_avg:31.46ms
+step:53/1490 train_time:1663ms step_avg:31.37ms
+step:54/1490 train_time:1697ms step_avg:31.43ms
+step:55/1490 train_time:1724ms step_avg:31.35ms
+step:56/1490 train_time:1759ms step_avg:31.41ms
+step:57/1490 train_time:1786ms step_avg:31.33ms
+step:58/1490 train_time:1820ms step_avg:31.38ms
+step:59/1490 train_time:1847ms step_avg:31.31ms
+step:60/1490 train_time:1882ms step_avg:31.36ms
+step:61/1490 train_time:1909ms step_avg:31.29ms
+step:62/1490 train_time:1944ms step_avg:31.35ms
+step:63/1490 train_time:1972ms step_avg:31.30ms
+step:64/1490 train_time:2007ms step_avg:31.35ms
+step:65/1490 train_time:2035ms step_avg:31.30ms
+step:66/1490 train_time:2070ms step_avg:31.36ms
+step:67/1490 train_time:2097ms step_avg:31.30ms
+step:68/1490 train_time:2132ms step_avg:31.36ms
+step:69/1490 train_time:2160ms step_avg:31.31ms
+step:70/1490 train_time:2195ms step_avg:31.36ms
+step:71/1490 train_time:2223ms step_avg:31.31ms
+step:72/1490 train_time:2257ms step_avg:31.35ms
+step:73/1490 train_time:2284ms step_avg:31.29ms
+step:74/1490 train_time:2319ms step_avg:31.33ms
+step:75/1490 train_time:2346ms step_avg:31.28ms
+step:76/1490 train_time:2380ms step_avg:31.32ms
+step:77/1490 train_time:2408ms step_avg:31.27ms
+step:78/1490 train_time:2443ms step_avg:31.32ms
+step:79/1490 train_time:2470ms step_avg:31.26ms
+step:80/1490 train_time:2504ms step_avg:31.30ms
+step:81/1490 train_time:2532ms step_avg:31.25ms
+step:82/1490 train_time:2566ms step_avg:31.30ms
+step:83/1490 train_time:2593ms step_avg:31.24ms
+step:84/1490 train_time:2628ms step_avg:31.29ms
+step:85/1490 train_time:2655ms step_avg:31.23ms
+step:86/1490 train_time:2690ms step_avg:31.28ms
+step:87/1490 train_time:2717ms step_avg:31.23ms
+step:88/1490 train_time:2752ms step_avg:31.27ms
+step:89/1490 train_time:2779ms step_avg:31.22ms
+step:90/1490 train_time:2813ms step_avg:31.26ms
+step:91/1490 train_time:2841ms step_avg:31.22ms
+step:92/1490 train_time:2875ms step_avg:31.25ms
+step:93/1490 train_time:2902ms step_avg:31.21ms
+step:94/1490 train_time:2936ms step_avg:31.24ms
+step:95/1490 train_time:2964ms step_avg:31.20ms
+step:96/1490 train_time:2998ms step_avg:31.23ms
+step:97/1490 train_time:3025ms step_avg:31.19ms
+step:98/1490 train_time:3060ms step_avg:31.22ms
+step:99/1490 train_time:3087ms step_avg:31.19ms
+step:100/1490 train_time:3122ms step_avg:31.22ms
+step:101/1490 train_time:3150ms step_avg:31.19ms
+step:102/1490 train_time:3185ms step_avg:31.22ms
+step:103/1490 train_time:3212ms step_avg:31.19ms
+step:104/1490 train_time:3247ms step_avg:31.22ms
+step:105/1490 train_time:3274ms step_avg:31.18ms
+step:106/1490 train_time:3309ms step_avg:31.22ms
+step:107/1490 train_time:3336ms step_avg:31.18ms
+step:108/1490 train_time:3371ms step_avg:31.21ms
+step:109/1490 train_time:3399ms step_avg:31.18ms
+step:110/1490 train_time:3433ms step_avg:31.21ms
+step:111/1490 train_time:3461ms step_avg:31.18ms
+step:112/1490 train_time:3495ms step_avg:31.21ms
+step:113/1490 train_time:3522ms step_avg:31.17ms
+step:114/1490 train_time:3556ms step_avg:31.20ms
+step:115/1490 train_time:3583ms step_avg:31.16ms
+step:116/1490 train_time:3617ms step_avg:31.18ms
+step:117/1490 train_time:3644ms step_avg:31.15ms
+step:118/1490 train_time:3679ms step_avg:31.18ms
+step:119/1490 train_time:3706ms step_avg:31.14ms
+step:120/1490 train_time:3740ms step_avg:31.17ms
+step:121/1490 train_time:3768ms step_avg:31.14ms
+step:122/1490 train_time:3802ms step_avg:31.16ms
+step:123/1490 train_time:3829ms step_avg:31.13ms
+step:124/1490 train_time:3864ms step_avg:31.16ms
+step:125/1490 train_time:3891ms step_avg:31.13ms
+step:126/1490 train_time:3926ms step_avg:31.16ms
+step:127/1490 train_time:3953ms step_avg:31.13ms
+step:128/1490 train_time:3988ms step_avg:31.15ms
+step:129/1490 train_time:4015ms step_avg:31.12ms
+step:130/1490 train_time:4049ms step_avg:31.15ms
+step:131/1490 train_time:4076ms step_avg:31.12ms
+step:132/1490 train_time:4111ms step_avg:31.15ms
+step:133/1490 train_time:4139ms step_avg:31.12ms
+step:134/1490 train_time:4174ms step_avg:31.15ms
+step:135/1490 train_time:4201ms step_avg:31.12ms
+step:136/1490 train_time:4236ms step_avg:31.14ms
+step:137/1490 train_time:4263ms step_avg:31.11ms
+step:138/1490 train_time:4298ms step_avg:31.14ms
+step:139/1490 train_time:4325ms step_avg:31.12ms
+step:140/1490 train_time:4359ms step_avg:31.14ms
+step:141/1490 train_time:4386ms step_avg:31.11ms
+step:142/1490 train_time:4421ms step_avg:31.13ms
+step:143/1490 train_time:4448ms step_avg:31.11ms
+step:144/1490 train_time:4483ms step_avg:31.13ms
+step:145/1490 train_time:4510ms step_avg:31.11ms
+step:146/1490 train_time:4546ms step_avg:31.13ms
+step:147/1490 train_time:4573ms step_avg:31.11ms
+step:148/1490 train_time:4607ms step_avg:31.13ms
+step:149/1490 train_time:4634ms step_avg:31.10ms
+step:150/1490 train_time:4669ms step_avg:31.12ms
+step:151/1490 train_time:4696ms step_avg:31.10ms
+step:152/1490 train_time:4731ms step_avg:31.12ms
+step:153/1490 train_time:4758ms step_avg:31.10ms
+step:154/1490 train_time:4793ms step_avg:31.12ms
+step:155/1490 train_time:4820ms step_avg:31.10ms
+step:156/1490 train_time:4855ms step_avg:31.12ms
+step:157/1490 train_time:4882ms step_avg:31.10ms
+step:158/1490 train_time:4916ms step_avg:31.12ms
+step:159/1490 train_time:4943ms step_avg:31.09ms
+step:160/1490 train_time:4978ms step_avg:31.11ms
+step:161/1490 train_time:5005ms step_avg:31.09ms
+step:162/1490 train_time:5040ms step_avg:31.11ms
+step:163/1490 train_time:5067ms step_avg:31.09ms
+step:164/1490 train_time:5102ms step_avg:31.11ms
+step:165/1490 train_time:5129ms step_avg:31.09ms
+step:166/1490 train_time:5164ms step_avg:31.11ms
+step:167/1490 train_time:5191ms step_avg:31.09ms
+step:168/1490 train_time:5227ms step_avg:31.11ms
+step:169/1490 train_time:5254ms step_avg:31.09ms
+step:170/1490 train_time:5289ms step_avg:31.11ms
+step:171/1490 train_time:5315ms step_avg:31.08ms
+step:172/1490 train_time:5350ms step_avg:31.11ms
+step:173/1490 train_time:5377ms step_avg:31.08ms
+step:174/1490 train_time:5412ms step_avg:31.10ms
+step:175/1490 train_time:5440ms step_avg:31.08ms
+step:176/1490 train_time:5474ms step_avg:31.10ms
+step:177/1490 train_time:5501ms step_avg:31.08ms
+step:178/1490 train_time:5536ms step_avg:31.10ms
+step:179/1490 train_time:5563ms step_avg:31.08ms
+step:180/1490 train_time:5597ms step_avg:31.09ms
+step:181/1490 train_time:5624ms step_avg:31.07ms
+step:182/1490 train_time:5658ms step_avg:31.09ms
+step:183/1490 train_time:5686ms step_avg:31.07ms
+step:184/1490 train_time:5720ms step_avg:31.09ms
+step:185/1490 train_time:5748ms step_avg:31.07ms
+step:186/1490 train_time:5782ms step_avg:31.09ms
+step:187/1490 train_time:5810ms step_avg:31.07ms
+step:188/1490 train_time:5845ms step_avg:31.09ms
+step:189/1490 train_time:5872ms step_avg:31.07ms
+step:190/1490 train_time:5907ms step_avg:31.09ms
+step:191/1490 train_time:5934ms step_avg:31.07ms
+step:192/1490 train_time:5968ms step_avg:31.09ms
+step:193/1490 train_time:5995ms step_avg:31.06ms
+step:194/1490 train_time:6030ms step_avg:31.08ms
+step:195/1490 train_time:6057ms step_avg:31.06ms
+step:196/1490 train_time:6092ms step_avg:31.08ms
+step:197/1490 train_time:6119ms step_avg:31.06ms
+step:198/1490 train_time:6154ms step_avg:31.08ms
+step:199/1490 train_time:6181ms step_avg:31.06ms
+step:200/1490 train_time:6215ms step_avg:31.08ms
+step:201/1490 train_time:6242ms step_avg:31.05ms
+step:202/1490 train_time:6277ms step_avg:31.07ms
+step:203/1490 train_time:6304ms step_avg:31.05ms
+step:204/1490 train_time:6339ms step_avg:31.07ms
+step:205/1490 train_time:6366ms step_avg:31.05ms
+step:206/1490 train_time:6400ms step_avg:31.07ms
+step:207/1490 train_time:6427ms step_avg:31.05ms
+step:208/1490 train_time:6461ms step_avg:31.06ms
+step:209/1490 train_time:6489ms step_avg:31.05ms
+step:210/1490 train_time:6523ms step_avg:31.06ms
+step:211/1490 train_time:6551ms step_avg:31.05ms
+step:212/1490 train_time:6586ms step_avg:31.07ms
+step:213/1490 train_time:6613ms step_avg:31.05ms
+step:214/1490 train_time:6647ms step_avg:31.06ms
+step:215/1490 train_time:6675ms step_avg:31.04ms
+step:216/1490 train_time:6709ms step_avg:31.06ms
+step:217/1490 train_time:6737ms step_avg:31.04ms
+step:218/1490 train_time:6771ms step_avg:31.06ms
+step:219/1490 train_time:6799ms step_avg:31.04ms
+step:220/1490 train_time:6833ms step_avg:31.06ms
+step:221/1490 train_time:6861ms step_avg:31.04ms
+step:222/1490 train_time:6895ms step_avg:31.06ms
+step:223/1490 train_time:6921ms step_avg:31.04ms
+step:224/1490 train_time:6956ms step_avg:31.05ms
+step:225/1490 train_time:6983ms step_avg:31.03ms
+step:226/1490 train_time:7017ms step_avg:31.05ms
+step:227/1490 train_time:7044ms step_avg:31.03ms
+step:228/1490 train_time:7079ms step_avg:31.05ms
+step:229/1490 train_time:7106ms step_avg:31.03ms
+step:230/1490 train_time:7141ms step_avg:31.05ms
+step:231/1490 train_time:7168ms step_avg:31.03ms
+step:232/1490 train_time:7203ms step_avg:31.05ms
+step:233/1490 train_time:7230ms step_avg:31.03ms
+step:234/1490 train_time:7265ms step_avg:31.05ms
+step:235/1490 train_time:7292ms step_avg:31.03ms
+step:236/1490 train_time:7327ms step_avg:31.05ms
+step:237/1490 train_time:7354ms step_avg:31.03ms
+step:238/1490 train_time:7388ms step_avg:31.04ms
+step:239/1490 train_time:7415ms step_avg:31.03ms
+step:240/1490 train_time:7450ms step_avg:31.04ms
+step:241/1490 train_time:7478ms step_avg:31.03ms
+step:242/1490 train_time:7512ms step_avg:31.04ms
+step:243/1490 train_time:7540ms step_avg:31.03ms
+step:244/1490 train_time:7574ms step_avg:31.04ms
+step:245/1490 train_time:7601ms step_avg:31.03ms
+step:246/1490 train_time:7635ms step_avg:31.04ms
+step:247/1490 train_time:7663ms step_avg:31.02ms
+step:248/1490 train_time:7697ms step_avg:31.04ms
+step:249/1490 train_time:7724ms step_avg:31.02ms
+step:250/1490 train_time:7759ms step_avg:31.04ms
+step:250/1490 val_loss:4.4977 train_time:7798ms step_avg:31.19ms
+step:251/1490 train_time:7816ms step_avg:31.14ms
+step:252/1490 train_time:7836ms step_avg:31.10ms
+step:253/1490 train_time:7851ms step_avg:31.03ms
+step:254/1490 train_time:7886ms step_avg:31.05ms
+step:255/1490 train_time:7915ms step_avg:31.04ms
+step:256/1490 train_time:7951ms step_avg:31.06ms
+step:257/1490 train_time:7978ms step_avg:31.04ms
+step:258/1490 train_time:8013ms step_avg:31.06ms
+step:259/1490 train_time:8040ms step_avg:31.04ms
+step:260/1490 train_time:8075ms step_avg:31.06ms
+step:261/1490 train_time:8102ms step_avg:31.04ms
+step:262/1490 train_time:8137ms step_avg:31.06ms
+step:263/1490 train_time:8163ms step_avg:31.04ms
+step:264/1490 train_time:8198ms step_avg:31.05ms
+step:265/1490 train_time:8225ms step_avg:31.04ms
+step:266/1490 train_time:8259ms step_avg:31.05ms
+step:267/1490 train_time:8285ms step_avg:31.03ms
+step:268/1490 train_time:8320ms step_avg:31.04ms
+step:269/1490 train_time:8346ms step_avg:31.03ms
+step:270/1490 train_time:8381ms step_avg:31.04ms
+step:271/1490 train_time:8408ms step_avg:31.03ms
+step:272/1490 train_time:8442ms step_avg:31.04ms
+step:273/1490 train_time:8469ms step_avg:31.02ms
+step:274/1490 train_time:8504ms step_avg:31.03ms
+step:275/1490 train_time:8530ms step_avg:31.02ms
+step:276/1490 train_time:8565ms step_avg:31.03ms
+step:277/1490 train_time:8592ms step_avg:31.02ms
+step:278/1490 train_time:8626ms step_avg:31.03ms
+step:279/1490 train_time:8653ms step_avg:31.01ms
+step:280/1490 train_time:8687ms step_avg:31.02ms
+step:281/1490 train_time:8714ms step_avg:31.01ms
+step:282/1490 train_time:8748ms step_avg:31.02ms
+step:283/1490 train_time:8776ms step_avg:31.01ms
+step:284/1490 train_time:8811ms step_avg:31.02ms
+step:285/1490 train_time:8838ms step_avg:31.01ms
+step:286/1490 train_time:8873ms step_avg:31.02ms
+step:287/1490 train_time:8901ms step_avg:31.01ms
+step:288/1490 train_time:8935ms step_avg:31.02ms
+step:289/1490 train_time:8963ms step_avg:31.01ms
+step:290/1490 train_time:8997ms step_avg:31.03ms
+step:291/1490 train_time:9024ms step_avg:31.01ms
+step:292/1490 train_time:9059ms step_avg:31.02ms
+step:293/1490 train_time:9086ms step_avg:31.01ms
+step:294/1490 train_time:9121ms step_avg:31.02ms
+step:295/1490 train_time:9148ms step_avg:31.01ms
+step:296/1490 train_time:9182ms step_avg:31.02ms
+step:297/1490 train_time:9209ms step_avg:31.01ms
+step:298/1490 train_time:9244ms step_avg:31.02ms
+step:299/1490 train_time:9271ms step_avg:31.01ms
+step:300/1490 train_time:9306ms step_avg:31.02ms
+step:301/1490 train_time:9333ms step_avg:31.01ms
+step:302/1490 train_time:9367ms step_avg:31.02ms
+step:303/1490 train_time:9394ms step_avg:31.00ms
+step:304/1490 train_time:9429ms step_avg:31.02ms
+step:305/1490 train_time:9455ms step_avg:31.00ms
+step:306/1490 train_time:9490ms step_avg:31.01ms
+step:307/1490 train_time:9516ms step_avg:31.00ms
+step:308/1490 train_time:9551ms step_avg:31.01ms
+step:309/1490 train_time:9577ms step_avg:30.99ms
+step:310/1490 train_time:9611ms step_avg:31.00ms
+step:311/1490 train_time:9638ms step_avg:30.99ms
+step:312/1490 train_time:9672ms step_avg:31.00ms
+step:313/1490 train_time:9700ms step_avg:30.99ms
+step:314/1490 train_time:9734ms step_avg:31.00ms
+step:315/1490 train_time:9761ms step_avg:30.99ms
+step:316/1490 train_time:9796ms step_avg:31.00ms
+step:317/1490 train_time:9823ms step_avg:30.99ms
+step:318/1490 train_time:9858ms step_avg:31.00ms
+step:319/1490 train_time:9885ms step_avg:30.99ms
+step:320/1490 train_time:9920ms step_avg:31.00ms
+step:321/1490 train_time:9947ms step_avg:30.99ms
+step:322/1490 train_time:9981ms step_avg:31.00ms
+step:323/1490 train_time:10008ms step_avg:30.99ms
+step:324/1490 train_time:10043ms step_avg:31.00ms
+step:325/1490 train_time:10070ms step_avg:30.99ms
+step:326/1490 train_time:10105ms step_avg:31.00ms
+step:327/1490 train_time:10132ms step_avg:30.99ms
+step:328/1490 train_time:10167ms step_avg:31.00ms
+step:329/1490 train_time:10194ms step_avg:30.99ms
+step:330/1490 train_time:10228ms step_avg:31.00ms
+step:331/1490 train_time:10256ms step_avg:30.98ms
+step:332/1490 train_time:10290ms step_avg:30.99ms
+step:333/1490 train_time:10317ms step_avg:30.98ms
+step:334/1490 train_time:10351ms step_avg:30.99ms
+step:335/1490 train_time:10378ms step_avg:30.98ms
+step:336/1490 train_time:10412ms step_avg:30.99ms
+step:337/1490 train_time:10439ms step_avg:30.98ms
+step:338/1490 train_time:10473ms step_avg:30.99ms
+step:339/1490 train_time:10501ms step_avg:30.98ms
+step:340/1490 train_time:10535ms step_avg:30.99ms
+step:341/1490 train_time:10562ms step_avg:30.97ms
+step:342/1490 train_time:10596ms step_avg:30.98ms
+step:343/1490 train_time:10624ms step_avg:30.97ms
+step:344/1490 train_time:10658ms step_avg:30.98ms
+step:345/1490 train_time:10685ms step_avg:30.97ms
+step:346/1490 train_time:10720ms step_avg:30.98ms
+step:347/1490 train_time:10747ms step_avg:30.97ms
+step:348/1490 train_time:10781ms step_avg:30.98ms
+step:349/1490 train_time:10809ms step_avg:30.97ms
+step:350/1490 train_time:10844ms step_avg:30.98ms
+step:351/1490 train_time:10871ms step_avg:30.97ms
+step:352/1490 train_time:10906ms step_avg:30.98ms
+step:353/1490 train_time:10933ms step_avg:30.97ms
+step:354/1490 train_time:10967ms step_avg:30.98ms
+step:355/1490 train_time:10994ms step_avg:30.97ms
+step:356/1490 train_time:11029ms step_avg:30.98ms
+step:357/1490 train_time:11056ms step_avg:30.97ms
+step:358/1490 train_time:11090ms step_avg:30.98ms
+step:359/1490 train_time:11117ms step_avg:30.97ms
+step:360/1490 train_time:11152ms step_avg:30.98ms
+step:361/1490 train_time:11179ms step_avg:30.97ms
+step:362/1490 train_time:11213ms step_avg:30.98ms
+step:363/1490 train_time:11241ms step_avg:30.97ms
+step:364/1490 train_time:11275ms step_avg:30.98ms
+step:365/1490 train_time:11303ms step_avg:30.97ms
+step:366/1490 train_time:11337ms step_avg:30.98ms
+step:367/1490 train_time:11364ms step_avg:30.97ms
+step:368/1490 train_time:11398ms step_avg:30.97ms
+step:369/1490 train_time:11426ms step_avg:30.96ms
+step:370/1490 train_time:11460ms step_avg:30.97ms
+step:371/1490 train_time:11487ms step_avg:30.96ms
+step:372/1490 train_time:11521ms step_avg:30.97ms
+step:373/1490 train_time:11548ms step_avg:30.96ms
+step:374/1490 train_time:11582ms step_avg:30.97ms
+step:375/1490 train_time:11610ms step_avg:30.96ms
+step:376/1490 train_time:11644ms step_avg:30.97ms
+step:377/1490 train_time:11671ms step_avg:30.96ms
+step:378/1490 train_time:11705ms step_avg:30.97ms
+step:379/1490 train_time:11733ms step_avg:30.96ms
+step:380/1490 train_time:11767ms step_avg:30.97ms
+step:381/1490 train_time:11794ms step_avg:30.96ms
+step:382/1490 train_time:11828ms step_avg:30.96ms
+step:383/1490 train_time:11856ms step_avg:30.95ms
+step:384/1490 train_time:11890ms step_avg:30.96ms
+step:385/1490 train_time:11917ms step_avg:30.95ms
+step:386/1490 train_time:11951ms step_avg:30.96ms
+step:387/1490 train_time:11978ms step_avg:30.95ms
+step:388/1490 train_time:12013ms step_avg:30.96ms
+step:389/1490 train_time:12040ms step_avg:30.95ms
+step:390/1490 train_time:12074ms step_avg:30.96ms
+step:391/1490 train_time:12101ms step_avg:30.95ms
+step:392/1490 train_time:12136ms step_avg:30.96ms
+step:393/1490 train_time:12163ms step_avg:30.95ms
+step:394/1490 train_time:12197ms step_avg:30.96ms
+step:395/1490 train_time:12224ms step_avg:30.95ms
+step:396/1490 train_time:12259ms step_avg:30.96ms
+step:397/1490 train_time:12286ms step_avg:30.95ms
+step:398/1490 train_time:12321ms step_avg:30.96ms
+step:399/1490 train_time:12348ms step_avg:30.95ms
+step:400/1490 train_time:12382ms step_avg:30.96ms
+step:401/1490 train_time:12409ms step_avg:30.95ms
+step:402/1490 train_time:12444ms step_avg:30.95ms
+step:403/1490 train_time:12471ms step_avg:30.95ms
+step:404/1490 train_time:12506ms step_avg:30.96ms
+step:405/1490 train_time:12533ms step_avg:30.95ms
+step:406/1490 train_time:12567ms step_avg:30.95ms
+step:407/1490 train_time:12595ms step_avg:30.94ms
+step:408/1490 train_time:12629ms step_avg:30.95ms
+step:409/1490 train_time:12656ms step_avg:30.94ms
+step:410/1490 train_time:12690ms step_avg:30.95ms
+step:411/1490 train_time:12717ms step_avg:30.94ms
+step:412/1490 train_time:12752ms step_avg:30.95ms
+step:413/1490 train_time:12778ms step_avg:30.94ms
+step:414/1490 train_time:12813ms step_avg:30.95ms
+step:415/1490 train_time:12839ms step_avg:30.94ms
+step:416/1490 train_time:12873ms step_avg:30.95ms
+step:417/1490 train_time:12901ms step_avg:30.94ms
+step:418/1490 train_time:12935ms step_avg:30.95ms
+step:419/1490 train_time:12962ms step_avg:30.94ms
+step:420/1490 train_time:12997ms step_avg:30.94ms
+step:421/1490 train_time:13024ms step_avg:30.94ms
+step:422/1490 train_time:13058ms step_avg:30.94ms
+step:423/1490 train_time:13085ms step_avg:30.93ms
+step:424/1490 train_time:13120ms step_avg:30.94ms
+step:425/1490 train_time:13147ms step_avg:30.93ms
+step:426/1490 train_time:13181ms step_avg:30.94ms
+step:427/1490 train_time:13208ms step_avg:30.93ms
+step:428/1490 train_time:13243ms step_avg:30.94ms
+step:429/1490 train_time:13270ms step_avg:30.93ms
+step:430/1490 train_time:13305ms step_avg:30.94ms
+step:431/1490 train_time:13332ms step_avg:30.93ms
+step:432/1490 train_time:13366ms step_avg:30.94ms
+step:433/1490 train_time:13393ms step_avg:30.93ms
+step:434/1490 train_time:13428ms step_avg:30.94ms
+step:435/1490 train_time:13455ms step_avg:30.93ms
+step:436/1490 train_time:13489ms step_avg:30.94ms
+step:437/1490 train_time:13516ms step_avg:30.93ms
+step:438/1490 train_time:13551ms step_avg:30.94ms
+step:439/1490 train_time:13578ms step_avg:30.93ms
+step:440/1490 train_time:13612ms step_avg:30.94ms
+step:441/1490 train_time:13639ms step_avg:30.93ms
+step:442/1490 train_time:13673ms step_avg:30.93ms
+step:443/1490 train_time:13700ms step_avg:30.93ms
+step:444/1490 train_time:13735ms step_avg:30.93ms
+step:445/1490 train_time:13762ms step_avg:30.93ms
+step:446/1490 train_time:13796ms step_avg:30.93ms
+step:447/1490 train_time:13823ms step_avg:30.92ms
+step:448/1490 train_time:13858ms step_avg:30.93ms
+step:449/1490 train_time:13885ms step_avg:30.92ms
+step:450/1490 train_time:13919ms step_avg:30.93ms
+step:451/1490 train_time:13946ms step_avg:30.92ms
+step:452/1490 train_time:13980ms step_avg:30.93ms
+step:453/1490 train_time:14008ms step_avg:30.92ms
+step:454/1490 train_time:14042ms step_avg:30.93ms
+step:455/1490 train_time:14070ms step_avg:30.92ms
+step:456/1490 train_time:14104ms step_avg:30.93ms
+step:457/1490 train_time:14131ms step_avg:30.92ms
+step:458/1490 train_time:14166ms step_avg:30.93ms
+step:459/1490 train_time:14193ms step_avg:30.92ms
+step:460/1490 train_time:14228ms step_avg:30.93ms
+step:461/1490 train_time:14255ms step_avg:30.92ms
+step:462/1490 train_time:14289ms step_avg:30.93ms
+step:463/1490 train_time:14316ms step_avg:30.92ms
+step:464/1490 train_time:14350ms step_avg:30.93ms
+step:465/1490 train_time:14377ms step_avg:30.92ms
+step:466/1490 train_time:14411ms step_avg:30.93ms
+step:467/1490 train_time:14439ms step_avg:30.92ms
+step:468/1490 train_time:14473ms step_avg:30.92ms
+step:469/1490 train_time:14500ms step_avg:30.92ms
+step:470/1490 train_time:14535ms step_avg:30.92ms
+step:471/1490 train_time:14562ms step_avg:30.92ms
+step:472/1490 train_time:14596ms step_avg:30.92ms
+step:473/1490 train_time:14623ms step_avg:30.92ms
+step:474/1490 train_time:14658ms step_avg:30.92ms
+step:475/1490 train_time:14685ms step_avg:30.92ms
+step:476/1490 train_time:14719ms step_avg:30.92ms
+step:477/1490 train_time:14746ms step_avg:30.91ms
+step:478/1490 train_time:14780ms step_avg:30.92ms
+step:479/1490 train_time:14807ms step_avg:30.91ms
+step:480/1490 train_time:14841ms step_avg:30.92ms
+step:481/1490 train_time:14868ms step_avg:30.91ms
+step:482/1490 train_time:14903ms step_avg:30.92ms
+step:483/1490 train_time:14930ms step_avg:30.91ms
+step:484/1490 train_time:14967ms step_avg:30.92ms
+step:485/1490 train_time:15019ms step_avg:30.97ms
+step:486/1490 train_time:15078ms step_avg:31.02ms
+step:487/1490 train_time:15132ms step_avg:31.07ms
+step:488/1490 train_time:15191ms step_avg:31.13ms
+step:489/1490 train_time:15244ms step_avg:31.17ms
+step:490/1490 train_time:15304ms step_avg:31.23ms
+step:491/1490 train_time:15359ms step_avg:31.28ms
+step:492/1490 train_time:15417ms step_avg:31.34ms
+step:493/1490 train_time:15470ms step_avg:31.38ms
+step:494/1490 train_time:15529ms step_avg:31.44ms
+step:495/1490 train_time:15583ms step_avg:31.48ms
+step:496/1490 train_time:15643ms step_avg:31.54ms
+step:497/1490 train_time:15696ms step_avg:31.58ms
+step:498/1490 train_time:15755ms step_avg:31.64ms
+step:499/1490 train_time:15808ms step_avg:31.68ms
+step:500/1490 train_time:15867ms step_avg:31.73ms
+step:500/1490 val_loss:4.2330 train_time:15934ms step_avg:31.87ms
+step:501/1490 train_time:15951ms step_avg:31.84ms
+step:502/1490 train_time:15981ms step_avg:31.83ms
+step:503/1490 train_time:16040ms step_avg:31.89ms
+step:504/1490 train_time:16102ms step_avg:31.95ms
+step:505/1490 train_time:16156ms step_avg:31.99ms
+step:506/1490 train_time:16216ms step_avg:32.05ms
+step:507/1490 train_time:16271ms step_avg:32.09ms
+step:508/1490 train_time:16329ms step_avg:32.14ms
+step:509/1490 train_time:16382ms step_avg:32.18ms
+step:510/1490 train_time:16440ms step_avg:32.24ms
+step:511/1490 train_time:16493ms step_avg:32.28ms
+step:512/1490 train_time:16550ms step_avg:32.33ms
+step:513/1490 train_time:16603ms step_avg:32.36ms
+step:514/1490 train_time:16661ms step_avg:32.41ms
+step:515/1490 train_time:16713ms step_avg:32.45ms
+step:516/1490 train_time:16771ms step_avg:32.50ms
+step:517/1490 train_time:16824ms step_avg:32.54ms
+step:518/1490 train_time:16883ms step_avg:32.59ms
+step:519/1490 train_time:16937ms step_avg:32.63ms
+step:520/1490 train_time:16997ms step_avg:32.69ms
+step:521/1490 train_time:17051ms step_avg:32.73ms
+step:522/1490 train_time:17111ms step_avg:32.78ms
+step:523/1490 train_time:17166ms step_avg:32.82ms
+step:524/1490 train_time:17225ms step_avg:32.87ms
+step:525/1490 train_time:17279ms step_avg:32.91ms
+step:526/1490 train_time:17339ms step_avg:32.96ms
+step:527/1490 train_time:17393ms step_avg:33.00ms
+step:528/1490 train_time:17451ms step_avg:33.05ms
+step:529/1490 train_time:17504ms step_avg:33.09ms
+step:530/1490 train_time:17563ms step_avg:33.14ms
+step:531/1490 train_time:17615ms step_avg:33.17ms
+step:532/1490 train_time:17673ms step_avg:33.22ms
+step:533/1490 train_time:17726ms step_avg:33.26ms
+step:534/1490 train_time:17784ms step_avg:33.30ms
+step:535/1490 train_time:17836ms step_avg:33.34ms
+step:536/1490 train_time:17895ms step_avg:33.39ms
+step:537/1490 train_time:17949ms step_avg:33.42ms
+step:538/1490 train_time:18009ms step_avg:33.47ms
+step:539/1490 train_time:18065ms step_avg:33.52ms
+step:540/1490 train_time:18124ms step_avg:33.56ms
+step:541/1490 train_time:18179ms step_avg:33.60ms
+step:542/1490 train_time:18238ms step_avg:33.65ms
+step:543/1490 train_time:18292ms step_avg:33.69ms
+step:544/1490 train_time:18350ms step_avg:33.73ms
+step:545/1490 train_time:18404ms step_avg:33.77ms
+step:546/1490 train_time:18463ms step_avg:33.82ms
+step:547/1490 train_time:18516ms step_avg:33.85ms
+step:548/1490 train_time:18574ms step_avg:33.89ms
+step:549/1490 train_time:18626ms step_avg:33.93ms
+step:550/1490 train_time:18685ms step_avg:33.97ms
+step:551/1490 train_time:18737ms step_avg:34.01ms
+step:552/1490 train_time:18796ms step_avg:34.05ms
+step:553/1490 train_time:18849ms step_avg:34.09ms
+step:554/1490 train_time:18909ms step_avg:34.13ms
+step:555/1490 train_time:18963ms step_avg:34.17ms
+step:556/1490 train_time:19022ms step_avg:34.21ms
+step:557/1490 train_time:19077ms step_avg:34.25ms
+step:558/1490 train_time:19136ms step_avg:34.29ms
+step:559/1490 train_time:19189ms step_avg:34.33ms
+step:560/1490 train_time:19249ms step_avg:34.37ms
+step:561/1490 train_time:19303ms step_avg:34.41ms
+step:562/1490 train_time:19362ms step_avg:34.45ms
+step:563/1490 train_time:19416ms step_avg:34.49ms
+step:564/1490 train_time:19475ms step_avg:34.53ms
+step:565/1490 train_time:19527ms step_avg:34.56ms
+step:566/1490 train_time:19586ms step_avg:34.60ms
+step:567/1490 train_time:19638ms step_avg:34.64ms
+step:568/1490 train_time:19697ms step_avg:34.68ms
+step:569/1490 train_time:19749ms step_avg:34.71ms
+step:570/1490 train_time:19809ms step_avg:34.75ms
+step:571/1490 train_time:19862ms step_avg:34.79ms
+step:572/1490 train_time:19921ms step_avg:34.83ms
+step:573/1490 train_time:19975ms step_avg:34.86ms
+step:574/1490 train_time:20034ms step_avg:34.90ms
+step:575/1490 train_time:20088ms step_avg:34.94ms
+step:576/1490 train_time:20147ms step_avg:34.98ms
+step:577/1490 train_time:20201ms step_avg:35.01ms
+step:578/1490 train_time:20261ms step_avg:35.05ms
+step:579/1490 train_time:20314ms step_avg:35.09ms
+step:580/1490 train_time:20373ms step_avg:35.13ms
+step:581/1490 train_time:20426ms step_avg:35.16ms
+step:582/1490 train_time:20485ms step_avg:35.20ms
+step:583/1490 train_time:20538ms step_avg:35.23ms
+step:584/1490 train_time:20597ms step_avg:35.27ms
+step:585/1490 train_time:20650ms step_avg:35.30ms
+step:586/1490 train_time:20709ms step_avg:35.34ms
+step:587/1490 train_time:20761ms step_avg:35.37ms
+step:588/1490 train_time:20820ms step_avg:35.41ms
+step:589/1490 train_time:20874ms step_avg:35.44ms
+step:590/1490 train_time:20932ms step_avg:35.48ms
+step:591/1490 train_time:20986ms step_avg:35.51ms
+step:592/1490 train_time:21045ms step_avg:35.55ms
+step:593/1490 train_time:21100ms step_avg:35.58ms
+step:594/1490 train_time:21159ms step_avg:35.62ms
+step:595/1490 train_time:21212ms step_avg:35.65ms
+step:596/1490 train_time:21271ms step_avg:35.69ms
+step:597/1490 train_time:21324ms step_avg:35.72ms
+step:598/1490 train_time:21383ms step_avg:35.76ms
+step:599/1490 train_time:21437ms step_avg:35.79ms
+step:600/1490 train_time:21497ms step_avg:35.83ms
+step:601/1490 train_time:21550ms step_avg:35.86ms
+step:602/1490 train_time:21609ms step_avg:35.89ms
+step:603/1490 train_time:21661ms step_avg:35.92ms
+step:604/1490 train_time:21720ms step_avg:35.96ms
+step:605/1490 train_time:21774ms step_avg:35.99ms
+step:606/1490 train_time:21832ms step_avg:36.03ms
+step:607/1490 train_time:21886ms step_avg:36.06ms
+step:608/1490 train_time:21945ms step_avg:36.09ms
+step:609/1490 train_time:21999ms step_avg:36.12ms
+step:610/1490 train_time:22058ms step_avg:36.16ms
+step:611/1490 train_time:22111ms step_avg:36.19ms
+step:612/1490 train_time:22170ms step_avg:36.23ms
+step:613/1490 train_time:22224ms step_avg:36.25ms
+step:614/1490 train_time:22283ms step_avg:36.29ms
+step:615/1490 train_time:22336ms step_avg:36.32ms
+step:616/1490 train_time:22395ms step_avg:36.36ms
+step:617/1490 train_time:22448ms step_avg:36.38ms
+step:618/1490 train_time:22508ms step_avg:36.42ms
+step:619/1490 train_time:22561ms step_avg:36.45ms
+step:620/1490 train_time:22620ms step_avg:36.48ms
+step:621/1490 train_time:22673ms step_avg:36.51ms
+step:622/1490 train_time:22732ms step_avg:36.55ms
+step:623/1490 train_time:22786ms step_avg:36.57ms
+step:624/1490 train_time:22844ms step_avg:36.61ms
+step:625/1490 train_time:22897ms step_avg:36.64ms
+step:626/1490 train_time:22956ms step_avg:36.67ms
+step:627/1490 train_time:23010ms step_avg:36.70ms
+step:628/1490 train_time:23069ms step_avg:36.73ms
+step:629/1490 train_time:23123ms step_avg:36.76ms
+step:630/1490 train_time:23182ms step_avg:36.80ms
+step:631/1490 train_time:23236ms step_avg:36.82ms
+step:632/1490 train_time:23294ms step_avg:36.86ms
+step:633/1490 train_time:23347ms step_avg:36.88ms
+step:634/1490 train_time:23406ms step_avg:36.92ms
+step:635/1490 train_time:23460ms step_avg:36.94ms
+step:636/1490 train_time:23518ms step_avg:36.98ms
+step:637/1490 train_time:23572ms step_avg:37.00ms
+step:638/1490 train_time:23631ms step_avg:37.04ms
+step:639/1490 train_time:23684ms step_avg:37.06ms
+step:640/1490 train_time:23743ms step_avg:37.10ms
+step:641/1490 train_time:23797ms step_avg:37.12ms
+step:642/1490 train_time:23855ms step_avg:37.16ms
+step:643/1490 train_time:23909ms step_avg:37.18ms
+step:644/1490 train_time:23969ms step_avg:37.22ms
+step:645/1490 train_time:24021ms step_avg:37.24ms
+step:646/1490 train_time:24080ms step_avg:37.28ms
+step:647/1490 train_time:24134ms step_avg:37.30ms
+step:648/1490 train_time:24193ms step_avg:37.33ms
+step:649/1490 train_time:24246ms step_avg:37.36ms
+step:650/1490 train_time:24306ms step_avg:37.39ms
+step:651/1490 train_time:24359ms step_avg:37.42ms
+step:652/1490 train_time:24419ms step_avg:37.45ms
+step:653/1490 train_time:24471ms step_avg:37.48ms
+step:654/1490 train_time:24530ms step_avg:37.51ms
+step:655/1490 train_time:24584ms step_avg:37.53ms
+step:656/1490 train_time:24642ms step_avg:37.56ms
+step:657/1490 train_time:24695ms step_avg:37.59ms
+step:658/1490 train_time:24754ms step_avg:37.62ms
+step:659/1490 train_time:24808ms step_avg:37.65ms
+step:660/1490 train_time:24868ms step_avg:37.68ms
+step:661/1490 train_time:24920ms step_avg:37.70ms
+step:662/1490 train_time:24980ms step_avg:37.73ms
+step:663/1490 train_time:25033ms step_avg:37.76ms
+step:664/1490 train_time:25092ms step_avg:37.79ms
+step:665/1490 train_time:25145ms step_avg:37.81ms
+step:666/1490 train_time:25205ms step_avg:37.85ms
+step:667/1490 train_time:25258ms step_avg:37.87ms
+step:668/1490 train_time:25317ms step_avg:37.90ms
+step:669/1490 train_time:25371ms step_avg:37.92ms
+step:670/1490 train_time:25430ms step_avg:37.95ms
+step:671/1490 train_time:25483ms step_avg:37.98ms
+step:672/1490 train_time:25541ms step_avg:38.01ms
+step:673/1490 train_time:25595ms step_avg:38.03ms
+step:674/1490 train_time:25654ms step_avg:38.06ms
+step:675/1490 train_time:25708ms step_avg:38.09ms
+step:676/1490 train_time:25767ms step_avg:38.12ms
+step:677/1490 train_time:25820ms step_avg:38.14ms
+step:678/1490 train_time:25880ms step_avg:38.17ms
+step:679/1490 train_time:25933ms step_avg:38.19ms
+step:680/1490 train_time:25992ms step_avg:38.22ms
+step:681/1490 train_time:26044ms step_avg:38.24ms
+step:682/1490 train_time:26104ms step_avg:38.28ms
+step:683/1490 train_time:26157ms step_avg:38.30ms
+step:684/1490 train_time:26216ms step_avg:38.33ms
+step:685/1490 train_time:26269ms step_avg:38.35ms
+step:686/1490 train_time:26328ms step_avg:38.38ms
+step:687/1490 train_time:26382ms step_avg:38.40ms
+step:688/1490 train_time:26441ms step_avg:38.43ms
+step:689/1490 train_time:26495ms step_avg:38.45ms
+step:690/1490 train_time:26553ms step_avg:38.48ms
+step:691/1490 train_time:26607ms step_avg:38.50ms
+step:692/1490 train_time:26666ms step_avg:38.54ms
+step:693/1490 train_time:26719ms step_avg:38.56ms
+step:694/1490 train_time:26777ms step_avg:38.58ms
+step:695/1490 train_time:26831ms step_avg:38.61ms
+step:696/1490 train_time:26890ms step_avg:38.63ms
+step:697/1490 train_time:26943ms step_avg:38.66ms
+step:698/1490 train_time:27002ms step_avg:38.69ms
+step:699/1490 train_time:27056ms step_avg:38.71ms
+step:700/1490 train_time:27114ms step_avg:38.73ms
+step:701/1490 train_time:27167ms step_avg:38.75ms
+step:702/1490 train_time:27226ms step_avg:38.78ms
+step:703/1490 train_time:27280ms step_avg:38.80ms
+step:704/1490 train_time:27339ms step_avg:38.83ms
+step:705/1490 train_time:27393ms step_avg:38.85ms
+step:706/1490 train_time:27451ms step_avg:38.88ms
+step:707/1490 train_time:27505ms step_avg:38.90ms
+step:708/1490 train_time:27564ms step_avg:38.93ms
+step:709/1490 train_time:27617ms step_avg:38.95ms
+step:710/1490 train_time:27676ms step_avg:38.98ms
+step:711/1490 train_time:27729ms step_avg:39.00ms
+step:712/1490 train_time:27788ms step_avg:39.03ms
+step:713/1490 train_time:27841ms step_avg:39.05ms
+step:714/1490 train_time:27901ms step_avg:39.08ms
+step:715/1490 train_time:27954ms step_avg:39.10ms
+step:716/1490 train_time:28013ms step_avg:39.12ms
+step:717/1490 train_time:28067ms step_avg:39.14ms
+step:718/1490 train_time:28125ms step_avg:39.17ms
+step:719/1490 train_time:28179ms step_avg:39.19ms
+step:720/1490 train_time:28238ms step_avg:39.22ms
+step:721/1490 train_time:28291ms step_avg:39.24ms
+step:722/1490 train_time:28350ms step_avg:39.27ms
+step:723/1490 train_time:28404ms step_avg:39.29ms
+step:724/1490 train_time:28463ms step_avg:39.31ms
+step:725/1490 train_time:28516ms step_avg:39.33ms
+step:726/1490 train_time:28574ms step_avg:39.36ms
+step:727/1490 train_time:28628ms step_avg:39.38ms
+step:728/1490 train_time:28687ms step_avg:39.40ms
+step:729/1490 train_time:28740ms step_avg:39.42ms
+step:730/1490 train_time:28799ms step_avg:39.45ms
+step:731/1490 train_time:28853ms step_avg:39.47ms
+step:732/1490 train_time:28912ms step_avg:39.50ms
+step:733/1490 train_time:28966ms step_avg:39.52ms
+step:734/1490 train_time:29024ms step_avg:39.54ms
+step:735/1490 train_time:29077ms step_avg:39.56ms
+step:736/1490 train_time:29136ms step_avg:39.59ms
+step:737/1490 train_time:29189ms step_avg:39.61ms
+step:738/1490 train_time:29247ms step_avg:39.63ms
+step:739/1490 train_time:29301ms step_avg:39.65ms
+step:740/1490 train_time:29361ms step_avg:39.68ms
+step:741/1490 train_time:29414ms step_avg:39.70ms
+step:742/1490 train_time:29473ms step_avg:39.72ms
+step:743/1490 train_time:29526ms step_avg:39.74ms
+step:744/1490 train_time:29585ms step_avg:39.76ms
+step:745/1490 train_time:29638ms step_avg:39.78ms
+step:746/1490 train_time:29697ms step_avg:39.81ms
+step:747/1490 train_time:29750ms step_avg:39.83ms
+step:748/1490 train_time:29809ms step_avg:39.85ms
+step:749/1490 train_time:29863ms step_avg:39.87ms
+step:750/1490 train_time:29922ms step_avg:39.90ms
+step:750/1490 val_loss:3.8043 train_time:29991ms step_avg:39.99ms
+step:751/1490 train_time:30009ms step_avg:39.96ms
+step:752/1490 train_time:30036ms step_avg:39.94ms
+step:753/1490 train_time:30093ms step_avg:39.96ms
+step:754/1490 train_time:30158ms step_avg:40.00ms
+step:755/1490 train_time:30215ms step_avg:40.02ms
+step:756/1490 train_time:30274ms step_avg:40.05ms
+step:757/1490 train_time:30327ms step_avg:40.06ms
+step:758/1490 train_time:30385ms step_avg:40.09ms
+step:759/1490 train_time:30437ms step_avg:40.10ms
+step:760/1490 train_time:30495ms step_avg:40.13ms
+step:761/1490 train_time:30548ms step_avg:40.14ms
+step:762/1490 train_time:30606ms step_avg:40.17ms
+step:763/1490 train_time:30658ms step_avg:40.18ms
+step:764/1490 train_time:30717ms step_avg:40.20ms
+step:765/1490 train_time:30769ms step_avg:40.22ms
+step:766/1490 train_time:30827ms step_avg:40.24ms
+step:767/1490 train_time:30880ms step_avg:40.26ms
+step:768/1490 train_time:30939ms step_avg:40.28ms
+step:769/1490 train_time:30993ms step_avg:40.30ms
+step:770/1490 train_time:31053ms step_avg:40.33ms
+step:771/1490 train_time:31108ms step_avg:40.35ms
+step:772/1490 train_time:31169ms step_avg:40.37ms
+step:773/1490 train_time:31225ms step_avg:40.39ms
+step:774/1490 train_time:31285ms step_avg:40.42ms
+step:775/1490 train_time:31338ms step_avg:40.44ms
+step:776/1490 train_time:31396ms step_avg:40.46ms
+step:777/1490 train_time:31449ms step_avg:40.47ms
+step:778/1490 train_time:31507ms step_avg:40.50ms
+step:779/1490 train_time:31560ms step_avg:40.51ms
+step:780/1490 train_time:31618ms step_avg:40.54ms
+step:781/1490 train_time:31671ms step_avg:40.55ms
+step:782/1490 train_time:31729ms step_avg:40.57ms
+step:783/1490 train_time:31782ms step_avg:40.59ms
+step:784/1490 train_time:31840ms step_avg:40.61ms
+step:785/1490 train_time:31893ms step_avg:40.63ms
+step:786/1490 train_time:31952ms step_avg:40.65ms
+step:787/1490 train_time:32006ms step_avg:40.67ms
+step:788/1490 train_time:32065ms step_avg:40.69ms
+step:789/1490 train_time:32120ms step_avg:40.71ms
+step:790/1490 train_time:32181ms step_avg:40.74ms
+step:791/1490 train_time:32234ms step_avg:40.75ms
+step:792/1490 train_time:32293ms step_avg:40.77ms
+step:793/1490 train_time:32347ms step_avg:40.79ms
+step:794/1490 train_time:32406ms step_avg:40.81ms
+step:795/1490 train_time:32459ms step_avg:40.83ms
+step:796/1490 train_time:32517ms step_avg:40.85ms
+step:797/1490 train_time:32570ms step_avg:40.87ms
+step:798/1490 train_time:32628ms step_avg:40.89ms
+step:799/1490 train_time:32682ms step_avg:40.90ms
+step:800/1490 train_time:32740ms step_avg:40.92ms
+step:801/1490 train_time:32793ms step_avg:40.94ms
+step:802/1490 train_time:32850ms step_avg:40.96ms
+step:803/1490 train_time:32904ms step_avg:40.98ms
+step:804/1490 train_time:32963ms step_avg:41.00ms
+step:805/1490 train_time:33017ms step_avg:41.02ms
+step:806/1490 train_time:33077ms step_avg:41.04ms
+step:807/1490 train_time:33131ms step_avg:41.05ms
+step:808/1490 train_time:33191ms step_avg:41.08ms
+step:809/1490 train_time:33245ms step_avg:41.09ms
+step:810/1490 train_time:33303ms step_avg:41.11ms
+step:811/1490 train_time:33357ms step_avg:41.13ms
+step:812/1490 train_time:33416ms step_avg:41.15ms
+step:813/1490 train_time:33469ms step_avg:41.17ms
+step:814/1490 train_time:33528ms step_avg:41.19ms
+step:815/1490 train_time:33581ms step_avg:41.20ms
+step:816/1490 train_time:33640ms step_avg:41.23ms
+step:817/1490 train_time:33692ms step_avg:41.24ms
+step:818/1490 train_time:33751ms step_avg:41.26ms
+step:819/1490 train_time:33805ms step_avg:41.28ms
+step:820/1490 train_time:33863ms step_avg:41.30ms
+step:821/1490 train_time:33916ms step_avg:41.31ms
+step:822/1490 train_time:33975ms step_avg:41.33ms
+step:823/1490 train_time:34028ms step_avg:41.35ms
+step:824/1490 train_time:34088ms step_avg:41.37ms
+step:825/1490 train_time:34141ms step_avg:41.38ms
+step:826/1490 train_time:34201ms step_avg:41.41ms
+step:827/1490 train_time:34255ms step_avg:41.42ms
+step:828/1490 train_time:34314ms step_avg:41.44ms
+step:829/1490 train_time:34367ms step_avg:41.46ms
+step:830/1490 train_time:34426ms step_avg:41.48ms
+step:831/1490 train_time:34478ms step_avg:41.49ms
+step:832/1490 train_time:34537ms step_avg:41.51ms
+step:833/1490 train_time:34590ms step_avg:41.53ms
+step:834/1490 train_time:34649ms step_avg:41.55ms
+step:835/1490 train_time:34702ms step_avg:41.56ms
+step:836/1490 train_time:34760ms step_avg:41.58ms
+step:837/1490 train_time:34814ms step_avg:41.59ms
+step:838/1490 train_time:34872ms step_avg:41.61ms
+step:839/1490 train_time:34926ms step_avg:41.63ms
+step:840/1490 train_time:34985ms step_avg:41.65ms
+step:841/1490 train_time:35038ms step_avg:41.66ms
+step:842/1490 train_time:35097ms step_avg:41.68ms
+step:843/1490 train_time:35150ms step_avg:41.70ms
+step:844/1490 train_time:35210ms step_avg:41.72ms
+step:845/1490 train_time:35264ms step_avg:41.73ms
+step:846/1490 train_time:35323ms step_avg:41.75ms
+step:847/1490 train_time:35377ms step_avg:41.77ms
+step:848/1490 train_time:35435ms step_avg:41.79ms
+step:849/1490 train_time:35488ms step_avg:41.80ms
+step:850/1490 train_time:35546ms step_avg:41.82ms
+step:851/1490 train_time:35599ms step_avg:41.83ms
+step:852/1490 train_time:35658ms step_avg:41.85ms
+step:853/1490 train_time:35711ms step_avg:41.87ms
+step:854/1490 train_time:35770ms step_avg:41.88ms
+step:855/1490 train_time:35824ms step_avg:41.90ms
+step:856/1490 train_time:35883ms step_avg:41.92ms
+step:857/1490 train_time:35936ms step_avg:41.93ms
+step:858/1490 train_time:35994ms step_avg:41.95ms
+step:859/1490 train_time:36048ms step_avg:41.96ms
+step:860/1490 train_time:36106ms step_avg:41.98ms
+step:861/1490 train_time:36159ms step_avg:42.00ms
+step:862/1490 train_time:36219ms step_avg:42.02ms
+step:863/1490 train_time:36272ms step_avg:42.03ms
+step:864/1490 train_time:36331ms step_avg:42.05ms
+step:865/1490 train_time:36385ms step_avg:42.06ms
+step:866/1490 train_time:36444ms step_avg:42.08ms
+step:867/1490 train_time:36497ms step_avg:42.10ms
+step:868/1490 train_time:36556ms step_avg:42.11ms
+step:869/1490 train_time:36609ms step_avg:42.13ms
+step:870/1490 train_time:36668ms step_avg:42.15ms
+step:871/1490 train_time:36723ms step_avg:42.16ms
+step:872/1490 train_time:36782ms step_avg:42.18ms
+step:873/1490 train_time:36834ms step_avg:42.19ms
+step:874/1490 train_time:36893ms step_avg:42.21ms
+step:875/1490 train_time:36946ms step_avg:42.22ms
+step:876/1490 train_time:37005ms step_avg:42.24ms
+step:877/1490 train_time:37058ms step_avg:42.26ms
+step:878/1490 train_time:37117ms step_avg:42.28ms
+step:879/1490 train_time:37170ms step_avg:42.29ms
+step:880/1490 train_time:37229ms step_avg:42.31ms
+step:881/1490 train_time:37283ms step_avg:42.32ms
+step:882/1490 train_time:37342ms step_avg:42.34ms
+step:883/1490 train_time:37395ms step_avg:42.35ms
+step:884/1490 train_time:37453ms step_avg:42.37ms
+step:885/1490 train_time:37507ms step_avg:42.38ms
+step:886/1490 train_time:37566ms step_avg:42.40ms
+step:887/1490 train_time:37620ms step_avg:42.41ms
+step:888/1490 train_time:37679ms step_avg:42.43ms
+step:889/1490 train_time:37732ms step_avg:42.44ms
+step:890/1490 train_time:37791ms step_avg:42.46ms
+step:891/1490 train_time:37844ms step_avg:42.47ms
+step:892/1490 train_time:37903ms step_avg:42.49ms
+step:893/1490 train_time:37956ms step_avg:42.50ms
+step:894/1490 train_time:38014ms step_avg:42.52ms
+step:895/1490 train_time:38066ms step_avg:42.53ms
+step:896/1490 train_time:38125ms step_avg:42.55ms
+step:897/1490 train_time:38179ms step_avg:42.56ms
+step:898/1490 train_time:38238ms step_avg:42.58ms
+step:899/1490 train_time:38291ms step_avg:42.59ms
+step:900/1490 train_time:38350ms step_avg:42.61ms
+step:901/1490 train_time:38404ms step_avg:42.62ms
+step:902/1490 train_time:38463ms step_avg:42.64ms
+step:903/1490 train_time:38517ms step_avg:42.65ms
+step:904/1490 train_time:38576ms step_avg:42.67ms
+step:905/1490 train_time:38629ms step_avg:42.68ms
+step:906/1490 train_time:38688ms step_avg:42.70ms
+step:907/1490 train_time:38741ms step_avg:42.71ms
+step:908/1490 train_time:38801ms step_avg:42.73ms
+step:909/1490 train_time:38854ms step_avg:42.74ms
+step:910/1490 train_time:38913ms step_avg:42.76ms
+step:911/1490 train_time:38966ms step_avg:42.77ms
+step:912/1490 train_time:39026ms step_avg:42.79ms
+step:913/1490 train_time:39079ms step_avg:42.80ms
+step:914/1490 train_time:39138ms step_avg:42.82ms
+step:915/1490 train_time:39191ms step_avg:42.83ms
+step:916/1490 train_time:39250ms step_avg:42.85ms
+step:917/1490 train_time:39304ms step_avg:42.86ms
+step:918/1490 train_time:39362ms step_avg:42.88ms
+step:919/1490 train_time:39416ms step_avg:42.89ms
+step:920/1490 train_time:39475ms step_avg:42.91ms
+step:921/1490 train_time:39529ms step_avg:42.92ms
+step:922/1490 train_time:39587ms step_avg:42.94ms
+step:923/1490 train_time:39640ms step_avg:42.95ms
+step:924/1490 train_time:39699ms step_avg:42.96ms
+step:925/1490 train_time:39752ms step_avg:42.98ms
+step:926/1490 train_time:39812ms step_avg:42.99ms
+step:927/1490 train_time:39865ms step_avg:43.00ms
+step:928/1490 train_time:39924ms step_avg:43.02ms
+step:929/1490 train_time:39977ms step_avg:43.03ms
+step:930/1490 train_time:40036ms step_avg:43.05ms
+step:931/1490 train_time:40089ms step_avg:43.06ms
+step:932/1490 train_time:40147ms step_avg:43.08ms
+step:933/1490 train_time:40200ms step_avg:43.09ms
+step:934/1490 train_time:40260ms step_avg:43.11ms
+step:935/1490 train_time:40314ms step_avg:43.12ms
+step:936/1490 train_time:40372ms step_avg:43.13ms
+step:937/1490 train_time:40427ms step_avg:43.14ms
+step:938/1490 train_time:40486ms step_avg:43.16ms
+step:939/1490 train_time:40539ms step_avg:43.17ms
+step:940/1490 train_time:40598ms step_avg:43.19ms
+step:941/1490 train_time:40651ms step_avg:43.20ms
+step:942/1490 train_time:40709ms step_avg:43.22ms
+step:943/1490 train_time:40762ms step_avg:43.23ms
+step:944/1490 train_time:40822ms step_avg:43.24ms
+step:945/1490 train_time:40875ms step_avg:43.25ms
+step:946/1490 train_time:40933ms step_avg:43.27ms
+step:947/1490 train_time:40986ms step_avg:43.28ms
+step:948/1490 train_time:41045ms step_avg:43.30ms
+step:949/1490 train_time:41098ms step_avg:43.31ms
+step:950/1490 train_time:41156ms step_avg:43.32ms
+step:951/1490 train_time:41211ms step_avg:43.33ms
+step:952/1490 train_time:41270ms step_avg:43.35ms
+step:953/1490 train_time:41323ms step_avg:43.36ms
+step:954/1490 train_time:41383ms step_avg:43.38ms
+step:955/1490 train_time:41436ms step_avg:43.39ms
+step:956/1490 train_time:41495ms step_avg:43.40ms
+step:957/1490 train_time:41548ms step_avg:43.42ms
+step:958/1490 train_time:41607ms step_avg:43.43ms
+step:959/1490 train_time:41660ms step_avg:43.44ms
+step:960/1490 train_time:41720ms step_avg:43.46ms
+step:961/1490 train_time:41773ms step_avg:43.47ms
+step:962/1490 train_time:41831ms step_avg:43.48ms
+step:963/1490 train_time:41885ms step_avg:43.49ms
+step:964/1490 train_time:41943ms step_avg:43.51ms
+step:965/1490 train_time:41998ms step_avg:43.52ms
+step:966/1490 train_time:42056ms step_avg:43.54ms
+step:967/1490 train_time:42110ms step_avg:43.55ms
+step:968/1490 train_time:42171ms step_avg:43.57ms
+step:969/1490 train_time:42250ms step_avg:43.60ms
+step:970/1490 train_time:42334ms step_avg:43.64ms
+step:971/1490 train_time:42413ms step_avg:43.68ms
+step:972/1490 train_time:42498ms step_avg:43.72ms
+step:973/1490 train_time:42577ms step_avg:43.76ms
+step:974/1490 train_time:42661ms step_avg:43.80ms
+step:975/1490 train_time:42741ms step_avg:43.84ms
+step:976/1490 train_time:42826ms step_avg:43.88ms
+step:977/1490 train_time:42905ms step_avg:43.91ms
+step:978/1490 train_time:42990ms step_avg:43.96ms
+step:979/1490 train_time:43069ms step_avg:43.99ms
+step:980/1490 train_time:43154ms step_avg:44.03ms
+step:981/1490 train_time:43232ms step_avg:44.07ms
+step:982/1490 train_time:43317ms step_avg:44.11ms
+step:983/1490 train_time:43397ms step_avg:44.15ms
+step:984/1490 train_time:43482ms step_avg:44.19ms
+step:985/1490 train_time:43562ms step_avg:44.23ms
+step:986/1490 train_time:43646ms step_avg:44.27ms
+step:987/1490 train_time:43725ms step_avg:44.30ms
+step:988/1490 train_time:43811ms step_avg:44.34ms
+step:989/1490 train_time:43889ms step_avg:44.38ms
+step:990/1490 train_time:43972ms step_avg:44.42ms
+step:991/1490 train_time:44052ms step_avg:44.45ms
+step:992/1490 train_time:44137ms step_avg:44.49ms
+step:993/1490 train_time:44217ms step_avg:44.53ms
+step:994/1490 train_time:44301ms step_avg:44.57ms
+step:995/1490 train_time:44380ms step_avg:44.60ms
+step:996/1490 train_time:44466ms step_avg:44.64ms
+step:997/1490 train_time:44545ms step_avg:44.68ms
+step:998/1490 train_time:44629ms step_avg:44.72ms
+step:999/1490 train_time:44709ms step_avg:44.75ms
+step:1000/1490 train_time:44793ms step_avg:44.79ms
+step:1000/1490 val_loss:3.5182 train_time:44890ms step_avg:44.89ms
+step:1001/1490 train_time:44909ms step_avg:44.86ms
+step:1002/1490 train_time:44962ms step_avg:44.87ms
+step:1003/1490 train_time:45047ms step_avg:44.91ms
+step:1004/1490 train_time:45134ms step_avg:44.95ms
+step:1005/1490 train_time:45212ms step_avg:44.99ms
+step:1006/1490 train_time:45294ms step_avg:45.02ms
+step:1007/1490 train_time:45372ms step_avg:45.06ms
+step:1008/1490 train_time:45456ms step_avg:45.10ms
+step:1009/1490 train_time:45533ms step_avg:45.13ms
+step:1010/1490 train_time:45617ms step_avg:45.17ms
+step:1011/1490 train_time:45695ms step_avg:45.20ms
+step:1012/1490 train_time:45779ms step_avg:45.24ms
+step:1013/1490 train_time:45859ms step_avg:45.27ms
+step:1014/1490 train_time:45946ms step_avg:45.31ms
+step:1015/1490 train_time:46028ms step_avg:45.35ms
+step:1016/1490 train_time:46116ms step_avg:45.39ms
+step:1017/1490 train_time:46194ms step_avg:45.42ms
+step:1018/1490 train_time:46279ms step_avg:45.46ms
+step:1019/1490 train_time:46358ms step_avg:45.49ms
+step:1020/1490 train_time:46442ms step_avg:45.53ms
+step:1021/1490 train_time:46519ms step_avg:45.56ms
+step:1022/1490 train_time:46603ms step_avg:45.60ms
+step:1023/1490 train_time:46681ms step_avg:45.63ms
+step:1024/1490 train_time:46765ms step_avg:45.67ms
+step:1025/1490 train_time:46845ms step_avg:45.70ms
+step:1026/1490 train_time:46931ms step_avg:45.74ms
+step:1027/1490 train_time:47012ms step_avg:45.78ms
+step:1028/1490 train_time:47096ms step_avg:45.81ms
+step:1029/1490 train_time:47177ms step_avg:45.85ms
+step:1030/1490 train_time:47262ms step_avg:45.89ms
+step:1031/1490 train_time:47341ms step_avg:45.92ms
+step:1032/1490 train_time:47426ms step_avg:45.96ms
+step:1033/1490 train_time:47505ms step_avg:45.99ms
+step:1034/1490 train_time:47588ms step_avg:46.02ms
+step:1035/1490 train_time:47666ms step_avg:46.05ms
+step:1036/1490 train_time:47751ms step_avg:46.09ms
+step:1037/1490 train_time:47829ms step_avg:46.12ms
+step:1038/1490 train_time:47915ms step_avg:46.16ms
+step:1039/1490 train_time:47995ms step_avg:46.19ms
+step:1040/1490 train_time:48081ms step_avg:46.23ms
+step:1041/1490 train_time:48163ms step_avg:46.27ms
+step:1042/1490 train_time:48247ms step_avg:46.30ms
+step:1043/1490 train_time:48326ms step_avg:46.33ms
+step:1044/1490 train_time:48411ms step_avg:46.37ms
+step:1045/1490 train_time:48490ms step_avg:46.40ms
+step:1046/1490 train_time:48573ms step_avg:46.44ms
+step:1047/1490 train_time:48651ms step_avg:46.47ms
+step:1048/1490 train_time:48734ms step_avg:46.50ms
+step:1049/1490 train_time:48813ms step_avg:46.53ms
+step:1050/1490 train_time:48897ms step_avg:46.57ms
+step:1051/1490 train_time:48977ms step_avg:46.60ms
+step:1052/1490 train_time:49062ms step_avg:46.64ms
+step:1053/1490 train_time:49144ms step_avg:46.67ms
+step:1054/1490 train_time:49229ms step_avg:46.71ms
+step:1055/1490 train_time:49310ms step_avg:46.74ms
+step:1056/1490 train_time:49393ms step_avg:46.77ms
+step:1057/1490 train_time:49472ms step_avg:46.80ms
+step:1058/1490 train_time:49556ms step_avg:46.84ms
+step:1059/1490 train_time:49634ms step_avg:46.87ms
+step:1060/1490 train_time:49719ms step_avg:46.90ms
+step:1061/1490 train_time:49800ms step_avg:46.94ms
+step:1062/1490 train_time:49883ms step_avg:46.97ms
+step:1063/1490 train_time:49962ms step_avg:47.00ms
+step:1064/1490 train_time:50047ms step_avg:47.04ms
+step:1065/1490 train_time:50126ms step_avg:47.07ms
+step:1066/1490 train_time:50211ms step_avg:47.10ms
+step:1067/1490 train_time:50292ms step_avg:47.13ms
+step:1068/1490 train_time:50375ms step_avg:47.17ms
+step:1069/1490 train_time:50454ms step_avg:47.20ms
+step:1070/1490 train_time:50539ms step_avg:47.23ms
+step:1071/1490 train_time:50620ms step_avg:47.26ms
+step:1072/1490 train_time:50703ms step_avg:47.30ms
+step:1073/1490 train_time:50780ms step_avg:47.33ms
+step:1074/1490 train_time:50865ms step_avg:47.36ms
+step:1075/1490 train_time:50944ms step_avg:47.39ms
+step:1076/1490 train_time:51030ms step_avg:47.43ms
+step:1077/1490 train_time:51110ms step_avg:47.46ms
+step:1078/1490 train_time:51193ms step_avg:47.49ms
+step:1079/1490 train_time:51272ms step_avg:47.52ms
+step:1080/1490 train_time:51358ms step_avg:47.55ms
+step:1081/1490 train_time:51438ms step_avg:47.58ms
+step:1082/1490 train_time:51522ms step_avg:47.62ms
+step:1083/1490 train_time:51601ms step_avg:47.65ms
+step:1084/1490 train_time:51686ms step_avg:47.68ms
+step:1085/1490 train_time:51766ms step_avg:47.71ms
+step:1086/1490 train_time:51849ms step_avg:47.74ms
+step:1087/1490 train_time:51928ms step_avg:47.77ms
+step:1088/1490 train_time:52012ms step_avg:47.81ms
+step:1089/1490 train_time:52091ms step_avg:47.83ms
+step:1090/1490 train_time:52176ms step_avg:47.87ms
+step:1091/1490 train_time:52256ms step_avg:47.90ms
+step:1092/1490 train_time:52340ms step_avg:47.93ms
+step:1093/1490 train_time:52420ms step_avg:47.96ms
+step:1094/1490 train_time:52504ms step_avg:47.99ms
+step:1095/1490 train_time:52583ms step_avg:48.02ms
+step:1096/1490 train_time:52666ms step_avg:48.05ms
+step:1097/1490 train_time:52745ms step_avg:48.08ms
+step:1098/1490 train_time:52829ms step_avg:48.11ms
+step:1099/1490 train_time:52909ms step_avg:48.14ms
+step:1100/1490 train_time:52993ms step_avg:48.18ms
+step:1101/1490 train_time:53073ms step_avg:48.20ms
+step:1102/1490 train_time:53157ms step_avg:48.24ms
+step:1103/1490 train_time:53236ms step_avg:48.26ms
+step:1104/1490 train_time:53320ms step_avg:48.30ms
+step:1105/1490 train_time:53400ms step_avg:48.33ms
+step:1106/1490 train_time:53484ms step_avg:48.36ms
+step:1107/1490 train_time:53564ms step_avg:48.39ms
+step:1108/1490 train_time:53649ms step_avg:48.42ms
+step:1109/1490 train_time:53728ms step_avg:48.45ms
+step:1110/1490 train_time:53811ms step_avg:48.48ms
+step:1111/1490 train_time:53890ms step_avg:48.51ms
+step:1112/1490 train_time:53974ms step_avg:48.54ms
+step:1113/1490 train_time:54054ms step_avg:48.57ms
+step:1114/1490 train_time:54139ms step_avg:48.60ms
+step:1115/1490 train_time:54218ms step_avg:48.63ms
+step:1116/1490 train_time:54305ms step_avg:48.66ms
+step:1117/1490 train_time:54383ms step_avg:48.69ms
+step:1118/1490 train_time:54468ms step_avg:48.72ms
+step:1119/1490 train_time:54547ms step_avg:48.75ms
+step:1120/1490 train_time:54633ms step_avg:48.78ms
+step:1121/1490 train_time:54712ms step_avg:48.81ms
+step:1122/1490 train_time:54796ms step_avg:48.84ms
+step:1123/1490 train_time:54876ms step_avg:48.87ms
+step:1124/1490 train_time:54961ms step_avg:48.90ms
+step:1125/1490 train_time:55041ms step_avg:48.93ms
+step:1126/1490 train_time:55124ms step_avg:48.96ms
+step:1127/1490 train_time:55203ms step_avg:48.98ms
+step:1128/1490 train_time:55288ms step_avg:49.01ms
+step:1129/1490 train_time:55367ms step_avg:49.04ms
+step:1130/1490 train_time:55452ms step_avg:49.07ms
+step:1131/1490 train_time:55530ms step_avg:49.10ms
+step:1132/1490 train_time:55615ms step_avg:49.13ms
+step:1133/1490 train_time:55693ms step_avg:49.16ms
+step:1134/1490 train_time:55779ms step_avg:49.19ms
+step:1135/1490 train_time:55859ms step_avg:49.21ms
+step:1136/1490 train_time:55944ms step_avg:49.25ms
+step:1137/1490 train_time:56024ms step_avg:49.27ms
+step:1138/1490 train_time:56108ms step_avg:49.30ms
+step:1139/1490 train_time:56186ms step_avg:49.33ms
+step:1140/1490 train_time:56271ms step_avg:49.36ms
+step:1141/1490 train_time:56350ms step_avg:49.39ms
+step:1142/1490 train_time:56434ms step_avg:49.42ms
+step:1143/1490 train_time:56513ms step_avg:49.44ms
+step:1144/1490 train_time:56598ms step_avg:49.47ms
+step:1145/1490 train_time:56678ms step_avg:49.50ms
+step:1146/1490 train_time:56763ms step_avg:49.53ms
+step:1147/1490 train_time:56842ms step_avg:49.56ms
+step:1148/1490 train_time:56926ms step_avg:49.59ms
+step:1149/1490 train_time:57006ms step_avg:49.61ms
+step:1150/1490 train_time:57091ms step_avg:49.64ms
+step:1151/1490 train_time:57170ms step_avg:49.67ms
+step:1152/1490 train_time:57254ms step_avg:49.70ms
+step:1153/1490 train_time:57333ms step_avg:49.72ms
+step:1154/1490 train_time:57418ms step_avg:49.76ms
+step:1155/1490 train_time:57497ms step_avg:49.78ms
+step:1156/1490 train_time:57582ms step_avg:49.81ms
+step:1157/1490 train_time:57662ms step_avg:49.84ms
+step:1158/1490 train_time:57748ms step_avg:49.87ms
+step:1159/1490 train_time:57827ms step_avg:49.89ms
+step:1160/1490 train_time:57910ms step_avg:49.92ms
+step:1161/1490 train_time:57989ms step_avg:49.95ms
+step:1162/1490 train_time:58074ms step_avg:49.98ms
+step:1163/1490 train_time:58153ms step_avg:50.00ms
+step:1164/1490 train_time:58237ms step_avg:50.03ms
+step:1165/1490 train_time:58316ms step_avg:50.06ms
+step:1166/1490 train_time:58401ms step_avg:50.09ms
+step:1167/1490 train_time:58480ms step_avg:50.11ms
+step:1168/1490 train_time:58566ms step_avg:50.14ms
+step:1169/1490 train_time:58645ms step_avg:50.17ms
+step:1170/1490 train_time:58730ms step_avg:50.20ms
+step:1171/1490 train_time:58809ms step_avg:50.22ms
+step:1172/1490 train_time:58893ms step_avg:50.25ms
+step:1173/1490 train_time:58972ms step_avg:50.27ms
+step:1174/1490 train_time:59057ms step_avg:50.30ms
+step:1175/1490 train_time:59137ms step_avg:50.33ms
+step:1176/1490 train_time:59222ms step_avg:50.36ms
+step:1177/1490 train_time:59301ms step_avg:50.38ms
+step:1178/1490 train_time:59384ms step_avg:50.41ms
+step:1179/1490 train_time:59463ms step_avg:50.43ms
+step:1180/1490 train_time:59548ms step_avg:50.46ms
+step:1181/1490 train_time:59627ms step_avg:50.49ms
+step:1182/1490 train_time:59711ms step_avg:50.52ms
+step:1183/1490 train_time:59790ms step_avg:50.54ms
+step:1184/1490 train_time:59873ms step_avg:50.57ms
+step:1185/1490 train_time:59952ms step_avg:50.59ms
+step:1186/1490 train_time:60038ms step_avg:50.62ms
+step:1187/1490 train_time:60117ms step_avg:50.65ms
+step:1188/1490 train_time:60202ms step_avg:50.68ms
+step:1189/1490 train_time:60282ms step_avg:50.70ms
+step:1190/1490 train_time:60366ms step_avg:50.73ms
+step:1191/1490 train_time:60445ms step_avg:50.75ms
+step:1192/1490 train_time:60530ms step_avg:50.78ms
+step:1193/1490 train_time:60611ms step_avg:50.81ms
+step:1194/1490 train_time:60696ms step_avg:50.83ms
+step:1195/1490 train_time:60775ms step_avg:50.86ms
+step:1196/1490 train_time:60859ms step_avg:50.89ms
+step:1197/1490 train_time:60938ms step_avg:50.91ms
+step:1198/1490 train_time:61021ms step_avg:50.94ms
+step:1199/1490 train_time:61100ms step_avg:50.96ms
+step:1200/1490 train_time:61186ms step_avg:50.99ms
+step:1201/1490 train_time:61265ms step_avg:51.01ms
+step:1202/1490 train_time:61351ms step_avg:51.04ms
+step:1203/1490 train_time:61431ms step_avg:51.06ms
+step:1204/1490 train_time:61514ms step_avg:51.09ms
+step:1205/1490 train_time:61593ms step_avg:51.11ms
+step:1206/1490 train_time:61677ms step_avg:51.14ms
+step:1207/1490 train_time:61757ms step_avg:51.17ms
+step:1208/1490 train_time:61842ms step_avg:51.19ms
+step:1209/1490 train_time:61921ms step_avg:51.22ms
+step:1210/1490 train_time:62005ms step_avg:51.24ms
+step:1211/1490 train_time:62083ms step_avg:51.27ms
+step:1212/1490 train_time:62168ms step_avg:51.29ms
+step:1213/1490 train_time:62247ms step_avg:51.32ms
+step:1214/1490 train_time:62333ms step_avg:51.35ms
+step:1215/1490 train_time:62413ms step_avg:51.37ms
+step:1216/1490 train_time:62498ms step_avg:51.40ms
+step:1217/1490 train_time:62578ms step_avg:51.42ms
+step:1218/1490 train_time:62662ms step_avg:51.45ms
+step:1219/1490 train_time:62741ms step_avg:51.47ms
+step:1220/1490 train_time:62826ms step_avg:51.50ms
+step:1221/1490 train_time:62906ms step_avg:51.52ms
+step:1222/1490 train_time:62990ms step_avg:51.55ms
+step:1223/1490 train_time:63069ms step_avg:51.57ms
+step:1224/1490 train_time:63154ms step_avg:51.60ms
+step:1225/1490 train_time:63232ms step_avg:51.62ms
+step:1226/1490 train_time:63318ms step_avg:51.65ms
+step:1227/1490 train_time:63398ms step_avg:51.67ms
+step:1228/1490 train_time:63482ms step_avg:51.70ms
+step:1229/1490 train_time:63562ms step_avg:51.72ms
+step:1230/1490 train_time:63647ms step_avg:51.75ms
+step:1231/1490 train_time:63726ms step_avg:51.77ms
+step:1232/1490 train_time:63810ms step_avg:51.79ms
+step:1233/1490 train_time:63889ms step_avg:51.82ms
+step:1234/1490 train_time:63974ms step_avg:51.84ms
+step:1235/1490 train_time:64053ms step_avg:51.87ms
+step:1236/1490 train_time:64138ms step_avg:51.89ms
+step:1237/1490 train_time:64217ms step_avg:51.91ms
+step:1238/1490 train_time:64302ms step_avg:51.94ms
+step:1239/1490 train_time:64381ms step_avg:51.96ms
+step:1240/1490 train_time:64467ms step_avg:51.99ms
+step:1241/1490 train_time:64547ms step_avg:52.01ms
+step:1242/1490 train_time:64631ms step_avg:52.04ms
+step:1243/1490 train_time:64712ms step_avg:52.06ms
+step:1244/1490 train_time:64796ms step_avg:52.09ms
+step:1245/1490 train_time:64874ms step_avg:52.11ms
+step:1246/1490 train_time:64959ms step_avg:52.13ms
+step:1247/1490 train_time:65039ms step_avg:52.16ms
+step:1248/1490 train_time:65124ms step_avg:52.18ms
+step:1249/1490 train_time:65203ms step_avg:52.20ms
+step:1250/1490 train_time:65288ms step_avg:52.23ms
+step:1250/1490 val_loss:3.3724 train_time:65384ms step_avg:52.31ms
+step:1251/1490 train_time:65403ms step_avg:52.28ms
+step:1252/1490 train_time:65455ms step_avg:52.28ms
+step:1253/1490 train_time:65536ms step_avg:52.30ms
+step:1254/1490 train_time:65621ms step_avg:52.33ms
+step:1255/1490 train_time:65700ms step_avg:52.35ms
+step:1256/1490 train_time:65784ms step_avg:52.38ms
+step:1257/1490 train_time:65864ms step_avg:52.40ms
+step:1258/1490 train_time:65948ms step_avg:52.42ms
+step:1259/1490 train_time:66029ms step_avg:52.45ms
+step:1260/1490 train_time:66111ms step_avg:52.47ms
+step:1261/1490 train_time:66188ms step_avg:52.49ms
+step:1262/1490 train_time:66272ms step_avg:52.51ms
+step:1263/1490 train_time:66352ms step_avg:52.54ms
+step:1264/1490 train_time:66439ms step_avg:52.56ms
+step:1265/1490 train_time:66521ms step_avg:52.59ms
+step:1266/1490 train_time:66608ms step_avg:52.61ms
+step:1267/1490 train_time:66687ms step_avg:52.63ms
+step:1268/1490 train_time:66773ms step_avg:52.66ms
+step:1269/1490 train_time:66852ms step_avg:52.68ms
+step:1270/1490 train_time:66936ms step_avg:52.71ms
+step:1271/1490 train_time:67014ms step_avg:52.73ms
+step:1272/1490 train_time:67098ms step_avg:52.75ms
+step:1273/1490 train_time:67177ms step_avg:52.77ms
+step:1274/1490 train_time:67262ms step_avg:52.80ms
+step:1275/1490 train_time:67342ms step_avg:52.82ms
+step:1276/1490 train_time:67429ms step_avg:52.84ms
+step:1277/1490 train_time:67509ms step_avg:52.87ms
+step:1278/1490 train_time:67593ms step_avg:52.89ms
+step:1279/1490 train_time:67672ms step_avg:52.91ms
+step:1280/1490 train_time:67759ms step_avg:52.94ms
+step:1281/1490 train_time:67838ms step_avg:52.96ms
+step:1282/1490 train_time:67922ms step_avg:52.98ms
+step:1283/1490 train_time:68002ms step_avg:53.00ms
+step:1284/1490 train_time:68086ms step_avg:53.03ms
+step:1285/1490 train_time:68165ms step_avg:53.05ms
+step:1286/1490 train_time:68250ms step_avg:53.07ms
+step:1287/1490 train_time:68330ms step_avg:53.09ms
+step:1288/1490 train_time:68416ms step_avg:53.12ms
+step:1289/1490 train_time:68497ms step_avg:53.14ms
+step:1290/1490 train_time:68582ms step_avg:53.16ms
+step:1291/1490 train_time:68662ms step_avg:53.19ms
+step:1292/1490 train_time:68748ms step_avg:53.21ms
+step:1293/1490 train_time:68827ms step_avg:53.23ms
+step:1294/1490 train_time:68913ms step_avg:53.26ms
+step:1295/1490 train_time:68991ms step_avg:53.27ms
+step:1296/1490 train_time:69075ms step_avg:53.30ms
+step:1297/1490 train_time:69154ms step_avg:53.32ms
+step:1298/1490 train_time:69239ms step_avg:53.34ms
+step:1299/1490 train_time:69319ms step_avg:53.36ms
+step:1300/1490 train_time:69405ms step_avg:53.39ms
+step:1301/1490 train_time:69485ms step_avg:53.41ms
+step:1302/1490 train_time:69570ms step_avg:53.43ms
+step:1303/1490 train_time:69650ms step_avg:53.45ms
+step:1304/1490 train_time:69735ms step_avg:53.48ms
+step:1305/1490 train_time:69815ms step_avg:53.50ms
+step:1306/1490 train_time:69899ms step_avg:53.52ms
+step:1307/1490 train_time:69979ms step_avg:53.54ms
+step:1308/1490 train_time:70062ms step_avg:53.56ms
+step:1309/1490 train_time:70142ms step_avg:53.58ms
+step:1310/1490 train_time:70225ms step_avg:53.61ms
+step:1311/1490 train_time:70306ms step_avg:53.63ms
+step:1312/1490 train_time:70391ms step_avg:53.65ms
+step:1313/1490 train_time:70472ms step_avg:53.67ms
+step:1314/1490 train_time:70559ms step_avg:53.70ms
+step:1315/1490 train_time:70637ms step_avg:53.72ms
+step:1316/1490 train_time:70721ms step_avg:53.74ms
+step:1317/1490 train_time:70801ms step_avg:53.76ms
+step:1318/1490 train_time:70886ms step_avg:53.78ms
+step:1319/1490 train_time:70966ms step_avg:53.80ms
+step:1320/1490 train_time:71051ms step_avg:53.83ms
+step:1321/1490 train_time:71129ms step_avg:53.84ms
+step:1322/1490 train_time:71214ms step_avg:53.87ms
+step:1323/1490 train_time:71292ms step_avg:53.89ms
+step:1324/1490 train_time:71379ms step_avg:53.91ms
+step:1325/1490 train_time:71459ms step_avg:53.93ms
+step:1326/1490 train_time:71545ms step_avg:53.96ms
+step:1327/1490 train_time:71626ms step_avg:53.98ms
+step:1328/1490 train_time:71711ms step_avg:54.00ms
+step:1329/1490 train_time:71790ms step_avg:54.02ms
+step:1330/1490 train_time:71874ms step_avg:54.04ms
+step:1331/1490 train_time:71954ms step_avg:54.06ms
+step:1332/1490 train_time:72039ms step_avg:54.08ms
+step:1333/1490 train_time:72120ms step_avg:54.10ms
+step:1334/1490 train_time:72205ms step_avg:54.13ms
+step:1335/1490 train_time:72284ms step_avg:54.15ms
+step:1336/1490 train_time:72368ms step_avg:54.17ms
+step:1337/1490 train_time:72447ms step_avg:54.19ms
+step:1338/1490 train_time:72532ms step_avg:54.21ms
+step:1339/1490 train_time:72612ms step_avg:54.23ms
+step:1340/1490 train_time:72698ms step_avg:54.25ms
+step:1341/1490 train_time:72777ms step_avg:54.27ms
+step:1342/1490 train_time:72863ms step_avg:54.29ms
+step:1343/1490 train_time:72943ms step_avg:54.31ms
+step:1344/1490 train_time:73027ms step_avg:54.34ms
+step:1345/1490 train_time:73106ms step_avg:54.35ms
+step:1346/1490 train_time:73191ms step_avg:54.38ms
+step:1347/1490 train_time:73271ms step_avg:54.40ms
+step:1348/1490 train_time:73355ms step_avg:54.42ms
+step:1349/1490 train_time:73434ms step_avg:54.44ms
+step:1350/1490 train_time:73519ms step_avg:54.46ms
+step:1351/1490 train_time:73599ms step_avg:54.48ms
+step:1352/1490 train_time:73683ms step_avg:54.50ms
+step:1353/1490 train_time:73764ms step_avg:54.52ms
+step:1354/1490 train_time:73849ms step_avg:54.54ms
+step:1355/1490 train_time:73928ms step_avg:54.56ms
+step:1356/1490 train_time:74013ms step_avg:54.58ms
+step:1357/1490 train_time:74091ms step_avg:54.60ms
+step:1358/1490 train_time:74176ms step_avg:54.62ms
+step:1359/1490 train_time:74255ms step_avg:54.64ms
+step:1360/1490 train_time:74341ms step_avg:54.66ms
+step:1361/1490 train_time:74421ms step_avg:54.68ms
+step:1362/1490 train_time:74506ms step_avg:54.70ms
+step:1363/1490 train_time:74586ms step_avg:54.72ms
+step:1364/1490 train_time:74670ms step_avg:54.74ms
+step:1365/1490 train_time:74750ms step_avg:54.76ms
+step:1366/1490 train_time:74834ms step_avg:54.78ms
+step:1367/1490 train_time:74913ms step_avg:54.80ms
+step:1368/1490 train_time:74998ms step_avg:54.82ms
+step:1369/1490 train_time:75077ms step_avg:54.84ms
+step:1370/1490 train_time:75162ms step_avg:54.86ms
+step:1371/1490 train_time:75241ms step_avg:54.88ms
+step:1372/1490 train_time:75327ms step_avg:54.90ms
+step:1373/1490 train_time:75407ms step_avg:54.92ms
+step:1374/1490 train_time:75491ms step_avg:54.94ms
+step:1375/1490 train_time:75571ms step_avg:54.96ms
+step:1376/1490 train_time:75656ms step_avg:54.98ms
+step:1377/1490 train_time:75736ms step_avg:55.00ms
+step:1378/1490 train_time:75821ms step_avg:55.02ms
+step:1379/1490 train_time:75901ms step_avg:55.04ms
+step:1380/1490 train_time:75986ms step_avg:55.06ms
+step:1381/1490 train_time:76065ms step_avg:55.08ms
+step:1382/1490 train_time:76149ms step_avg:55.10ms
+step:1383/1490 train_time:76229ms step_avg:55.12ms
+step:1384/1490 train_time:76314ms step_avg:55.14ms
+step:1385/1490 train_time:76393ms step_avg:55.16ms
+step:1386/1490 train_time:76476ms step_avg:55.18ms
+step:1387/1490 train_time:76556ms step_avg:55.20ms
+step:1388/1490 train_time:76642ms step_avg:55.22ms
+step:1389/1490 train_time:76722ms step_avg:55.24ms
+step:1390/1490 train_time:76807ms step_avg:55.26ms
+step:1391/1490 train_time:76885ms step_avg:55.27ms
+step:1392/1490 train_time:76971ms step_avg:55.29ms
+step:1393/1490 train_time:77049ms step_avg:55.31ms
+step:1394/1490 train_time:77134ms step_avg:55.33ms
+step:1395/1490 train_time:77213ms step_avg:55.35ms
+step:1396/1490 train_time:77299ms step_avg:55.37ms
+step:1397/1490 train_time:77379ms step_avg:55.39ms
+step:1398/1490 train_time:77464ms step_avg:55.41ms
+step:1399/1490 train_time:77544ms step_avg:55.43ms
+step:1400/1490 train_time:77630ms step_avg:55.45ms
+step:1401/1490 train_time:77710ms step_avg:55.47ms
+step:1402/1490 train_time:77794ms step_avg:55.49ms
+step:1403/1490 train_time:77872ms step_avg:55.50ms
+step:1404/1490 train_time:77960ms step_avg:55.53ms
+step:1405/1490 train_time:78040ms step_avg:55.54ms
+step:1406/1490 train_time:78126ms step_avg:55.57ms
+step:1407/1490 train_time:78206ms step_avg:55.58ms
+step:1408/1490 train_time:78290ms step_avg:55.60ms
+step:1409/1490 train_time:78368ms step_avg:55.62ms
+step:1410/1490 train_time:78454ms step_avg:55.64ms
+step:1411/1490 train_time:78532ms step_avg:55.66ms
+step:1412/1490 train_time:78618ms step_avg:55.68ms
+step:1413/1490 train_time:78699ms step_avg:55.70ms
+step:1414/1490 train_time:78783ms step_avg:55.72ms
+step:1415/1490 train_time:78864ms step_avg:55.73ms
+step:1416/1490 train_time:78948ms step_avg:55.75ms
+step:1417/1490 train_time:79027ms step_avg:55.77ms
+step:1418/1490 train_time:79111ms step_avg:55.79ms
+step:1419/1490 train_time:79190ms step_avg:55.81ms
+step:1420/1490 train_time:79275ms step_avg:55.83ms
+step:1421/1490 train_time:79354ms step_avg:55.84ms
+step:1422/1490 train_time:79440ms step_avg:55.86ms
+step:1423/1490 train_time:79520ms step_avg:55.88ms
+step:1424/1490 train_time:79605ms step_avg:55.90ms
+step:1425/1490 train_time:79685ms step_avg:55.92ms
+step:1426/1490 train_time:79771ms step_avg:55.94ms
+step:1427/1490 train_time:79848ms step_avg:55.96ms
+step:1428/1490 train_time:79933ms step_avg:55.98ms
+step:1429/1490 train_time:80012ms step_avg:55.99ms
+step:1430/1490 train_time:80097ms step_avg:56.01ms
+step:1431/1490 train_time:80178ms step_avg:56.03ms
+step:1432/1490 train_time:80264ms step_avg:56.05ms
+step:1433/1490 train_time:80342ms step_avg:56.07ms
+step:1434/1490 train_time:80428ms step_avg:56.09ms
+step:1435/1490 train_time:80507ms step_avg:56.10ms
+step:1436/1490 train_time:80593ms step_avg:56.12ms
+step:1437/1490 train_time:80673ms step_avg:56.14ms
+step:1438/1490 train_time:80757ms step_avg:56.16ms
+step:1439/1490 train_time:80836ms step_avg:56.17ms
+step:1440/1490 train_time:80922ms step_avg:56.20ms
+step:1441/1490 train_time:81001ms step_avg:56.21ms
+step:1442/1490 train_time:81086ms step_avg:56.23ms
+step:1443/1490 train_time:81165ms step_avg:56.25ms
+step:1444/1490 train_time:81249ms step_avg:56.27ms
+step:1445/1490 train_time:81328ms step_avg:56.28ms
+step:1446/1490 train_time:81414ms step_avg:56.30ms
+step:1447/1490 train_time:81493ms step_avg:56.32ms
+step:1448/1490 train_time:81579ms step_avg:56.34ms
+step:1449/1490 train_time:81660ms step_avg:56.36ms
+step:1450/1490 train_time:81745ms step_avg:56.38ms
+step:1451/1490 train_time:81829ms step_avg:56.39ms
+step:1452/1490 train_time:81915ms step_avg:56.42ms
+step:1453/1490 train_time:81993ms step_avg:56.43ms
+step:1454/1490 train_time:82078ms step_avg:56.45ms
+step:1455/1490 train_time:82160ms step_avg:56.47ms
+step:1456/1490 train_time:82246ms step_avg:56.49ms
+step:1457/1490 train_time:82328ms step_avg:56.50ms
+step:1458/1490 train_time:82413ms step_avg:56.52ms
+step:1459/1490 train_time:82492ms step_avg:56.54ms
+step:1460/1490 train_time:82577ms step_avg:56.56ms
+step:1461/1490 train_time:82657ms step_avg:56.58ms
+step:1462/1490 train_time:82743ms step_avg:56.60ms
+step:1463/1490 train_time:82824ms step_avg:56.61ms
+step:1464/1490 train_time:82909ms step_avg:56.63ms
+step:1465/1490 train_time:82989ms step_avg:56.65ms
+step:1466/1490 train_time:83074ms step_avg:56.67ms
+step:1467/1490 train_time:83153ms step_avg:56.68ms
+step:1468/1490 train_time:83239ms step_avg:56.70ms
+step:1469/1490 train_time:83319ms step_avg:56.72ms
+step:1470/1490 train_time:83404ms step_avg:56.74ms
+step:1471/1490 train_time:83483ms step_avg:56.75ms
+step:1472/1490 train_time:83569ms step_avg:56.77ms
+step:1473/1490 train_time:83648ms step_avg:56.79ms
+step:1474/1490 train_time:83735ms step_avg:56.81ms
+step:1475/1490 train_time:83814ms step_avg:56.82ms
+step:1476/1490 train_time:83899ms step_avg:56.84ms
+step:1477/1490 train_time:83979ms step_avg:56.86ms
+step:1478/1490 train_time:84065ms step_avg:56.88ms
+step:1479/1490 train_time:84145ms step_avg:56.89ms
+step:1480/1490 train_time:84230ms step_avg:56.91ms
+step:1481/1490 train_time:84309ms step_avg:56.93ms
+step:1482/1490 train_time:84395ms step_avg:56.95ms
+step:1483/1490 train_time:84475ms step_avg:56.96ms
+step:1484/1490 train_time:84560ms step_avg:56.98ms
+step:1485/1490 train_time:84641ms step_avg:57.00ms
+step:1486/1490 train_time:84726ms step_avg:57.02ms
+step:1487/1490 train_time:84806ms step_avg:57.03ms
+step:1488/1490 train_time:84892ms step_avg:57.05ms
+step:1489/1490 train_time:84972ms step_avg:57.07ms
+step:1490/1490 train_time:85056ms step_avg:57.08ms
+step:1490/1490 val_loss:3.2794 train_time:85153ms step_avg:57.15ms
+peak memory allocated: 31276 MiB reserved: 44906 MiB

--- a/records/track_1_short/2026-04-4_FuseCEFwdAndBwd/runs/e5c56c8f-1b70-4458-8486-5b195362ceae.txt
+++ b/records/track_1_short/2026-04-4_FuseCEFwdAndBwd/runs/e5c56c8f-1b70-4458-8486-5b195362ceae.txt
@@ -1,0 +1,4731 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+CE_KERNEL_BLOCK_SIZE = 256
+CE_KERNEL_VOCAB_SIZE = 50304
+
+CE_KERNEL_DECLS = f"""
+constexpr int VOCAB_SIZE = {CE_KERNEL_VOCAB_SIZE};
+constexpr int BLOCK_SIZE = {CE_KERNEL_BLOCK_SIZE};
+"""
+
+CE_KERNEL_SOURCE = """
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+#define __nv_fp8_e5m2 char
+#define uint16_t unsigned short
+#define uint8_t unsigned char
+#define int64_t long long
+
+__device__ __forceinline__ __nv_fp8_e5m2 f32_to_fp8_e5m2(float x) {
+    uint16_t packed;
+    asm volatile(
+        "cvt.rn.satfinite.e5m2x2.f32 %0, %1, %2;"
+        : "=h"(packed)
+        : "f"(x), "f"(0.0f)
+    );
+    __nv_fp8_e5m2 result;
+    *reinterpret_cast<uint8_t*>(&result) = (packed & (0xFF << 8)) >> 8;
+    return result;
+}
+
+struct __align__(16) __nv_bfloat168 {
+    __nv_bfloat16 data[8];
+    __device__ __nv_bfloat16& operator[](int i) { return data[i]; }
+    __device__ const __nv_bfloat16& operator[](int i) const { return data[i]; }
+};
+
+struct __align__(8) __nv_fp8_e5m28 {
+    __nv_fp8_e5m2 data[8];
+    __device__ __nv_fp8_e5m2& operator[](int i) { return data[i]; }
+    __device__ const __nv_fp8_e5m2& operator[](int i) const { return data[i]; }
+};
+
+template<typename T> __device__ constexpr T CEIL_DIV(T a, T b) { return (a + b - 1) / b; }
+
+//__device__ float sigmoid(float x) {
+//  return 1.0f / (1.0f + __expf(-x));
+//}
+__device__ float sigmoid(float x) {
+  return 0.5f + __tanhf(x * 0.5f) * 0.5f;
+}
+
+extern "C"
+__launch_bounds__(BLOCK_SIZE, 2)
+__global__ void ce_fwd_bwd_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    const int64_t* __restrict__ targets,
+    const float* __restrict__ mtp_weights,
+    float* __restrict__ losses,
+    __nv_fp8_e5m2* grad_input,
+    int batch_size,
+    int n_predict,
+    double A_param,
+    double B_param,
+    double C_param,
+    double grad_s_param,
+    double grad_scale_param)
+{
+  constexpr int VEC_WIDTH = 8;
+  constexpr int NUM_FULL_LOADS = VOCAB_SIZE / (BLOCK_SIZE * VEC_WIDTH);
+  constexpr int NUM_LOADS = CEIL_DIV(VOCAB_SIZE, BLOCK_SIZE * VEC_WIDTH);
+
+  float A = (float)A_param;
+  float B = (float)B_param;
+  float C = (float)C_param;
+  float grad_s = (float)grad_s_param;
+  float grad_scale = (float)grad_scale_param;
+
+  extern __shared__ __nv_bfloat16 smem[];
+
+  static_assert(VEC_WIDTH == 8);
+
+  const __nv_bfloat16 *block_logit_ptr = logits + VOCAB_SIZE * blockIdx.x;
+
+  float inv_C = 1 / C;
+  float B_div_C = B * inv_C;
+  float thread_max = -CUDART_INF_F;
+
+  #pragma unroll 25
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 result = *(__nv_bfloat168*)(&block_logit_ptr[idx]);
+      __nv_bfloat168 result_sigmoid;
+      #pragma unroll
+      for (int k = 0; k < VEC_WIDTH; k++) {
+        float tmp = __bfloat162float(result[k]);
+        tmp = sigmoid(tmp * inv_C + B_div_C);
+        result_sigmoid[k] = __float2bfloat16(tmp);
+        tmp = A * tmp;
+        thread_max = max(tmp, thread_max);
+      }
+      *(__nv_bfloat168*)(&smem[idx]) = result_sigmoid;
+    }
+  }
+
+  constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+  int warp_id = threadIdx.x / 32;
+  __shared__ float block_maxs[NUM_WARPS];
+  __shared__ float block_sums[NUM_WARPS];
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_max = fmaxf(thread_max, __shfl_down_sync(0xFFFFFFFF, thread_max, offset));
+
+  if (threadIdx.x % 32 == 0) {
+    block_maxs[warp_id] = thread_max;
+  }
+
+  __syncthreads();
+
+  float block_max = -CUDART_INF_F;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_max = fmaxf(block_max, block_maxs[i]);
+  }
+
+  float thread_sum = 0.0f;
+  #pragma unroll 2
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_bfloat168 l;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      l = *(__nv_bfloat168*)(&smem[idx]);
+    }
+    #pragma unroll
+    for (int k = 0; k < VEC_WIDTH; k++) {
+      float tmp = A * __bfloat162float(l[k]);
+      tmp = __expf(tmp - block_max);
+      if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+        thread_sum += tmp;
+      }
+    }
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_sum += __shfl_down_sync(0xFFFFFFFF, thread_sum, offset);
+
+  if (threadIdx.x % 32 == 0) {
+    block_sums[warp_id] = thread_sum;
+  }
+
+  __syncthreads();
+
+  float block_sum = 0.0f;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_sum += block_sums[i];
+  }
+
+  float lse = block_max + __logf(block_sum);
+
+  if (threadIdx.x == 0) {
+    float total_loss = 0.0f;
+    for (int k = 0; k < n_predict; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size) {
+        float weight = mtp_weights[k];
+        int64_t target = targets[target_idx];
+        if (target >= 0 && target < VOCAB_SIZE) {
+          float z_target = A * __bfloat162float(smem[target]);
+          total_loss += weight * (lse - z_target);
+        }
+      }
+    }
+    losses[blockIdx.x] = total_loss;
+  }
+
+  float S_w = 0.0f;
+
+  for (int i = 0; i < n_predict; i++) {
+    S_w += mtp_weights[i];
+  }
+
+  #pragma unroll 4
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_fp8_e5m28 result;
+
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 sigmoid_us = *(__nv_bfloat168*)(&smem[idx]);
+      #pragma unroll
+      for (int j = 0; j < VEC_WIDTH; j++) {
+        float sigmoid_u = __bfloat162float(sigmoid_us[j]);
+        float z = A * sigmoid_u;
+        float p = __expf(z - lse);
+
+        float term1 = S_w * p;
+        float term2 = 0.0f;
+
+        float grad_z = term1 - term2;
+        float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+        auto result_tmp = f32_to_fp8_e5m2(grad_x);
+        result[j] = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+      }
+      *(__nv_fp8_e5m28*)(&grad_input[blockIdx.x * VOCAB_SIZE + idx]) = result;
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < n_predict && blockIdx.x + threadIdx.x < batch_size) {
+    int i = threadIdx.x;
+    int64_t target = targets[blockIdx.x + i];
+
+    float sigmoid_u = __bfloat162float(smem[target]);
+    float z = A * sigmoid_u;
+    float p = __expf(z - lse);
+
+    float term1 = S_w * p;
+    float term2 = 0.0f;
+
+    #pragma unroll
+    for (int k = 0; k < 3; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size && k < n_predict) {
+        if (targets[target_idx] == target) {
+          term2 += mtp_weights[k];
+        }
+      }
+    }
+
+    float grad_z = term1 - term2;
+    float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+    auto result_tmp = f32_to_fp8_e5m2(grad_x);
+    auto result = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+    grad_input[blockIdx.x * VOCAB_SIZE + target] = result;
+  }
+}
+"""
+
+
+ce_fwd_bwd_kernel = torch.cuda._compile_kernel(
+    CE_KERNEL_DECLS + CE_KERNEL_SOURCE,
+    "ce_fwd_bwd_kernel",
+    compute_capability="90",
+    cuda_include_dirs=["/usr/local/cuda/include/"],
+    nvcc_options=["-lineinfo", "--use_fast_math"],
+)
+ce_fwd_bwd_kernel.set_shared_memory_config(CE_KERNEL_VOCAB_SIZE * 2)
+
+@torch.library.custom_op("nanogpt::ce_fwd_bwd", mutates_args={"losses", "grad_input"})
+def ce_fwd_bwd(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    mtp_weights: torch.Tensor,
+    losses: torch.Tensor,
+    grad_input: torch.Tensor,
+    n_rows: int,
+    n_predict: int,
+    A: float,
+    B: float,
+    C: float,
+    grad_s: float,
+    grad_scale: float,
+) -> None:
+    grid = (n_rows, 1, 1)
+    ce_fwd_bwd_kernel(
+        grid,
+        (CE_KERNEL_BLOCK_SIZE, 1, 1),
+        (logits, targets, mtp_weights, losses, grad_input,
+         n_rows, n_predict, A, B, C, grad_s, grad_scale),
+        shared_mem=CE_KERNEL_VOCAB_SIZE * 2,
+    )
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, grad_scale, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+
+        ce_fwd_bwd(logits, targets, mtp_weights, losses, grad_input,
+             n_rows, n_predict, A, B, C, grad_s, grad_scale)
+        #grid = (n_rows,)
+        #fused_softcapped_entropy_fwd_kernel[grid](
+        #    logits, losses, lse, targets, mtp_weights,
+        #    logits.stride(0), logits.stride(1),
+        #    n_rows, n_cols, n_predict,
+        #    A, B, C,
+        #    BLOCK_SIZE=2048,
+        #    num_warps=2
+        #)
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_output = grad_output.contiguous()
+
+        #grad_input_ref = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        #grid = (n_rows,)
+        #fused_softcapped_entropy_bwd_kernel[grid](
+        #    grad_input_ref, grad_output, lse, logits, targets, mtp_weights,
+        #    logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+        #    n_rows, n_cols, n_predict,
+        #    A, B, C,
+        #    grad_s,
+        #    BLOCK_SIZE=1024,
+        #    num_warps=4,
+        #    N_PREDICT=n_predict,
+        #)
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.12.3 (main, Mar  3 2026, 12:15:18) [GCC 13.3.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Sat Apr  4 05:41:56 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:8D:00.0 Off |                    0 |
+| N/A   46C    P0            127W /  700W |    1521MiB /  81559MiB |      2%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:91:00.0 Off |                    0 |
+| N/A   36C    P0            120W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:95:00.0 Off |                    0 |
+| N/A   45C    P0            128W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:99:00.0 Off |                    0 |
+| N/A   37C    P0            126W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   45C    P0            122W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AF:00.0 Off |                    0 |
+| N/A   37C    P0            121W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:B3:00.0 Off |                    0 |
+| N/A   46C    P0            126W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:B7:00.0 Off |                    0 |
+| N/A   36C    P0            122W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A           36633      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    1   N/A  N/A           36634      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    2   N/A  N/A           36635      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    3   N/A  N/A           36636      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    4   N/A  N/A           36637      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    5   N/A  N/A           36638      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    6   N/A  N/A           36639      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
+|    7   N/A  N/A           36640      C   ...dded-nanogpt/venv/bin/python3       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8328 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:75ms step_avg:75.22ms
+step:2/1490 train_time:95ms step_avg:47.68ms
+step:3/1490 train_time:111ms step_avg:37.08ms
+step:4/1490 train_time:145ms step_avg:36.24ms
+step:5/1490 train_time:172ms step_avg:34.40ms
+step:6/1490 train_time:206ms step_avg:34.29ms
+step:7/1490 train_time:233ms step_avg:33.33ms
+step:8/1490 train_time:267ms step_avg:33.41ms
+step:9/1490 train_time:294ms step_avg:32.68ms
+step:10/1490 train_time:328ms step_avg:32.84ms
+step:11/1490 train_time:356ms step_avg:32.35ms
+step:12/1490 train_time:390ms step_avg:32.50ms
+step:13/1490 train_time:417ms step_avg:32.10ms
+step:14/1490 train_time:451ms step_avg:32.23ms
+step:15/1490 train_time:478ms step_avg:31.90ms
+step:16/1490 train_time:513ms step_avg:32.03ms
+step:17/1490 train_time:540ms step_avg:31.75ms
+step:18/1490 train_time:574ms step_avg:31.87ms
+step:19/1490 train_time:601ms step_avg:31.63ms
+step:20/1490 train_time:635ms step_avg:31.74ms
+step:21/1490 train_time:662ms step_avg:31.54ms
+step:22/1490 train_time:697ms step_avg:31.66ms
+step:23/1490 train_time:724ms step_avg:31.47ms
+step:24/1490 train_time:758ms step_avg:31.58ms
+step:25/1490 train_time:785ms step_avg:31.40ms
+step:26/1490 train_time:819ms step_avg:31.51ms
+step:27/1490 train_time:846ms step_avg:31.35ms
+step:28/1490 train_time:880ms step_avg:31.45ms
+step:29/1490 train_time:908ms step_avg:31.30ms
+step:30/1490 train_time:942ms step_avg:31.40ms
+step:31/1490 train_time:970ms step_avg:31.30ms
+step:32/1490 train_time:1007ms step_avg:31.46ms
+step:33/1490 train_time:1035ms step_avg:31.36ms
+step:34/1490 train_time:1070ms step_avg:31.47ms
+step:35/1490 train_time:1098ms step_avg:31.38ms
+step:36/1490 train_time:1133ms step_avg:31.47ms
+step:37/1490 train_time:1161ms step_avg:31.39ms
+step:38/1490 train_time:1196ms step_avg:31.47ms
+step:39/1490 train_time:1224ms step_avg:31.38ms
+step:40/1490 train_time:1258ms step_avg:31.46ms
+step:41/1490 train_time:1286ms step_avg:31.36ms
+step:42/1490 train_time:1321ms step_avg:31.44ms
+step:43/1490 train_time:1348ms step_avg:31.34ms
+step:44/1490 train_time:1382ms step_avg:31.41ms
+step:45/1490 train_time:1409ms step_avg:31.32ms
+step:46/1490 train_time:1443ms step_avg:31.38ms
+step:47/1490 train_time:1471ms step_avg:31.30ms
+step:48/1490 train_time:1505ms step_avg:31.36ms
+step:49/1490 train_time:1533ms step_avg:31.29ms
+step:50/1490 train_time:1567ms step_avg:31.34ms
+step:51/1490 train_time:1595ms step_avg:31.27ms
+step:52/1490 train_time:1629ms step_avg:31.32ms
+step:53/1490 train_time:1656ms step_avg:31.25ms
+step:54/1490 train_time:1691ms step_avg:31.31ms
+step:55/1490 train_time:1718ms step_avg:31.24ms
+step:56/1490 train_time:1752ms step_avg:31.29ms
+step:57/1490 train_time:1779ms step_avg:31.21ms
+step:58/1490 train_time:1813ms step_avg:31.26ms
+step:59/1490 train_time:1840ms step_avg:31.19ms
+step:60/1490 train_time:1874ms step_avg:31.24ms
+step:61/1490 train_time:1902ms step_avg:31.18ms
+step:62/1490 train_time:1936ms step_avg:31.23ms
+step:63/1490 train_time:1964ms step_avg:31.17ms
+step:64/1490 train_time:1998ms step_avg:31.22ms
+step:65/1490 train_time:2026ms step_avg:31.16ms
+step:66/1490 train_time:2060ms step_avg:31.22ms
+step:67/1490 train_time:2088ms step_avg:31.16ms
+step:68/1490 train_time:2123ms step_avg:31.22ms
+step:69/1490 train_time:2151ms step_avg:31.17ms
+step:70/1490 train_time:2185ms step_avg:31.22ms
+step:71/1490 train_time:2213ms step_avg:31.17ms
+step:72/1490 train_time:2247ms step_avg:31.21ms
+step:73/1490 train_time:2275ms step_avg:31.17ms
+step:74/1490 train_time:2309ms step_avg:31.21ms
+step:75/1490 train_time:2337ms step_avg:31.16ms
+step:76/1490 train_time:2371ms step_avg:31.20ms
+step:77/1490 train_time:2399ms step_avg:31.15ms
+step:78/1490 train_time:2433ms step_avg:31.19ms
+step:79/1490 train_time:2461ms step_avg:31.16ms
+step:80/1490 train_time:2496ms step_avg:31.20ms
+step:81/1490 train_time:2524ms step_avg:31.16ms
+step:82/1490 train_time:2558ms step_avg:31.20ms
+step:83/1490 train_time:2586ms step_avg:31.15ms
+step:84/1490 train_time:2620ms step_avg:31.19ms
+step:85/1490 train_time:2647ms step_avg:31.14ms
+step:86/1490 train_time:2682ms step_avg:31.18ms
+step:87/1490 train_time:2709ms step_avg:31.13ms
+step:88/1490 train_time:2743ms step_avg:31.17ms
+step:89/1490 train_time:2771ms step_avg:31.13ms
+step:90/1490 train_time:2805ms step_avg:31.16ms
+step:91/1490 train_time:2832ms step_avg:31.12ms
+step:92/1490 train_time:2867ms step_avg:31.16ms
+step:93/1490 train_time:2894ms step_avg:31.12ms
+step:94/1490 train_time:2928ms step_avg:31.15ms
+step:95/1490 train_time:2956ms step_avg:31.11ms
+step:96/1490 train_time:2990ms step_avg:31.14ms
+step:97/1490 train_time:3017ms step_avg:31.11ms
+step:98/1490 train_time:3051ms step_avg:31.14ms
+step:99/1490 train_time:3079ms step_avg:31.10ms
+step:100/1490 train_time:3113ms step_avg:31.13ms
+step:101/1490 train_time:3141ms step_avg:31.10ms
+step:102/1490 train_time:3176ms step_avg:31.14ms
+step:103/1490 train_time:3204ms step_avg:31.11ms
+step:104/1490 train_time:3239ms step_avg:31.14ms
+step:105/1490 train_time:3266ms step_avg:31.11ms
+step:106/1490 train_time:3301ms step_avg:31.14ms
+step:107/1490 train_time:3328ms step_avg:31.10ms
+step:108/1490 train_time:3362ms step_avg:31.13ms
+step:109/1490 train_time:3390ms step_avg:31.11ms
+step:110/1490 train_time:3425ms step_avg:31.13ms
+step:111/1490 train_time:3453ms step_avg:31.11ms
+step:112/1490 train_time:3487ms step_avg:31.13ms
+step:113/1490 train_time:3514ms step_avg:31.10ms
+step:114/1490 train_time:3548ms step_avg:31.12ms
+step:115/1490 train_time:3576ms step_avg:31.09ms
+step:116/1490 train_time:3610ms step_avg:31.12ms
+step:117/1490 train_time:3637ms step_avg:31.08ms
+step:118/1490 train_time:3671ms step_avg:31.11ms
+step:119/1490 train_time:3698ms step_avg:31.07ms
+step:120/1490 train_time:3732ms step_avg:31.10ms
+step:121/1490 train_time:3760ms step_avg:31.07ms
+step:122/1490 train_time:3794ms step_avg:31.10ms
+step:123/1490 train_time:3821ms step_avg:31.07ms
+step:124/1490 train_time:3856ms step_avg:31.09ms
+step:125/1490 train_time:3884ms step_avg:31.07ms
+step:126/1490 train_time:3918ms step_avg:31.09ms
+step:127/1490 train_time:3945ms step_avg:31.06ms
+step:128/1490 train_time:3979ms step_avg:31.09ms
+step:129/1490 train_time:4006ms step_avg:31.06ms
+step:130/1490 train_time:4040ms step_avg:31.08ms
+step:131/1490 train_time:4068ms step_avg:31.06ms
+step:132/1490 train_time:4103ms step_avg:31.08ms
+step:133/1490 train_time:4131ms step_avg:31.06ms
+step:134/1490 train_time:4165ms step_avg:31.08ms
+step:135/1490 train_time:4193ms step_avg:31.06ms
+step:136/1490 train_time:4227ms step_avg:31.08ms
+step:137/1490 train_time:4254ms step_avg:31.05ms
+step:138/1490 train_time:4288ms step_avg:31.07ms
+step:139/1490 train_time:4315ms step_avg:31.05ms
+step:140/1490 train_time:4349ms step_avg:31.07ms
+step:141/1490 train_time:4377ms step_avg:31.04ms
+step:142/1490 train_time:4411ms step_avg:31.06ms
+step:143/1490 train_time:4439ms step_avg:31.04ms
+step:144/1490 train_time:4473ms step_avg:31.06ms
+step:145/1490 train_time:4500ms step_avg:31.03ms
+step:146/1490 train_time:4534ms step_avg:31.06ms
+step:147/1490 train_time:4562ms step_avg:31.03ms
+step:148/1490 train_time:4596ms step_avg:31.05ms
+step:149/1490 train_time:4624ms step_avg:31.03ms
+step:150/1490 train_time:4658ms step_avg:31.05ms
+step:151/1490 train_time:4686ms step_avg:31.03ms
+step:152/1490 train_time:4719ms step_avg:31.05ms
+step:153/1490 train_time:4746ms step_avg:31.02ms
+step:154/1490 train_time:4781ms step_avg:31.04ms
+step:155/1490 train_time:4808ms step_avg:31.02ms
+step:156/1490 train_time:4843ms step_avg:31.04ms
+step:157/1490 train_time:4870ms step_avg:31.02ms
+step:158/1490 train_time:4904ms step_avg:31.04ms
+step:159/1490 train_time:4932ms step_avg:31.02ms
+step:160/1490 train_time:4966ms step_avg:31.04ms
+step:161/1490 train_time:4993ms step_avg:31.01ms
+step:162/1490 train_time:5027ms step_avg:31.03ms
+step:163/1490 train_time:5055ms step_avg:31.01ms
+step:164/1490 train_time:5089ms step_avg:31.03ms
+step:165/1490 train_time:5116ms step_avg:31.01ms
+step:166/1490 train_time:5151ms step_avg:31.03ms
+step:167/1490 train_time:5178ms step_avg:31.01ms
+step:168/1490 train_time:5213ms step_avg:31.03ms
+step:169/1490 train_time:5240ms step_avg:31.01ms
+step:170/1490 train_time:5274ms step_avg:31.03ms
+step:171/1490 train_time:5302ms step_avg:31.00ms
+step:172/1490 train_time:5336ms step_avg:31.02ms
+step:173/1490 train_time:5364ms step_avg:31.00ms
+step:174/1490 train_time:5398ms step_avg:31.02ms
+step:175/1490 train_time:5426ms step_avg:31.00ms
+step:176/1490 train_time:5460ms step_avg:31.02ms
+step:177/1490 train_time:5487ms step_avg:31.00ms
+step:178/1490 train_time:5521ms step_avg:31.02ms
+step:179/1490 train_time:5549ms step_avg:31.00ms
+step:180/1490 train_time:5583ms step_avg:31.02ms
+step:181/1490 train_time:5611ms step_avg:31.00ms
+step:182/1490 train_time:5645ms step_avg:31.02ms
+step:183/1490 train_time:5672ms step_avg:31.00ms
+step:184/1490 train_time:5706ms step_avg:31.01ms
+step:185/1490 train_time:5734ms step_avg:30.99ms
+step:186/1490 train_time:5767ms step_avg:31.01ms
+step:187/1490 train_time:5795ms step_avg:30.99ms
+step:188/1490 train_time:5829ms step_avg:31.00ms
+step:189/1490 train_time:5856ms step_avg:30.98ms
+step:190/1490 train_time:5890ms step_avg:31.00ms
+step:191/1490 train_time:5917ms step_avg:30.98ms
+step:192/1490 train_time:5952ms step_avg:31.00ms
+step:193/1490 train_time:5979ms step_avg:30.98ms
+step:194/1490 train_time:6013ms step_avg:30.99ms
+step:195/1490 train_time:6040ms step_avg:30.98ms
+step:196/1490 train_time:6075ms step_avg:30.99ms
+step:197/1490 train_time:6102ms step_avg:30.98ms
+step:198/1490 train_time:6137ms step_avg:30.99ms
+step:199/1490 train_time:6164ms step_avg:30.98ms
+step:200/1490 train_time:6198ms step_avg:30.99ms
+step:201/1490 train_time:6226ms step_avg:30.97ms
+step:202/1490 train_time:6260ms step_avg:30.99ms
+step:203/1490 train_time:6287ms step_avg:30.97ms
+step:204/1490 train_time:6321ms step_avg:30.99ms
+step:205/1490 train_time:6349ms step_avg:30.97ms
+step:206/1490 train_time:6383ms step_avg:30.99ms
+step:207/1490 train_time:6411ms step_avg:30.97ms
+step:208/1490 train_time:6445ms step_avg:30.98ms
+step:209/1490 train_time:6473ms step_avg:30.97ms
+step:210/1490 train_time:6507ms step_avg:30.98ms
+step:211/1490 train_time:6534ms step_avg:30.97ms
+step:212/1490 train_time:6568ms step_avg:30.98ms
+step:213/1490 train_time:6595ms step_avg:30.96ms
+step:214/1490 train_time:6629ms step_avg:30.98ms
+step:215/1490 train_time:6657ms step_avg:30.96ms
+step:216/1490 train_time:6691ms step_avg:30.98ms
+step:217/1490 train_time:6718ms step_avg:30.96ms
+step:218/1490 train_time:6752ms step_avg:30.97ms
+step:219/1490 train_time:6780ms step_avg:30.96ms
+step:220/1490 train_time:6814ms step_avg:30.97ms
+step:221/1490 train_time:6841ms step_avg:30.95ms
+step:222/1490 train_time:6875ms step_avg:30.97ms
+step:223/1490 train_time:6902ms step_avg:30.95ms
+step:224/1490 train_time:6937ms step_avg:30.97ms
+step:225/1490 train_time:6964ms step_avg:30.95ms
+step:226/1490 train_time:6998ms step_avg:30.96ms
+step:227/1490 train_time:7025ms step_avg:30.95ms
+step:228/1490 train_time:7059ms step_avg:30.96ms
+step:229/1490 train_time:7086ms step_avg:30.94ms
+step:230/1490 train_time:7121ms step_avg:30.96ms
+step:231/1490 train_time:7148ms step_avg:30.94ms
+step:232/1490 train_time:7183ms step_avg:30.96ms
+step:233/1490 train_time:7210ms step_avg:30.94ms
+step:234/1490 train_time:7244ms step_avg:30.96ms
+step:235/1490 train_time:7272ms step_avg:30.95ms
+step:236/1490 train_time:7306ms step_avg:30.96ms
+step:237/1490 train_time:7334ms step_avg:30.94ms
+step:238/1490 train_time:7368ms step_avg:30.96ms
+step:239/1490 train_time:7395ms step_avg:30.94ms
+step:240/1490 train_time:7429ms step_avg:30.95ms
+step:241/1490 train_time:7456ms step_avg:30.94ms
+step:242/1490 train_time:7490ms step_avg:30.95ms
+step:243/1490 train_time:7518ms step_avg:30.94ms
+step:244/1490 train_time:7552ms step_avg:30.95ms
+step:245/1490 train_time:7580ms step_avg:30.94ms
+step:246/1490 train_time:7613ms step_avg:30.95ms
+step:247/1490 train_time:7641ms step_avg:30.93ms
+step:248/1490 train_time:7675ms step_avg:30.95ms
+step:249/1490 train_time:7702ms step_avg:30.93ms
+step:250/1490 train_time:7737ms step_avg:30.95ms
+step:250/1490 val_loss:4.5006 train_time:7776ms step_avg:31.11ms
+step:251/1490 train_time:7794ms step_avg:31.05ms
+step:252/1490 train_time:7812ms step_avg:31.00ms
+step:253/1490 train_time:7828ms step_avg:30.94ms
+step:254/1490 train_time:7863ms step_avg:30.96ms
+step:255/1490 train_time:7891ms step_avg:30.95ms
+step:256/1490 train_time:7927ms step_avg:30.96ms
+step:257/1490 train_time:7955ms step_avg:30.95ms
+step:258/1490 train_time:7989ms step_avg:30.97ms
+step:259/1490 train_time:8017ms step_avg:30.95ms
+step:260/1490 train_time:8052ms step_avg:30.97ms
+step:261/1490 train_time:8079ms step_avg:30.95ms
+step:262/1490 train_time:8114ms step_avg:30.97ms
+step:263/1490 train_time:8141ms step_avg:30.95ms
+step:264/1490 train_time:8174ms step_avg:30.96ms
+step:265/1490 train_time:8202ms step_avg:30.95ms
+step:266/1490 train_time:8236ms step_avg:30.96ms
+step:267/1490 train_time:8263ms step_avg:30.95ms
+step:268/1490 train_time:8297ms step_avg:30.96ms
+step:269/1490 train_time:8324ms step_avg:30.94ms
+step:270/1490 train_time:8358ms step_avg:30.95ms
+step:271/1490 train_time:8385ms step_avg:30.94ms
+step:272/1490 train_time:8419ms step_avg:30.95ms
+step:273/1490 train_time:8446ms step_avg:30.94ms
+step:274/1490 train_time:8480ms step_avg:30.95ms
+step:275/1490 train_time:8507ms step_avg:30.94ms
+step:276/1490 train_time:8541ms step_avg:30.95ms
+step:277/1490 train_time:8569ms step_avg:30.93ms
+step:278/1490 train_time:8603ms step_avg:30.94ms
+step:279/1490 train_time:8630ms step_avg:30.93ms
+step:280/1490 train_time:8664ms step_avg:30.94ms
+step:281/1490 train_time:8691ms step_avg:30.93ms
+step:282/1490 train_time:8726ms step_avg:30.94ms
+step:283/1490 train_time:8753ms step_avg:30.93ms
+step:284/1490 train_time:8788ms step_avg:30.94ms
+step:285/1490 train_time:8816ms step_avg:30.93ms
+step:286/1490 train_time:8850ms step_avg:30.95ms
+step:287/1490 train_time:8878ms step_avg:30.93ms
+step:288/1490 train_time:8913ms step_avg:30.95ms
+step:289/1490 train_time:8940ms step_avg:30.94ms
+step:290/1490 train_time:8975ms step_avg:30.95ms
+step:291/1490 train_time:9002ms step_avg:30.94ms
+step:292/1490 train_time:9036ms step_avg:30.95ms
+step:293/1490 train_time:9064ms step_avg:30.94ms
+step:294/1490 train_time:9099ms step_avg:30.95ms
+step:295/1490 train_time:9126ms step_avg:30.94ms
+step:296/1490 train_time:9160ms step_avg:30.95ms
+step:297/1490 train_time:9188ms step_avg:30.94ms
+step:298/1490 train_time:9222ms step_avg:30.95ms
+step:299/1490 train_time:9249ms step_avg:30.93ms
+step:300/1490 train_time:9283ms step_avg:30.94ms
+step:301/1490 train_time:9311ms step_avg:30.93ms
+step:302/1490 train_time:9345ms step_avg:30.94ms
+step:303/1490 train_time:9372ms step_avg:30.93ms
+step:304/1490 train_time:9406ms step_avg:30.94ms
+step:305/1490 train_time:9433ms step_avg:30.93ms
+step:306/1490 train_time:9467ms step_avg:30.94ms
+step:307/1490 train_time:9494ms step_avg:30.93ms
+step:308/1490 train_time:9528ms step_avg:30.94ms
+step:309/1490 train_time:9556ms step_avg:30.92ms
+step:310/1490 train_time:9590ms step_avg:30.93ms
+step:311/1490 train_time:9617ms step_avg:30.92ms
+step:312/1490 train_time:9651ms step_avg:30.93ms
+step:313/1490 train_time:9679ms step_avg:30.92ms
+step:314/1490 train_time:9714ms step_avg:30.94ms
+step:315/1490 train_time:9741ms step_avg:30.92ms
+step:316/1490 train_time:9775ms step_avg:30.94ms
+step:317/1490 train_time:9803ms step_avg:30.92ms
+step:318/1490 train_time:9837ms step_avg:30.93ms
+step:319/1490 train_time:9865ms step_avg:30.93ms
+step:320/1490 train_time:9900ms step_avg:30.94ms
+step:321/1490 train_time:9927ms step_avg:30.93ms
+step:322/1490 train_time:9962ms step_avg:30.94ms
+step:323/1490 train_time:9989ms step_avg:30.93ms
+step:324/1490 train_time:10023ms step_avg:30.94ms
+step:325/1490 train_time:10050ms step_avg:30.92ms
+step:326/1490 train_time:10084ms step_avg:30.93ms
+step:327/1490 train_time:10112ms step_avg:30.92ms
+step:328/1490 train_time:10146ms step_avg:30.93ms
+step:329/1490 train_time:10173ms step_avg:30.92ms
+step:330/1490 train_time:10207ms step_avg:30.93ms
+step:331/1490 train_time:10235ms step_avg:30.92ms
+step:332/1490 train_time:10269ms step_avg:30.93ms
+step:333/1490 train_time:10296ms step_avg:30.92ms
+step:334/1490 train_time:10330ms step_avg:30.93ms
+step:335/1490 train_time:10358ms step_avg:30.92ms
+step:336/1490 train_time:10392ms step_avg:30.93ms
+step:337/1490 train_time:10419ms step_avg:30.92ms
+step:338/1490 train_time:10453ms step_avg:30.93ms
+step:339/1490 train_time:10480ms step_avg:30.92ms
+step:340/1490 train_time:10514ms step_avg:30.92ms
+step:341/1490 train_time:10541ms step_avg:30.91ms
+step:342/1490 train_time:10575ms step_avg:30.92ms
+step:343/1490 train_time:10603ms step_avg:30.91ms
+step:344/1490 train_time:10637ms step_avg:30.92ms
+step:345/1490 train_time:10664ms step_avg:30.91ms
+step:346/1490 train_time:10698ms step_avg:30.92ms
+step:347/1490 train_time:10726ms step_avg:30.91ms
+step:348/1490 train_time:10763ms step_avg:30.93ms
+step:349/1490 train_time:10788ms step_avg:30.91ms
+step:350/1490 train_time:10822ms step_avg:30.92ms
+step:351/1490 train_time:10850ms step_avg:30.91ms
+step:352/1490 train_time:10884ms step_avg:30.92ms
+step:353/1490 train_time:10911ms step_avg:30.91ms
+step:354/1490 train_time:10945ms step_avg:30.92ms
+step:355/1490 train_time:10973ms step_avg:30.91ms
+step:356/1490 train_time:11007ms step_avg:30.92ms
+step:357/1490 train_time:11034ms step_avg:30.91ms
+step:358/1490 train_time:11068ms step_avg:30.92ms
+step:359/1490 train_time:11096ms step_avg:30.91ms
+step:360/1490 train_time:11130ms step_avg:30.92ms
+step:361/1490 train_time:11158ms step_avg:30.91ms
+step:362/1490 train_time:11192ms step_avg:30.92ms
+step:363/1490 train_time:11220ms step_avg:30.91ms
+step:364/1490 train_time:11254ms step_avg:30.92ms
+step:365/1490 train_time:11281ms step_avg:30.91ms
+step:366/1490 train_time:11315ms step_avg:30.92ms
+step:367/1490 train_time:11342ms step_avg:30.91ms
+step:368/1490 train_time:11376ms step_avg:30.91ms
+step:369/1490 train_time:11404ms step_avg:30.90ms
+step:370/1490 train_time:11438ms step_avg:30.91ms
+step:371/1490 train_time:11465ms step_avg:30.90ms
+step:372/1490 train_time:11499ms step_avg:30.91ms
+step:373/1490 train_time:11527ms step_avg:30.90ms
+step:374/1490 train_time:11561ms step_avg:30.91ms
+step:375/1490 train_time:11589ms step_avg:30.90ms
+step:376/1490 train_time:11623ms step_avg:30.91ms
+step:377/1490 train_time:11650ms step_avg:30.90ms
+step:378/1490 train_time:11684ms step_avg:30.91ms
+step:379/1490 train_time:11711ms step_avg:30.90ms
+step:380/1490 train_time:11745ms step_avg:30.91ms
+step:381/1490 train_time:11773ms step_avg:30.90ms
+step:382/1490 train_time:11807ms step_avg:30.91ms
+step:383/1490 train_time:11834ms step_avg:30.90ms
+step:384/1490 train_time:11868ms step_avg:30.91ms
+step:385/1490 train_time:11896ms step_avg:30.90ms
+step:386/1490 train_time:11930ms step_avg:30.91ms
+step:387/1490 train_time:11958ms step_avg:30.90ms
+step:388/1490 train_time:11992ms step_avg:30.91ms
+step:389/1490 train_time:12020ms step_avg:30.90ms
+step:390/1490 train_time:12054ms step_avg:30.91ms
+step:391/1490 train_time:12081ms step_avg:30.90ms
+step:392/1490 train_time:12115ms step_avg:30.91ms
+step:393/1490 train_time:12143ms step_avg:30.90ms
+step:394/1490 train_time:12177ms step_avg:30.91ms
+step:395/1490 train_time:12205ms step_avg:30.90ms
+step:396/1490 train_time:12239ms step_avg:30.91ms
+step:397/1490 train_time:12266ms step_avg:30.90ms
+step:398/1490 train_time:12301ms step_avg:30.91ms
+step:399/1490 train_time:12328ms step_avg:30.90ms
+step:400/1490 train_time:12362ms step_avg:30.91ms
+step:401/1490 train_time:12390ms step_avg:30.90ms
+step:402/1490 train_time:12424ms step_avg:30.91ms
+step:403/1490 train_time:12451ms step_avg:30.90ms
+step:404/1490 train_time:12485ms step_avg:30.90ms
+step:405/1490 train_time:12512ms step_avg:30.89ms
+step:406/1490 train_time:12546ms step_avg:30.90ms
+step:407/1490 train_time:12573ms step_avg:30.89ms
+step:408/1490 train_time:12607ms step_avg:30.90ms
+step:409/1490 train_time:12635ms step_avg:30.89ms
+step:410/1490 train_time:12669ms step_avg:30.90ms
+step:411/1490 train_time:12696ms step_avg:30.89ms
+step:412/1490 train_time:12730ms step_avg:30.90ms
+step:413/1490 train_time:12757ms step_avg:30.89ms
+step:414/1490 train_time:12791ms step_avg:30.90ms
+step:415/1490 train_time:12819ms step_avg:30.89ms
+step:416/1490 train_time:12853ms step_avg:30.90ms
+step:417/1490 train_time:12880ms step_avg:30.89ms
+step:418/1490 train_time:12915ms step_avg:30.90ms
+step:419/1490 train_time:12942ms step_avg:30.89ms
+step:420/1490 train_time:12976ms step_avg:30.89ms
+step:421/1490 train_time:13003ms step_avg:30.89ms
+step:422/1490 train_time:13037ms step_avg:30.89ms
+step:423/1490 train_time:13065ms step_avg:30.89ms
+step:424/1490 train_time:13099ms step_avg:30.89ms
+step:425/1490 train_time:13127ms step_avg:30.89ms
+step:426/1490 train_time:13161ms step_avg:30.89ms
+step:427/1490 train_time:13188ms step_avg:30.89ms
+step:428/1490 train_time:13222ms step_avg:30.89ms
+step:429/1490 train_time:13250ms step_avg:30.89ms
+step:430/1490 train_time:13284ms step_avg:30.89ms
+step:431/1490 train_time:13311ms step_avg:30.88ms
+step:432/1490 train_time:13345ms step_avg:30.89ms
+step:433/1490 train_time:13372ms step_avg:30.88ms
+step:434/1490 train_time:13407ms step_avg:30.89ms
+step:435/1490 train_time:13434ms step_avg:30.88ms
+step:436/1490 train_time:13468ms step_avg:30.89ms
+step:437/1490 train_time:13496ms step_avg:30.88ms
+step:438/1490 train_time:13530ms step_avg:30.89ms
+step:439/1490 train_time:13557ms step_avg:30.88ms
+step:440/1490 train_time:13591ms step_avg:30.89ms
+step:441/1490 train_time:13619ms step_avg:30.88ms
+step:442/1490 train_time:13653ms step_avg:30.89ms
+step:443/1490 train_time:13680ms step_avg:30.88ms
+step:444/1490 train_time:13714ms step_avg:30.89ms
+step:445/1490 train_time:13741ms step_avg:30.88ms
+step:446/1490 train_time:13775ms step_avg:30.89ms
+step:447/1490 train_time:13803ms step_avg:30.88ms
+step:448/1490 train_time:13837ms step_avg:30.89ms
+step:449/1490 train_time:13864ms step_avg:30.88ms
+step:450/1490 train_time:13898ms step_avg:30.89ms
+step:451/1490 train_time:13926ms step_avg:30.88ms
+step:452/1490 train_time:13960ms step_avg:30.89ms
+step:453/1490 train_time:13987ms step_avg:30.88ms
+step:454/1490 train_time:14021ms step_avg:30.88ms
+step:455/1490 train_time:14049ms step_avg:30.88ms
+step:456/1490 train_time:14083ms step_avg:30.88ms
+step:457/1490 train_time:14110ms step_avg:30.88ms
+step:458/1490 train_time:14145ms step_avg:30.88ms
+step:459/1490 train_time:14172ms step_avg:30.88ms
+step:460/1490 train_time:14206ms step_avg:30.88ms
+step:461/1490 train_time:14233ms step_avg:30.87ms
+step:462/1490 train_time:14268ms step_avg:30.88ms
+step:463/1490 train_time:14295ms step_avg:30.87ms
+step:464/1490 train_time:14329ms step_avg:30.88ms
+step:465/1490 train_time:14356ms step_avg:30.87ms
+step:466/1490 train_time:14391ms step_avg:30.88ms
+step:467/1490 train_time:14419ms step_avg:30.87ms
+step:468/1490 train_time:14453ms step_avg:30.88ms
+step:469/1490 train_time:14480ms step_avg:30.87ms
+step:470/1490 train_time:14514ms step_avg:30.88ms
+step:471/1490 train_time:14542ms step_avg:30.87ms
+step:472/1490 train_time:14576ms step_avg:30.88ms
+step:473/1490 train_time:14604ms step_avg:30.87ms
+step:474/1490 train_time:14638ms step_avg:30.88ms
+step:475/1490 train_time:14666ms step_avg:30.88ms
+step:476/1490 train_time:14700ms step_avg:30.88ms
+step:477/1490 train_time:14727ms step_avg:30.87ms
+step:478/1490 train_time:14761ms step_avg:30.88ms
+step:479/1490 train_time:14789ms step_avg:30.87ms
+step:480/1490 train_time:14823ms step_avg:30.88ms
+step:481/1490 train_time:14850ms step_avg:30.87ms
+step:482/1490 train_time:14884ms step_avg:30.88ms
+step:483/1490 train_time:14912ms step_avg:30.87ms
+step:484/1490 train_time:14948ms step_avg:30.88ms
+step:485/1490 train_time:15000ms step_avg:30.93ms
+step:486/1490 train_time:15059ms step_avg:30.99ms
+step:487/1490 train_time:15113ms step_avg:31.03ms
+step:488/1490 train_time:15172ms step_avg:31.09ms
+step:489/1490 train_time:15224ms step_avg:31.13ms
+step:490/1490 train_time:15284ms step_avg:31.19ms
+step:491/1490 train_time:15338ms step_avg:31.24ms
+step:492/1490 train_time:15397ms step_avg:31.29ms
+step:493/1490 train_time:15451ms step_avg:31.34ms
+step:494/1490 train_time:15509ms step_avg:31.40ms
+step:495/1490 train_time:15563ms step_avg:31.44ms
+step:496/1490 train_time:15622ms step_avg:31.49ms
+step:497/1490 train_time:15675ms step_avg:31.54ms
+step:498/1490 train_time:15735ms step_avg:31.60ms
+step:499/1490 train_time:15790ms step_avg:31.64ms
+step:500/1490 train_time:15848ms step_avg:31.70ms
+step:500/1490 val_loss:4.2348 train_time:15916ms step_avg:31.83ms
+step:501/1490 train_time:15931ms step_avg:31.80ms
+step:502/1490 train_time:15962ms step_avg:31.80ms
+step:503/1490 train_time:16018ms step_avg:31.84ms
+step:504/1490 train_time:16079ms step_avg:31.90ms
+step:505/1490 train_time:16137ms step_avg:31.95ms
+step:506/1490 train_time:16196ms step_avg:32.01ms
+step:507/1490 train_time:16248ms step_avg:32.05ms
+step:508/1490 train_time:16306ms step_avg:32.10ms
+step:509/1490 train_time:16359ms step_avg:32.14ms
+step:510/1490 train_time:16418ms step_avg:32.19ms
+step:511/1490 train_time:16470ms step_avg:32.23ms
+step:512/1490 train_time:16528ms step_avg:32.28ms
+step:513/1490 train_time:16581ms step_avg:32.32ms
+step:514/1490 train_time:16640ms step_avg:32.37ms
+step:515/1490 train_time:16693ms step_avg:32.41ms
+step:516/1490 train_time:16751ms step_avg:32.46ms
+step:517/1490 train_time:16804ms step_avg:32.50ms
+step:518/1490 train_time:16863ms step_avg:32.55ms
+step:519/1490 train_time:16917ms step_avg:32.60ms
+step:520/1490 train_time:16979ms step_avg:32.65ms
+step:521/1490 train_time:17034ms step_avg:32.69ms
+step:522/1490 train_time:17095ms step_avg:32.75ms
+step:523/1490 train_time:17149ms step_avg:32.79ms
+step:524/1490 train_time:17208ms step_avg:32.84ms
+step:525/1490 train_time:17262ms step_avg:32.88ms
+step:526/1490 train_time:17320ms step_avg:32.93ms
+step:527/1490 train_time:17374ms step_avg:32.97ms
+step:528/1490 train_time:17432ms step_avg:33.02ms
+step:529/1490 train_time:17485ms step_avg:33.05ms
+step:530/1490 train_time:17543ms step_avg:33.10ms
+step:531/1490 train_time:17597ms step_avg:33.14ms
+step:532/1490 train_time:17656ms step_avg:33.19ms
+step:533/1490 train_time:17708ms step_avg:33.22ms
+step:534/1490 train_time:17768ms step_avg:33.27ms
+step:535/1490 train_time:17820ms step_avg:33.31ms
+step:536/1490 train_time:17880ms step_avg:33.36ms
+step:537/1490 train_time:17934ms step_avg:33.40ms
+step:538/1490 train_time:17993ms step_avg:33.44ms
+step:539/1490 train_time:18047ms step_avg:33.48ms
+step:540/1490 train_time:18109ms step_avg:33.53ms
+step:541/1490 train_time:18163ms step_avg:33.57ms
+step:542/1490 train_time:18221ms step_avg:33.62ms
+step:543/1490 train_time:18275ms step_avg:33.66ms
+step:544/1490 train_time:18334ms step_avg:33.70ms
+step:545/1490 train_time:18388ms step_avg:33.74ms
+step:546/1490 train_time:18446ms step_avg:33.78ms
+step:547/1490 train_time:18499ms step_avg:33.82ms
+step:548/1490 train_time:18559ms step_avg:33.87ms
+step:549/1490 train_time:18612ms step_avg:33.90ms
+step:550/1490 train_time:18670ms step_avg:33.94ms
+step:551/1490 train_time:18722ms step_avg:33.98ms
+step:552/1490 train_time:18781ms step_avg:34.02ms
+step:553/1490 train_time:18834ms step_avg:34.06ms
+step:554/1490 train_time:18893ms step_avg:34.10ms
+step:555/1490 train_time:18947ms step_avg:34.14ms
+step:556/1490 train_time:19007ms step_avg:34.19ms
+step:557/1490 train_time:19062ms step_avg:34.22ms
+step:558/1490 train_time:19121ms step_avg:34.27ms
+step:559/1490 train_time:19175ms step_avg:34.30ms
+step:560/1490 train_time:19234ms step_avg:34.35ms
+step:561/1490 train_time:19288ms step_avg:34.38ms
+step:562/1490 train_time:19346ms step_avg:34.42ms
+step:563/1490 train_time:19400ms step_avg:34.46ms
+step:564/1490 train_time:19459ms step_avg:34.50ms
+step:565/1490 train_time:19512ms step_avg:34.53ms
+step:566/1490 train_time:19571ms step_avg:34.58ms
+step:567/1490 train_time:19623ms step_avg:34.61ms
+step:568/1490 train_time:19682ms step_avg:34.65ms
+step:569/1490 train_time:19735ms step_avg:34.68ms
+step:570/1490 train_time:19793ms step_avg:34.72ms
+step:571/1490 train_time:19847ms step_avg:34.76ms
+step:572/1490 train_time:19906ms step_avg:34.80ms
+step:573/1490 train_time:19961ms step_avg:34.84ms
+step:574/1490 train_time:20020ms step_avg:34.88ms
+step:575/1490 train_time:20074ms step_avg:34.91ms
+step:576/1490 train_time:20133ms step_avg:34.95ms
+step:577/1490 train_time:20187ms step_avg:34.99ms
+step:578/1490 train_time:20246ms step_avg:35.03ms
+step:579/1490 train_time:20300ms step_avg:35.06ms
+step:580/1490 train_time:20360ms step_avg:35.10ms
+step:581/1490 train_time:20413ms step_avg:35.13ms
+step:582/1490 train_time:20472ms step_avg:35.18ms
+step:583/1490 train_time:20525ms step_avg:35.21ms
+step:584/1490 train_time:20584ms step_avg:35.25ms
+step:585/1490 train_time:20637ms step_avg:35.28ms
+step:586/1490 train_time:20694ms step_avg:35.31ms
+step:587/1490 train_time:20747ms step_avg:35.34ms
+step:588/1490 train_time:20807ms step_avg:35.39ms
+step:589/1490 train_time:20861ms step_avg:35.42ms
+step:590/1490 train_time:20919ms step_avg:35.46ms
+step:591/1490 train_time:20973ms step_avg:35.49ms
+step:592/1490 train_time:21032ms step_avg:35.53ms
+step:593/1490 train_time:21086ms step_avg:35.56ms
+step:594/1490 train_time:21145ms step_avg:35.60ms
+step:595/1490 train_time:21200ms step_avg:35.63ms
+step:596/1490 train_time:21260ms step_avg:35.67ms
+step:597/1490 train_time:21313ms step_avg:35.70ms
+step:598/1490 train_time:21372ms step_avg:35.74ms
+step:599/1490 train_time:21425ms step_avg:35.77ms
+step:600/1490 train_time:21484ms step_avg:35.81ms
+step:601/1490 train_time:21537ms step_avg:35.84ms
+step:602/1490 train_time:21596ms step_avg:35.87ms
+step:603/1490 train_time:21647ms step_avg:35.90ms
+step:604/1490 train_time:21707ms step_avg:35.94ms
+step:605/1490 train_time:21760ms step_avg:35.97ms
+step:606/1490 train_time:21819ms step_avg:36.01ms
+step:607/1490 train_time:21873ms step_avg:36.03ms
+step:608/1490 train_time:21932ms step_avg:36.07ms
+step:609/1490 train_time:21986ms step_avg:36.10ms
+step:610/1490 train_time:22044ms step_avg:36.14ms
+step:611/1490 train_time:22098ms step_avg:36.17ms
+step:612/1490 train_time:22157ms step_avg:36.20ms
+step:613/1490 train_time:22211ms step_avg:36.23ms
+step:614/1490 train_time:22271ms step_avg:36.27ms
+step:615/1490 train_time:22324ms step_avg:36.30ms
+step:616/1490 train_time:22384ms step_avg:36.34ms
+step:617/1490 train_time:22437ms step_avg:36.36ms
+step:618/1490 train_time:22496ms step_avg:36.40ms
+step:619/1490 train_time:22549ms step_avg:36.43ms
+step:620/1490 train_time:22608ms step_avg:36.46ms
+step:621/1490 train_time:22661ms step_avg:36.49ms
+step:622/1490 train_time:22720ms step_avg:36.53ms
+step:623/1490 train_time:22773ms step_avg:36.55ms
+step:624/1490 train_time:22832ms step_avg:36.59ms
+step:625/1490 train_time:22885ms step_avg:36.62ms
+step:626/1490 train_time:22944ms step_avg:36.65ms
+step:627/1490 train_time:22999ms step_avg:36.68ms
+step:628/1490 train_time:23058ms step_avg:36.72ms
+step:629/1490 train_time:23113ms step_avg:36.74ms
+step:630/1490 train_time:23171ms step_avg:36.78ms
+step:631/1490 train_time:23225ms step_avg:36.81ms
+step:632/1490 train_time:23284ms step_avg:36.84ms
+step:633/1490 train_time:23338ms step_avg:36.87ms
+step:634/1490 train_time:23396ms step_avg:36.90ms
+step:635/1490 train_time:23450ms step_avg:36.93ms
+step:636/1490 train_time:23509ms step_avg:36.96ms
+step:637/1490 train_time:23563ms step_avg:36.99ms
+step:638/1490 train_time:23621ms step_avg:37.02ms
+step:639/1490 train_time:23675ms step_avg:37.05ms
+step:640/1490 train_time:23733ms step_avg:37.08ms
+step:641/1490 train_time:23788ms step_avg:37.11ms
+step:642/1490 train_time:23846ms step_avg:37.14ms
+step:643/1490 train_time:23900ms step_avg:37.17ms
+step:644/1490 train_time:23959ms step_avg:37.20ms
+step:645/1490 train_time:24013ms step_avg:37.23ms
+step:646/1490 train_time:24071ms step_avg:37.26ms
+step:647/1490 train_time:24124ms step_avg:37.29ms
+step:648/1490 train_time:24183ms step_avg:37.32ms
+step:649/1490 train_time:24237ms step_avg:37.34ms
+step:650/1490 train_time:24296ms step_avg:37.38ms
+step:651/1490 train_time:24349ms step_avg:37.40ms
+step:652/1490 train_time:24410ms step_avg:37.44ms
+step:653/1490 train_time:24463ms step_avg:37.46ms
+step:654/1490 train_time:24521ms step_avg:37.49ms
+step:655/1490 train_time:24575ms step_avg:37.52ms
+step:656/1490 train_time:24634ms step_avg:37.55ms
+step:657/1490 train_time:24687ms step_avg:37.58ms
+step:658/1490 train_time:24746ms step_avg:37.61ms
+step:659/1490 train_time:24800ms step_avg:37.63ms
+step:660/1490 train_time:24859ms step_avg:37.67ms
+step:661/1490 train_time:24912ms step_avg:37.69ms
+step:662/1490 train_time:24971ms step_avg:37.72ms
+step:663/1490 train_time:25025ms step_avg:37.74ms
+step:664/1490 train_time:25084ms step_avg:37.78ms
+step:665/1490 train_time:25137ms step_avg:37.80ms
+step:666/1490 train_time:25196ms step_avg:37.83ms
+step:667/1490 train_time:25249ms step_avg:37.85ms
+step:668/1490 train_time:25309ms step_avg:37.89ms
+step:669/1490 train_time:25362ms step_avg:37.91ms
+step:670/1490 train_time:25421ms step_avg:37.94ms
+step:671/1490 train_time:25474ms step_avg:37.96ms
+step:672/1490 train_time:25533ms step_avg:37.99ms
+step:673/1490 train_time:25586ms step_avg:38.02ms
+step:674/1490 train_time:25645ms step_avg:38.05ms
+step:675/1490 train_time:25699ms step_avg:38.07ms
+step:676/1490 train_time:25758ms step_avg:38.10ms
+step:677/1490 train_time:25812ms step_avg:38.13ms
+step:678/1490 train_time:25870ms step_avg:38.16ms
+step:679/1490 train_time:25923ms step_avg:38.18ms
+step:680/1490 train_time:25982ms step_avg:38.21ms
+step:681/1490 train_time:26035ms step_avg:38.23ms
+step:682/1490 train_time:26094ms step_avg:38.26ms
+step:683/1490 train_time:26146ms step_avg:38.28ms
+step:684/1490 train_time:26206ms step_avg:38.31ms
+step:685/1490 train_time:26259ms step_avg:38.33ms
+step:686/1490 train_time:26317ms step_avg:38.36ms
+step:687/1490 train_time:26372ms step_avg:38.39ms
+step:688/1490 train_time:26430ms step_avg:38.42ms
+step:689/1490 train_time:26483ms step_avg:38.44ms
+step:690/1490 train_time:26542ms step_avg:38.47ms
+step:691/1490 train_time:26596ms step_avg:38.49ms
+step:692/1490 train_time:26655ms step_avg:38.52ms
+step:693/1490 train_time:26708ms step_avg:38.54ms
+step:694/1490 train_time:26768ms step_avg:38.57ms
+step:695/1490 train_time:26820ms step_avg:38.59ms
+step:696/1490 train_time:26880ms step_avg:38.62ms
+step:697/1490 train_time:26934ms step_avg:38.64ms
+step:698/1490 train_time:26992ms step_avg:38.67ms
+step:699/1490 train_time:27046ms step_avg:38.69ms
+step:700/1490 train_time:27105ms step_avg:38.72ms
+step:701/1490 train_time:27159ms step_avg:38.74ms
+step:702/1490 train_time:27218ms step_avg:38.77ms
+step:703/1490 train_time:27270ms step_avg:38.79ms
+step:704/1490 train_time:27329ms step_avg:38.82ms
+step:705/1490 train_time:27382ms step_avg:38.84ms
+step:706/1490 train_time:27441ms step_avg:38.87ms
+step:707/1490 train_time:27496ms step_avg:38.89ms
+step:708/1490 train_time:27554ms step_avg:38.92ms
+step:709/1490 train_time:27607ms step_avg:38.94ms
+step:710/1490 train_time:27666ms step_avg:38.97ms
+step:711/1490 train_time:27719ms step_avg:38.99ms
+step:712/1490 train_time:27779ms step_avg:39.01ms
+step:713/1490 train_time:27832ms step_avg:39.04ms
+step:714/1490 train_time:27891ms step_avg:39.06ms
+step:715/1490 train_time:27944ms step_avg:39.08ms
+step:716/1490 train_time:28004ms step_avg:39.11ms
+step:717/1490 train_time:28058ms step_avg:39.13ms
+step:718/1490 train_time:28116ms step_avg:39.16ms
+step:719/1490 train_time:28171ms step_avg:39.18ms
+step:720/1490 train_time:28229ms step_avg:39.21ms
+step:721/1490 train_time:28283ms step_avg:39.23ms
+step:722/1490 train_time:28342ms step_avg:39.25ms
+step:723/1490 train_time:28395ms step_avg:39.27ms
+step:724/1490 train_time:28454ms step_avg:39.30ms
+step:725/1490 train_time:28507ms step_avg:39.32ms
+step:726/1490 train_time:28566ms step_avg:39.35ms
+step:727/1490 train_time:28619ms step_avg:39.37ms
+step:728/1490 train_time:28678ms step_avg:39.39ms
+step:729/1490 train_time:28731ms step_avg:39.41ms
+step:730/1490 train_time:28789ms step_avg:39.44ms
+step:731/1490 train_time:28842ms step_avg:39.46ms
+step:732/1490 train_time:28902ms step_avg:39.48ms
+step:733/1490 train_time:28955ms step_avg:39.50ms
+step:734/1490 train_time:29013ms step_avg:39.53ms
+step:735/1490 train_time:29067ms step_avg:39.55ms
+step:736/1490 train_time:29125ms step_avg:39.57ms
+step:737/1490 train_time:29178ms step_avg:39.59ms
+step:738/1490 train_time:29238ms step_avg:39.62ms
+step:739/1490 train_time:29293ms step_avg:39.64ms
+step:740/1490 train_time:29351ms step_avg:39.66ms
+step:741/1490 train_time:29406ms step_avg:39.68ms
+step:742/1490 train_time:29464ms step_avg:39.71ms
+step:743/1490 train_time:29518ms step_avg:39.73ms
+step:744/1490 train_time:29577ms step_avg:39.75ms
+step:745/1490 train_time:29630ms step_avg:39.77ms
+step:746/1490 train_time:29689ms step_avg:39.80ms
+step:747/1490 train_time:29742ms step_avg:39.81ms
+step:748/1490 train_time:29801ms step_avg:39.84ms
+step:749/1490 train_time:29854ms step_avg:39.86ms
+step:750/1490 train_time:29913ms step_avg:39.88ms
+step:750/1490 val_loss:3.8094 train_time:29982ms step_avg:39.98ms
+step:751/1490 train_time:29998ms step_avg:39.94ms
+step:752/1490 train_time:30028ms step_avg:39.93ms
+step:753/1490 train_time:30084ms step_avg:39.95ms
+step:754/1490 train_time:30148ms step_avg:39.98ms
+step:755/1490 train_time:30201ms step_avg:40.00ms
+step:756/1490 train_time:30259ms step_avg:40.03ms
+step:757/1490 train_time:30314ms step_avg:40.04ms
+step:758/1490 train_time:30372ms step_avg:40.07ms
+step:759/1490 train_time:30426ms step_avg:40.09ms
+step:760/1490 train_time:30484ms step_avg:40.11ms
+step:761/1490 train_time:30537ms step_avg:40.13ms
+step:762/1490 train_time:30595ms step_avg:40.15ms
+step:763/1490 train_time:30647ms step_avg:40.17ms
+step:764/1490 train_time:30705ms step_avg:40.19ms
+step:765/1490 train_time:30758ms step_avg:40.21ms
+step:766/1490 train_time:30816ms step_avg:40.23ms
+step:767/1490 train_time:30868ms step_avg:40.25ms
+step:768/1490 train_time:30928ms step_avg:40.27ms
+step:769/1490 train_time:30982ms step_avg:40.29ms
+step:770/1490 train_time:31044ms step_avg:40.32ms
+step:771/1490 train_time:31098ms step_avg:40.34ms
+step:772/1490 train_time:31157ms step_avg:40.36ms
+step:773/1490 train_time:31212ms step_avg:40.38ms
+step:774/1490 train_time:31271ms step_avg:40.40ms
+step:775/1490 train_time:31324ms step_avg:40.42ms
+step:776/1490 train_time:31383ms step_avg:40.44ms
+step:777/1490 train_time:31436ms step_avg:40.46ms
+step:778/1490 train_time:31494ms step_avg:40.48ms
+step:779/1490 train_time:31547ms step_avg:40.50ms
+step:780/1490 train_time:31605ms step_avg:40.52ms
+step:781/1490 train_time:31658ms step_avg:40.54ms
+step:782/1490 train_time:31716ms step_avg:40.56ms
+step:783/1490 train_time:31768ms step_avg:40.57ms
+step:784/1490 train_time:31827ms step_avg:40.60ms
+step:785/1490 train_time:31880ms step_avg:40.61ms
+step:786/1490 train_time:31939ms step_avg:40.63ms
+step:787/1490 train_time:31994ms step_avg:40.65ms
+step:788/1490 train_time:32053ms step_avg:40.68ms
+step:789/1490 train_time:32107ms step_avg:40.69ms
+step:790/1490 train_time:32168ms step_avg:40.72ms
+step:791/1490 train_time:32223ms step_avg:40.74ms
+step:792/1490 train_time:32283ms step_avg:40.76ms
+step:793/1490 train_time:32337ms step_avg:40.78ms
+step:794/1490 train_time:32395ms step_avg:40.80ms
+step:795/1490 train_time:32449ms step_avg:40.82ms
+step:796/1490 train_time:32507ms step_avg:40.84ms
+step:797/1490 train_time:32560ms step_avg:40.85ms
+step:798/1490 train_time:32619ms step_avg:40.88ms
+step:799/1490 train_time:32672ms step_avg:40.89ms
+step:800/1490 train_time:32731ms step_avg:40.91ms
+step:801/1490 train_time:32784ms step_avg:40.93ms
+step:802/1490 train_time:32842ms step_avg:40.95ms
+step:803/1490 train_time:32896ms step_avg:40.97ms
+step:804/1490 train_time:32955ms step_avg:40.99ms
+step:805/1490 train_time:33009ms step_avg:41.00ms
+step:806/1490 train_time:33068ms step_avg:41.03ms
+step:807/1490 train_time:33122ms step_avg:41.04ms
+step:808/1490 train_time:33182ms step_avg:41.07ms
+step:809/1490 train_time:33235ms step_avg:41.08ms
+step:810/1490 train_time:33295ms step_avg:41.10ms
+step:811/1490 train_time:33348ms step_avg:41.12ms
+step:812/1490 train_time:33407ms step_avg:41.14ms
+step:813/1490 train_time:33461ms step_avg:41.16ms
+step:814/1490 train_time:33519ms step_avg:41.18ms
+step:815/1490 train_time:33571ms step_avg:41.19ms
+step:816/1490 train_time:33631ms step_avg:41.21ms
+step:817/1490 train_time:33684ms step_avg:41.23ms
+step:818/1490 train_time:33743ms step_avg:41.25ms
+step:819/1490 train_time:33797ms step_avg:41.27ms
+step:820/1490 train_time:33855ms step_avg:41.29ms
+step:821/1490 train_time:33909ms step_avg:41.30ms
+step:822/1490 train_time:33967ms step_avg:41.32ms
+step:823/1490 train_time:34022ms step_avg:41.34ms
+step:824/1490 train_time:34080ms step_avg:41.36ms
+step:825/1490 train_time:34134ms step_avg:41.37ms
+step:826/1490 train_time:34195ms step_avg:41.40ms
+step:827/1490 train_time:34248ms step_avg:41.41ms
+step:828/1490 train_time:34307ms step_avg:41.43ms
+step:829/1490 train_time:34360ms step_avg:41.45ms
+step:830/1490 train_time:34420ms step_avg:41.47ms
+step:831/1490 train_time:34473ms step_avg:41.48ms
+step:832/1490 train_time:34532ms step_avg:41.50ms
+step:833/1490 train_time:34585ms step_avg:41.52ms
+step:834/1490 train_time:34644ms step_avg:41.54ms
+step:835/1490 train_time:34696ms step_avg:41.55ms
+step:836/1490 train_time:34755ms step_avg:41.57ms
+step:837/1490 train_time:34809ms step_avg:41.59ms
+step:838/1490 train_time:34867ms step_avg:41.61ms
+step:839/1490 train_time:34920ms step_avg:41.62ms
+step:840/1490 train_time:34979ms step_avg:41.64ms
+step:841/1490 train_time:35033ms step_avg:41.66ms
+step:842/1490 train_time:35093ms step_avg:41.68ms
+step:843/1490 train_time:35146ms step_avg:41.69ms
+step:844/1490 train_time:35206ms step_avg:41.71ms
+step:845/1490 train_time:35260ms step_avg:41.73ms
+step:846/1490 train_time:35319ms step_avg:41.75ms
+step:847/1490 train_time:35372ms step_avg:41.76ms
+step:848/1490 train_time:35431ms step_avg:41.78ms
+step:849/1490 train_time:35485ms step_avg:41.80ms
+step:850/1490 train_time:35543ms step_avg:41.82ms
+step:851/1490 train_time:35596ms step_avg:41.83ms
+step:852/1490 train_time:35655ms step_avg:41.85ms
+step:853/1490 train_time:35709ms step_avg:41.86ms
+step:854/1490 train_time:35768ms step_avg:41.88ms
+step:855/1490 train_time:35822ms step_avg:41.90ms
+step:856/1490 train_time:35881ms step_avg:41.92ms
+step:857/1490 train_time:35934ms step_avg:41.93ms
+step:858/1490 train_time:35993ms step_avg:41.95ms
+step:859/1490 train_time:36046ms step_avg:41.96ms
+step:860/1490 train_time:36106ms step_avg:41.98ms
+step:861/1490 train_time:36160ms step_avg:42.00ms
+step:862/1490 train_time:36219ms step_avg:42.02ms
+step:863/1490 train_time:36272ms step_avg:42.03ms
+step:864/1490 train_time:36331ms step_avg:42.05ms
+step:865/1490 train_time:36384ms step_avg:42.06ms
+step:866/1490 train_time:36443ms step_avg:42.08ms
+step:867/1490 train_time:36497ms step_avg:42.10ms
+step:868/1490 train_time:36556ms step_avg:42.11ms
+step:869/1490 train_time:36609ms step_avg:42.13ms
+step:870/1490 train_time:36667ms step_avg:42.15ms
+step:871/1490 train_time:36721ms step_avg:42.16ms
+step:872/1490 train_time:36779ms step_avg:42.18ms
+step:873/1490 train_time:36831ms step_avg:42.19ms
+step:874/1490 train_time:36892ms step_avg:42.21ms
+step:875/1490 train_time:36945ms step_avg:42.22ms
+step:876/1490 train_time:37004ms step_avg:42.24ms
+step:877/1490 train_time:37057ms step_avg:42.25ms
+step:878/1490 train_time:37117ms step_avg:42.27ms
+step:879/1490 train_time:37170ms step_avg:42.29ms
+step:880/1490 train_time:37229ms step_avg:42.31ms
+step:881/1490 train_time:37283ms step_avg:42.32ms
+step:882/1490 train_time:37341ms step_avg:42.34ms
+step:883/1490 train_time:37394ms step_avg:42.35ms
+step:884/1490 train_time:37453ms step_avg:42.37ms
+step:885/1490 train_time:37507ms step_avg:42.38ms
+step:886/1490 train_time:37566ms step_avg:42.40ms
+step:887/1490 train_time:37620ms step_avg:42.41ms
+step:888/1490 train_time:37678ms step_avg:42.43ms
+step:889/1490 train_time:37732ms step_avg:42.44ms
+step:890/1490 train_time:37790ms step_avg:42.46ms
+step:891/1490 train_time:37843ms step_avg:42.47ms
+step:892/1490 train_time:37902ms step_avg:42.49ms
+step:893/1490 train_time:37955ms step_avg:42.50ms
+step:894/1490 train_time:38013ms step_avg:42.52ms
+step:895/1490 train_time:38067ms step_avg:42.53ms
+step:896/1490 train_time:38127ms step_avg:42.55ms
+step:897/1490 train_time:38181ms step_avg:42.56ms
+step:898/1490 train_time:38239ms step_avg:42.58ms
+step:899/1490 train_time:38293ms step_avg:42.59ms
+step:900/1490 train_time:38351ms step_avg:42.61ms
+step:901/1490 train_time:38405ms step_avg:42.62ms
+step:902/1490 train_time:38464ms step_avg:42.64ms
+step:903/1490 train_time:38518ms step_avg:42.66ms
+step:904/1490 train_time:38576ms step_avg:42.67ms
+step:905/1490 train_time:38629ms step_avg:42.68ms
+step:906/1490 train_time:38689ms step_avg:42.70ms
+step:907/1490 train_time:38741ms step_avg:42.71ms
+step:908/1490 train_time:38801ms step_avg:42.73ms
+step:909/1490 train_time:38853ms step_avg:42.74ms
+step:910/1490 train_time:38911ms step_avg:42.76ms
+step:911/1490 train_time:38964ms step_avg:42.77ms
+step:912/1490 train_time:39024ms step_avg:42.79ms
+step:913/1490 train_time:39077ms step_avg:42.80ms
+step:914/1490 train_time:39135ms step_avg:42.82ms
+step:915/1490 train_time:39189ms step_avg:42.83ms
+step:916/1490 train_time:39248ms step_avg:42.85ms
+step:917/1490 train_time:39302ms step_avg:42.86ms
+step:918/1490 train_time:39361ms step_avg:42.88ms
+step:919/1490 train_time:39415ms step_avg:42.89ms
+step:920/1490 train_time:39474ms step_avg:42.91ms
+step:921/1490 train_time:39528ms step_avg:42.92ms
+step:922/1490 train_time:39587ms step_avg:42.94ms
+step:923/1490 train_time:39639ms step_avg:42.95ms
+step:924/1490 train_time:39698ms step_avg:42.96ms
+step:925/1490 train_time:39751ms step_avg:42.97ms
+step:926/1490 train_time:39811ms step_avg:42.99ms
+step:927/1490 train_time:39864ms step_avg:43.00ms
+step:928/1490 train_time:39923ms step_avg:43.02ms
+step:929/1490 train_time:39977ms step_avg:43.03ms
+step:930/1490 train_time:40035ms step_avg:43.05ms
+step:931/1490 train_time:40089ms step_avg:43.06ms
+step:932/1490 train_time:40148ms step_avg:43.08ms
+step:933/1490 train_time:40201ms step_avg:43.09ms
+step:934/1490 train_time:40260ms step_avg:43.10ms
+step:935/1490 train_time:40314ms step_avg:43.12ms
+step:936/1490 train_time:40372ms step_avg:43.13ms
+step:937/1490 train_time:40427ms step_avg:43.15ms
+step:938/1490 train_time:40487ms step_avg:43.16ms
+step:939/1490 train_time:40540ms step_avg:43.17ms
+step:940/1490 train_time:40598ms step_avg:43.19ms
+step:941/1490 train_time:40651ms step_avg:43.20ms
+step:942/1490 train_time:40710ms step_avg:43.22ms
+step:943/1490 train_time:40763ms step_avg:43.23ms
+step:944/1490 train_time:40823ms step_avg:43.24ms
+step:945/1490 train_time:40876ms step_avg:43.25ms
+step:946/1490 train_time:40934ms step_avg:43.27ms
+step:947/1490 train_time:40988ms step_avg:43.28ms
+step:948/1490 train_time:41046ms step_avg:43.30ms
+step:949/1490 train_time:41100ms step_avg:43.31ms
+step:950/1490 train_time:41159ms step_avg:43.33ms
+step:951/1490 train_time:41212ms step_avg:43.34ms
+step:952/1490 train_time:41271ms step_avg:43.35ms
+step:953/1490 train_time:41325ms step_avg:43.36ms
+step:954/1490 train_time:41385ms step_avg:43.38ms
+step:955/1490 train_time:41438ms step_avg:43.39ms
+step:956/1490 train_time:41496ms step_avg:43.41ms
+step:957/1490 train_time:41549ms step_avg:43.42ms
+step:958/1490 train_time:41608ms step_avg:43.43ms
+step:959/1490 train_time:41661ms step_avg:43.44ms
+step:960/1490 train_time:41720ms step_avg:43.46ms
+step:961/1490 train_time:41773ms step_avg:43.47ms
+step:962/1490 train_time:41833ms step_avg:43.49ms
+step:963/1490 train_time:41885ms step_avg:43.49ms
+step:964/1490 train_time:41945ms step_avg:43.51ms
+step:965/1490 train_time:41998ms step_avg:43.52ms
+step:966/1490 train_time:42057ms step_avg:43.54ms
+step:967/1490 train_time:42111ms step_avg:43.55ms
+step:968/1490 train_time:42172ms step_avg:43.57ms
+step:969/1490 train_time:42251ms step_avg:43.60ms
+step:970/1490 train_time:42336ms step_avg:43.65ms
+step:971/1490 train_time:42415ms step_avg:43.68ms
+step:972/1490 train_time:42499ms step_avg:43.72ms
+step:973/1490 train_time:42578ms step_avg:43.76ms
+step:974/1490 train_time:42662ms step_avg:43.80ms
+step:975/1490 train_time:42742ms step_avg:43.84ms
+step:976/1490 train_time:42827ms step_avg:43.88ms
+step:977/1490 train_time:42907ms step_avg:43.92ms
+step:978/1490 train_time:42992ms step_avg:43.96ms
+step:979/1490 train_time:43070ms step_avg:43.99ms
+step:980/1490 train_time:43155ms step_avg:44.04ms
+step:981/1490 train_time:43234ms step_avg:44.07ms
+step:982/1490 train_time:43318ms step_avg:44.11ms
+step:983/1490 train_time:43397ms step_avg:44.15ms
+step:984/1490 train_time:43480ms step_avg:44.19ms
+step:985/1490 train_time:43561ms step_avg:44.22ms
+step:986/1490 train_time:43649ms step_avg:44.27ms
+step:987/1490 train_time:43729ms step_avg:44.31ms
+step:988/1490 train_time:43813ms step_avg:44.34ms
+step:989/1490 train_time:43892ms step_avg:44.38ms
+step:990/1490 train_time:43978ms step_avg:44.42ms
+step:991/1490 train_time:44058ms step_avg:44.46ms
+step:992/1490 train_time:44142ms step_avg:44.50ms
+step:993/1490 train_time:44221ms step_avg:44.53ms
+step:994/1490 train_time:44305ms step_avg:44.57ms
+step:995/1490 train_time:44383ms step_avg:44.61ms
+step:996/1490 train_time:44469ms step_avg:44.65ms
+step:997/1490 train_time:44548ms step_avg:44.68ms
+step:998/1490 train_time:44633ms step_avg:44.72ms
+step:999/1490 train_time:44713ms step_avg:44.76ms
+step:1000/1490 train_time:44797ms step_avg:44.80ms
+step:1000/1490 val_loss:3.5171 train_time:44895ms step_avg:44.90ms
+step:1001/1490 train_time:44912ms step_avg:44.87ms
+step:1002/1490 train_time:44968ms step_avg:44.88ms
+step:1003/1490 train_time:45051ms step_avg:44.92ms
+step:1004/1490 train_time:45137ms step_avg:44.96ms
+step:1005/1490 train_time:45217ms step_avg:44.99ms
+step:1006/1490 train_time:45301ms step_avg:45.03ms
+step:1007/1490 train_time:45381ms step_avg:45.07ms
+step:1008/1490 train_time:45464ms step_avg:45.10ms
+step:1009/1490 train_time:45543ms step_avg:45.14ms
+step:1010/1490 train_time:45627ms step_avg:45.18ms
+step:1011/1490 train_time:45704ms step_avg:45.21ms
+step:1012/1490 train_time:45787ms step_avg:45.24ms
+step:1013/1490 train_time:45867ms step_avg:45.28ms
+step:1014/1490 train_time:45953ms step_avg:45.32ms
+step:1015/1490 train_time:46035ms step_avg:45.35ms
+step:1016/1490 train_time:46121ms step_avg:45.39ms
+step:1017/1490 train_time:46201ms step_avg:45.43ms
+step:1018/1490 train_time:46286ms step_avg:45.47ms
+step:1019/1490 train_time:46364ms step_avg:45.50ms
+step:1020/1490 train_time:46448ms step_avg:45.54ms
+step:1021/1490 train_time:46526ms step_avg:45.57ms
+step:1022/1490 train_time:46610ms step_avg:45.61ms
+step:1023/1490 train_time:46688ms step_avg:45.64ms
+step:1024/1490 train_time:46771ms step_avg:45.67ms
+step:1025/1490 train_time:46848ms step_avg:45.71ms
+step:1026/1490 train_time:46935ms step_avg:45.75ms
+step:1027/1490 train_time:47016ms step_avg:45.78ms
+step:1028/1490 train_time:47101ms step_avg:45.82ms
+step:1029/1490 train_time:47181ms step_avg:45.85ms
+step:1030/1490 train_time:47267ms step_avg:45.89ms
+step:1031/1490 train_time:47345ms step_avg:45.92ms
+step:1032/1490 train_time:47430ms step_avg:45.96ms
+step:1033/1490 train_time:47509ms step_avg:45.99ms
+step:1034/1490 train_time:47593ms step_avg:46.03ms
+step:1035/1490 train_time:47674ms step_avg:46.06ms
+step:1036/1490 train_time:47758ms step_avg:46.10ms
+step:1037/1490 train_time:47837ms step_avg:46.13ms
+step:1038/1490 train_time:47921ms step_avg:46.17ms
+step:1039/1490 train_time:48001ms step_avg:46.20ms
+step:1040/1490 train_time:48087ms step_avg:46.24ms
+step:1041/1490 train_time:48168ms step_avg:46.27ms
+step:1042/1490 train_time:48252ms step_avg:46.31ms
+step:1043/1490 train_time:48331ms step_avg:46.34ms
+step:1044/1490 train_time:48416ms step_avg:46.38ms
+step:1045/1490 train_time:48495ms step_avg:46.41ms
+step:1046/1490 train_time:48580ms step_avg:46.44ms
+step:1047/1490 train_time:48659ms step_avg:46.47ms
+step:1048/1490 train_time:48743ms step_avg:46.51ms
+step:1049/1490 train_time:48822ms step_avg:46.54ms
+step:1050/1490 train_time:48907ms step_avg:46.58ms
+step:1051/1490 train_time:48987ms step_avg:46.61ms
+step:1052/1490 train_time:49071ms step_avg:46.65ms
+step:1053/1490 train_time:49152ms step_avg:46.68ms
+step:1054/1490 train_time:49237ms step_avg:46.71ms
+step:1055/1490 train_time:49317ms step_avg:46.75ms
+step:1056/1490 train_time:49401ms step_avg:46.78ms
+step:1057/1490 train_time:49480ms step_avg:46.81ms
+step:1058/1490 train_time:49566ms step_avg:46.85ms
+step:1059/1490 train_time:49645ms step_avg:46.88ms
+step:1060/1490 train_time:49729ms step_avg:46.91ms
+step:1061/1490 train_time:49808ms step_avg:46.94ms
+step:1062/1490 train_time:49893ms step_avg:46.98ms
+step:1063/1490 train_time:49973ms step_avg:47.01ms
+step:1064/1490 train_time:50058ms step_avg:47.05ms
+step:1065/1490 train_time:50138ms step_avg:47.08ms
+step:1066/1490 train_time:50222ms step_avg:47.11ms
+step:1067/1490 train_time:50302ms step_avg:47.14ms
+step:1068/1490 train_time:50387ms step_avg:47.18ms
+step:1069/1490 train_time:50465ms step_avg:47.21ms
+step:1070/1490 train_time:50550ms step_avg:47.24ms
+step:1071/1490 train_time:50629ms step_avg:47.27ms
+step:1072/1490 train_time:50713ms step_avg:47.31ms
+step:1073/1490 train_time:50792ms step_avg:47.34ms
+step:1074/1490 train_time:50877ms step_avg:47.37ms
+step:1075/1490 train_time:50956ms step_avg:47.40ms
+step:1076/1490 train_time:51040ms step_avg:47.44ms
+step:1077/1490 train_time:51121ms step_avg:47.47ms
+step:1078/1490 train_time:51206ms step_avg:47.50ms
+step:1079/1490 train_time:51286ms step_avg:47.53ms
+step:1080/1490 train_time:51370ms step_avg:47.56ms
+step:1081/1490 train_time:51448ms step_avg:47.59ms
+step:1082/1490 train_time:51535ms step_avg:47.63ms
+step:1083/1490 train_time:51614ms step_avg:47.66ms
+step:1084/1490 train_time:51699ms step_avg:47.69ms
+step:1085/1490 train_time:51779ms step_avg:47.72ms
+step:1086/1490 train_time:51865ms step_avg:47.76ms
+step:1087/1490 train_time:51944ms step_avg:47.79ms
+step:1088/1490 train_time:52027ms step_avg:47.82ms
+step:1089/1490 train_time:52107ms step_avg:47.85ms
+step:1090/1490 train_time:52192ms step_avg:47.88ms
+step:1091/1490 train_time:52271ms step_avg:47.91ms
+step:1092/1490 train_time:52356ms step_avg:47.95ms
+step:1093/1490 train_time:52435ms step_avg:47.97ms
+step:1094/1490 train_time:52520ms step_avg:48.01ms
+step:1095/1490 train_time:52599ms step_avg:48.04ms
+step:1096/1490 train_time:52684ms step_avg:48.07ms
+step:1097/1490 train_time:52764ms step_avg:48.10ms
+step:1098/1490 train_time:52848ms step_avg:48.13ms
+step:1099/1490 train_time:52927ms step_avg:48.16ms
+step:1100/1490 train_time:53011ms step_avg:48.19ms
+step:1101/1490 train_time:53090ms step_avg:48.22ms
+step:1102/1490 train_time:53175ms step_avg:48.25ms
+step:1103/1490 train_time:53255ms step_avg:48.28ms
+step:1104/1490 train_time:53340ms step_avg:48.32ms
+step:1105/1490 train_time:53420ms step_avg:48.34ms
+step:1106/1490 train_time:53505ms step_avg:48.38ms
+step:1107/1490 train_time:53584ms step_avg:48.41ms
+step:1108/1490 train_time:53670ms step_avg:48.44ms
+step:1109/1490 train_time:53749ms step_avg:48.47ms
+step:1110/1490 train_time:53832ms step_avg:48.50ms
+step:1111/1490 train_time:53910ms step_avg:48.52ms
+step:1112/1490 train_time:53995ms step_avg:48.56ms
+step:1113/1490 train_time:54076ms step_avg:48.59ms
+step:1114/1490 train_time:54161ms step_avg:48.62ms
+step:1115/1490 train_time:54240ms step_avg:48.65ms
+step:1116/1490 train_time:54327ms step_avg:48.68ms
+step:1117/1490 train_time:54405ms step_avg:48.71ms
+step:1118/1490 train_time:54489ms step_avg:48.74ms
+step:1119/1490 train_time:54569ms step_avg:48.77ms
+step:1120/1490 train_time:54654ms step_avg:48.80ms
+step:1121/1490 train_time:54733ms step_avg:48.83ms
+step:1122/1490 train_time:54817ms step_avg:48.86ms
+step:1123/1490 train_time:54896ms step_avg:48.88ms
+step:1124/1490 train_time:54981ms step_avg:48.92ms
+step:1125/1490 train_time:55060ms step_avg:48.94ms
+step:1126/1490 train_time:55145ms step_avg:48.97ms
+step:1127/1490 train_time:55224ms step_avg:49.00ms
+step:1128/1490 train_time:55310ms step_avg:49.03ms
+step:1129/1490 train_time:55389ms step_avg:49.06ms
+step:1130/1490 train_time:55474ms step_avg:49.09ms
+step:1131/1490 train_time:55554ms step_avg:49.12ms
+step:1132/1490 train_time:55639ms step_avg:49.15ms
+step:1133/1490 train_time:55719ms step_avg:49.18ms
+step:1134/1490 train_time:55804ms step_avg:49.21ms
+step:1135/1490 train_time:55883ms step_avg:49.24ms
+step:1136/1490 train_time:55968ms step_avg:49.27ms
+step:1137/1490 train_time:56047ms step_avg:49.29ms
+step:1138/1490 train_time:56132ms step_avg:49.32ms
+step:1139/1490 train_time:56210ms step_avg:49.35ms
+step:1140/1490 train_time:56296ms step_avg:49.38ms
+step:1141/1490 train_time:56377ms step_avg:49.41ms
+step:1142/1490 train_time:56462ms step_avg:49.44ms
+step:1143/1490 train_time:56541ms step_avg:49.47ms
+step:1144/1490 train_time:56626ms step_avg:49.50ms
+step:1145/1490 train_time:56705ms step_avg:49.52ms
+step:1146/1490 train_time:56789ms step_avg:49.55ms
+step:1147/1490 train_time:56869ms step_avg:49.58ms
+step:1148/1490 train_time:56952ms step_avg:49.61ms
+step:1149/1490 train_time:57032ms step_avg:49.64ms
+step:1150/1490 train_time:57117ms step_avg:49.67ms
+step:1151/1490 train_time:57196ms step_avg:49.69ms
+step:1152/1490 train_time:57281ms step_avg:49.72ms
+step:1153/1490 train_time:57361ms step_avg:49.75ms
+step:1154/1490 train_time:57446ms step_avg:49.78ms
+step:1155/1490 train_time:57526ms step_avg:49.81ms
+step:1156/1490 train_time:57609ms step_avg:49.84ms
+step:1157/1490 train_time:57689ms step_avg:49.86ms
+step:1158/1490 train_time:57774ms step_avg:49.89ms
+step:1159/1490 train_time:57853ms step_avg:49.92ms
+step:1160/1490 train_time:57937ms step_avg:49.95ms
+step:1161/1490 train_time:58017ms step_avg:49.97ms
+step:1162/1490 train_time:58100ms step_avg:50.00ms
+step:1163/1490 train_time:58180ms step_avg:50.03ms
+step:1164/1490 train_time:58264ms step_avg:50.06ms
+step:1165/1490 train_time:58343ms step_avg:50.08ms
+step:1166/1490 train_time:58429ms step_avg:50.11ms
+step:1167/1490 train_time:58508ms step_avg:50.14ms
+step:1168/1490 train_time:58593ms step_avg:50.17ms
+step:1169/1490 train_time:58673ms step_avg:50.19ms
+step:1170/1490 train_time:58757ms step_avg:50.22ms
+step:1171/1490 train_time:58836ms step_avg:50.24ms
+step:1172/1490 train_time:58921ms step_avg:50.27ms
+step:1173/1490 train_time:59001ms step_avg:50.30ms
+step:1174/1490 train_time:59086ms step_avg:50.33ms
+step:1175/1490 train_time:59165ms step_avg:50.35ms
+step:1176/1490 train_time:59251ms step_avg:50.38ms
+step:1177/1490 train_time:59330ms step_avg:50.41ms
+step:1178/1490 train_time:59414ms step_avg:50.44ms
+step:1179/1490 train_time:59494ms step_avg:50.46ms
+step:1180/1490 train_time:59579ms step_avg:50.49ms
+step:1181/1490 train_time:59658ms step_avg:50.51ms
+step:1182/1490 train_time:59744ms step_avg:50.55ms
+step:1183/1490 train_time:59825ms step_avg:50.57ms
+step:1184/1490 train_time:59907ms step_avg:50.60ms
+step:1185/1490 train_time:59986ms step_avg:50.62ms
+step:1186/1490 train_time:60071ms step_avg:50.65ms
+step:1187/1490 train_time:60149ms step_avg:50.67ms
+step:1188/1490 train_time:60235ms step_avg:50.70ms
+step:1189/1490 train_time:60314ms step_avg:50.73ms
+step:1190/1490 train_time:60398ms step_avg:50.75ms
+step:1191/1490 train_time:60478ms step_avg:50.78ms
+step:1192/1490 train_time:60563ms step_avg:50.81ms
+step:1193/1490 train_time:60643ms step_avg:50.83ms
+step:1194/1490 train_time:60727ms step_avg:50.86ms
+step:1195/1490 train_time:60806ms step_avg:50.88ms
+step:1196/1490 train_time:60890ms step_avg:50.91ms
+step:1197/1490 train_time:60970ms step_avg:50.94ms
+step:1198/1490 train_time:61056ms step_avg:50.96ms
+step:1199/1490 train_time:61136ms step_avg:50.99ms
+step:1200/1490 train_time:61222ms step_avg:51.02ms
+step:1201/1490 train_time:61301ms step_avg:51.04ms
+step:1202/1490 train_time:61385ms step_avg:51.07ms
+step:1203/1490 train_time:61465ms step_avg:51.09ms
+step:1204/1490 train_time:61549ms step_avg:51.12ms
+step:1205/1490 train_time:61629ms step_avg:51.14ms
+step:1206/1490 train_time:61714ms step_avg:51.17ms
+step:1207/1490 train_time:61792ms step_avg:51.19ms
+step:1208/1490 train_time:61877ms step_avg:51.22ms
+step:1209/1490 train_time:61957ms step_avg:51.25ms
+step:1210/1490 train_time:62040ms step_avg:51.27ms
+step:1211/1490 train_time:62120ms step_avg:51.30ms
+step:1212/1490 train_time:62205ms step_avg:51.32ms
+step:1213/1490 train_time:62284ms step_avg:51.35ms
+step:1214/1490 train_time:62369ms step_avg:51.38ms
+step:1215/1490 train_time:62448ms step_avg:51.40ms
+step:1216/1490 train_time:62535ms step_avg:51.43ms
+step:1217/1490 train_time:62615ms step_avg:51.45ms
+step:1218/1490 train_time:62699ms step_avg:51.48ms
+step:1219/1490 train_time:62778ms step_avg:51.50ms
+step:1220/1490 train_time:62863ms step_avg:51.53ms
+step:1221/1490 train_time:62942ms step_avg:51.55ms
+step:1222/1490 train_time:63027ms step_avg:51.58ms
+step:1223/1490 train_time:63107ms step_avg:51.60ms
+step:1224/1490 train_time:63191ms step_avg:51.63ms
+step:1225/1490 train_time:63271ms step_avg:51.65ms
+step:1226/1490 train_time:63357ms step_avg:51.68ms
+step:1227/1490 train_time:63437ms step_avg:51.70ms
+step:1228/1490 train_time:63521ms step_avg:51.73ms
+step:1229/1490 train_time:63600ms step_avg:51.75ms
+step:1230/1490 train_time:63686ms step_avg:51.78ms
+step:1231/1490 train_time:63765ms step_avg:51.80ms
+step:1232/1490 train_time:63850ms step_avg:51.83ms
+step:1233/1490 train_time:63929ms step_avg:51.85ms
+step:1234/1490 train_time:64012ms step_avg:51.87ms
+step:1235/1490 train_time:64091ms step_avg:51.90ms
+step:1236/1490 train_time:64177ms step_avg:51.92ms
+step:1237/1490 train_time:64257ms step_avg:51.95ms
+step:1238/1490 train_time:64341ms step_avg:51.97ms
+step:1239/1490 train_time:64420ms step_avg:51.99ms
+step:1240/1490 train_time:64505ms step_avg:52.02ms
+step:1241/1490 train_time:64585ms step_avg:52.04ms
+step:1242/1490 train_time:64670ms step_avg:52.07ms
+step:1243/1490 train_time:64749ms step_avg:52.09ms
+step:1244/1490 train_time:64834ms step_avg:52.12ms
+step:1245/1490 train_time:64912ms step_avg:52.14ms
+step:1246/1490 train_time:64997ms step_avg:52.16ms
+step:1247/1490 train_time:65077ms step_avg:52.19ms
+step:1248/1490 train_time:65162ms step_avg:52.21ms
+step:1249/1490 train_time:65240ms step_avg:52.23ms
+step:1250/1490 train_time:65327ms step_avg:52.26ms
+step:1250/1490 val_loss:3.3717 train_time:65423ms step_avg:52.34ms
+step:1251/1490 train_time:65440ms step_avg:52.31ms
+step:1252/1490 train_time:65493ms step_avg:52.31ms
+step:1253/1490 train_time:65578ms step_avg:52.34ms
+step:1254/1490 train_time:65664ms step_avg:52.36ms
+step:1255/1490 train_time:65742ms step_avg:52.38ms
+step:1256/1490 train_time:65827ms step_avg:52.41ms
+step:1257/1490 train_time:65906ms step_avg:52.43ms
+step:1258/1490 train_time:65990ms step_avg:52.46ms
+step:1259/1490 train_time:66069ms step_avg:52.48ms
+step:1260/1490 train_time:66152ms step_avg:52.50ms
+step:1261/1490 train_time:66231ms step_avg:52.52ms
+step:1262/1490 train_time:66314ms step_avg:52.55ms
+step:1263/1490 train_time:66392ms step_avg:52.57ms
+step:1264/1490 train_time:66480ms step_avg:52.59ms
+step:1265/1490 train_time:66562ms step_avg:52.62ms
+step:1266/1490 train_time:66648ms step_avg:52.64ms
+step:1267/1490 train_time:66729ms step_avg:52.67ms
+step:1268/1490 train_time:66814ms step_avg:52.69ms
+step:1269/1490 train_time:66894ms step_avg:52.71ms
+step:1270/1490 train_time:66978ms step_avg:52.74ms
+step:1271/1490 train_time:67057ms step_avg:52.76ms
+step:1272/1490 train_time:67142ms step_avg:52.78ms
+step:1273/1490 train_time:67221ms step_avg:52.80ms
+step:1274/1490 train_time:67305ms step_avg:52.83ms
+step:1275/1490 train_time:67384ms step_avg:52.85ms
+step:1276/1490 train_time:67471ms step_avg:52.88ms
+step:1277/1490 train_time:67550ms step_avg:52.90ms
+step:1278/1490 train_time:67637ms step_avg:52.92ms
+step:1279/1490 train_time:67718ms step_avg:52.95ms
+step:1280/1490 train_time:67802ms step_avg:52.97ms
+step:1281/1490 train_time:67882ms step_avg:52.99ms
+step:1282/1490 train_time:67966ms step_avg:53.02ms
+step:1283/1490 train_time:68044ms step_avg:53.04ms
+step:1284/1490 train_time:68129ms step_avg:53.06ms
+step:1285/1490 train_time:68207ms step_avg:53.08ms
+step:1286/1490 train_time:68291ms step_avg:53.10ms
+step:1287/1490 train_time:68373ms step_avg:53.13ms
+step:1288/1490 train_time:68458ms step_avg:53.15ms
+step:1289/1490 train_time:68538ms step_avg:53.17ms
+step:1290/1490 train_time:68624ms step_avg:53.20ms
+step:1291/1490 train_time:68704ms step_avg:53.22ms
+step:1292/1490 train_time:68789ms step_avg:53.24ms
+step:1293/1490 train_time:68868ms step_avg:53.26ms
+step:1294/1490 train_time:68952ms step_avg:53.29ms
+step:1295/1490 train_time:69032ms step_avg:53.31ms
+step:1296/1490 train_time:69117ms step_avg:53.33ms
+step:1297/1490 train_time:69197ms step_avg:53.35ms
+step:1298/1490 train_time:69282ms step_avg:53.38ms
+step:1299/1490 train_time:69361ms step_avg:53.40ms
+step:1300/1490 train_time:69447ms step_avg:53.42ms
+step:1301/1490 train_time:69529ms step_avg:53.44ms
+step:1302/1490 train_time:69613ms step_avg:53.47ms
+step:1303/1490 train_time:69693ms step_avg:53.49ms
+step:1304/1490 train_time:69777ms step_avg:53.51ms
+step:1305/1490 train_time:69858ms step_avg:53.53ms
+step:1306/1490 train_time:69942ms step_avg:53.55ms
+step:1307/1490 train_time:70022ms step_avg:53.57ms
+step:1308/1490 train_time:70107ms step_avg:53.60ms
+step:1309/1490 train_time:70187ms step_avg:53.62ms
+step:1310/1490 train_time:70271ms step_avg:53.64ms
+step:1311/1490 train_time:70350ms step_avg:53.66ms
+step:1312/1490 train_time:70435ms step_avg:53.69ms
+step:1313/1490 train_time:70515ms step_avg:53.71ms
+step:1314/1490 train_time:70600ms step_avg:53.73ms
+step:1315/1490 train_time:70679ms step_avg:53.75ms
+step:1316/1490 train_time:70765ms step_avg:53.77ms
+step:1317/1490 train_time:70844ms step_avg:53.79ms
+step:1318/1490 train_time:70929ms step_avg:53.82ms
+step:1319/1490 train_time:71007ms step_avg:53.83ms
+step:1320/1490 train_time:71092ms step_avg:53.86ms
+step:1321/1490 train_time:71171ms step_avg:53.88ms
+step:1322/1490 train_time:71256ms step_avg:53.90ms
+step:1323/1490 train_time:71336ms step_avg:53.92ms
+step:1324/1490 train_time:71422ms step_avg:53.94ms
+step:1325/1490 train_time:71501ms step_avg:53.96ms
+step:1326/1490 train_time:71587ms step_avg:53.99ms
+step:1327/1490 train_time:71665ms step_avg:54.01ms
+step:1328/1490 train_time:71749ms step_avg:54.03ms
+step:1329/1490 train_time:71830ms step_avg:54.05ms
+step:1330/1490 train_time:71914ms step_avg:54.07ms
+step:1331/1490 train_time:71993ms step_avg:54.09ms
+step:1332/1490 train_time:72078ms step_avg:54.11ms
+step:1333/1490 train_time:72158ms step_avg:54.13ms
+step:1334/1490 train_time:72243ms step_avg:54.15ms
+step:1335/1490 train_time:72322ms step_avg:54.17ms
+step:1336/1490 train_time:72408ms step_avg:54.20ms
+step:1337/1490 train_time:72487ms step_avg:54.22ms
+step:1338/1490 train_time:72571ms step_avg:54.24ms
+step:1339/1490 train_time:72651ms step_avg:54.26ms
+step:1340/1490 train_time:72736ms step_avg:54.28ms
+step:1341/1490 train_time:72816ms step_avg:54.30ms
+step:1342/1490 train_time:72899ms step_avg:54.32ms
+step:1343/1490 train_time:72978ms step_avg:54.34ms
+step:1344/1490 train_time:73062ms step_avg:54.36ms
+step:1345/1490 train_time:73141ms step_avg:54.38ms
+step:1346/1490 train_time:73226ms step_avg:54.40ms
+step:1347/1490 train_time:73304ms step_avg:54.42ms
+step:1348/1490 train_time:73389ms step_avg:54.44ms
+step:1349/1490 train_time:73469ms step_avg:54.46ms
+step:1350/1490 train_time:73555ms step_avg:54.48ms
+step:1351/1490 train_time:73634ms step_avg:54.50ms
+step:1352/1490 train_time:73719ms step_avg:54.53ms
+step:1353/1490 train_time:73799ms step_avg:54.54ms
+step:1354/1490 train_time:73883ms step_avg:54.57ms
+step:1355/1490 train_time:73962ms step_avg:54.58ms
+step:1356/1490 train_time:74048ms step_avg:54.61ms
+step:1357/1490 train_time:74129ms step_avg:54.63ms
+step:1358/1490 train_time:74214ms step_avg:54.65ms
+step:1359/1490 train_time:74292ms step_avg:54.67ms
+step:1360/1490 train_time:74379ms step_avg:54.69ms
+step:1361/1490 train_time:74458ms step_avg:54.71ms
+step:1362/1490 train_time:74542ms step_avg:54.73ms
+step:1363/1490 train_time:74621ms step_avg:54.75ms
+step:1364/1490 train_time:74708ms step_avg:54.77ms
+step:1365/1490 train_time:74787ms step_avg:54.79ms
+step:1366/1490 train_time:74871ms step_avg:54.81ms
+step:1367/1490 train_time:74949ms step_avg:54.83ms
+step:1368/1490 train_time:75034ms step_avg:54.85ms
+step:1369/1490 train_time:75113ms step_avg:54.87ms
+step:1370/1490 train_time:75199ms step_avg:54.89ms
+step:1371/1490 train_time:75279ms step_avg:54.91ms
+step:1372/1490 train_time:75364ms step_avg:54.93ms
+step:1373/1490 train_time:75443ms step_avg:54.95ms
+step:1374/1490 train_time:75528ms step_avg:54.97ms
+step:1375/1490 train_time:75607ms step_avg:54.99ms
+step:1376/1490 train_time:75692ms step_avg:55.01ms
+step:1377/1490 train_time:75772ms step_avg:55.03ms
+step:1378/1490 train_time:75857ms step_avg:55.05ms
+step:1379/1490 train_time:75938ms step_avg:55.07ms
+step:1380/1490 train_time:76023ms step_avg:55.09ms
+step:1381/1490 train_time:76101ms step_avg:55.11ms
+step:1382/1490 train_time:76186ms step_avg:55.13ms
+step:1383/1490 train_time:76265ms step_avg:55.14ms
+step:1384/1490 train_time:76349ms step_avg:55.17ms
+step:1385/1490 train_time:76428ms step_avg:55.18ms
+step:1386/1490 train_time:76512ms step_avg:55.20ms
+step:1387/1490 train_time:76592ms step_avg:55.22ms
+step:1388/1490 train_time:76678ms step_avg:55.24ms
+step:1389/1490 train_time:76758ms step_avg:55.26ms
+step:1390/1490 train_time:76844ms step_avg:55.28ms
+step:1391/1490 train_time:76924ms step_avg:55.30ms
+step:1392/1490 train_time:77008ms step_avg:55.32ms
+step:1393/1490 train_time:77088ms step_avg:55.34ms
+step:1394/1490 train_time:77172ms step_avg:55.36ms
+step:1395/1490 train_time:77252ms step_avg:55.38ms
+step:1396/1490 train_time:77337ms step_avg:55.40ms
+step:1397/1490 train_time:77417ms step_avg:55.42ms
+step:1398/1490 train_time:77502ms step_avg:55.44ms
+step:1399/1490 train_time:77582ms step_avg:55.46ms
+step:1400/1490 train_time:77667ms step_avg:55.48ms
+step:1401/1490 train_time:77746ms step_avg:55.49ms
+step:1402/1490 train_time:77831ms step_avg:55.51ms
+step:1403/1490 train_time:77910ms step_avg:55.53ms
+step:1404/1490 train_time:77995ms step_avg:55.55ms
+step:1405/1490 train_time:78077ms step_avg:55.57ms
+step:1406/1490 train_time:78162ms step_avg:55.59ms
+step:1407/1490 train_time:78242ms step_avg:55.61ms
+step:1408/1490 train_time:78327ms step_avg:55.63ms
+step:1409/1490 train_time:78406ms step_avg:55.65ms
+step:1410/1490 train_time:78490ms step_avg:55.67ms
+step:1411/1490 train_time:78569ms step_avg:55.68ms
+step:1412/1490 train_time:78654ms step_avg:55.70ms
+step:1413/1490 train_time:78734ms step_avg:55.72ms
+step:1414/1490 train_time:78819ms step_avg:55.74ms
+step:1415/1490 train_time:78899ms step_avg:55.76ms
+step:1416/1490 train_time:78984ms step_avg:55.78ms
+step:1417/1490 train_time:79064ms step_avg:55.80ms
+step:1418/1490 train_time:79149ms step_avg:55.82ms
+step:1419/1490 train_time:79229ms step_avg:55.83ms
+step:1420/1490 train_time:79312ms step_avg:55.85ms
+step:1421/1490 train_time:79391ms step_avg:55.87ms
+step:1422/1490 train_time:79477ms step_avg:55.89ms
+step:1423/1490 train_time:79557ms step_avg:55.91ms
+step:1424/1490 train_time:79643ms step_avg:55.93ms
+step:1425/1490 train_time:79722ms step_avg:55.95ms
+step:1426/1490 train_time:79806ms step_avg:55.97ms
+step:1427/1490 train_time:79886ms step_avg:55.98ms
+step:1428/1490 train_time:79971ms step_avg:56.00ms
+step:1429/1490 train_time:80051ms step_avg:56.02ms
+step:1430/1490 train_time:80136ms step_avg:56.04ms
+step:1431/1490 train_time:80217ms step_avg:56.06ms
+step:1432/1490 train_time:80301ms step_avg:56.08ms
+step:1433/1490 train_time:80382ms step_avg:56.09ms
+step:1434/1490 train_time:80469ms step_avg:56.11ms
+step:1435/1490 train_time:80548ms step_avg:56.13ms
+step:1436/1490 train_time:80633ms step_avg:56.15ms
+step:1437/1490 train_time:80711ms step_avg:56.17ms
+step:1438/1490 train_time:80797ms step_avg:56.19ms
+step:1439/1490 train_time:80878ms step_avg:56.20ms
+step:1440/1490 train_time:80962ms step_avg:56.22ms
+step:1441/1490 train_time:81042ms step_avg:56.24ms
+step:1442/1490 train_time:81129ms step_avg:56.26ms
+step:1443/1490 train_time:81207ms step_avg:56.28ms
+step:1444/1490 train_time:81292ms step_avg:56.30ms
+step:1445/1490 train_time:81371ms step_avg:56.31ms
+step:1446/1490 train_time:81456ms step_avg:56.33ms
+step:1447/1490 train_time:81537ms step_avg:56.35ms
+step:1448/1490 train_time:81622ms step_avg:56.37ms
+step:1449/1490 train_time:81701ms step_avg:56.38ms
+step:1450/1490 train_time:81787ms step_avg:56.40ms
+step:1451/1490 train_time:81870ms step_avg:56.42ms
+step:1452/1490 train_time:81957ms step_avg:56.44ms
+step:1453/1490 train_time:82037ms step_avg:56.46ms
+step:1454/1490 train_time:82124ms step_avg:56.48ms
+step:1455/1490 train_time:82204ms step_avg:56.50ms
+step:1456/1490 train_time:82288ms step_avg:56.52ms
+step:1457/1490 train_time:82368ms step_avg:56.53ms
+step:1458/1490 train_time:82452ms step_avg:56.55ms
+step:1459/1490 train_time:82531ms step_avg:56.57ms
+step:1460/1490 train_time:82616ms step_avg:56.59ms
+step:1461/1490 train_time:82695ms step_avg:56.60ms
+step:1462/1490 train_time:82781ms step_avg:56.62ms
+step:1463/1490 train_time:82862ms step_avg:56.64ms
+step:1464/1490 train_time:82946ms step_avg:56.66ms
+step:1465/1490 train_time:83027ms step_avg:56.67ms
+step:1466/1490 train_time:83111ms step_avg:56.69ms
+step:1467/1490 train_time:83190ms step_avg:56.71ms
+step:1468/1490 train_time:83277ms step_avg:56.73ms
+step:1469/1490 train_time:83357ms step_avg:56.74ms
+step:1470/1490 train_time:83442ms step_avg:56.76ms
+step:1471/1490 train_time:83521ms step_avg:56.78ms
+step:1472/1490 train_time:83605ms step_avg:56.80ms
+step:1473/1490 train_time:83686ms step_avg:56.81ms
+step:1474/1490 train_time:83771ms step_avg:56.83ms
+step:1475/1490 train_time:83850ms step_avg:56.85ms
+step:1476/1490 train_time:83938ms step_avg:56.87ms
+step:1477/1490 train_time:84019ms step_avg:56.88ms
+step:1478/1490 train_time:84104ms step_avg:56.90ms
+step:1479/1490 train_time:84184ms step_avg:56.92ms
+step:1480/1490 train_time:84270ms step_avg:56.94ms
+step:1481/1490 train_time:84348ms step_avg:56.95ms
+step:1482/1490 train_time:84433ms step_avg:56.97ms
+step:1483/1490 train_time:84512ms step_avg:56.99ms
+step:1484/1490 train_time:84598ms step_avg:57.01ms
+step:1485/1490 train_time:84679ms step_avg:57.02ms
+step:1486/1490 train_time:84764ms step_avg:57.04ms
+step:1487/1490 train_time:84843ms step_avg:57.06ms
+step:1488/1490 train_time:84929ms step_avg:57.08ms
+step:1489/1490 train_time:85009ms step_avg:57.09ms
+step:1490/1490 train_time:85093ms step_avg:57.11ms
+step:1490/1490 val_loss:3.2795 train_time:85193ms step_avg:57.18ms
+peak memory allocated: 31295 MiB reserved: 46666 MiB

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -1348,7 +1348,7 @@ class GPT(nn.Module):
         # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
         # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
         if self.training:
-            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale)
         else:
             logits = self.lm_head(x)
             logits = 23 * torch.sigmoid((logits + 5) / 7.5)

--- a/triton_kernels.py
+++ b/triton_kernels.py
@@ -533,132 +533,6 @@ class FusedLinearReLUSquareFunction(torch.autograd.Function):
         dx = dpre @ W1
         return dx.view(x.shape), dW1, dW2
 
-# -----------------------------------------------------------------------------
-# Fused Softcapped Cross Entropy
-
-
-@triton.jit
-def fused_softcapped_entropy_fwd_kernel(
-    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
-    stride_logits_n, stride_logits_v,
-    n_rows, n_cols, n_predict,
-    A, B, C,
-    BLOCK_SIZE: tl.constexpr
-):
-    row_idx = tl.program_id(0).to(tl.int64)
-    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
-
-    max_val = -float('inf')
-    sum_exp = 0.0
-
-    inv_C = 1.0 / C
-    B_div_C = B * inv_C
-
-    for off in range(0, n_cols, BLOCK_SIZE):
-        cols = off + tl.arange(0, BLOCK_SIZE)
-        mask = cols < n_cols
-        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
-        z = A * tl.sigmoid(val * inv_C + B_div_C)
-        z = tl.where(mask, z, -float('inf'))
-        curr_max = tl.max(z, axis=0)
-        new_max = tl.maximum(max_val, curr_max)
-        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
-        max_val = new_max
-
-    lse = max_val + tl.log(sum_exp)
-    tl.store(lse_ptr + row_idx, lse)
-
-    total_loss = 0.0
-    for k in range(n_predict):
-        target_idx = row_idx + k
-        if target_idx < n_rows:
-            weight = tl.load(mtp_weights_ptr + k)
-            if weight > 0:
-                target = tl.load(targets_ptr + target_idx).to(tl.int32)
-                if target >= 0 and target < n_cols:
-                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
-                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
-                    total_loss += weight * (lse - z_target)
-
-    tl.store(losses_ptr + row_idx, total_loss)
-
-@triton.jit
-def fused_softcapped_entropy_bwd_kernel(
-    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
-    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
-    n_rows, n_cols, n_predict,
-    A, B, C,
-    grad_s,
-    BLOCK_SIZE: tl.constexpr,
-    N_PREDICT: tl.constexpr
-):
-    row_idx = tl.program_id(0).to(tl.int64)
-
-    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
-    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
-
-    lse = tl.load(lse_ptr + row_idx)
-    grad_loss = tl.load(grad_output_ptr + row_idx)
-
-    inv_C = 1.0 / C
-    B_div_C = B * inv_C
-    inv_C_A = inv_C * A
-    inv_grad_s = 1.0 / grad_s
-
-    # Preload all targets and weights before the column loop
-    S_w = 0.0
-    t0: tl.int32 = -1
-    t1: tl.int32 = -1
-    t2: tl.int32 = -1
-    w0: tl.float32 = 0.0
-    w1: tl.float32 = 0.0
-    w2: tl.float32 = 0.0
-
-    if N_PREDICT >= 1:
-        if row_idx + 0 < n_rows:
-            w0 = tl.load(mtp_weights_ptr + 0)
-            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
-            S_w += w0
-
-    if N_PREDICT >= 2:
-        if row_idx + 1 < n_rows:
-            w1 = tl.load(mtp_weights_ptr + 1)
-            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
-            S_w += w1
-
-    if N_PREDICT >= 3:
-        if row_idx + 2 < n_rows:
-            w2 = tl.load(mtp_weights_ptr + 2)
-            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
-            S_w += w2
-
-    # Fuse all scalar multiplications
-    grad_scale = grad_loss * inv_grad_s
-    grad_scale_icA = grad_scale * inv_C_A
-
-    for off in range(0, n_cols, BLOCK_SIZE):
-        cols = off + tl.arange(0, BLOCK_SIZE)
-        mask = cols < n_cols
-        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
-        u = val * inv_C + B_div_C
-        sigmoid_u = tl.sigmoid(u)
-        z = A * sigmoid_u
-        p = tl.exp(z - lse)
-
-        term1 = S_w * p
-
-        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
-        if N_PREDICT >= 1:
-            term2 += tl.where(cols == t0, w0, 0.0)
-        if N_PREDICT >= 2:
-            term2 += tl.where(cols == t1, w1, 0.0)
-        if N_PREDICT >= 3:
-            term2 += tl.where(cols == t2, w2, 0.0)
-
-        grad_z = term1 - term2
-        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
-        grad_x = grad_x.to(tl.float8e5)
-        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
 
 # -----------------------------------------------------------------------------
 # Tiled transpose copy kernel: dst (N, M) = src (M, N).T
@@ -784,9 +658,278 @@ def transpose_add(src: torch.Tensor, dst: torch.Tensor):
     )
 
 
+CE_KERNEL_BLOCK_SIZE = 256
+CE_KERNEL_VOCAB_SIZE = 50304
+
+CE_KERNEL_DECLS = f"""
+constexpr int VOCAB_SIZE = {CE_KERNEL_VOCAB_SIZE};
+constexpr int BLOCK_SIZE = {CE_KERNEL_BLOCK_SIZE};
+"""
+
+CE_KERNEL_SOURCE = """
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+#define __nv_fp8_e5m2 char
+#define uint16_t unsigned short
+#define uint8_t unsigned char
+#define int64_t long long
+
+__device__ __forceinline__ __nv_fp8_e5m2 f32_to_fp8_e5m2(float x) {
+    uint16_t packed;
+    asm volatile(
+        "cvt.rn.satfinite.e5m2x2.f32 %0, %1, %2;"
+        : "=h"(packed)
+        : "f"(x), "f"(0.0f)
+    );
+    __nv_fp8_e5m2 result;
+    *reinterpret_cast<uint8_t*>(&result) = (packed & (0xFF << 8)) >> 8;
+    return result;
+}
+
+struct __align__(16) __nv_bfloat168 {
+    __nv_bfloat16 data[8];
+    __device__ __nv_bfloat16& operator[](int i) { return data[i]; }
+    __device__ const __nv_bfloat16& operator[](int i) const { return data[i]; }
+};
+
+struct __align__(8) __nv_fp8_e5m28 {
+    __nv_fp8_e5m2 data[8];
+    __device__ __nv_fp8_e5m2& operator[](int i) { return data[i]; }
+    __device__ const __nv_fp8_e5m2& operator[](int i) const { return data[i]; }
+};
+
+template<typename T> __device__ constexpr T CEIL_DIV(T a, T b) { return (a + b - 1) / b; }
+
+//__device__ float sigmoid(float x) {
+//  return 1.0f / (1.0f + __expf(-x));
+//}
+__device__ float sigmoid(float x) {
+  return 0.5f + __tanhf(x * 0.5f) * 0.5f;
+}
+
+extern "C"
+__launch_bounds__(BLOCK_SIZE, 2)
+__global__ void ce_fwd_bwd_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    const int64_t* __restrict__ targets,
+    const float* __restrict__ mtp_weights,
+    float* __restrict__ losses,
+    __nv_fp8_e5m2* grad_input,
+    int batch_size,
+    int n_predict,
+    double A_param,
+    double B_param,
+    double C_param,
+    double grad_s_param,
+    double grad_scale_param)
+{
+  constexpr int VEC_WIDTH = 8;
+  constexpr int NUM_FULL_LOADS = VOCAB_SIZE / (BLOCK_SIZE * VEC_WIDTH);
+  constexpr int NUM_LOADS = CEIL_DIV(VOCAB_SIZE, BLOCK_SIZE * VEC_WIDTH);
+
+  float A = (float)A_param;
+  float B = (float)B_param;
+  float C = (float)C_param;
+  float grad_s = (float)grad_s_param;
+  float grad_scale = (float)grad_scale_param;
+
+  extern __shared__ __nv_bfloat16 smem[];
+
+  static_assert(VEC_WIDTH == 8);
+
+  const __nv_bfloat16 *block_logit_ptr = logits + VOCAB_SIZE * blockIdx.x;
+
+  float inv_C = 1 / C;
+  float B_div_C = B * inv_C;
+  float thread_max = -CUDART_INF_F;
+
+  #pragma unroll 25
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 result = *(__nv_bfloat168*)(&block_logit_ptr[idx]);
+      __nv_bfloat168 result_sigmoid;
+      #pragma unroll
+      for (int k = 0; k < VEC_WIDTH; k++) {
+        float tmp = __bfloat162float(result[k]);
+        tmp = sigmoid(tmp * inv_C + B_div_C);
+        result_sigmoid[k] = __float2bfloat16(tmp);
+        tmp = A * tmp;
+        thread_max = max(tmp, thread_max);
+      }
+      *(__nv_bfloat168*)(&smem[idx]) = result_sigmoid;
+    }
+  }
+
+  constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+  int warp_id = threadIdx.x / 32;
+  __shared__ float block_maxs[NUM_WARPS];
+  __shared__ float block_sums[NUM_WARPS];
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_max = fmaxf(thread_max, __shfl_down_sync(0xFFFFFFFF, thread_max, offset));
+
+  if (threadIdx.x % 32 == 0) {
+    block_maxs[warp_id] = thread_max;
+  }
+
+  __syncthreads();
+
+  float block_max = -CUDART_INF_F;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_max = fmaxf(block_max, block_maxs[i]);
+  }
+
+  float thread_sum = 0.0f;
+  #pragma unroll 2
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_bfloat168 l;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      l = *(__nv_bfloat168*)(&smem[idx]);
+    }
+    #pragma unroll
+    for (int k = 0; k < VEC_WIDTH; k++) {
+      float tmp = A * __bfloat162float(l[k]);
+      tmp = __expf(tmp - block_max);
+      if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+        thread_sum += tmp;
+      }
+    }
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_sum += __shfl_down_sync(0xFFFFFFFF, thread_sum, offset);
+
+  if (threadIdx.x % 32 == 0) {
+    block_sums[warp_id] = thread_sum;
+  }
+
+  __syncthreads();
+
+  float block_sum = 0.0f;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_sum += block_sums[i];
+  }
+
+  float lse = block_max + __logf(block_sum);
+
+  if (threadIdx.x == 0) {
+    float total_loss = 0.0f;
+    for (int k = 0; k < n_predict; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size) {
+        float weight = mtp_weights[k];
+        int64_t target = targets[target_idx];
+        if (target >= 0 && target < VOCAB_SIZE) {
+          float z_target = A * __bfloat162float(smem[target]);
+          total_loss += weight * (lse - z_target);
+        }
+      }
+    }
+    losses[blockIdx.x] = total_loss;
+  }
+
+  float S_w = 0.0f;
+
+  for (int i = 0; i < n_predict; i++) {
+    S_w += mtp_weights[i];
+  }
+
+  #pragma unroll 4
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_fp8_e5m28 result;
+
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 sigmoid_us = *(__nv_bfloat168*)(&smem[idx]);
+      #pragma unroll
+      for (int j = 0; j < VEC_WIDTH; j++) {
+        float sigmoid_u = __bfloat162float(sigmoid_us[j]);
+        float z = A * sigmoid_u;
+        float p = __expf(z - lse);
+
+        float term1 = S_w * p;
+        float term2 = 0.0f;
+
+        float grad_z = term1 - term2;
+        float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+        auto result_tmp = f32_to_fp8_e5m2(grad_x);
+        result[j] = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+      }
+      *(__nv_fp8_e5m28*)(&grad_input[blockIdx.x * VOCAB_SIZE + idx]) = result;
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < n_predict && blockIdx.x + threadIdx.x < batch_size) {
+    int i = threadIdx.x;
+    int64_t target = targets[blockIdx.x + i];
+
+    float sigmoid_u = __bfloat162float(smem[target]);
+    float z = A * sigmoid_u;
+    float p = __expf(z - lse);
+
+    float term1 = S_w * p;
+    float term2 = 0.0f;
+
+    #pragma unroll
+    for (int k = 0; k < 3; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size && k < n_predict) {
+        if (targets[target_idx] == target) {
+          term2 += mtp_weights[k];
+        }
+      }
+    }
+
+    float grad_z = term1 - term2;
+    float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+    auto result_tmp = f32_to_fp8_e5m2(grad_x);
+    auto result = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+    grad_input[blockIdx.x * VOCAB_SIZE + target] = result;
+  }
+}
+"""
+
+ce_fwd_bwd_kernel = torch.cuda._compile_kernel(
+    CE_KERNEL_DECLS + CE_KERNEL_SOURCE,
+    "ce_fwd_bwd_kernel",
+    compute_capability="90",
+    cuda_include_dirs=["/usr/local/cuda/include/"],
+    nvcc_options=["-lineinfo", "--use_fast_math"],
+)
+ce_fwd_bwd_kernel.set_shared_memory_config(CE_KERNEL_VOCAB_SIZE * 2)
+
+@torch.library.custom_op("nanogpt::ce_fwd_bwd", mutates_args={"losses", "grad_input"})
+def ce_fwd_bwd(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    mtp_weights: torch.Tensor,
+    losses: torch.Tensor,
+    grad_input: torch.Tensor,
+    n_rows: int,
+    n_predict: int,
+    A: float,
+    B: float,
+    C: float,
+    grad_s: float,
+    grad_scale: float,
+) -> None:
+    grid = (n_rows, 1, 1)
+    ce_fwd_bwd_kernel(
+        grid,
+        (CE_KERNEL_BLOCK_SIZE, 1, 1),
+        (logits, targets, mtp_weights, losses, grad_input,
+         n_rows, n_predict, A, B, C, grad_s, grad_scale),
+        shared_mem=CE_KERNEL_VOCAB_SIZE * 2,
+    )
+
 class FusedSoftcappedCrossEntropy(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, grad_scale, A=23.0, B=5.0, C=7.5):
 
         x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
         w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
@@ -814,41 +957,23 @@ class FusedSoftcappedCrossEntropy(torch.autograd.Function):
         targets = targets.contiguous()
         mtp_weights = mtp_weights.contiguous()
 
-        grid = (n_rows,)
-        fused_softcapped_entropy_fwd_kernel[grid](
-            logits, losses, lse, targets, mtp_weights,
-            logits.stride(0), logits.stride(1),
-            n_rows, n_cols, n_predict,
-            A, B, C,
-            BLOCK_SIZE=2048,
-            num_warps=2
-        )
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
 
-        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ce_fwd_bwd(logits, targets, mtp_weights, losses, grad_input,
+             n_rows, n_predict, A, B, C, grad_s, grad_scale)
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input)
         ctx.params = (A, B, C, x_s, w_s, grad_s)
         return losses
 
     @staticmethod
     def backward(ctx, grad_output):
-        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input = ctx.saved_tensors
         A, B, C, x_s, w_s, grad_s = ctx.params
         n_rows, n_cols = logits.shape
         n_predict = mtp_weights.shape[0]
 
-        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
         grad_output = grad_output.contiguous()
-
-        grid = (n_rows,)
-        fused_softcapped_entropy_bwd_kernel[grid](
-            grad_input, grad_output, lse, logits, targets, mtp_weights,
-            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
-            n_rows, n_cols, n_predict,
-            A, B, C,
-            grad_s,
-            BLOCK_SIZE=1024,
-            num_warps=4,
-            N_PREDICT=n_predict,
-        )
 
         x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
         w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)


### PR DESCRIPTION
Fuses the fwd and bwd of CE into one kernel, to avoid recomputing the sigmoid for softcapping on backward pass.

Baseline retime: 86057ms
```
Losses: [3.2800, 3.2785, 3.2794, 3.2795, 3.2795]
Times: [85116, 85103, 85153, 85193, 85212]
```
New avg: 85155ms